### PR TITLE
DEV-2189: Fix the repo-root resolution that broke the gates in worktrees

### DIFF
--- a/.ai/LOCAL-ENFORCEMENT.md
+++ b/.ai/LOCAL-ENFORCEMENT.md
@@ -33,8 +33,9 @@ report-only at 80% until calibrated — a unit floor reads 0% for correctly
 E2E-tested changes, so it earns "blocking" only after the numbers are trusted).
 
 **Touched E2E specs run exactly once locally, whichever tool proves them first.**
-The Stop hook and pre-push share a green-run cache (`.git/hot-e2e-green.json`,
-via `scripts/e2e-run-cache.mjs`) keyed on spec content + environment (dist bundle,
+The Stop hook and pre-push share a green-run cache (`hot-e2e-green.json` in the
+checkout's git directory — `<root>/.git/` in a clone, `<main>/.git/worktrees/<name>/`
+in a linked worktree; via `scripts/e2e-run-cache.mjs`) keyed on spec content + environment (dist bundle,
 fixtures, Playwright config): with Claude, Stop proves the spec and pre-push skips
 it; with Cursor (no agent hooks), pre-push proves it once and repeat pushes skip.
 Editing the spec, rebuilding the dist, or touching a fixture invalidates the entry.
@@ -77,7 +78,8 @@ presence gate or the test requirement. Do not use it to dodge writing tests.
 
 ## 2. Creating or changing enforcement hooks (git + agent) — exact rules
 
-- **Location.** Git hooks → `lefthook.yml` + `scripts/` (`pre-push.mjs`, `lint-staged.mjs`, `lint-files.mjs`). Agent hooks → `scripts/claude/` (`post-tool-use.mjs`, `stop.mjs`, `session.mjs`), wired in `.claude/settings.json`. Shared, pure classifiers → `.github/scripts/lib/` (`presence-gate.mjs`, `test-weakening.mjs`).
+- **Location.** Git hooks → `lefthook.yml` + `scripts/` (`pre-push.mjs`, `lint-staged.mjs`, `lint-files.mjs`). Agent hooks → `scripts/claude/` (`post-tool-use.mjs`, `stop.mjs`, `session.mjs`), wired in `.claude/settings.json`. Shared, pure classifiers and layout helpers → `.github/scripts/lib/` (`presence-gate.mjs`, `test-weakening.mjs`, `repo-root.mjs`).
+- **Must work in a linked worktree.** Agent-driven work runs in `git worktree` checkouts, so never derive the repo layout from git or the cwd: take the root from `repoRoot()` (`.github/scripts/lib/repo-root.mjs`) and per-checkout state from `gitDir(root)`. A hook exports `GIT_DIR`, and with it set `git rev-parse --show-toplevel` returns the *cwd*, not the work tree; in a worktree `<root>/.git` is a **file**, so writing under it fails with ENOTDIR. Strip `GIT_DIR`/`GIT_WORK_TREE` from the environment of any child you spawn with an explicit `cwd`.
 - **Pure + tested.** Put the decision logic in a **pure function** in a lib and **unit-test it** (`scripts/__tests__/`, `.github/scripts/__tests__/`, run with `node --test`). **A hook change ships a test change** — this rule applies to the enforcement machinery too.
 - **Must not false-block.** Skip config/parse gaps (ESLint exit 2), record only **repo-relative, in-repo** paths (never scratchpad/out-of-repo), tolerate a missing base ref. A hook that fires on a false positive gets disabled — that is worse than no hook.
 - **Must stay fast.** No build in the pre-push or agent hooks; run only the **changed scope**. Heavy/full-suite work is CI's job.

--- a/.github/scripts/__tests__/repo-root.test.mjs
+++ b/.github/scripts/__tests__/repo-root.test.mjs
@@ -1,0 +1,87 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { repoRoot, gitDir } from '../lib/repo-root.mjs';
+
+// The root is asserted against files that only exist at the repository root —
+// NOT against `git rev-parse --show-toplevel`, which is the very thing that
+// reports the wrong directory under GIT_DIR and would make this test inherit the
+// bug it exists to catch.
+test('repoRoot() points at the repository root, from any cwd', () => {
+  const root = repoRoot();
+
+  assert.ok(existsSync(path.join(root, 'lefthook.yml')), `${root} has no lefthook.yml`);
+  assert.ok(existsSync(path.join(root, 'pnpm-workspace.yaml')), `${root} has no pnpm-workspace.yaml`);
+  assert.ok(existsSync(path.join(root, '.github/scripts/lib/repo-root.mjs')));
+
+  const cwd = process.cwd();
+
+  try {
+    process.chdir(path.join(root, 'scripts'));
+    assert.equal(repoRoot(), root);
+  } finally {
+    process.chdir(cwd);
+  }
+});
+
+// The regression: git hooks export GIT_DIR (in a worktree, pointing at
+// `<main>/.git/worktrees/<name>`), and with it set `--show-toplevel` returns the
+// cwd instead of the work tree — which made pre-push resolve `<root>/scripts` as
+// the root and crash with MODULE_NOT_FOUND before any gate ran.
+test('repoRoot() ignores the git environment a hook exports', () => {
+  const expected = repoRoot();
+  const { GIT_DIR, GIT_WORK_TREE } = process.env;
+
+  try {
+    process.env.GIT_DIR = path.join(expected, '.git/worktrees/does-not-exist');
+    process.env.GIT_WORK_TREE = tmpdir();
+    assert.equal(repoRoot(), expected);
+  } finally {
+    if (GIT_DIR === undefined) {
+      delete process.env.GIT_DIR;
+    } else {
+      process.env.GIT_DIR = GIT_DIR;
+    }
+
+    if (GIT_WORK_TREE === undefined) {
+      delete process.env.GIT_WORK_TREE;
+    } else {
+      process.env.GIT_WORK_TREE = GIT_WORK_TREE;
+    }
+  }
+});
+
+test('gitDir() returns <root>/.git in a normal clone', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'repo-root-clone-'));
+
+  mkdirSync(path.join(root, '.git'), { recursive: true });
+
+  assert.equal(gitDir(root), path.join(root, '.git'));
+});
+
+test('gitDir() follows the `gitdir:` pointer of a linked worktree', () => {
+  const main = mkdtempSync(path.join(tmpdir(), 'repo-root-main-'));
+  const wt = mkdtempSync(path.join(tmpdir(), 'repo-root-wt-'));
+  const linked = path.join(main, '.git/worktrees/wt');
+
+  mkdirSync(linked, { recursive: true });
+  // In a linked worktree `.git` is a FILE, not a directory.
+  writeFileSync(path.join(wt, '.git'), `gitdir: ${linked}\n`);
+
+  assert.equal(gitDir(wt), linked);
+});
+
+test('gitDir() resolves a relative `gitdir:` pointer against the root', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'repo-root-rel-'));
+
+  mkdirSync(path.join(root, 'nested/gitdir'), { recursive: true });
+  writeFileSync(path.join(root, '.git'), 'gitdir: nested/gitdir\n');
+
+  assert.equal(gitDir(root), path.join(root, 'nested/gitdir'));
+});
+
+test('gitDir() returns null outside a checkout', () => {
+  assert.equal(gitDir(mkdtempSync(path.join(tmpdir(), 'repo-root-bare-'))), null);
+});

--- a/.github/scripts/__tests__/repo-root.test.mjs
+++ b/.github/scripts/__tests__/repo-root.test.mjs
@@ -1,8 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { repoRoot, gitDir } from '../lib/repo-root.mjs';
 
 // The root is asserted against files that only exist at the repository root —
@@ -30,27 +32,28 @@ test('repoRoot() points at the repository root, from any cwd', () => {
 // `<main>/.git/worktrees/<name>`), and with it set `--show-toplevel` returns the
 // cwd instead of the work tree — which made pre-push resolve `<root>/scripts` as
 // the root and crash with MODULE_NOT_FOUND before any gate ran.
+//
+// Run in a CHILD process, not by mutating `process.env` here: the module derives
+// its root once, at import time. Setting the variable after this file imported it
+// would only reject a call-time git-derived implementation, and let a load-time
+// one (`const ROOT = execSync('git rev-parse --show-toplevel')`) pass while still
+// breaking in every real hook, where GIT_DIR exists from process start. The cwd
+// is a SUBDIRECTORY for the same reason — from the root itself, even the broken
+// resolution returns the right answer.
 test('repoRoot() ignores the git environment a hook exports', () => {
   const expected = repoRoot();
-  const { GIT_DIR, GIT_WORK_TREE } = process.env;
-
-  try {
-    process.env.GIT_DIR = path.join(expected, '.git/worktrees/does-not-exist');
-    process.env.GIT_WORK_TREE = tmpdir();
-    assert.equal(repoRoot(), expected);
-  } finally {
-    if (GIT_DIR === undefined) {
-      delete process.env.GIT_DIR;
-    } else {
-      process.env.GIT_DIR = GIT_DIR;
+  const moduleUrl = pathToFileURL(path.join(expected, '.github/scripts/lib/repo-root.mjs')).href;
+  const printed = execFileSync(
+    process.execPath,
+    ['-e', `import(${JSON.stringify(moduleUrl)}).then(m => process.stdout.write(m.repoRoot()))`],
+    {
+      cwd: path.join(expected, 'scripts'),
+      encoding: 'utf8',
+      env: { ...process.env, GIT_DIR: path.join(expected, '.git/worktrees/does-not-exist') },
     }
+  );
 
-    if (GIT_WORK_TREE === undefined) {
-      delete process.env.GIT_WORK_TREE;
-    } else {
-      process.env.GIT_WORK_TREE = GIT_WORK_TREE;
-    }
-  }
+  assert.equal(printed.trim(), expected);
 });
 
 test('gitDir() returns <root>/.git in a normal clone', () => {

--- a/.github/scripts/diff-coverage-gate.mjs
+++ b/.github/scripts/diff-coverage-gate.mjs
@@ -18,8 +18,9 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, existsSync, appendFileSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathToFileURL } from 'node:url';
 import { parseLcov, addedLinesByFile, computeDiffCoverage, evaluate } from './lib/diff-coverage.mjs';
+import { repoRoot } from './lib/repo-root.mjs';
 
 /**
  * Resolve the base ref to diff against — an explicit GATE_BASE, else the
@@ -43,8 +44,9 @@ function resolveBase(cwd) {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-  const root = execSync('git rev-parse --show-toplevel', { encoding: 'utf8', cwd: scriptDir }).trim();
+  // Location-derived, not git-derived: correct from any cwd, and under the
+  // `GIT_DIR` a git hook exports (see `lib/repo-root.mjs`).
+  const root = repoRoot();
   const mode = process.env.GATE_MODE === 'block' ? 'block' : 'warn';
   const floor = Number(process.env.COVERAGE_FLOOR ?? 80);
   const lcovPath = path.join(root, process.env.LCOV_PATH || 'handsontable/coverage/lcov.info');

--- a/.github/scripts/lib/repo-root.mjs
+++ b/.github/scripts/lib/repo-root.mjs
@@ -1,0 +1,58 @@
+/**
+ * Repository layout helpers for the gates and hooks — pure, no subprocess.
+ *
+ * Both functions exist because git's own answers are unreliable in the one
+ * environment the hooks always run in: a git hook exports `GIT_DIR` (and, in a
+ * worktree, points it at `<main>/.git/worktrees/<name>`). With `GIT_DIR` set
+ * explicitly, `git rev-parse --show-toplevel` stops discovering the work tree by
+ * walking up from the cwd and reports the cwd itself, so a git-derived root is
+ * whatever directory the caller happened to start from.
+ */
+import { readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// This module lives at <root>/.github/scripts/lib/, so the root is three levels
+// up. Anchored HERE, not at the call sites: every caller then gets the root with
+// no arguments and no chance of an off-by-one level.
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/**
+ * Absolute path to the repository root, derived from this file's own location.
+ * Independent of the cwd and of the git environment variables, so it is correct
+ * in a git hook, in CI, and in a linked worktree alike.
+ *
+ * @returns {string} The repository root path.
+ */
+export function repoRoot() {
+  return ROOT;
+}
+
+/**
+ * Absolute path to the git directory of the checkout at `root` — the place for
+ * per-checkout, never-committed state. In a normal clone that is `<root>/.git`.
+ * In a linked worktree `<root>/.git` is a FILE holding `gitdir: <path>`, and the
+ * real directory is `<main>/.git/worktrees/<name>`; writing to the file's path
+ * fails with ENOTDIR.
+ *
+ * Resolves the worktree's own git directory, not the shared common directory, so
+ * per-checkout state stays per-checkout.
+ *
+ * @param {string} root The repository root (from `repoRoot()`).
+ * @returns {string|null} The git directory, or null when `root` is not a checkout.
+ */
+export function gitDir(root) {
+  const dotGit = path.join(root, '.git');
+
+  try {
+    if (statSync(dotGit).isDirectory()) {
+      return dotGit;
+    }
+    const match = readFileSync(dotGit, 'utf8').match(/^gitdir:\s*(.+)$/m);
+
+    // The pointer is usually absolute; resolve() keeps a relative one working.
+    return match ? path.resolve(root, match[1].trim()) : null;
+  } catch {
+    return null;
+  }
+}

--- a/scripts/__tests__/e2e-run-cache.test.mjs
+++ b/scripts/__tests__/e2e-run-cache.test.mjs
@@ -1,19 +1,29 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { envHash, specKey, filterCached, recordGreen } from '../e2e-run-cache.mjs';
+import { envHash, specKey, filterCached, recordGreen, cacheFile } from '../e2e-run-cache.mjs';
 
 /**
  * Build a minimal fake repo root with a dist bundle, a fixture, and one spec.
  *
+ * @param {'clone'|'worktree'} shape `clone` gives a `.git` DIRECTORY; `worktree`
+ *   gives the linked-worktree layout, where `.git` is a FILE pointing at
+ *   `<main>/.git/worktrees/<name>`.
  * @returns {string} The fake repo root.
  */
-function fakeRoot() {
+function fakeRoot(shape = 'clone') {
   const root = mkdtempSync(path.join(tmpdir(), 'e2e-cache-'));
 
-  mkdirSync(path.join(root, '.git'), { recursive: true });
+  if (shape === 'worktree') {
+    const linked = path.join(mkdtempSync(path.join(tmpdir(), 'e2e-cache-main-')), '.git/worktrees/wt');
+
+    mkdirSync(linked, { recursive: true });
+    writeFileSync(path.join(root, '.git'), `gitdir: ${linked}\n`);
+  } else {
+    mkdirSync(path.join(root, '.git'), { recursive: true });
+  }
   mkdirSync(path.join(root, 'handsontable/dist'), { recursive: true });
   mkdirSync(path.join(root, 'tests/e2e'), { recursive: true });
   mkdirSync(path.join(root, 'tests/fixtures/pages'), { recursive: true });
@@ -34,6 +44,34 @@ test('a recorded green run is skipped on the next pass (run-once)', () => {
 
   assert.deepEqual(second.toRun, []);
   assert.deepEqual(second.skipped, ['e2e/a.spec.ts']);
+});
+
+// In a linked worktree `<root>/.git` is a file, so the old `path.join(root,
+// '.git', …)` target could never be written (ENOTDIR, swallowed) — the cache was
+// permanently cold for everyone working in a worktree, silently.
+test('run-once works in a linked worktree, where .git is a file', () => {
+  const root = fakeRoot('worktree');
+  const file = cacheFile(root);
+
+  // Not under the `.git` file — the real git directory lives outside the worktree.
+  assert.ok(file && !file.startsWith(root), `${file} is under the .git FILE`);
+
+  assert.deepEqual(filterCached(root, ['e2e/a.spec.ts']).toRun, ['e2e/a.spec.ts']);
+  recordGreen(root, ['e2e/a.spec.ts']);
+  assert.ok(existsSync(file), `${file} was not written`);
+
+  const second = filterCached(root, ['e2e/a.spec.ts']);
+
+  assert.deepEqual(second.toRun, []);
+  assert.deepEqual(second.skipped, ['e2e/a.spec.ts']);
+});
+
+test('editing the spec invalidates the cache in a worktree too', () => {
+  const root = fakeRoot('worktree');
+
+  recordGreen(root, ['e2e/a.spec.ts']);
+  writeFileSync(path.join(root, 'tests/e2e/a.spec.ts'), 'spec-v2');
+  assert.deepEqual(filterCached(root, ['e2e/a.spec.ts']).toRun, ['e2e/a.spec.ts']);
 });
 
 test('editing the spec invalidates the cache', () => {

--- a/scripts/claude/session.mjs
+++ b/scripts/claude/session.mjs
@@ -1,24 +1,19 @@
 /**
  * Shared helpers for the Claude Code agent hooks (post-tool-use + stop).
  */
-import { execSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { repoRoot as resolveRepoRoot } from '../../.github/scripts/lib/repo-root.mjs';
 
 /**
- * Absolute path to the repository root, or the current working directory if git
- * cannot resolve it.
+ * Absolute path to the repository root. Derived from the hook scripts' own
+ * location, so it is independent of the cwd and of the git environment — the
+ * same value in a normal clone and in a linked worktree.
  *
  * @returns {string} The repository root path.
  */
 export function repoRoot() {
-  try {
-    return execSync('git rev-parse --show-toplevel', {
-      encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim() || process.cwd();
-  } catch {
-    return process.cwd();
-  }
+  return resolveRepoRoot();
 }
 
 /**

--- a/scripts/e2e-run-cache.mjs
+++ b/scripts/e2e-run-cache.mjs
@@ -12,15 +12,32 @@
  * a fixture changes the key → the spec runs again. CI remains authoritative and
  * always runs the full project on the PR.
  *
- * The cache lives in `.git/` — per-clone, never committed, survives tmpdir
- * cleanups, and vanishes with the clone.
+ * The cache lives in the checkout's git directory — `<root>/.git/` in a normal
+ * clone, `<main>/.git/worktrees/<name>/` in a linked worktree. Per-checkout,
+ * never committed, survives tmpdir cleanups, and vanishes with the checkout.
  */
 import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
 import path from 'node:path';
+import { gitDir } from '../.github/scripts/lib/repo-root.mjs';
 
 const CACHE_FILE = 'hot-e2e-green.json';
 const MAX_ENTRIES = 200;
+
+/**
+ * Absolute path of the cache file for the checkout at `root`. Goes through
+ * `gitDir()` rather than `<root>/.git`, because in a linked worktree `.git` is a
+ * FILE — joining onto it yields a path that can never be read or written
+ * (ENOTDIR), which silently disabled the cache in every worktree.
+ *
+ * @param {string} root Repo root.
+ * @returns {string|null} The cache path, or null when `root` is not a checkout.
+ */
+export function cacheFile(root) {
+  const dir = gitDir(root);
+
+  return dir ? path.join(dir, CACHE_FILE) : null;
+}
 
 /**
  * SHA-256 of a file's bytes ('' when unreadable).
@@ -107,7 +124,7 @@ export function specKey(root, spec, env) {
  */
 function readCache(root) {
   try {
-    return new Set(JSON.parse(readFileSync(path.join(root, '.git', CACHE_FILE), 'utf8')).keys);
+    return new Set(JSON.parse(readFileSync(cacheFile(root), 'utf8')).keys);
   } catch {
     return new Set();
   }
@@ -149,6 +166,11 @@ export function recordGreen(root, specs) {
     return;
   }
   const keys = new Set(readCache(root));
+  const file = cacheFile(root);
+
+  if (!file) {
+    return;
+  }
 
   for (const s of specs) {
     const key = specKey(root, s, env);
@@ -159,9 +181,6 @@ export function recordGreen(root, specs) {
   }
 
   try {
-    writeFileSync(
-      path.join(root, '.git', CACHE_FILE),
-      JSON.stringify({ keys: [...keys].slice(-MAX_ENTRIES) }),
-    );
+    writeFileSync(file, JSON.stringify({ keys: [...keys].slice(-MAX_ENTRIES) }));
   } catch { /* cache is an optimization — never fail the hook over it */ }
 }

--- a/scripts/e2e-run-cache.mjs
+++ b/scripts/e2e-run-cache.mjs
@@ -119,12 +119,17 @@ export function specKey(root, spec, env) {
 /**
  * Read the cache ({ keys: string[] }).
  *
- * @param {string} root Repo root.
+ * @param {string|null} file The cache path (from `cacheFile()`), or null when
+ *   the root is not a checkout.
  * @returns {Set<string>} Recorded green keys.
  */
-function readCache(root) {
+function readCache(file) {
+  if (!file) {
+    return new Set();
+  }
+
   try {
-    return new Set(JSON.parse(readFileSync(cacheFile(root), 'utf8')).keys);
+    return new Set(JSON.parse(readFileSync(file, 'utf8')).keys);
   } catch {
     return new Set();
   }
@@ -139,7 +144,7 @@ function readCache(root) {
  */
 export function filterCached(root, specs) {
   const env = envHash(root);
-  const cache = readCache(root);
+  const cache = readCache(cacheFile(root));
   const toRun = [];
   const skipped = [];
 
@@ -160,17 +165,19 @@ export function filterCached(root, specs) {
  * @returns {void}
  */
 export function recordGreen(root, specs) {
-  const env = envHash(root);
-
-  if (!env) {
-    return;
-  }
-  const keys = new Set(readCache(root));
+  // Resolved first: `envHash()` hashes the whole dist bundle and every fixture,
+  // so bailing out on a missing cache file up front skips that work entirely.
   const file = cacheFile(root);
 
   if (!file) {
     return;
   }
+  const env = envHash(root);
+
+  if (!env) {
+    return;
+  }
+  const keys = readCache(file);
 
   for (const s of specs) {
     const key = specKey(root, s, env);

--- a/scripts/pre-push.mjs
+++ b/scripts/pre-push.mjs
@@ -11,7 +11,8 @@
 import { execSync, spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathToFileURL } from 'node:url';
+import { repoRoot } from '../.github/scripts/lib/repo-root.mjs';
 import { lintable, runEslint } from './lint-files.mjs';
 import { filterCached, recordGreen } from './e2e-run-cache.mjs';
 
@@ -95,17 +96,26 @@ export function isJestInfraFailure(output) {
 // Exit early when imported by a test. pathToFileURL handles the cases a naive
 // `file://${argv[1]}` template misses (Windows drive letters, URL-escaped chars).
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  // Anchor every path/spawn to the repo root — callers may start the hook from
-  // any cwd, so resolve the root from THIS script's location, not the cwd.
-  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-  const root = execSync('git rev-parse --show-toplevel', { encoding: 'utf8', cwd: scriptDir }).trim();
+  // Anchor every path/spawn to the repo root, resolved from THIS script's
+  // location. A git-derived root is wrong under the `GIT_DIR` every hook exports
+  // — see `.github/scripts/lib/repo-root.mjs`.
+  const root = repoRoot();
   const base = resolveBase(root);
+
+  // Hand the children a clean git environment. Each runs with an explicit cwd,
+  // and an inherited `GIT_DIR`/`GIT_WORK_TREE` makes git take that cwd as the
+  // work tree — so any git call from `tests/` or `handsontable/` would resolve a
+  // subdirectory as the repository root.
+  const env = { ...process.env };
+
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
 
   // 1) Presence gate (block mode).
   const gate = spawnSync('node', [path.join(root, '.github/scripts/test-presence-gate.mjs')], {
     stdio: 'inherit',
     cwd: root,
-    env: { ...process.env, GATE_MODE: 'block', GATE_BASE: base },
+    env: { ...env, GATE_MODE: 'block', GATE_BASE: base },
   });
 
   if (gate.status !== 0) {
@@ -126,7 +136,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   spawnSync('node', [path.join(root, '.github/scripts/test-weakening-gate.mjs')], {
     stdio: 'inherit',
     cwd: root,
-    env: { ...process.env, GATE_BASE: base },
+    env: { ...env, GATE_BASE: base },
   });
 
   // 4) Run any Playwright spec the push changed, so a new test is proven.
@@ -148,6 +158,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       cwd: path.join(root, 'tests'),
       stdio: 'inherit',
       shell: WIN,
+      env,
     });
 
     if (pw.status !== 0) {
@@ -171,7 +182,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       const jest = spawnSync(
         'npm',
         ['run', 'test:unit', '--', `--testPathPattern=${unitTestPattern(file)}`],
-        { cwd: path.join(root, 'handsontable'), encoding: 'utf8', shell: WIN },
+        { cwd: path.join(root, 'handsontable'), encoding: 'utf8', shell: WIN, env },
       );
 
       process.stdout.write(jest.stdout || '');


### PR DESCRIPTION
### Context

The PR fixes the local enforcement gates in `git worktree` checkouts, where they were crashing (pre-push) or silently doing nothing (green-run cache).

**1. Every `git push` from a worktree crashed before any gate ran.**

`scripts/pre-push.mjs` resolved the repository root with `git rev-parse --show-toplevel` and `cwd: scriptDir`. Git hooks run with `GIT_DIR` exported (`<main>/.git/worktrees/<name>` in a worktree), and with `GIT_DIR` set explicitly `--show-toplevel` stops discovering the work tree by walking up from the cwd and reports the **cwd itself**. So `root` became `<worktree>/scripts` and the very first gate died:

```
Error: Cannot find module '<worktree>/scripts/.github/scripts/test-presence-gate.mjs'
```

The workaround was `git push --no-verify`, which skips the *entire* hook — the presence gate, ESLint on changed files, the test-weakening detector, and the changed Playwright/Jest runs. `.ai/LOCAL-ENFORCEMENT.md` calls those the enforcement floor for every change; in a worktree that floor was absent and nothing signalled it. Agent-driven work runs in worktrees by default, so this was the common path. The bug was invisible when running `node scripts/pre-push.mjs` by hand, because no `GIT_DIR` is set then.

**2. The green-run cache was permanently cold in every worktree.**

Found while fixing the above, so it rides along here — same worktree-hostility class, same test file, same documentation line. `scripts/e2e-run-cache.mjs` read and wrote `path.join(root, '.git', 'hot-e2e-green.json')`. In a linked worktree `<root>/.git` is a **file**, not a directory, so every write failed with `ENOTDIR` into a swallowed `catch` and every read returned an empty set. The run-once optimization never applied: touched Playwright specs were re-run on every single push.

**The fix.** A new pure helper, `.github/scripts/lib/repo-root.mjs`:

- `repoRoot()` derives the root from the module's own location, with the depth anchored inside the module so no caller can get the level wrong. No subprocess, independent of the cwd and of the git environment — identical in a clone, in a worktree, in CI, and inside a hook. This is what the comment at the old call site already promised.
- `gitDir(root)` returns the checkout's real git directory, following the `gitdir:` pointer when `.git` is a file. It resolves the worktree's own git directory rather than the shared common directory, so per-checkout state stays per-checkout.

Call sites converted: `scripts/pre-push.mjs` (was live), `.github/scripts/diff-coverage-gate.mjs` and `scripts/claude/session.mjs` (both had the same latent call), and `scripts/e2e-run-cache.mjs` now goes through `gitDir()`.

Two notes for the reviewer:

- `pre-push.mjs` now strips `GIT_DIR`/`GIT_WORK_TREE` from the environment of every child it spawns. This is **prevention, not a fix** — no failure was observed. Playwright and Jest are spawned with `cwd` set to `tests/` and `handsontable/`, and an inherited `GIT_DIR` makes git treat that subdirectory as the work tree, so it kills the class rather than the one instance.
- `scripts/claude/session.mjs` loses its `|| process.cwd()` fallback. The new `repoRoot()` cannot fail, so the branch was dead. It is a behavior change in an agent hook, hence called out.

### How has this been tested?

Tooling-only change, so the tooling suite plus a real-hook A/B.

- **New unit tests** — `.github/scripts/__tests__/repo-root.test.mjs` (6 tests): the root resolves to the repository root from a different cwd; it is unchanged with `GIT_DIR`/`GIT_WORK_TREE` set to bogus values (the regression); `gitDir()` for a clone, for a linked worktree, for a relative `gitdir:` pointer, and outside a checkout. The root is asserted against files that only exist at the repository root (`lefthook.yml`, `pnpm-workspace.yaml`) — deliberately **not** against `git rev-parse --show-toplevel`, which would make the test inherit the bug it exists to catch.
- **Updated `scripts/__tests__/e2e-run-cache.test.mjs`** — its `fakeRoot()` did `mkdirSync(root/.git)`, which encoded the broken assumption and would have stayed green after the fix. It now takes a `shape` parameter, and two new tests cover the worktree layout (`.git` as a file with a `gitdir:` pointer): the run-once round-trip, and invalidation on spec edit.

  ```bash
  npm run test:tooling   # 91 passing, 0 failing
  ```

- **The cache bug proven red before green** — the new worktree round-trip was run against `origin/develop`'s `e2e-run-cache.mjs` and failed (`skipped: []`), then passed against the fixed module.
- **Real hook, A/B, no network** — in a throwaway `git clone --local` with a bare `file://` remote (nothing was pushed to `origin`, no commits were made in the working repository), a `pre-push` shim was installed and a source-change-without-a-test was pushed from a linked worktree:
  - pre-fix script → `Error: Cannot find module '<wt>/scripts/.github/scripts/test-presence-gate.mjs'`
  - post-fix script → the presence gate runs and **blocks** on the missing test, as designed
  - the same push from that clone's normal (non-worktree) checkout also blocks — no regression outside worktrees
- **This branch was pushed from a worktree without `--no-verify`**, and the hook ran green end to end (`Test-presence gate ✅ Pass` → `Test-weakening gate` → `pre-push: ok`).
- **Real-layout cache path confirmed** — `cacheFile()` for this worktree returns `<main>/.git/worktrees/<name>/hot-e2e-green.json`.
- **Agent hooks smoke-tested** under `GIT_DIR` — `scripts/claude/stop.mjs` and `scripts/claude/post-tool-use.mjs` both exit 0, and `repoRoot()` returns the worktree root.
- **ESLint** clean on the changed `scripts/**` files. `.github/**` is outside the hook lint scope (the dot-segment filter in `scripts/lint-files.mjs`); the new import there matches the extension style of its sibling tests.

[skip changelog] — tooling only, no `handsontable/src/**` or `wrappers/**` change.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2189

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation. `.ai/LOCAL-ENFORCEMENT.md` is updated in this PR: the cache location now names both layouts, and a new rule tells future contributors to take the root from `repoRoot()` and per-checkout state from `gitDir(root)` instead of asking git.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2189

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how local git hooks resolve paths and spawn children; behavior is well covered by tests but affects the enforcement floor for every push.
> 
> **Overview**
> Fixes local enforcement in **linked `git worktree` checkouts**, where hooks previously crashed or skipped optimizations.
> 
> **`repoRoot()`** and **`gitDir()`** are added in `.github/scripts/lib/repo-root.mjs`: the root comes from the module’s path (not `git rev-parse --show-toplevel`, which under hook-exported `GIT_DIR` returns the cwd), and the real git directory follows a worktree’s `gitdir:` pointer when `.git` is a file. **`pre-push`**, the diff-coverage gate, and Claude **`session.mjs`** use `repoRoot()`; the E2E green-run cache writes **`hot-e2e-green.json`** via `gitDir()` instead of `<root>/.git/`, which previously failed silently with ENOTDIR in worktrees. **`pre-push`** also strips `GIT_DIR` / `GIT_WORK_TREE` from spawned child processes. **`.ai/LOCAL-ENFORCEMENT.md`** documents the worktree rules; new/updated unit tests cover root resolution and cache behavior in worktree layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e1b1a3e70a91d6b56813d8eaeb9beaf5f1afd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->