### PR TITLE
docs: clarify regressions in the LTS Backport Decision Matrix

### DIFF
--- a/docs/content/guides/upgrade-and-migration/long-term-support/long-term-support.md
+++ b/docs/content/guides/upgrade-and-migration/long-term-support/long-term-support.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Long Term Support (LTS) - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
+menuTag: updated
 ---
 LTS (Long-Term Support) versions are Handsontable release lines that are maintained and supported for an extended period. 
 
@@ -53,7 +54,7 @@ Dates below are offered as general guidance and are subject to change.
 Every major release progresses through distinct support phases:
 
 *   **Current** - The latest version under active development, receiving all new features, bug fixes, and improvements. Both LTS and Current-only releases start here for 6 months.
-*   **Active LTS** - Available only for even-numbered releases. During this 10-month phase, releases receive critical bug fixes, and security updates. No new features are added to maintain stability.
+*   **Active LTS** - Available only for even-numbered releases. During this 10-month phase, releases receive critical bug fixes, including [regressions](#critical-bugs-and-regressions), and security updates. No new features are added to maintain stability.
 *   **Maintenance LTS** - The final 14-month phase for LTS releases, where only security fixes are applied. This provides a transition period for migration to newer LTS versions.
 *   **End-of-Life** - No further updates, security patches, or support. Users should migrate to a supported version before this phase.
 
@@ -85,7 +86,7 @@ The LTS model is designed to minimize disruption while ensuring applications sta
 
 Backporting involves taking specific fixes from newer versions and retrofitting (cherry-picking) them to LTS releases, ensuring production systems receive critical updates without the disruption of major upgrades. Our backport policy prioritizes stability while addressing essential security and reliability concerns.
 
-The backport process is selective and risk-aware. Not all fixes from newer versions are suitable for backporting—only those that meet strict criteria for importance and stability. This approach ensures LTS releases remain stable and predictable while still receiving necessary updates.
+The backport process is selective and risk-aware. Not all fixes from newer versions are suitable for backporting - only those that meet strict criteria for importance and stability. This approach ensures LTS releases remain stable and predictable while still receiving necessary updates.
 
 ### Backport Decision Matrix
 
@@ -94,15 +95,52 @@ The following matrix defines which types of fixes are backported to each support
 | Issue Type | Current | Active LTS | Maintenance LTS |
 | ---| ---| --- | --- |
 | Security vulnerability | ✅  | ✅  | ✅  |
-| Critical bug | ✅ | ✅ | - |
+| Critical bug, including regressions | ✅ | ✅ | - |
 | Major/Minor bug | ✅ | - | - |
 | Performance | ✅ | - | - |
 | Feature | ✅ | - | - |
 
 *   **Security vulnerabilities** receive immediate attention across all supported versions, including those in Maintenance LTS. These fixes are prioritized and released as quickly as possible to protect production deployments.
-*   **Critical bugs** that significantly impact functionality are backported to Active LTS releases in the next patch version. These fixes undergo thorough testing to ensure they don't introduce new issues.
-*   **Bugs and performance improvements** are backported to Active LTS only when they present low risk and critical importance. The evaluation considers the fix complexity, potential for regression, and number of affected users
-*   **New features** are never backported to LTS releases. This policy maintains the stability promise of LTS versions—users can confidently apply updates knowing they contain only fixes, not functionality changes that might require application modifications.
+*   **Critical bugs** that significantly impact functionality are backported to Active LTS releases in the next patch version. These fixes undergo thorough testing to ensure they don't introduce new issues. Most critical bugs reported against an LTS line are regressions - see [Critical Bugs and Regressions](#critical-bugs-and-regressions).
+*   **Major and minor bugs, and performance improvements**, are not backported to Active LTS as a rule. A fix is considered by exception only when it carries low risk and high importance. The evaluation considers the fix complexity, potential for regression, and number of affected users.
+*   **New features** are never backported to LTS releases. This policy maintains the stability promise of LTS versions - you can confidently apply updates knowing they contain only fixes, not functionality changes that might require application modifications.
+
+### Critical Bugs and Regressions
+
+The term that decides a backport is **critical bug**, not "regression". A critical bug is a defect in a supported version that breaks a documented feature, corrupts data, or blocks a core workflow with no reasonable workaround. Severity is judged by the impact on your application, not by how the defect appeared.
+
+A **regression** describes how a critical bug reached you: something that worked before, and stopped working. Regressions are the most common source of critical bugs in an LTS line, and they are the clearest breach of the LTS stability promise. They are still assessed against the same severity bar. A regression that changes only a cosmetic detail remains a major or minor bug, and it is not backported.
+
+#### Two Classes of Regression
+
+Both classes qualify as critical bugs in Active LTS, and they carry different urgency:
+
+| Regression class | What changed | Example | Urgency in Active LTS |
+| --- | --- | --- | --- |
+| **Version regression** | Handsontable's own code, between two releases of the same LTS line | Column sorting works in `16.0` and `16.1`, and breaks in `16.2` | Standard. Fixed in the next scheduled patch release of the LTS line. |
+| **Environment regression** | The runtime around Handsontable: a browser, framework, or operating system update | The grid renders correctly in Chrome 150, and breaks in Chrome 151 | Elevated. Prioritized above other critical bugs, and released in a patch of the LTS line as soon as the fix passes testing. |
+
+An environment regression outranks a version regression because nothing in your application changed. Running unchanged on the [supported browsers](@/guides/technical-specification/supported-browsers/supported-browsers.md) for the entire support window is the core guarantee of an LTS line, and you cannot pin a browser version the way you pin a package version. A version regression, by contrast, only reaches you when you choose to install a newer patch, so you can stay on the last working patch until the fix ships.
+
+#### What Does Not Count as a Regression
+
+*   **Behavior that never worked in the LTS line.** A defect present since the first release of the line is a bug, not a regression. It reaches Active LTS only when it is critical.
+*   **Intentional changes.** Behavior changed on purpose in a new major version is covered by the [versioning policy](@/guides/upgrade-and-migration/versioning-policy/versioning-policy.md) and the migration guides.
+*   **Removals announced in advance** under the [deprecation policy](@/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md).
+*   **Breakage on an unsupported browser**, or on a browser version older than the two latest, which fall outside the [supported browsers](@/guides/technical-specification/supported-browsers/supported-browsers.md) list.
+
+#### Regressions in Maintenance LTS
+
+Neither class of regression is backported during the Maintenance LTS phase, where only security fixes are applied. If a browser update breaks a line that is already in Maintenance LTS, upgrade to the current Active LTS line.
+
+### Reporting a Regression
+
+Report a regression through the [issue tracker](https://github.com/handsontable/handsontable/issues/new/choose). Include the following, so the report can be classified and prioritized without a round trip:
+
+*   The last version that worked, and the first version that broke, such as "works in `16.1`, breaks in `16.2`".
+*   The browser and operating system, with their versions, and the last combination that worked, such as "works in Chrome 150, breaks in Chrome 151".
+*   A minimal, runnable reproduction.
+*   The impact on your application, and any workaround you found.
 
 ## Support Commitment
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context

The LTS page states that critical bugs are backported to Active LTS, but it never says how a regression maps onto that rule. Readers ask whether "regression" is its own backport category. It is not - "critical bug" is the term the policy turns on, and a regression is the most common way a critical bug reaches an LTS line.

This PR keeps `critical bug` as the deciding term and adds the missing regression detail underneath the matrix.

What changed on `long-term-support.md`:

- The matrix row now reads **Critical bug, including regressions**, so the table itself answers the question.
- New **Critical Bugs and Regressions** section. It defines a critical bug by impact (breaks a documented feature, corrupts data, or blocks a core workflow with no reasonable workaround), and defines a regression as how that bug reached you. A cosmetic regression stays a major or minor bug and is not backported.
- New **Two Classes of Regression** table covering the two cases raised in the request:
  - **Version regression** - Handsontable's own code broke between two releases of the same LTS line (works in `16.0` and `16.1`, breaks in `16.2`). Standard urgency, fixed in the next scheduled patch.
  - **Environment regression** - the runtime around Handsontable changed (renders in Chrome 150, breaks in Chrome 151). Elevated urgency, prioritized above other critical bugs, because nothing in the reader's application changed and a browser version cannot be pinned the way a package version can. This is stated as the core LTS guarantee.
- New **What Does Not Count as a Regression** list: behavior that never worked in the line, intentional major-version changes, announced deprecation removals, and breakage on unsupported browsers.
- New **Regressions in Maintenance LTS** note: neither class is backported there, only security fixes, so upgrade to Active LTS.
- New **Reporting a Regression** section listing the last-good and first-broken version, the browser and operating system versions, a minimal reproduction, and the impact - the facts needed to classify a report without a round trip.
- Two consistency fixes in the section being edited: the "Major/Minor bug" bullet said such fixes are backported to Active LTS while the matrix says they are not, so it now reads as an exception path; the em dashes were replaced with hyphens per `docs/AGENTS.md`.
- `menuTag: updated` added to the frontmatter, and the Active LTS bullet in **Support Phases** now links to the new section.

No policy is changed. The matrix outcomes per phase are the same as before.

### Test evidence (required for source changes)

Docs-only change - no source under `handsontable/src/**` or `wrappers/**`, so no unit, E2E, or type tests apply.

- Unit tests added/modified (`*.unit.js`): none - docs-only change
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none - docs-only change
- Type tests (`*.types.ts`) updated if public API changed: none - no API change
- For a bug fix - the spec that fails without this fix: n/a
- Demo page / recorded trace (for UI changes): rendered page screenshots below

Rendered on the local Astro dev server at `/docs/javascript-data-grid/long-term-support/`. All three internal links resolve (`/docs/javascript-data-grid/supported-browsers/`, `/versioning-policy/`, `/deprecation-policy/` all return 200), and both in-page links resolve to the `#critical-bugs-and-regressions` heading id.

Backport Decision Matrix with the renamed row and the reworked bullets:

[Backport Decision Matrix](https://cursor.com/agents/bc-7a40e589-5f7b-42c2-a669-8e865bdd9bc0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flts_backport_matrix.png)

New Critical Bugs and Regressions section:

[Critical Bugs and Regressions section](https://cursor.com/agents/bc-7a40e589-5f7b-42c2-a669-8e865bdd9bc0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flts_critical_bugs_and_regressions.png)

New Reporting a Regression section:

[Reporting a Regression section](https://cursor.com/agents/bc-7a40e589-5f7b-42c2-a669-8e865bdd9bc0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flts_reporting_a_regression.png)

### Commands run

```
npm --prefix docs run docs:lint
> eslint --ext .js,.mjs,.ts,.astro src content
(exit 0, no findings)

curl -s -o /dev/null -w "%{http_code}" http://localhost:4321/docs/javascript-data-grid/long-term-support/
200
```

[skip changelog]

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
- [ ] This change needs a manual QA pass

### Docs PR checklist

- [x] `type:` field present in frontmatter (`explanation`, unchanged)
- [x] Page uses the correct Diataxis template for its type
- [x] Title matches the Diataxis naming convention for its type (unchanged)
- [x] No banned placeholder data
- [x] All example data is domain-realistic and internally consistent
- [x] Active voice and second person ("you") used throughout the new text
- [x] No banned words: simply, just, easy, straightforward, note that, please
- [x] Heading hierarchy is correct (h2 to h3 to h4, no skipped levels)
- [x] Hyphens used as clause separators, no en or em dashes
- [x] Page already registered in `content/guides/sidebar.js`
- [x] `menuTag: updated` set on this substantively changed page
- [x] `[skip changelog]` in the PR body (docs changes do not need a changelog entry)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a40e589-5f7b-42c2-a669-8e865bdd9bc0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a40e589-5f7b-42c2-a669-8e865bdd9bc0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

