### PR TITLE
DEV-2181: Fix the changelog issuesOrigin default, docs, and add a guard

### DIFF
--- a/.changelogs/README.md
+++ b/.changelogs/README.md
@@ -18,6 +18,48 @@ Documentation-only, test-only, and CI/tooling PRs **pass automatically** — no 
 ...and re-run the failed **Changelog** check from the PR's checks tab (or push any new commit — `git commit --allow-empty` works). The check reads the PR body at run time; editing the description alone does not re-trigger it. The override is logged together with the source files it waves through, so reviewers can judge it.
 
 
+## Entry format
+
+Every `.json` file in this directory holds a single entry with six required fields:
+
+```json
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the cell editor closing unexpectedly on scroll.",
+  "type": "fixed",
+  "issueOrPR": 12345,
+  "breaking": false,
+  "framework": "none"
+}
+```
+
+| Field | Accepted values | Meaning |
+|---|---|---|
+| `issuesOrigin` | `private`, `public` | Whether `issueOrPR` is a public GitHub issue number. See below. |
+| `title` | non-empty string | User-facing description of the change, ending with a period. |
+| `type` | `added`, `changed`, `deprecated`, `removed`, `fixed`, `security` | The `CHANGELOG.md` section the entry lands in. |
+| `issueOrPR` | number | The cited GitHub number. Also the filename. |
+| `breaking` | boolean | Breaking changes are listed first within their section. |
+| `framework` | `none`, `react`, `vue`, `angular` | Prefixes the entry with the framework name; `none` for core. |
+
+### `issuesOrigin`
+
+This field answers one question: **is the number in `issueOrPR` a public GitHub issue?** It says nothing about the pull request, and nothing about the repository being public.
+
+It selects the link path in the generated `CHANGELOG.md`, and `bin/changelog` names the file after `issueOrPR`, so the two fields move together:
+
+| `issuesOrigin` | `issueOrPR` | Filename | Rendered link |
+|---|---|---|---|
+| `private` — the default, and almost always correct | pull request number | `<PR-number>.json` | `https://github.com/handsontable/handsontable/pull/<n>` |
+| `public` — rare | public GitHub **issue** number | `<issue-number>.json` | `https://github.com/handsontable/handsontable/issues/<n>` |
+
+Work tracked in a private ClickUp task is `private` — that covers every change with a `DEV-xxx` ID. Reach for `public` only when the entry cites a real public GitHub issue number.
+
+A wrong value does not break the published output, because GitHub redirects `/issues/<n>` to `/pull/<n>` when the number belongs to a pull request. It does publish the wrong path in the release notes, and it makes the field carry no information.
+
+When you create an entry interactively, `bin/changelog entry` warns if you pick `public` for a number that resolves to a pull request. The warning needs network access and is skipped silently without it, and it cannot see entries you write by hand.
+
+
 ## Changelog helper
 
 This repository includes a script that aids in creating new changelog entries and compiling them into the final `CHANGELOG.md` file.

--- a/.claude/skills/changelog-creation/SKILL.md
+++ b/.claude/skills/changelog-creation/SKILL.md
@@ -17,7 +17,7 @@ Add `[skip changelog]` in the PR description to explicitly skip.
 
 ## Workflow: Create the PR First, Then the Changelog
 
-The changelog file is named after the GitHub PR number, so the PR must exist before the entry is written. Guessing the next available number by reading `.changelogs/` or the GitHub API is unreliable — another PR can be opened between the check and the push, and the filename will no longer match.
+This is the `issuesOrigin: "private"` flow — the default, and what almost every entry uses. The changelog file is named after the GitHub PR number, so the PR must exist before the entry is written. Guessing the next available number by reading `.changelogs/` or the GitHub API is unreliable — another PR can be opened between the check and the push, and the filename will no longer match.
 
 Correct order:
 
@@ -27,13 +27,15 @@ Correct order:
 4. Create `.changelogs/<PR-number>.json` at the **repo root** using that number, set `"issueOrPR"` to the same number. The correct path is always `<repo-root>/.changelogs/<PR-number>.json` — never inside a package subdirectory like `handsontable/.changelogs/`.
 5. Commit the new file with a message like `DEV-xxx: Add changelog entry for PR #<number>` and push — the PR picks it up.
 
+For the rare case where the entry cites a **public GitHub issue** instead, see [Issue Origin](#issue-origin) below.
+
 ## JSON Format
 
 Create a file at `.changelogs/{PR-number}.json` (using the PR number returned by `gh pr create`):
 
 ```json
 {
-  "issuesOrigin": "public",
+  "issuesOrigin": "private",
   "title": "User-facing description of what changed.",
   "type": "fixed",
   "issueOrPR": 12345,
@@ -41,6 +43,21 @@ Create a file at `.changelogs/{PR-number}.json` (using the PR number returned by
   "framework": "none"
 }
 ```
+
+## Issue Origin
+
+`issuesOrigin` answers one question: **is the number in `issueOrPR` a public GitHub issue?** It says nothing about the PR, and nothing about whether the repository is public.
+
+The field picks the link path in the generated `CHANGELOG.md`, and `bin/changelog` derives the filename from `issueOrPR`, so the two fields move together:
+
+| `issuesOrigin` | `issueOrPR` | Filename | Rendered link |
+|---|---|---|---|
+| `"private"` — default, almost always | PR number | `<PR-number>.json` | `.../pull/<n>` |
+| `"public"` — rare | public GitHub **issue** number | `<issue-number>.json` | `.../issues/<n>` |
+
+Use `"private"` when the work is tracked in a private ClickUp task — this is the normal case, including every task with a `DEV-xxx` ID. Use `"public"` only when you are citing a real public GitHub issue number; then name the file after the issue, not the PR.
+
+Getting this wrong is not fatal — GitHub redirects `/issues/<n>` to `/pull/<n>` — but it publishes a wrong path in the release notes and makes the field meaningless.
 
 ## Categorization Guide
 
@@ -92,5 +109,6 @@ Create **one changelog entry per PR**, even if the PR fixes multiple issues. The
 3. Write a clear, user-facing `title` ending with a period.
 4. Set `breaking` to `true` only if the change breaks existing behavior.
 5. Set `framework` to match the affected package, or `"none"` for core.
-6. Name the file `<PR-number>.json` and set `"issueOrPR"` to the same number. Do not guess or infer the number — read it from the created PR. Write to `<repo-root>/.changelogs/<PR-number>.json` — **not** inside any package subdirectory (e.g. `handsontable/.changelogs/` is wrong).
-7. Commit and push the new changelog file to the same feature branch so the open PR picks it up.
+6. Leave `issuesOrigin` as `"private"` unless the entry cites a real public GitHub issue number — see [Issue Origin](#issue-origin).
+7. Name the file `<PR-number>.json` and set `"issueOrPR"` to the same number. Do not guess or infer the number — read it from the created PR. Write to `<repo-root>/.changelogs/<PR-number>.json` — **not** inside any package subdirectory (e.g. `handsontable/.changelogs/` is wrong). With `"public"`, both the filename and `issueOrPR` use the **issue** number instead.
+8. Commit and push the new changelog file to the same feature branch so the open PR picks it up.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -12,7 +12,7 @@ Read and apply the review checklists from these files:
 
 ## Repository-level checks
 
-- **Changelog**: If package source code changes, require a new `/.changelogs/*.json` file. Skip if the PR description contains `[skip changelog]`.
+- **Changelog**: If package source code changes, require a new `/.changelogs/*.json` file. Skip if the PR description contains `[skip changelog]`. In that file, `issuesOrigin` must be `private` with `issueOrPR` equal to the PR number and the file named `<PR-number>.json` — **unless** the entry cites a real public GitHub issue, in which case `public` is correct and both `issueOrPR` and the filename use the issue number. See `/.changelogs/README.md`.
 - **Breaking change**: If a PR introduces a breaking change, require the `Breaking change` label and migration guide updates in `/docs/content/guides/upgrade-and-migration/`.
 - **Docs**: For user-facing behavior or UX changes, require matching docs updates in `/docs/content/`.
 - **Agent guidance**: If a PR introduces new conventions, constraints, or gotchas, require an `/AGENTS.md` update.

--- a/bin/changelog
+++ b/bin/changelog
@@ -46,6 +46,53 @@ const stringifyChangelogEntryObject = ({ issuesOrigin, title, issueOrPR, framewo
   return `${breakingFragment}${frameworkFragment}${title} ${issueLinkFragment}`;
 };
 
+/**
+ * Warns when an entry claims `issuesOrigin: 'public'` but the cited number
+ * belongs to a pull request, not an issue. That combination renders an
+ * `/issues/<n>` link for a pull request; GitHub redirects it, so the output
+ * still resolves, but the published path is wrong and the field stops
+ * carrying any information.
+ *
+ * Best-effort only. Every failure - offline, air-gapped, rate-limited,
+ * unexpected response - is swallowed, because a changelog entry must never
+ * depend on network access. It also only covers entries created through this
+ * command; a hand-written `.changelogs/*.json` file never reaches it.
+ *
+ * @param {object} entry A valid changelog entry object.
+ * @param {string} entry.issuesOrigin The entry's issue origin (`private` or `public`).
+ * @param {number} entry.issueOrPR The cited GitHub issue or pull request number.
+ * @returns {Promise<void>}
+ */
+const warnWhenPublicNumberIsPullRequest = async({ issuesOrigin, issueOrPR }) => {
+  if (issuesOrigin !== 'public') {
+    return;
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/handsontable/handsontable/issues/${issueOrPR}`,
+      { signal: AbortSignal.timeout(3000) }
+    );
+
+    if (!response.ok) {
+      return;
+    }
+
+    const { pull_request: pullRequest } = await response.json();
+
+    if (!pullRequest) {
+      return;
+    }
+
+    console.log(chalk.yellow(`\
+Warning: #${issueOrPR} is a pull request, but this entry sets \`issuesOrigin\` to
+"public", which links it as an issue. Unless you meant to cite a public GitHub
+issue number, use "private" - it links the pull request instead.`));
+  } catch {
+    // Intentionally silent - see the note about network access above.
+  }
+};
+
 const askToProceedOrExit = async(message = 'Proceed?') => {
   const { shouldProceed } = isTTY ? await inquirer.prompt({
     name: 'shouldProceed',
@@ -188,6 +235,8 @@ This is how it will look like compiled to markdown in ${chalk.reset.blue.underli
 ${chalk.yellow.italic(`### ${uppercaseFirstLetter(changelogEntry.type)}
 - ${stringifyChangelogEntryObject(changelogEntry)}`)}
 `);
+
+  await warnWhenPublicNumberIsPullRequest(changelogEntry);
 
   await askToProceedOrExit();
 


### PR DESCRIPTION
### Context

The PR fixes the `issuesOrigin` field in `.changelogs/*.json`, which is currently wrong on every agent-authored entry.

`bin/changelog` is the field's only consumer:

```js
const linkType = issuesOrigin === 'private' ? 'pull' : 'issues';
```

It answers one question — is the number in `issueOrPR` a public GitHub issue? — and it also decides the filename, because `bin/changelog` names the file after `issueOrPR`.

Three things went wrong together:

1. `.claude/skills/changelog-creation/SKILL.md` hardcoded `"issuesOrigin": "public"` in its JSON template and never explained the field, so every agent copied the wrong value.
2. `.changelogs/README.md` did not document the field at all.
3. `.cursor/BUGBOT.md` said nothing about it, so Bugbot's learned rule flags the mistake on every PR as unstructured review noise.

Result: of the 66 entries in `.changelogs/`, all 37 with `issuesOrigin: "public"` cite a pull request number, not an issue number. Zero are correct. GitHub 302-redirects `/issues/<n>` to `/pull/<n>`, so the published links still resolve — the cost is that the field encodes no information and the review noise recurs.

**What this PR does**

- Flips the skill template to `"issuesOrigin": "private"` and adds an `## Issue Origin` section explaining the two coherent modes.
- Scopes the skill's "name the file after the PR number" rule to `private` mode, and spells out the `public` exception. Without this the template flip would have left the skill self-contradictory, and the next agent with a real public issue would hit the same trap in reverse.
- Documents the full entry format, including `issuesOrigin`, in `.changelogs/README.md`.
- Adds a non-fatal warning to `bin/changelog entry` when `issuesOrigin` is `public` but the cited number resolves to a pull request.
- Extends the `.cursor/BUGBOT.md` changelog bullet with both the rule and its legitimate `public` exception, so the learned rule stops false-positiving on a correct entry.

**The two modes, as now documented**

| `issuesOrigin` | `issueOrPR` | Filename | Rendered link |
|---|---|---|---|
| `private` — default, almost always | PR number | `<PR-number>.json` | `.../pull/<n>` |
| `public` — rare | public GitHub **issue** number | `<issue-number>.json` | `.../issues/<n>` |

**Deliberate decisions**

- **The 37 existing entries are left as-is.** The next `bin/changelog consume` will publish them as `/issues/<PR-number>` links. They resolve via redirect, and `docs/src/plugins/changelog-parser.mjs` already captures both `issues` and `pull` kinds, so nothing downstream breaks.
- **`bin/changelog`'s prompt default needed no change.** `changelogIssuesOriginTypes[0]` is already `private`, and the `issueOrPR` prompt message already branches between "related public PR" and "related public issue".
- **The guard is not wired into `consume` / CI.** `.github/workflows/checks.yml` runs `consume --dry-run`, and there is no offline way to tell an issue number from a PR number — a GitHub API call there would break the repository's air-gapped support. The trade-off is that the guard does not fire for hand-written JSON files, which is the actual failure mode this PR documents. The skill, README, and Bugbot changes are what cover that case.
- **Placement deviates from the plan**: the warning prints *after* the markdown preview rather than before it. The preview shows the wrong `/issues/` link, so the warning reads as an explanation of what was just displayed.

**Pre-existing, not fixed here**: the `entry` command declares a `--issue` option, not `--issueOrPR`, and neither `--issuesOrigin` nor `--issueOrPR` is a declared yargs option. Both work only through yargs' unknown-flag passthrough.

### How has this been tested?

No automated test is added. Nothing under `handsontable/src/**` or `wrappers/**` changes, and `bin/` has no test harness — `npm run test:tooling` globs only `.github/scripts/__tests__`, `scripts/__tests__`, `scripts/claude/__tests__`, and `evals/__tests__`. Covering the guard means extracting a helper into `bin/lib/` and widening that glob; happy to do it if a reviewer wants it.

Verified manually:

```bash
# All 66 entries still validate — this is the exact CI step from checks.yml.
node bin/changelog consume --date 2050-01-01 --dry-run

# Lint.
npx eslint bin/changelog

# The Cursor mirror regenerates with "private" (gitignored, nothing to commit).
npm run sync-skills
grep -n issuesOrigin .cursor/rules/changelog-creation.mdc
```

Guard behavior, checked case by case:

- **Interactive TTY** (the path the README promises): ran `node bin/changelog entry`, picked `public` at the list prompt, entered `13154` — the warning fires after the preview. Declined at the confirm prompt; no file written.
- **`private`** — no warning, no network call.
- **`public` + a number that 404s** — silent.
- **Network unreachable** (`NODE_USE_ENV_PROXY=1 HTTPS_PROXY=http://127.0.0.1:1`) — silent, and the entry is still created.

All test entries created during verification were removed.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2181

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Tooling and agent-guidance only: `bin/changelog`, `.changelogs/README.md`, `.claude/skills/`, `.cursor/`.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog] — tooling and documentation only, no shippable source change.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2181

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and documentation only; no changes to Handsontable runtime or release consume/CI behavior beyond optional network warning during interactive entry creation.
> 
> **Overview**
> Fixes misleading **`issuesOrigin`** guidance that caused agent-authored changelog entries to use `"public"` when citing PR numbers, so release notes linked to `/issues/` instead of `/pull/`.
> 
> **Documentation:** `.changelogs/README.md` now documents the full JSON schema and when to use `private` vs `public`. The changelog-creation skill template defaults to **`"private"`**, adds an **Issue Origin** section (filename/`issueOrPR` alignment), and updates the checklist. **`.cursor/BUGBOT.md`** spells out the same rule so review stops false-flagging correct entries.
> 
> **Tooling:** `bin/changelog entry` calls a new **`warnWhenPublicNumberIsPullRequest`** helper after the markdown preview when `issuesOrigin` is `public` but the GitHub API shows the number is a PR; failures are silent (offline-safe). Existing `.changelogs/*.json` files are intentionally unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a12715939f4a784da1d2174f51dc91a7df621d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->