### PR TITLE
DEV-2192: Enforce a license bar min-width and scroll the excess in the slot

### DIFF
--- a/.changelogs/13167.json
+++ b/.changelogs/13167.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the license notification bar content overflowing on grids narrower than 300px.",
+  "type": "fixed",
+  "issueOrPR": 13167,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -56,6 +56,10 @@
 
   .ht-slot-top, .ht-slot-bottom {
     flex: 0 0 auto;
+    // A slot element may enforce its own minimum width (for example the license
+    // notification bar); on grids narrower than that the slot scrolls the excess
+    // instead of letting the element overflow the grid.
+    overflow-x: auto;
   }
 
   .ht-slot-element {

--- a/handsontable/src/styles/components/core/_license-notification.scss
+++ b/handsontable/src/styles/components/core/_license-notification.scss
@@ -13,6 +13,10 @@
     color: var(--ht-license-foreground-color);
     background-color: var(--ht-license-background-color, #f7f7f9);
     text-align: left;
+    // The grid defines the notification width, so on narrow grids unbreakable tokens
+    // (for example the support e-mail address) would otherwise overflow the bar. The
+    // minimum width keeps the message readable; the slot container scrolls the excess.
+    min-width: 300px;
 
     a {
       font-size: var(--ht-license-font-size);

--- a/tests/e2e/license-bar.spec.ts
+++ b/tests/e2e/license-bar.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '../fixtures/test';
+import { LicenseBarPage } from '../fixtures/pages/LicenseBarPage';
+
+const LICENSE_BAR_MIN_WIDTH = 300;
+
+/**
+ * DEV-2192: the license notification bar takes its width from the grid
+ * (DEV-1108), so on narrow grids its content — most notably the unbreakable
+ * support e-mail address — used to overflow the bar. The bar now enforces a
+ * minimum width and the bottom slot scrolls the excess horizontally.
+ */
+test.describe('license notification bar on a narrow grid', () => {
+  let licenseBar: LicenseBarPage;
+
+  test.beforeEach(async ({ page, theme }) => {
+    licenseBar = new LicenseBarPage(page, theme);
+  });
+
+  for (const gridWidth of [100, 150, 299]) {
+    test(`keeps its minimum width and scrolls within the slot at grid width ${gridWidth}px`, async () => {
+      await licenseBar.goto(gridWidth);
+
+      // The bar never shrinks below its minimum width, so its content fits
+      // inside the bar's own box.
+      expect(await licenseBar.barWidthPx()).toBeGreaterThanOrEqual(LICENSE_BAR_MIN_WIDTH);
+      expect(await licenseBar.barContentOverflowPx()).toBe(0);
+
+      // The grid is narrower than the bar, so the slot must scroll the excess
+      // instead of clipping it or letting it spill outside the grid.
+      const { hiddenContentPx, scrollsHorizontally } = await licenseBar.slotOverflowState();
+
+      expect(hiddenContentPx).toBeGreaterThan(0);
+      expect(scrollsHorizontally).toBe(true);
+    });
+  }
+
+  test('does not scroll when the grid is at least as wide as the bar minimum width', async () => {
+    await licenseBar.goto(400);
+
+    expect(await licenseBar.barContentOverflowPx()).toBe(0);
+
+    const { hiddenContentPx } = await licenseBar.slotOverflowState();
+
+    expect(hiddenContentPx).toBe(0);
+  });
+});

--- a/tests/fixtures/demo/license-bar.html
+++ b/tests/fixtures/demo/license-bar.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable license bar e2e fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Active theme from the ?theme= query param set by the Playwright project.
+    // Mapped through a fixed allowlist to a LITERAL (default main), so a crafted
+    // ?theme= can never be reflected into the document — no XSS. Exposed as
+    // window.htTheme so the grid init below reuses the sanitized value.
+    window.htTheme = ({ horizon: 'horizon', classic: 'classic' })[new URLSearchParams(location.search).get('theme')] || 'main';
+    // Written into <head> so the themed stylesheet is present before first render.
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } </style>
+</head>
+<body>
+  <!--
+    E2E fixture for the license notification bar (DEV-2192). The grid is
+    intentionally narrow and initialized WITHOUT a license key, so the license
+    notification renders in the bottom slot and its content (including the
+    unbreakable support e-mail address) must fit the grid-defined bar width.
+    The grid width is configurable via the ?width= query param (sanitized to a
+    positive integer, default 150) so tests can probe several narrow widths.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script src="/handsontable/dist/handsontable.full.min.js"></script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const widthParam = parseInt(new URLSearchParams(location.search).get('width'), 10);
+    const gridWidth = Number.isInteger(widthParam) && widthParam > 0 ? widthParam : 150;
+
+    const hot = new Handsontable(container, {
+      data: [
+        ['A1', 'B1'],
+        ['A2', 'B2'],
+        ['A3', 'B3'],
+      ],
+      colHeaders: true,
+      rowHeaders: true,
+      width: gridWidth,
+      height: 150,
+      // licenseKey intentionally missing — the license notification bar must render.
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/LicenseBarPage.ts
+++ b/tests/fixtures/pages/LicenseBarPage.ts
@@ -1,0 +1,67 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the license notification bar fixture.
+ *
+ * The fixture renders a deliberately narrow grid without a license key, so the
+ * license notification appears in the bottom slot. The bar's width is defined
+ * by the grid (DEV-1108). On grids narrower than the bar's minimum width the
+ * bottom slot scrolls the excess horizontally instead of letting the bar's
+ * content overflow the grid (DEV-2192).
+ */
+export class LicenseBarPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly grid: Locator;
+  readonly slot: Locator;
+  readonly bar: Locator;
+  readonly supportLink: Locator;
+
+  constructor(page: Page, theme = 'main') {
+    this.page = page;
+    this.theme = theme;
+    this.grid = page.getByTestId('grid');
+    this.slot = page.locator('.ht-slot-bottom');
+    this.bar = page.locator('.hot-display-license-info');
+    this.supportLink = this.bar.getByRole('link', { name: 'support@handsontable.com' });
+  }
+
+  /**
+   * Navigate to the fixture with the given grid width and wait for the
+   * license bar to render. Waits on a real DOM condition (the bar and its
+   * support link are visible) — no fixed timeouts.
+   */
+  async goto(gridWidth: number): Promise<void> {
+    await this.page.goto(`/tests/fixtures/demo/license-bar.html?theme=${this.theme}&width=${gridWidth}`);
+    await expect(this.bar).toBeVisible();
+    await expect(this.supportLink).toBeVisible();
+  }
+
+  /**
+   * The bar's rendered width in pixels — must never fall below its CSS
+   * minimum width, regardless of how narrow the grid is.
+   */
+  async barWidthPx(): Promise<number> {
+    return this.bar.evaluate(element => element.getBoundingClientRect().width);
+  }
+
+  /**
+   * The bar's horizontal content overflow in pixels — 0 when everything
+   * fits within the bar's own box.
+   */
+  async barContentOverflowPx(): Promise<number> {
+    return this.bar.evaluate(element => element.scrollWidth - element.clientWidth);
+  }
+
+  /**
+   * The bottom slot's horizontal overflow state: how many pixels of content
+   * exceed the slot's visible width, and whether the slot is set up to
+   * scroll (rather than clip or spill) that excess.
+   */
+  async slotOverflowState(): Promise<{ hiddenContentPx: number; scrollsHorizontally: boolean }> {
+    return this.slot.evaluate(element => ({
+      hiddenContentPx: element.scrollWidth - element.clientWidth,
+      scrollsHorizontally: ['auto', 'scroll'].includes(getComputedStyle(element).overflowX),
+    }));
+  }
+}


### PR DESCRIPTION
### Context

The PR fixes the license notification bar overflowing its box on narrow grids. Since DEV-1108 the bar takes its width from the grid, so on grids narrower than the message the unbreakable tokens (most notably the support e-mail address) spilled outside the bar.

The fix gives the bar a `min-width: 300px` and makes the edge slot containers (`.ht-slot-top`, `.ht-slot-bottom`) scroll horizontally (`overflow-x: auto`), so on grids narrower than 300px the excess scrolls within the slot instead of overflowing the grid.

<img width="1063" height="368" alt="image" src="https://github.com/user-attachments/assets/020aad27-d071-4309-95fc-12cac639577b" />


### How has this been tested?

- New Playwright E2E spec `tests/e2e/license-bar.spec.ts` with the `LicenseBarPage` page object and the `tests/fixtures/demo/license-bar.html` fixture. It verifies that on 100/150/299px grids the bar keeps its 300px minimum width with no content overflow and the bottom slot scrolls the excess, and that a 400px grid needs no scrolling. Run with:
  ```bash
  cd tests && npx playwright test license-bar
  ```
  All 12 tests pass (4 tests × 3 themes).
- `npm run stylelint --prefix handsontable` passes.
- Verified manually in the browser on grids of 100/150/300/400px width in all three themes.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2192

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2192

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS and layout-slot overflow behavior plus E2E tests; no auth, data, or core grid logic changes.
> 
> **Overview**
> Fixes the license notification bar overflowing on grids **narrower than 300px** by giving `.hot-display-license-info` a **`min-width: 300px`** and enabling **`overflow-x: auto`** on `.ht-slot-top` / `.ht-slot-bottom` so wider slot content scrolls inside the slot instead of spilling past the grid.
> 
> Adds Playwright coverage (`license-bar.spec.ts`, HTML fixture, `LicenseBarPage`) for 100/150/299px (bar stays ≥300px, no bar overflow, slot scrolls) and 400px (no slot scroll). Changelog entry **13167**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5699b97421abad4a8b793d0e3389d7f970661926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->