### PR TITLE
DEV-2191: Forward Angular editor shortcut group

### DIFF
--- a/.changelogs/13160.json
+++ b/.changelogs/13160.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed custom editor shortcut groups in the Angular wrapper.",
+  "type": "fixed",
+  "issueOrPR": 13160,
+  "breaking": false,
+  "framework": "angular"
+}

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/editor-factory-adapter.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/editor-factory-adapter.spec.ts
@@ -13,6 +13,19 @@ class CustomEditorComponent extends HotCellEditorAdvancedComponent<number> {
   onFocus(): void {}
 }
 
+@Component({
+  selector: 'hot-shortcuts-group-editor',
+  template: '<input />',
+  standalone: true,
+})
+class ShortcutsGroupEditorComponent extends HotCellEditorAdvancedComponent<number> {
+  shortcutsGroup = 'myEditor';
+  shortcuts = [{
+    keys: [['ArrowLeft']],
+    callback: (): void => {},
+  }];
+}
+
 describe('FactoryEditorAdapter', () => {
   let instance: Handsontable.Core;
   let customEditor: ComponentFixture<CustomEditorComponent>;
@@ -52,6 +65,32 @@ describe('FactoryEditorAdapter', () => {
 
   it('should create an instance', () => {
     expect(adapter).toBeDefined();
+  });
+
+  it('should register shortcuts in the group defined by the component', () => {
+    const shortcutEditor = TestBed.createComponent(ShortcutsGroupEditorComponent);
+    const environmentInjector = TestBed.inject(EnvironmentInjector);
+    const EditorClass = FactoryEditorAdapter(shortcutEditor.componentRef);
+    const container = document.createElement('div');
+    const shortcutInstance = new Handsontable(container, {
+      licenseKey: 'non-commercial-and-evaluation',
+      columns: [{ editor: EditorClass }],
+      data: [[1]],
+    });
+
+    document.body.appendChild(container);
+    (shortcutInstance as any)._angularEnvironmentInjector = environmentInjector;
+    shortcutInstance.selectCell(0, 0);
+    shortcutInstance.getActiveEditor().beginEditing();
+
+    const editorContext = shortcutInstance.getShortcutManager().getContext('editor');
+    const shortcuts = editorContext.getShortcuts(['arrowleft']);
+
+    expect(shortcuts.some(shortcut => shortcut.group === 'myEditor')).toBe(true);
+
+    shortcutInstance.destroy();
+    shortcutEditor.destroy();
+    container.remove();
   });
 
   describe('init', () => {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/editor-factory-adapter.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/editor-factory-adapter.ts
@@ -25,6 +25,7 @@ export const FactoryEditorAdapter = (componentRef: ComponentRef<HotCellEditorAdv
   editorFactory<ExtendedEditor<any>>({
     position: componentRef.instance.position,
     shortcuts: componentRef.instance.shortcuts,
+    shortcutsGroup: componentRef.instance.shortcutsGroup,
     config: componentRef.instance.config,
     init(editor: EditorInstance): void {
       editor._componentRef = componentRef;


### PR DESCRIPTION
### Context

The PR fixes the Angular wrapper silently ignoring `shortcutsGroup` on advanced custom editor components. The adapter forwarded `shortcuts` to `editorFactory`, but omitted the accompanying group, so shortcuts were always registered and removed under core's `customEditor` default.

### How has this been tested?

- Added a Jest regression test that verifies an Angular component's `myEditor` group is used in the editor shortcut context.
- `npm --prefix handsontable run build`
- `npm --prefix wrappers/angular-wrapper run lint`
- `npm --prefix wrappers/angular-wrapper run test -- --runInBand --runTestsByPath projects/hot-table/src/lib/editor/editor-factory-adapter.spec.ts`
- `npm --prefix wrappers/angular-wrapper run test -- --runInBand`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2191

### Affected project(s):

- [ ] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2191

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line adapter wiring plus tests; no security or data-path changes.
> 
> **Overview**
> Fixes the Angular wrapper ignoring **`shortcutsGroup`** on advanced custom cell editors. **`FactoryEditorAdapter`** now passes **`componentRef.instance.shortcutsGroup`** into **`editorFactory`** alongside **`shortcuts`**, so editor keyboard shortcuts register under the component’s group instead of always using core’s default **`customEditor`** group.
> 
> A Jest regression test asserts that shortcuts appear in the editor shortcut context with group **`myEditor`** when the component sets that group. Changelog entry added for **`@handsontable/angular-wrapper`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c67f900bb8e356b7700e789e05b2b75c41ae966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->