### PR TITLE
DEV-2138: Set an explicit shortcuts group in the editorFactory recipes

### DIFF
--- a/docs/cloudflare/__tests__/_worker.test.mjs
+++ b/docs/cloudflare/__tests__/_worker.test.mjs
@@ -311,7 +311,25 @@ test('still maps cell-type recipes that have a framework-specific counterpart pa
   );
   await assertRedirect(
     worker,
-    '/docs/angular-data-grid/recipes/cell-types/react-rating/',
-    '/docs/angular-data-grid/recipes/cell-types/rating/',
+    '/docs/javascript-data-grid/recipes/cell-types/react-rating/',
+    '/docs/javascript-data-grid/recipes/cell-types/rating/',
   );
+});
+
+test('bounces every Angular alias of the Feedback and Star Rating recipes to the cell-types index', async() => {
+  const worker = loadWorker();
+  const aliases = [
+    '/docs/angular-data-grid/recipes/cell-types/feedback/',
+    '/docs/angular-data-grid/recipes/cell-types/feedback-angular/',
+    '/docs/angular-data-grid/recipes/cell-types/feedback-react/',
+    '/docs/angular-data-grid/recipes/feedback-angular/',
+    '/docs/angular-data-grid/recipes/cell-types/rating/',
+    '/docs/angular-data-grid/recipes/cell-types/rating-angular/',
+    '/docs/angular-data-grid/recipes/cell-types/react-rating/',
+    '/docs/angular-data-grid/recipes/stars-rating-angular/',
+  ];
+
+  for (const alias of aliases) {
+    await assertRedirect(worker, alias, '/docs/angular-data-grid/recipes/cell-types/');
+  }
 });

--- a/docs/cloudflare/_worker.js
+++ b/docs/cloudflare/_worker.js
@@ -995,16 +995,23 @@ async function route(request, env) {
     {
       const forced301 = {
         '/docs/angular-data-grid/recipes/color-picker-angular/': '/docs/angular-data-grid/recipes/cell-types/color-picker/',
-        '/docs/angular-data-grid/recipes/feedback-angular/': '/docs/angular-data-grid/recipes/cell-types/feedback/',
-        '/docs/angular-data-grid/recipes/stars-rating-angular/': '/docs/angular-data-grid/recipes/cell-types/rating/',
+        // The Angular Feedback and Star Rating recipes are temporarily unreachable: their
+        // editors pass `shortcuts` through `HotCellEditorAdvancedComponent`, and the adapter
+        // does not forward `shortcutsGroup`, so the editor throws on Handsontable 18.0.0.
+        // Point every Angular alias at the cell-types index until the core default shortcuts
+        // group ships (18.1.0), then restore the destinations below.
+        '/docs/angular-data-grid/recipes/cell-types/feedback/': '/docs/angular-data-grid/recipes/cell-types/',
+        '/docs/angular-data-grid/recipes/cell-types/rating/': '/docs/angular-data-grid/recipes/cell-types/',
+        '/docs/angular-data-grid/recipes/feedback-angular/': '/docs/angular-data-grid/recipes/cell-types/',
+        '/docs/angular-data-grid/recipes/stars-rating-angular/': '/docs/angular-data-grid/recipes/cell-types/',
         '/docs/angular-data-grid/recipes/datepicker-angular/': '/docs/angular-data-grid/recipes/cell-types/datepicker/',
         '/docs/angular-data-grid/recipes/cell-types/color-picker-angular/': '/docs/angular-data-grid/recipes/cell-types/color-picker/',
         '/docs/javascript-data-grid/recipes/cell-types/color-picker-angular/': '/docs/javascript-data-grid/recipes/cell-types/color-picker/',
         '/docs/react-data-grid/recipes/cell-types/color-picker-angular/': '/docs/react-data-grid/recipes/cell-types/colorful-picker/',
-        '/docs/angular-data-grid/recipes/cell-types/feedback-angular/': '/docs/angular-data-grid/recipes/cell-types/feedback/',
+        '/docs/angular-data-grid/recipes/cell-types/feedback-angular/': '/docs/angular-data-grid/recipes/cell-types/',
         '/docs/javascript-data-grid/recipes/cell-types/feedback-angular/': '/docs/javascript-data-grid/recipes/cell-types/feedback/',
         '/docs/react-data-grid/recipes/cell-types/feedback-angular/': '/docs/react-data-grid/recipes/cell-types/feedback-react/',
-        '/docs/angular-data-grid/recipes/cell-types/rating-angular/': '/docs/angular-data-grid/recipes/cell-types/rating/',
+        '/docs/angular-data-grid/recipes/cell-types/rating-angular/': '/docs/angular-data-grid/recipes/cell-types/',
         '/docs/javascript-data-grid/recipes/cell-types/rating-angular/': '/docs/javascript-data-grid/recipes/cell-types/rating/',
         '/docs/react-data-grid/recipes/cell-types/rating-angular/': '/docs/react-data-grid/recipes/cell-types/react-rating/',
         '/docs/angular-data-grid/recipes/cell-types/datepicker-angular/': '/docs/angular-data-grid/recipes/cell-types/datepicker/',
@@ -1015,8 +1022,8 @@ async function route(request, env) {
         '/docs/javascript-data-grid/recipes/cell-types/feedback-react/': '/docs/javascript-data-grid/recipes/cell-types/feedback/',
         '/docs/javascript-data-grid/recipes/cell-types/react-rating/': '/docs/javascript-data-grid/recipes/cell-types/rating/',
         '/docs/angular-data-grid/recipes/cell-types/colorful-picker/': '/docs/angular-data-grid/recipes/cell-types/color-picker/',
-        '/docs/angular-data-grid/recipes/cell-types/feedback-react/': '/docs/angular-data-grid/recipes/cell-types/feedback/',
-        '/docs/angular-data-grid/recipes/cell-types/react-rating/': '/docs/angular-data-grid/recipes/cell-types/rating/',
+        '/docs/angular-data-grid/recipes/cell-types/feedback-react/': '/docs/angular-data-grid/recipes/cell-types/',
+        '/docs/angular-data-grid/recipes/cell-types/react-rating/': '/docs/angular-data-grid/recipes/cell-types/',
         '/docs/javascript-data-grid/recipes/cell-types/datepicker/': '/docs/javascript-data-grid/recipes/cell-types/',
         '/docs/react-data-grid/recipes/cell-types/datepicker/': '/docs/react-data-grid/recipes/cell-types/',
       };

--- a/docs/content/recipes/cell-types/color-picker/color-picker.md
+++ b/docs/content/recipes/cell-types/color-picker/color-picker.md
@@ -430,6 +430,7 @@ const cellDefinition = {
     setValue(editor, value) {
       editor.input.value = value;
     },
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['Tab']],

--- a/docs/content/recipes/cell-types/color-picker/javascript/example1.js
+++ b/docs/content/recipes/cell-types/color-picker/javascript/example1.js
@@ -276,6 +276,7 @@ const cellDefinition = {
     setValue(editor, value) {
       editor.input.value = value;
     },
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['Tab']],

--- a/docs/content/recipes/cell-types/color-picker/javascript/example1.ts
+++ b/docs/content/recipes/cell-types/color-picker/javascript/example1.ts
@@ -281,6 +281,7 @@ const cellDefinition: Pick<CellProperties, 'renderer' | 'validator' | 'editor'> 
     setValue(editor, value) {
       editor.input.value = value;
     },
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['Tab']],

--- a/docs/content/recipes/cell-types/color-picker/react/example1.jsx
+++ b/docs/content/recipes/cell-types/color-picker/react/example1.jsx
@@ -84,6 +84,7 @@ const colorPickerEditor = editorFactory({
   setValue(editor, value) {
     editor.input.value = value;
   },
+  shortcutsGroup: 'customEditor',
   shortcuts: [
     {
       keys: [['Tab']],

--- a/docs/content/recipes/cell-types/color-picker/react/example1.tsx
+++ b/docs/content/recipes/cell-types/color-picker/react/example1.tsx
@@ -93,6 +93,7 @@ const colorPickerEditor = editorFactory<ColorPickerEditorInstance>({
   setValue(editor, value) {
     editor.input.value = value;
   },
+  shortcutsGroup: 'customEditor',
   shortcuts: [
     {
       keys: [['Tab']],

--- a/docs/content/recipes/cell-types/feedback/feedback.md
+++ b/docs/content/recipes/cell-types/feedback/feedback.md
@@ -295,6 +295,7 @@ const cellDefinition = {
   editor: editorFactory<{ input: HTMLDivElement; value: string; config: string[] }>({
     config: ['👍', '👎', '🤷'],
     value: '👍',
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['ArrowRight'], ['Tab']],

--- a/docs/content/recipes/cell-types/feedback/javascript/example1.js
+++ b/docs/content/recipes/cell-types/feedback/javascript/example1.js
@@ -20,6 +20,7 @@ const cellDefinition = {
   editor: editorFactory({
     config: ['👍', '👎', '🤷'],
     value: '👍',
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['ArrowRight'], ['Tab']],

--- a/docs/content/recipes/cell-types/feedback/javascript/example1.ts
+++ b/docs/content/recipes/cell-types/feedback/javascript/example1.ts
@@ -30,6 +30,7 @@ const cellDefinition: Pick<
   >({
     config: ["👍", "👎", "🤷"],
     value: "👍",
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [["ArrowRight"], ["Tab"]],

--- a/docs/content/recipes/cell-types/feedback/react/example1.jsx
+++ b/docs/content/recipes/cell-types/feedback/react/example1.jsx
@@ -19,6 +19,7 @@ const feedbackCellDefinition = {
   editor: editorFactory({
     config: ['👍', '👎', '🤷'],
     value: '👍',
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['ArrowRight'], ['Tab']],

--- a/docs/content/recipes/cell-types/feedback/react/example1.tsx
+++ b/docs/content/recipes/cell-types/feedback/react/example1.tsx
@@ -27,6 +27,7 @@ const feedbackCellDefinition: Pick<CellProperties, 'renderer' | 'validator' | 'e
   editor: editorFactory<FeedbackEditorInstance>({
     config: ['👍', '👎', '🤷'],
     value: '👍',
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['ArrowRight'], ['Tab']],

--- a/docs/content/recipes/cell-types/moment-date/javascript/example1.js
+++ b/docs/content/recipes/cell-types/moment-date/javascript/example1.js
@@ -178,6 +178,7 @@ const cellDateTypeDefinition = {
   },
   editor: editorFactory({
     position: 'portal',
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['ArrowLeft']],

--- a/docs/content/recipes/cell-types/moment-date/javascript/example1.ts
+++ b/docs/content/recipes/cell-types/moment-date/javascript/example1.ts
@@ -175,6 +175,7 @@ const cellDateTypeDefinition = {
   },
   editor: editorFactory({
     position: 'portal',
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['ArrowLeft']],

--- a/docs/content/recipes/cell-types/moment-date/moment-date.md
+++ b/docs/content/recipes/cell-types/moment-date/moment-date.md
@@ -190,6 +190,7 @@ The editor uses `editorFactory` with `position: 'portal'` to overlay a Pikaday c
 ```typescript
 editor: editorFactory({
   position: 'portal',
+  shortcutsGroup: 'customEditor',
   shortcuts: [
     {
       keys: [['ArrowLeft']],

--- a/docs/content/recipes/cell-types/moment-date/react/example1.jsx
+++ b/docs/content/recipes/cell-types/moment-date/react/example1.jsx
@@ -70,6 +70,7 @@ const cellDateTypeDefinition = {
   },
   editor: editorFactory({
     position: 'portal',
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['ArrowLeft']],

--- a/docs/content/recipes/cell-types/moment-date/react/example1.tsx
+++ b/docs/content/recipes/cell-types/moment-date/react/example1.tsx
@@ -77,6 +77,7 @@ const cellDateTypeDefinition = {
   },
   editor: editorFactory<MomentDateEditorInstance>({
     position: 'portal',
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['ArrowLeft']],

--- a/docs/content/recipes/cell-types/pikaday/javascript/example1.js
+++ b/docs/content/recipes/cell-types/pikaday/javascript/example1.js
@@ -199,6 +199,7 @@ const cellDefinition = {
   }),
   editor: editorFactory({
     position: 'portal',
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['ArrowLeft']],

--- a/docs/content/recipes/cell-types/pikaday/javascript/example1.ts
+++ b/docs/content/recipes/cell-types/pikaday/javascript/example1.ts
@@ -242,6 +242,7 @@ const cellDefinition: Pick<
     EditorMethodsType
   >({
     position: "portal",
+    shortcutsGroup: "customEditor",
     shortcuts: [{
       keys: [["ArrowLeft"]],
       callback: (editor, _event) => {

--- a/docs/content/recipes/cell-types/pikaday/pikaday.md
+++ b/docs/content/recipes/cell-types/pikaday/pikaday.md
@@ -598,6 +598,7 @@ const cellDefinition: Pick<
     EditorMethodsType
   >({
     position: 'portal',
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       // ... keyboard shortcuts from Step 13
     ],

--- a/docs/content/recipes/cell-types/pikaday/react/example1.jsx
+++ b/docs/content/recipes/cell-types/pikaday/react/example1.jsx
@@ -19,6 +19,7 @@ const pikadayRenderer = rendererFactory(({ td, value, cellProperties }) => {
 
 const pikadayEditor = editorFactory({
   position: 'portal',
+  shortcutsGroup: 'customEditor',
   shortcuts: [
     {
       keys: [['ArrowLeft']],

--- a/docs/content/recipes/cell-types/pikaday/react/example1.tsx
+++ b/docs/content/recipes/cell-types/pikaday/react/example1.tsx
@@ -26,6 +26,7 @@ const pikadayRenderer = rendererFactory(({ td, value, cellProperties }) => {
 
 const pikadayEditor = editorFactory<PikadayEditorInstance>({
   position: 'portal',
+  shortcutsGroup: 'customEditor',
   shortcuts: [
     {
       keys: [['ArrowLeft']],

--- a/docs/content/recipes/cell-types/rating/javascript/example1.js
+++ b/docs/content/recipes/cell-types/rating/javascript/example1.js
@@ -35,6 +35,7 @@ const cellDefinition = {
     callback(value >= 0 && value <= 100);
   },
   editor: editorFactory({
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['1'], ['2'], ['3'], ['4'], ['5']],

--- a/docs/content/recipes/cell-types/rating/javascript/example1.ts
+++ b/docs/content/recipes/cell-types/rating/javascript/example1.ts
@@ -41,6 +41,7 @@ const cellDefinition: Pick<
   },
 
   editor: editorFactory<{ input: HTMLDivElement }>({
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [["1"], ["2"], ["3"], ["4"], ["5"]],

--- a/docs/content/recipes/cell-types/rating/rating.md
+++ b/docs/content/recipes/cell-types/rating/rating.md
@@ -392,6 +392,7 @@ const cellDefinition = {
     callback(value >= 0 && value <= 100);
   },
   editor: editorFactory<{ input: HTMLDivElement }>({
+    shortcutsGroup: 'customEditor',
     shortcuts: [
       {
         keys: [['1'], ['2'], ['3'], ['4'], ['5']],

--- a/docs/content/recipes/cell-types/rating/react/example1.jsx
+++ b/docs/content/recipes/cell-types/rating/react/example1.jsx
@@ -22,6 +22,7 @@ const ratingValidator = (value, callback) => {
 };
 
 const ratingEditor = editorFactory({
+  shortcutsGroup: 'customEditor',
   shortcuts: [
     {
       keys: [['1'], ['2'], ['3'], ['4'], ['5']],

--- a/docs/content/recipes/cell-types/rating/react/example1.tsx
+++ b/docs/content/recipes/cell-types/rating/react/example1.tsx
@@ -28,6 +28,7 @@ const ratingValidator = (value: unknown, callback: (valid: boolean) => void) => 
 };
 
 const ratingEditor = editorFactory<RatingEditorInstance>({
+  shortcutsGroup: 'customEditor',
   shortcuts: [
     {
       keys: [['1'], ['2'], ['3'], ['4'], ['5']],

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -36,8 +36,12 @@ const dataManagementItems = [
 const cellTypesItems = [
   // JavaScript + Angular + Vue (shared multi-framework pages)
   { path: 'cell-types/color-picker/color-picker', title: 'Color picker', onlyFor: ['javascript', 'angular', 'vue'] },
-  { path: 'cell-types/feedback/feedback', title: 'Feedback', onlyFor: ['javascript', 'angular', 'vue'] },
-  { path: 'cell-types/rating/rating', title: 'Star Rating', onlyFor: ['javascript', 'angular', 'vue'] },
+  // Angular is temporarily hidden on these two pages: their Angular editors pass
+  // `shortcuts` through `HotCellEditorAdvancedComponent`, and the adapter does not
+  // forward `shortcutsGroup`, so the editor throws on Handsontable 18.0.0. Restore
+  // 'angular' once the core default shortcuts group ships (18.1.0).
+  { path: 'cell-types/feedback/feedback', title: 'Feedback', onlyFor: ['javascript', 'vue'] },
+  { path: 'cell-types/rating/rating', title: 'Star Rating', onlyFor: ['javascript', 'vue'] },
   // All frameworks
   { path: 'cell-types/radio/radio', title: 'Radio buttons', onlyFor: ['javascript', 'react', 'angular', 'vue'] },
   { path: 'cell-types/numbro/numbro', title: 'Numbro', onlyFor: ['javascript', 'react', 'angular', 'vue'] },


### PR DESCRIPTION
### Context

The PR fixes the `editorFactory` recipes crashing on Handsontable 18.0.0 with `You need to define the shortcut's group.` as soon as the editor opens. The reported case is the [Pikaday recipe on production docs](https://handsontable.com/docs/javascript-data-grid/recipes/cell-types/pikaday/), where the date picker never appears.

18.0.0 passes `shortcutsGroup` straight into `addShortcuts()`, and `ShortcutContext` throws when it is `undefined`. Core gained a `'customEditor'` default in #13130, so the develop previews already work - but every recipe that declares `shortcuts` without a group still crashes for a reader running the released version, and it crashes on `prod-docs/18.0`, whose previews are built from that branch's own core (`docs/astro.config.mjs` aliases `handsontable` to `handsontable/tmp/`).

Five recipes are affected, not just Pikaday: Pikaday, Moment.js-based date, Color picker, Feedback, and Star Rating. Passing the group explicitly makes them work on both 18.0.0 and 18.1.0, and it matches what the [custom cells guide](https://handsontable.com/docs/javascript-data-grid/cell-function/#simplified-custom-cell-definitions) already documents.

The Angular variants cannot be fixed the same way. `FactoryEditorAdapter` forwards `shortcuts` but not `shortcutsGroup`, so the component-level option is dropped before it reaches `editorFactory` - a separate wrapper bug. Until that is fixed, this PR hides the Angular Feedback and Star Rating recipes: `'angular'` is removed from their `onlyFor` lists, and every Angular alias in the Cloudflare worker points at the cell-types index.

**This commit is meant to be reverted.** Once 18.1.0 ships, the core default makes `shortcutsGroup` redundant in the examples and the Angular pages should come back. The commit message says so too.

`'customEditor'` is deliberately the same literal as core's `DEFAULT_SHORTCUTS_GROUP`, so the examples behave identically before and after the revert.

### How has this been tested?

**Automated:**

```shell
npm run docs:test:plugins --prefix docs   # 225/225 pass, including 1 new worker test
```

The new test (`docs/cloudflare/__tests__/_worker.test.mjs`) asserts all eight Angular aliases of the Feedback and Star Rating recipes redirect to `/docs/angular-data-grid/recipes/cell-types/`.

**Manual A/B in a browser, against a core built to reproduce 18.0.0 behavior.** Because develop's core already defaults the group, `handsontable/src/editors/factory.ts` was temporarily reverted locally (never committed) so the served `tmp/` bundle matched the released version:

| Page | Without `shortcutsGroup` | With `shortcutsGroup` |
|---|---|---|
| `recipes/cell-types/pikaday` | `pageerror: You need to define the shortcut's group.`, picker never opens | Picker opens, <kbd>Escape</kbd> closes, console clean |
| `recipes/cell-types/rating` | Same error on editor open | Editor opens, console clean |

Color picker, Feedback, and Moment.js-based date were not opened in a browser - identical mechanism, and all 20 insertions were reviewed in the diff to confirm each one sits inside its `editorFactory` config.

The redirects are covered by the worker test only. The Astro dev server does not run the Cloudflare worker, so the 301s were not exercised in a browser.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2138

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

Documentation-only change - no package source is touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, example code, and redirect rules only; no core or package runtime changes.
> 
> **Overview**
> Fixes **Handsontable 18.0.0** doc recipe demos that crash on editor open with `You need to define the shortcut's group.` by adding **`shortcutsGroup: 'customEditor'`** to every `editorFactory` config that declares **`shortcuts`** (color picker, feedback, moment-date, Pikaday, star rating) across JS/TS/React examples and guide snippets.
> 
> Because the **Angular wrapper** does not forward **`shortcutsGroup`**, Feedback and Star Rating stay broken on Angular until a separate adapter fix or **18.1.0** defaults land. This PR **removes Angular** from those recipes’ **`onlyFor`** in **`sidebar.js`** and **301-redirects** all Angular Feedback/Rating URL aliases to **`/docs/angular-data-grid/recipes/cell-types/`**, with a new **`_worker.test.mjs`** case covering eight aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e2c05bcb33c05b1a780a6cdb00f90322d58b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->