### PR TITLE
DEV-2180: Fix Pikaday recipe layout

### DIFF
--- a/docs/content/recipes/cell-types/pikaday/angular/example1.css
+++ b/docs/content/recipes/cell-types/pikaday/angular/example1.css
@@ -137,8 +137,9 @@
 [class*='ht-theme-'] .pika-single .pika-table .pika-button {
   width: 100%;
   aspect-ratio: 1 / 1;
+  box-sizing: border-box;
   margin: 0;
-  padding: 10px;
+  padding: 0;
   background: transparent;
   color: var(--ht-foreground-color);
   border: none;

--- a/docs/content/recipes/cell-types/pikaday/angular/example1.css
+++ b/docs/content/recipes/cell-types/pikaday/angular/example1.css
@@ -105,8 +105,10 @@
   mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.49268 11.2929L6.19978 8.00001L9.49268 4.70712' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E%0A");
 }
 
+.pika-single .pika-table,
 [class*='ht-theme-'] .pika-single .pika-table {
   border-collapse: collapse;
+  table-layout: fixed;
 }
 
 [class*='ht-theme-'] .pika-single .pika-table thead {
@@ -131,6 +133,7 @@
   vertical-align: middle;
 }
 
+.pika-single .pika-table .pika-button,
 [class*='ht-theme-'] .pika-single .pika-table .pika-button {
   width: 100%;
   aspect-ratio: 1 / 1;
@@ -143,6 +146,7 @@
   box-shadow: none;
   cursor: pointer;
   font-size: inherit;
+  text-align: center !important;
 }
 
 [class*='ht-theme-'] .pika-single .pika-table .pika-button:hover,

--- a/docs/content/recipes/cell-types/pikaday/angular/example1.ts
+++ b/docs/content/recipes/cell-types/pikaday/angular/example1.ts
@@ -20,7 +20,7 @@ const DATE_FORMAT_US = 'MM/DD/YYYY';
   styles: [
     `
     :host { display: block; }
-    .pikaday-container { width: 260px; }
+    .pikaday-container { width: 278px; }
   `,
   ],
 })

--- a/docs/content/recipes/cell-types/pikaday/angular/example1.ts
+++ b/docs/content/recipes/cell-types/pikaday/angular/example1.ts
@@ -20,7 +20,7 @@ const DATE_FORMAT_US = 'MM/DD/YYYY';
   styles: [
     `
     :host { display: block; }
-    .pikaday-container { width: 250px; }
+    .pikaday-container { width: 260px; }
   `,
   ],
 })

--- a/docs/content/recipes/cell-types/pikaday/angular/example1.ts
+++ b/docs/content/recipes/cell-types/pikaday/angular/example1.ts
@@ -9,6 +9,7 @@ import {
 import moment from 'moment';
 import Pikaday from 'pikaday';
 import 'pikaday/css/pikaday.css';
+import './example1.css';
 
 const DATE_FORMAT_US = 'MM/DD/YYYY';
 

--- a/docs/content/recipes/cell-types/pikaday/javascript/example1.css
+++ b/docs/content/recipes/cell-types/pikaday/javascript/example1.css
@@ -131,8 +131,10 @@
   mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.49268 11.2929L6.19978 8.00001L9.49268 4.70712' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E%0A");
 }
 
+.pika-single .pika-table,
 [class*='ht-theme-'] .pika-single .pika-table {
   border-collapse: collapse;
+  table-layout: fixed;
 }
 
 [class*='ht-theme-'] .pika-single .pika-table thead {
@@ -157,6 +159,7 @@
   vertical-align: middle;
 }
 
+.pika-single .pika-table .pika-button,
 [class*='ht-theme-'] .pika-single .pika-table .pika-button {
   width: 100%;
   aspect-ratio: 1 / 1;
@@ -169,6 +172,7 @@
   box-shadow: none;
   cursor: pointer;
   font-size: inherit;
+  text-align: center !important;
 }
 
 [class*='ht-theme-'] .pika-single .pika-table .pika-button:hover,

--- a/docs/content/recipes/cell-types/pikaday/javascript/example1.css
+++ b/docs/content/recipes/cell-types/pikaday/javascript/example1.css
@@ -163,8 +163,9 @@
 [class*='ht-theme-'] .pika-single .pika-table .pika-button {
   width: 100%;
   aspect-ratio: 1 / 1;
+  box-sizing: border-box;
   margin: 0;
-  padding: 10px;
+  padding: 0;
   background: transparent;
   color: var(--ht-foreground-color);
   border: none;

--- a/docs/content/recipes/cell-types/pikaday/pikaday.md
+++ b/docs/content/recipes/cell-types/pikaday/pikaday.md
@@ -602,9 +602,20 @@ Two stylesheets are involved. Style the editor input to match Handsontable's nat
 }
 
 .pika-single .pika-table .pika-button {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
   background: transparent;
   color: var(--ht-foreground-color);
   border-radius: var(--ht-button-border-radius);
+  text-align: center !important;
+}
+
+.pika-single .pika-table {
+  border-collapse: collapse;
+  table-layout: fixed;
 }
 
 .pika-single .pika-table td.is-selected .pika-button {
@@ -613,11 +624,33 @@ Two stylesheets are involved. Style the editor input to match Handsontable's nat
 }
 ```
 
+`table-layout: fixed` gives the calendar equal-width day columns, including when week numbers are enabled. `box-sizing: border-box` and zero padding keep one- and two-digit day labels centered in their buttons.
+
 The full rule set is in the CSS tab of the example above, including the arrow replacement and the right-to-left flip.
 
 **Why this works without extra wiring:** the editor uses `position: 'portal'`, so its container is attached to the body-level `.ht-portal` element, and Handsontable puts the active `ht-theme-*` class on that element. Every `--ht-*` variable and the theme's `color-scheme` resolve on the calendar's own ancestor, so the panel follows the grid's theme -- light or dark -- with no JavaScript.
 
 Handsontable shipped equivalent rules until 18.0, when the native date input replaced the built-in Pikaday editor. They now belong to your application.
+
+::: only-for angular
+
+The Angular editor imports the recipe stylesheet directly. Give its portal container a `278px` width so it includes Pikaday's month margins on both sides.
+
+```typescript
+import 'pikaday/css/pikaday.css';
+import './example1.css';
+
+@Component({
+  styles: [
+    `
+    :host { display: block; }
+    .pikaday-container { width: 278px; }
+  `,
+  ],
+})
+```
+
+:::
 
 ## Step 16: Complete Cell Definition
 

--- a/docs/content/recipes/cell-types/pikaday/react/example1.css
+++ b/docs/content/recipes/cell-types/pikaday/react/example1.css
@@ -131,8 +131,10 @@
   mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.49268 11.2929L6.19978 8.00001L9.49268 4.70712' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E%0A");
 }
 
+.pika-single .pika-table,
 [class*='ht-theme-'] .pika-single .pika-table {
   border-collapse: collapse;
+  table-layout: fixed;
 }
 
 [class*='ht-theme-'] .pika-single .pika-table thead {
@@ -157,6 +159,7 @@
   vertical-align: middle;
 }
 
+.pika-single .pika-table .pika-button,
 [class*='ht-theme-'] .pika-single .pika-table .pika-button {
   width: 100%;
   aspect-ratio: 1 / 1;
@@ -169,6 +172,7 @@
   box-shadow: none;
   cursor: pointer;
   font-size: inherit;
+  text-align: center !important;
 }
 
 [class*='ht-theme-'] .pika-single .pika-table .pika-button:hover,

--- a/docs/content/recipes/cell-types/pikaday/react/example1.css
+++ b/docs/content/recipes/cell-types/pikaday/react/example1.css
@@ -163,8 +163,9 @@
 [class*='ht-theme-'] .pika-single .pika-table .pika-button {
   width: 100%;
   aspect-ratio: 1 / 1;
+  box-sizing: border-box;
   margin: 0;
-  padding: 10px;
+  padding: 0;
   background: transparent;
   color: var(--ht-foreground-color);
   border: none;

--- a/docs/tests/pikadayRecipe.spec.ts
+++ b/docs/tests/pikadayRecipe.spec.ts
@@ -33,11 +33,25 @@ test.describe('Pikaday recipe', () => {
         clientWidth: element.clientWidth,
         scrollWidth: element.scrollWidth,
       }));
+      const textAlignmentErrors = await calendar.locator('.pika-button').evaluateAll(buttons =>
+        buttons.map((button) => {
+          const range = button.ownerDocument.createRange();
+
+          range.selectNodeContents(button);
+
+          const textRect = range.getBoundingClientRect();
+          const buttonRect = button.getBoundingClientRect();
+
+          return Math.abs(
+            textRect.left + textRect.width / 2 - (buttonRect.left + buttonRect.width / 2),
+          );
+        }).filter(offset => offset > 1));
 
       expect(cellCount).toBe(calendarColumns);
       expect(widthDifference).toBeLessThanOrEqual(1);
       expect(horizontalMetrics.scrollWidth).toBeLessThanOrEqual(horizontalMetrics.clientWidth);
       expect(calendarMetrics.scrollWidth).toBeLessThanOrEqual(calendarMetrics.clientWidth);
+      expect(textAlignmentErrors).toEqual([]);
       await expect(calendar.locator('.pika-button').first()).toHaveCSS('text-align', 'center');
     });
   }

--- a/docs/tests/pikadayRecipe.spec.ts
+++ b/docs/tests/pikadayRecipe.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+const frameworkConfigs = [
+  { path: 'javascript-data-grid', calendarColumns: 8 },
+  { path: 'react-data-grid', calendarColumns: 8 },
+  { path: 'angular-data-grid', calendarColumns: 7 },
+];
+
+test.describe('Pikaday recipe', () => {
+  for (const { path, calendarColumns } of frameworkConfigs) {
+    test(`keeps the calendar aligned in ${path}`, async({ page, baseURL }) => {
+      await page.goto(`${baseURL}/${path}/recipes/cell-types/pikaday`);
+
+      const dateCell = page.locator('.handsontable td').filter({ hasText: '10/05/2025' }).first();
+
+      await dateCell.dblclick();
+
+      const calendar = page.locator('.pika-single:visible');
+      const table = calendar.locator('.pika-table');
+      const weekRowCells = table.locator('tbody tr').first().locator('td');
+
+      await expect(calendar).toBeVisible();
+      const cellCount = await weekRowCells.count();
+
+      const cellWidths = await weekRowCells.evaluateAll(cells =>
+        cells.map(cell => cell.getBoundingClientRect().width));
+      const widthDifference = Math.max(...cellWidths) - Math.min(...cellWidths);
+      const horizontalMetrics = await table.evaluate(element => ({
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+      }));
+
+      expect(cellCount).toBe(calendarColumns);
+      expect(widthDifference).toBeLessThanOrEqual(1);
+      expect(horizontalMetrics.scrollWidth).toBeLessThanOrEqual(horizontalMetrics.clientWidth);
+      await expect(calendar.locator('.pika-button').first()).toHaveCSS('text-align', 'center');
+    });
+  }
+});

--- a/docs/tests/pikadayRecipe.spec.ts
+++ b/docs/tests/pikadayRecipe.spec.ts
@@ -33,6 +33,15 @@ test.describe('Pikaday recipe', () => {
         clientWidth: element.clientWidth,
         scrollWidth: element.scrollWidth,
       }));
+      const calendarGutters = await calendar.evaluate(element => {
+        const calendarRect = element.getBoundingClientRect();
+        const monthRect = element.querySelector('.pika-lendar').getBoundingClientRect();
+
+        return {
+          left: monthRect.left - calendarRect.left,
+          right: calendarRect.right - monthRect.right,
+        };
+      });
       const textAlignmentErrors = await calendar.locator('.pika-button').evaluateAll(buttons =>
         buttons.map((button) => {
           const range = button.ownerDocument.createRange();
@@ -51,6 +60,7 @@ test.describe('Pikaday recipe', () => {
       expect(widthDifference).toBeLessThanOrEqual(1);
       expect(horizontalMetrics.scrollWidth).toBeLessThanOrEqual(horizontalMetrics.clientWidth);
       expect(calendarMetrics.scrollWidth).toBeLessThanOrEqual(calendarMetrics.clientWidth);
+      expect(Math.abs(calendarGutters.left - calendarGutters.right)).toBeLessThanOrEqual(1);
       expect(textAlignmentErrors).toEqual([]);
       await expect(calendar.locator('.pika-button').first()).toHaveCSS('text-align', 'center');
     });

--- a/docs/tests/pikadayRecipe.spec.ts
+++ b/docs/tests/pikadayRecipe.spec.ts
@@ -29,10 +29,15 @@ test.describe('Pikaday recipe', () => {
         clientWidth: element.clientWidth,
         scrollWidth: element.scrollWidth,
       }));
+      const calendarMetrics = await calendar.evaluate(element => ({
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+      }));
 
       expect(cellCount).toBe(calendarColumns);
       expect(widthDifference).toBeLessThanOrEqual(1);
       expect(horizontalMetrics.scrollWidth).toBeLessThanOrEqual(horizontalMetrics.clientWidth);
+      expect(calendarMetrics.scrollWidth).toBeLessThanOrEqual(calendarMetrics.clientWidth);
       await expect(calendar.locator('.pika-button').first()).toHaveCSS('text-align', 'center');
     });
   }


### PR DESCRIPTION
### Context

The PR fixes the Pikaday recipe calendar overflowing and misaligning day labels when week numbers are shown. It applies consistent table layout rules to the JavaScript, React, and Angular examples, and loads the Angular recipe stylesheet at runtime.

### Test evidence (required for source changes)

- Unit tests added/modified (`*.unit.js`): none -- the change has no isolated logic.
- E2E tests added/modified: `docs/tests/pikadayRecipe.spec.ts`.
- Type tests (`*.types.ts`) updated: none -- no public API changed.
- Fails without the fix: `Pikaday recipe › keeps the calendar aligned` reports unequal column widths for JavaScript and React, and right-aligned day labels for Angular.
- Demo page / recorded trace: `https://app.clickup.com/t/9015210959/DEV-2180`.

### Commands run

- `pnpm --dir docs exec playwright test tests/pikadayRecipe.spec.ts`
- `pnpm --dir docs exec playwright test tests/recipeConsoleErrors.spec.ts --grep 'recipes/cell-types/pikaday'`
- `pnpm --dir docs run docs:lint`
- `pnpm --dir docs exec eslint tests/pikadayRecipe.spec.ts`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2180

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
- [ ] This change needs a manual QA pass.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2180

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and recipe example CSS only; no Handsontable core or public API changes.
> 
> **Overview**
> Fixes **Pikaday recipe** calendar overflow and uneven day columns (especially with week numbers) by tightening the example CSS across JavaScript, React, and Angular.
> 
> Shared stylesheet updates add **`table-layout: fixed`**, square day cells (`width: 100%`, `aspect-ratio`), **`box-sizing: border-box`**, zero button padding, and **centered** day labels. Selectors now target **`.pika-single`** directly so layout rules apply even when theme classes are not on the calendar ancestor.
> 
> The **Angular** example imports `./example1.css` at runtime and widens the portal container from **250px to 278px** to account for Pikaday’s side margins. The recipe doc documents the layout rationale and the Angular-only setup.
> 
> Adds **`docs/tests/pikadayRecipe.spec.ts`** Playwright coverage for equal column widths, no horizontal overflow, balanced gutters, and centered day text on all three demo pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 452a8123434bd2b79e91932134acffa9bfbed16d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->