### PR TITLE
HOT-15499: Make menus follow their anchor on outside element scroll

### DIFF
--- a/.changelogs/12719.json
+++ b/.changelogs/12719.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed open menus (context menu, dropdown menu, and filters) becoming detached from the grid when a scrollable parent container or the grid viewport was scrolled. Menus now follow their anchor and close when it scrolls out of view.",
+  "type": "fixed",
+  "issueOrPR": 12719,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
@@ -2769,7 +2769,14 @@ describe('ContextMenu', () => {
       expect($('.htContextMenu').is(':visible')).toBe(true);
     });
 
-    it('should not close the menu, when table is scrolled', async() => {
+    // #12719: with an anchor provider (the right-clicked cell), a scroll on an element outside
+    // `.htMenu` — including the grid's own viewport (`wtHolder`) — repositions the menu to follow
+    // that cell instead of closing it. The menu closes only once the anchor derenders (scrolls out
+    // of Walkontable's render window). There is no suppression window anymore: the mechanism below
+    // is follow-vs-derender, not open-time timing. Neither scroll here (to `scrollTop + 60`, nor
+    // the further one to `scrollTop + 100` after the menu is reopened at the same cell) pushes row
+    // 15 out of the render window, so the menu keeps following and stays open through both.
+    it('should keep the menu following its anchor across multiple outside scrolls, when the anchor stays rendered (#12719)', async() => {
       handsontable({
         data: createSpreadsheetData(40, 30),
         colWidths: 50, // can also be a number or a function
@@ -2798,10 +2805,20 @@ describe('ContextMenu', () => {
 
       await scrollViewportVertically(scrollTop + 100);
 
+      // #12719: the anchor cell (row 15) is still within the render window at this scroll
+      // position, so the menu keeps following it and stays open rather than closing.
       expect($('.htContextMenu').is(':visible')).toBe(true);
     });
 
-    it('should not attempt to close menu, when table is scrolled and the menu is already closed', async() => {
+    // #12719: this asserts that outside scroll handling never routes through the plugin-level
+    // `ContextMenu#close()` API (spied on below) — it doesn't, whether the menu follows its
+    // anchor or derenders-and-closes, because the scroll-driven close path lives entirely on the
+    // `Menu` instance (`Menu#close()`, called as `this.close(true)` from `Menu#followAnchor`/
+    // `#onDocumentScroll` in menu.ts) and never calls back into `ContextMenu#close()`. So this
+    // spy does not discriminate follow-vs-derender; it only proves the plugin's public `close()`
+    // API is untouched by scroll handling. Actual follow-vs-derender behavior is covered by the
+    // Playwright menu-scroll suite (tests/e2e).
+    it('should not call the plugin-level `close()` API when the table is scrolled, regardless of follow-vs-derender (#12719)', async() => {
       handsontable({
         data: createSpreadsheetData(40, 30),
         colWidths: 50, // can also be a number or a function

--- a/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts/shiftMetaBackslashOrShiftF10.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts/shiftMetaBackslashOrShiftF10.spec.js
@@ -76,13 +76,16 @@ describe('ContextMenu keyboard shortcut', () => {
       await keyDownUp(keyboardShortcut);
 
       expect(plugin.open).toHaveBeenCalledTimes(1);
+      // #12719: the keyboard-triggered menu now follows its anchor cell on scroll, so `open()`
+      // receives a third argument - an anchor rect provider - in addition to the position and
+      // offset objects asserted below.
       expect(plugin.open).toHaveBeenCalledWith({
         left: cellRect.left,
         top: cellRect.top + cellRect.height - 1,
       }, {
         left: cellRect.width,
         above: -cellRect.height,
-      });
+      }, jasmine.any(Function));
     });
 
     it('should internally call `open()` method with correct cell coordinates - active second selection layer', async() => {
@@ -106,13 +109,16 @@ describe('ContextMenu keyboard shortcut', () => {
       await keyDownUp(keyboardShortcut);
 
       expect(plugin.open).toHaveBeenCalledTimes(1);
+      // #12719: the keyboard-triggered menu now follows its anchor cell on scroll, so `open()`
+      // receives a third argument - an anchor rect provider - in addition to the position and
+      // offset objects asserted below.
       expect(plugin.open).toHaveBeenCalledWith({
         left: cellRect.left,
         top: cellRect.top + cellRect.height - 1,
       }, {
         left: cellRect.width,
         above: -cellRect.height,
-      });
+      }, jasmine.any(Function));
     });
 
     it('should internally call `open()` method with correct row header coordinates', async() => {
@@ -132,13 +138,16 @@ describe('ContextMenu keyboard shortcut', () => {
       await keyDownUp(keyboardShortcut);
 
       expect(plugin.open).toHaveBeenCalledTimes(1);
+      // #12719: the keyboard-triggered menu now follows its anchor cell on scroll, so `open()`
+      // receives a third argument - an anchor rect provider - in addition to the position and
+      // offset objects asserted below.
       expect(plugin.open).toHaveBeenCalledWith({
         left: cellRect.left,
         top: cellRect.top + cellRect.height - 1,
       }, {
         left: cellRect.width,
         above: -cellRect.height,
-      });
+      }, jasmine.any(Function));
     });
 
     it('should internally call `open()` method with correct column header coordinates', async() => {
@@ -158,13 +167,16 @@ describe('ContextMenu keyboard shortcut', () => {
       await keyDownUp(keyboardShortcut);
 
       expect(plugin.open).toHaveBeenCalledTimes(1);
+      // #12719: the keyboard-triggered menu now follows its anchor cell on scroll, so `open()`
+      // receives a third argument - an anchor rect provider - in addition to the position and
+      // offset objects asserted below.
       expect(plugin.open).toHaveBeenCalledWith({
         left: cellRect.left,
         top: cellRect.top + cellRect.height - 1,
       }, {
         left: cellRect.width,
         above: -cellRect.height,
-      });
+      }, jasmine.any(Function));
     });
 
     it('should internally call `open()` method with correct corner coordinates', async() => {
@@ -184,13 +196,16 @@ describe('ContextMenu keyboard shortcut', () => {
       await keyDownUp(keyboardShortcut);
 
       expect(plugin.open).toHaveBeenCalledTimes(1);
+      // #12719: the keyboard-triggered menu now follows its anchor cell on scroll, so `open()`
+      // receives a third argument - an anchor rect provider - in addition to the position and
+      // offset objects asserted below.
       expect(plugin.open).toHaveBeenCalledWith({
         left: cellRect.left,
         top: cellRect.top + cellRect.height - 1,
       }, {
         left: cellRect.width,
         above: -cellRect.height,
-      });
+      }, jasmine.any(Function));
     });
 
     it('should open the menu and select the first item by default', async() => {
@@ -231,13 +246,16 @@ describe('ContextMenu keyboard shortcut', () => {
       const cellRect = getCell(400, 40).getBoundingClientRect();
 
       expect(plugin.open).toHaveBeenCalledTimes(1);
+      // #12719: the keyboard-triggered menu now follows its anchor cell on scroll, so `open()`
+      // receives a third argument - an anchor rect provider - in addition to the position and
+      // offset objects asserted below.
       expect(plugin.open).toHaveBeenCalledWith({
         left: cellRect.left,
         top: cellRect.top + cellRect.height - 1,
       }, {
         left: cellRect.width,
         above: -cellRect.height,
-      });
+      }, jasmine.any(Function));
       // The scroll position depends on cell 400,40 being scrolled into view in a 300x300 container.
       // Read the actual scroll positions from the overlays to verify they scrolled to the cell.
       expect(inlineStartOverlay().getScrollPosition()).toBeGreaterThan(0);

--- a/handsontable/src/plugins/contextMenu/contextMenu.ts
+++ b/handsontable/src/plugins/contextMenu/contextMenu.ts
@@ -7,6 +7,7 @@ import { ItemsFactory } from './itemsFactory';
 import {
   Menu,
 } from './menu';
+import type { MenuAnchorRectProvider } from './menu';
 import { getDocumentOffsetByElement } from './utils';
 import { eventTargetEl, hasClass, isHTMLElement } from '../../helpers/dom/element';
 import {
@@ -45,6 +46,10 @@ export interface MenuItemConfig {
   submenu?: { items: MenuItemConfig[] };
   [key: string]: unknown;
 }
+
+// Re-exported so consumers of this plugin's public `open()` signature (and `DropdownMenu`'s,
+// which shares the same `Menu` class) don't have to reach into the internal `menu/` module.
+export type { MenuAnchorRectProvider };
 
 export const PLUGIN_KEY = 'contextMenu';
 export const PLUGIN_PRIORITY = 70;
@@ -269,6 +274,10 @@ export class ContextMenu extends BasePlugin {
           }, {
             left: rect.width,
             above: -rect.height,
+          }, () => {
+            const anchorCell = this.hot.getCell(highlight.row!, highlight.col!, true);
+
+            return anchorCell ? anchorCell.getBoundingClientRect() : null;
           });
           // Make sure the first item is selected (role=menuitem). Otherwise, screen readers
           // will block the Esc key for the whole menu.
@@ -302,6 +311,8 @@ export class ContextMenu extends BasePlugin {
    * `Event` instance (e.g., a `MouseEvent`).
    * @param {{ above: number, below: number, left: number, right: number }} offset An object that applies
    * an offset to the menu position.
+   * @param {Function} [anchorRectProvider] Returns the current anchor rectangle for
+   * scroll-follow repositioning, or `null` when the anchor is no longer rendered.
    * @fires Hooks#beforeContextMenuShow
    * @fires Hooks#afterContextMenuShow
    * @example
@@ -316,7 +327,8 @@ export class ContextMenu extends BasePlugin {
     position: Record<string, number> | Event,
     offset: { above?: number; below?: number; left?: number; right?: number } = {
       above: 0, below: 0, left: 0, right: 0
-    }
+    },
+    anchorRectProvider?: MenuAnchorRectProvider,
   ): void {
     if (this.menu?.isOpened()) {
       return;
@@ -334,7 +346,7 @@ export class ContextMenu extends BasePlugin {
       this.menu!.setOffset(key, value);
     });
 
-    this.menu!.setPosition(position);
+    this.menu!.setPosition(position, anchorRectProvider);
   }
 
   /**
@@ -453,11 +465,27 @@ export class ContextMenu extends BasePlugin {
     }
 
     const offset = getDocumentOffsetByElement(this.menu!.container, this.hot.rootDocument);
+    const anchorCell = element.closest<HTMLElement>('td, th');
+    let anchorRectProvider: MenuAnchorRectProvider | undefined;
+
+    if (anchorCell) {
+      const cellCoords = this.hot.getCoords(anchorCell);
+
+      if (cellCoords && cellCoords.row !== null && cellCoords.col !== null) {
+        const { row, col } = cellCoords;
+
+        anchorRectProvider = () => {
+          const cell = this.hot.getCell(row, col, true);
+
+          return cell ? cell.getBoundingClientRect() : null;
+        };
+      }
+    }
 
     this.open({
       top: (event as MouseEvent).clientY + offset.top,
       left: (event as MouseEvent).clientX + offset.left,
-    });
+    }, undefined, anchorRectProvider);
   };
 
   /**

--- a/handsontable/src/plugins/contextMenu/index.ts
+++ b/handsontable/src/plugins/contextMenu/index.ts
@@ -4,4 +4,4 @@ export {
   ContextMenu,
 } from './contextMenu';
 
-export type { PredefinedMenuItemKey, MenuItemConfig } from './contextMenu';
+export type { PredefinedMenuItemKey, MenuItemConfig, MenuAnchorRectProvider } from './contextMenu';

--- a/handsontable/src/plugins/contextMenu/menu/menu.ts
+++ b/handsontable/src/plugins/contextMenu/menu/menu.ts
@@ -420,10 +420,6 @@ export class Menu {
     this.container.removeAttribute('style');
     this.container.style.display = 'block';
 
-    // Registered per-open so that scroll listeners fire in menu open order — a menu
-    // anchored inside another menu then always repositions AFTER its anchor was moved.
-    this.#registerScrollListeners();
-
     const delayedOpenSubMenu = debounce((...args: unknown[]) => this.openSubMenu(args[0] as number), 300);
     const minWidthOfMenu = (Number(this.options.minWidth) || MIN_WIDTH);
     let noItemsDefined = false;
@@ -442,6 +438,11 @@ export class Menu {
     } else if (filteredItems.length === 0) {
       return;
     }
+
+    // Registered per-open (and after the empty-items early return, which would leak
+    // them) so that scroll listeners fire in menu open order — a menu anchored inside
+    // another menu then always repositions AFTER its anchor was moved.
+    this.#registerScrollListeners();
 
     filteredItems = filterSeparators(filteredItems);
 

--- a/handsontable/src/plugins/contextMenu/menu/menu.ts
+++ b/handsontable/src/plugins/contextMenu/menu/menu.ts
@@ -204,6 +204,18 @@ export class Menu {
    * @type {number|null}
    */
   #suppressHoverSubMenuToggleFrameId: number | null = null;
+  /**
+   * Detach functions for the document `scroll` listeners active while the menu is open.
+   * Scroll listeners are registered in `open()` (not in the constructor) so that they
+   * fire in menu OPEN order: a menu whose anchor lives inside another menu's container
+   * (a sub-menu, or the filters condition select menu inside the dropdown menu) always
+   * opens after that menu, so its `#followAnchor` runs after the anchor has been moved.
+   * Construction order gives no such guarantee — e.g. `updateSettings` recreates the
+   * dropdown menu while the condition select menu is long-lived (#13168).
+   *
+   * @type {Function[]}
+   */
+  #detachScrollListeners: Array<() => void> = [];
 
   /**
    * Getter for the table border width.
@@ -275,11 +287,37 @@ export class Menu {
       this.eventManager.addEventListener(frame.document, 'mousedown', event => this.onDocumentMouseDown(event));
       this.eventManager.addEventListener(frame.document, 'touchstart', event => this.onDocumentMouseDown(event));
       this.eventManager.addEventListener(frame.document, 'contextmenu', event => this.onDocumentContextMenu(event));
-      this.eventManager.addEventListener(frame.document, 'scroll',
-        event => this.onDocumentScroll(event), { capture: true, passive: true });
 
       frame = getParentWindow(frame);
     }
+  }
+
+  /**
+   * Registers the document `scroll` listeners (capture phase, all parent frames) that
+   * keep the menu attached to its anchor. Called from `open()` — see
+   * `#detachScrollListeners` for why the registration is open-scoped.
+   */
+  #registerScrollListeners() {
+    this.#clearScrollListeners();
+
+    let frame: Window | null = this.hot.rootWindow;
+
+    while (frame) {
+      this.#detachScrollListeners.push(
+        this.eventManager.addEventListener(frame.document, 'scroll',
+          event => this.onDocumentScroll(event), { capture: true, passive: true }),
+      );
+
+      frame = getParentWindow(frame);
+    }
+  }
+
+  /**
+   * Removes the document `scroll` listeners registered by `#registerScrollListeners()`.
+   */
+  #clearScrollListeners() {
+    this.#detachScrollListeners.forEach(detach => detach());
+    this.#detachScrollListeners.length = 0;
   }
 
   /**
@@ -381,6 +419,10 @@ export class Menu {
 
     this.container.removeAttribute('style');
     this.container.style.display = 'block';
+
+    // Registered per-open so that scroll listeners fire in menu open order — a menu
+    // anchored inside another menu then always repositions AFTER its anchor was moved.
+    this.#registerScrollListeners();
 
     const delayedOpenSubMenu = debounce((...args: unknown[]) => this.openSubMenu(args[0] as number), 300);
     const minWidthOfMenu = (Number(this.options.minWidth) || MIN_WIDTH);
@@ -559,6 +601,7 @@ export class Menu {
       this.hotMenu = null;
       this.#anchorRectProvider = null;
       this.#scrollFollowBaseline = null;
+      this.#clearScrollListeners();
 
       if (this.#suppressHoverSubMenuToggleFrameId !== null) {
         this.hot.rootWindow.cancelAnimationFrame(this.#suppressHoverSubMenuToggleFrameId);

--- a/handsontable/src/plugins/contextMenu/menu/menu.ts
+++ b/handsontable/src/plugins/contextMenu/menu/menu.ts
@@ -21,6 +21,7 @@ import {
   addClass,
   eventTargetEl,
   isChildOf,
+  isHTMLElement,
   getParentWindow,
   hasClass,
   setAttribute,
@@ -50,6 +51,12 @@ const MIN_WIDTH = 215;
 function hasName(value: unknown): value is { name: unknown } {
   return typeof value === 'object' && value !== null && 'name' in value;
 }
+
+/**
+ * Returns the current bounding rectangle of the element the menu is anchored to,
+ * or `null` when the anchor is not rendered anymore (scrolled out of the viewport).
+ */
+export type MenuAnchorRectProvider = () => DOMRect | null;
 
 interface MenuOptions {
   // eslint-disable-next-line no-use-before-define
@@ -162,6 +169,41 @@ export class Menu {
    * @type {number}
    */
   #tableBorderWidth: number | undefined;
+  /**
+   * Provides the current anchor rectangle for scroll-follow repositioning, or `null`
+   * when the anchor is no longer rendered. Set through `setPosition()`.
+   *
+   * @type {Function|null}
+   */
+  #anchorRectProvider: MenuAnchorRectProvider | null = null;
+  /**
+   * Position baseline captured when the menu is positioned: the offset between the
+   * menu's document coordinates and its anchor (or the grid root when no anchor
+   * provider is available). Used to keep the menu attached while outside elements scroll.
+   *
+   * @type {object|null}
+   */
+  #scrollFollowBaseline: { offsetLeft: number; offsetTop: number } | null = null;
+  /**
+   * When `true`, `afterOnCellMouseOver` ignores the hover instead of opening/closing a
+   * sub-menu. Armed for a couple of animation frames right after `#followAnchor` moves
+   * the menu: repositioning a menu item out from under a stationary mouse cursor makes
+   * the browser recompute `:hover` and fire `mouseout`/`mouseover` on the next frame(s)
+   * with NO real pointer movement involved — left unguarded, that spurious hover would
+   * toggle sub-menus as if the user had moved the mouse (#12719).
+   *
+   * @type {boolean}
+   */
+  #suppressHoverSubMenuToggle = false;
+  /**
+   * The identifier of the latest pending animation frame request that lifts
+   * `#suppressHoverSubMenuToggle`, so a new repositioning can cancel and re-arm the
+   * window instead of having it cut short by an earlier one (continuous scrolling
+   * repositions the menu on every scroll event).
+   *
+   * @type {number|null}
+   */
+  #suppressHoverSubMenuToggleFrameId: number | null = null;
 
   /**
    * Getter for the table border width.
@@ -233,6 +275,8 @@ export class Menu {
       this.eventManager.addEventListener(frame.document, 'mousedown', event => this.onDocumentMouseDown(event));
       this.eventManager.addEventListener(frame.document, 'touchstart', event => this.onDocumentMouseDown(event));
       this.eventManager.addEventListener(frame.document, 'contextmenu', event => this.onDocumentContextMenu(event));
+      this.eventManager.addEventListener(frame.document, 'scroll',
+        event => this.onDocumentScroll(event), { capture: true, passive: true });
 
       frame = getParentWindow(frame);
     }
@@ -397,9 +441,25 @@ export class Menu {
       },
       beforeRefreshDimensions: () => false,
       beforeOnCellMouseOver: (event: MouseEvent, coords: { row: number; col: number }) => {
+        // See the matching guard in `afterOnCellMouseOver` below — keeps the keyboard
+        // (PageUp/PageDown) page-cursor base row from silently drifting to whatever row
+        // the spurious hover lands on.
+        if (this.#suppressHoverSubMenuToggle) {
+          return;
+        }
+
         this.#navigator!.setPageCursorAt(coords.row);
       },
       afterOnCellMouseOver: (event: MouseEvent, coords: { row: number; col: number }) => {
+        // Dropped, not deferred: a genuine hover that lands on a new row while this
+        // window is armed gets no submenu toggle at all — the user has to cross another
+        // row boundary (a fresh `mouseover`) for the hover to register. Rare in practice
+        // (the window is 2 frames) and preferable to replaying a possibly-stale coords.row
+        // once the window closes.
+        if (this.#suppressHoverSubMenuToggle) {
+          return;
+        }
+
         if (this.isAllSubMenusClosed()) {
           delayedOpenSubMenu(coords.row);
         } else {
@@ -497,6 +557,15 @@ export class Menu {
       this.container.style.display = 'none';
       this.hotMenu!.destroy();
       this.hotMenu = null;
+      this.#anchorRectProvider = null;
+      this.#scrollFollowBaseline = null;
+
+      if (this.#suppressHoverSubMenuToggleFrameId !== null) {
+        this.hot.rootWindow.cancelAnimationFrame(this.#suppressHoverSubMenuToggleFrameId);
+        this.#suppressHoverSubMenuToggleFrameId = null;
+      }
+
+      this.#suppressHoverSubMenuToggle = false;
       this.hot.getSettings().outsideClickDeselects = this.origOutsideClickDeselects;
       this.runLocalHooks('afterClose');
 
@@ -550,7 +619,10 @@ export class Menu {
 
     subMenu.setMenuItems(dataItem.submenu!.items);
     subMenu.open();
-    subMenu.setPosition(cell.getBoundingClientRect());
+    subMenu.setPosition(
+      cell.getBoundingClientRect(),
+      () => (cell.isConnected ? cell.getBoundingClientRect() : null),
+    );
     this.hotSubMenus[dataItem.key!] = subMenu;
 
     // Update the accessibility tags on the cell being the base for the submenu.
@@ -625,6 +697,7 @@ export class Menu {
     this.clearLocalHooks();
     this.close();
     this.parentMenu = null;
+
     this.eventManager.destroy();
 
     if (menuContainerParentElement) {
@@ -702,8 +775,10 @@ export class Menu {
    * Set menu position based on dom event or based on literal object.
    *
    * @param {Event|object} coords Event or literal Object with coordinates.
+   * @param {Function} [anchorRectProvider] Returns the current anchor rectangle for
+   * scroll-follow repositioning, or `null` when the anchor is no longer rendered.
    */
-  setPosition(coords: Event | DOMRect | Record<string, unknown>) {
+  setPosition(coords: Event | DOMRect | Record<string, unknown>, anchorRectProvider?: MenuAnchorRectProvider) {
     if (this.isSubMenu()) {
       this.positioner.setParentElement(this.parentMenu!.container);
     }
@@ -711,6 +786,26 @@ export class Menu {
     this.positioner
       .setElement(this.container)
       .updatePosition(coords);
+
+    this.#anchorRectProvider = anchorRectProvider ?? null;
+    this.#captureScrollFollowBaseline();
+  }
+
+  /**
+   * Captures the offset between the menu's measured document position and its anchor's
+   * (or the grid root element's, when no anchor provider is set). Both sides are
+   * MEASURED rects — never `style.left/top`, which are not document coordinates when
+   * the menu lives in a custom `uiContainer` with its own containing block. The offset
+   * stays constant while outside elements scroll; repositioning restores it.
+   */
+  #captureScrollFollowBaseline() {
+    const menuRect = this.container.getBoundingClientRect();
+    const anchorRect = this.#anchorRectProvider?.() ?? this.hot.rootElement.getBoundingClientRect();
+
+    this.#scrollFollowBaseline = {
+      offsetLeft: menuRect.left - anchorRect.left,
+      offsetTop: menuRect.top - anchorRect.top,
+    };
   }
 
   /**
@@ -811,6 +906,99 @@ export class Menu {
     } else if ((this.isAllSubMenusClosed() || this.isSubMenu()) && !isChildOf(eventTargetEl(event)!, '.htMenu')) {
       this.close(true);
     }
+  }
+
+  /**
+   * Document's scroll listener (capture phase). When an element outside of the menu
+   * is scrolled, repositions the menu so it stays visually attached to its anchor
+   * (column header, cell, or parent menu item) — the menu is rendered in a portal
+   * positioned in document coordinates, so it would otherwise stay stranded (#12719).
+   * Closes the menu when the anchor is scrolled out of the rendered viewport.
+   * Ignored: page/document scroll (document coordinates already track it), scrolls
+   * within the menu, and scrolls of elements that contain the menu (custom
+   * `uiContainer` — the menu moves natively with its container).
+   *
+   * @private
+   * @param {Event} event The scroll event object.
+   */
+  onDocumentScroll(event: Event) {
+    if (!this.isOpened() || this.#scrollFollowBaseline === null) {
+      return;
+    }
+
+    if (!isHTMLElement(event.target) || isChildOf(event.target, '.htMenu')) {
+      return;
+    }
+
+    this.#followAnchor(event.target);
+  }
+
+  /**
+   * Repositions the menu to restore its captured offset to the anchor. The correction
+   * is computed from MEASURED rects (desired document position minus actual document
+   * position) and applied as an increment to the current inline `left`/`top` styles,
+   * which keeps the math correct in any containing block (default body portal or a
+   * custom `uiContainer`) and makes scrolls the menu already follows natively a no-op.
+   * Closes the menu when the anchor provider reports the anchor as no longer rendered,
+   * or — when no provider is available — when the scroll happened inside the grid root
+   * element (an anchor-less menu cannot track content movement within the grid).
+   *
+   * @param {HTMLElement} scrolledElement The element whose scroll triggered the update.
+   */
+  #followAnchor(scrolledElement: HTMLElement) {
+    let anchorRect: DOMRect | null;
+
+    if (this.#anchorRectProvider) {
+      anchorRect = this.#anchorRectProvider();
+    } else if (scrolledElement === this.hot.rootElement || isChildOf(scrolledElement, this.hot.rootElement)) {
+      this.close(true);
+
+      return;
+    } else {
+      anchorRect = this.hot.rootElement.getBoundingClientRect();
+    }
+
+    if (anchorRect === null) {
+      this.close(true);
+
+      return;
+    }
+
+    const { offsetLeft, offsetTop } = this.#scrollFollowBaseline!;
+    const menuRect = this.container.getBoundingClientRect();
+    const correctionLeft = (anchorRect.left + offsetLeft) - menuRect.left;
+    const correctionTop = (anchorRect.top + offsetTop) - menuRect.top;
+
+    if (correctionLeft === 0 && correctionTop === 0) {
+      return;
+    }
+
+    this.container.style.left = `${(Number.parseFloat(this.container.style.left) || 0) + correctionLeft}px`;
+    this.container.style.top = `${(Number.parseFloat(this.container.style.top) || 0) + correctionTop}px`;
+
+    this.#armHoverSuppression();
+  }
+
+  /**
+   * Arms `#suppressHoverSubMenuToggle` for two animation frames. The browser recomputes
+   * `:hover` (and dispatches the resulting `mouseout`/`mouseover`) on a frame AFTER the
+   * layout-affecting style change that just moved menu content out from under the
+   * pointer, not synchronously with it — one frame is not reliably enough to outlast it.
+   * Re-arming cancels a still-pending lift so continuous scrolling keeps the window open.
+   */
+  #armHoverSuppression() {
+    this.#suppressHoverSubMenuToggle = true;
+
+    if (this.#suppressHoverSubMenuToggleFrameId !== null) {
+      this.hot.rootWindow.cancelAnimationFrame(this.#suppressHoverSubMenuToggleFrameId);
+    }
+
+    this.#suppressHoverSubMenuToggleFrameId = this.hot.rootWindow.requestAnimationFrame(() => {
+      this.#suppressHoverSubMenuToggleFrameId = this.hot.rootWindow.requestAnimationFrame(() => {
+        this.#suppressHoverSubMenuToggle = false;
+        this.#suppressHoverSubMenuToggleFrameId = null;
+      });
+    });
   }
 
   /**

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
@@ -9,6 +9,7 @@ import {
 } from '../../helpers/dom/element';
 import { ItemsFactory } from '../contextMenu/itemsFactory';
 import { Menu } from '../contextMenu/menu';
+import type { MenuAnchorRectProvider } from '../contextMenu/menu';
 import { Hooks } from '../../core/hooks';
 import {
   COLUMN_LEFT,
@@ -27,6 +28,10 @@ Hooks.getSingleton().register('beforeDropdownMenuShow');
 Hooks.getSingleton().register('afterDropdownMenuShow');
 Hooks.getSingleton().register('afterDropdownMenuHide');
 Hooks.getSingleton().register('afterDropdownMenuExecute');
+
+// Re-exported because this plugin's public `open()` accepts a `MenuAnchorRectProvider`
+// (defined alongside the shared `Menu` class in `contextMenu/menu`) as its third parameter.
+export type { MenuAnchorRectProvider };
 
 export const PLUGIN_KEY = 'dropdownMenu';
 export const PLUGIN_PRIORITY = 230;
@@ -387,6 +392,15 @@ export class DropdownMenu extends BasePlugin {
         const menuTop = isRowspanned
           ? (th.getBoundingClientRect().top + th.clientHeight)
           : buttonRect.bottom;
+        // Anchor to `target`'s own resolved coordinates, not `(headerRow, from.col)`: the
+        // hidden-nested-placeholder fallback above can point `target` at a DIFFERENT
+        // column's button (a preceding, non-hidden header cell) while leaving `from.col`
+        // referencing the originally-selected placeholder column, which has no button —
+        // that mismatch made the provider always return `null` and close the menu on the
+        // first outside scroll instead of following it (#12719).
+        const anchorCoords = th ? this.hot.getCoords(th) : null;
+        const anchorRow = anchorCoords?.row ?? headerRow;
+        const anchorColumn = anchorCoords?.col ?? null;
 
         this.open({
           left: buttonRect.left + offset.left,
@@ -396,6 +410,11 @@ export class DropdownMenu extends BasePlugin {
           right: 0,
           above: 0,
           below: isRowspanned ? -1 : 3,
+        }, anchorColumn === null ? undefined : () => {
+          const headerCell = this.hot.getCell(anchorRow, anchorColumn, true);
+          const button = headerCell?.querySelector(`.${BUTTON_CLASS_NAME}`);
+
+          return button ? button.getBoundingClientRect() : null;
         });
         // Make sure the first item is selected (role=menuitem). Otherwise, screen readers
         // will block the Esc key for the whole menu.
@@ -463,6 +482,8 @@ export class DropdownMenu extends BasePlugin {
    * `Event` instance (e.g., a `MouseEvent`).
    * @param {{ above: number, below: number, left: number, right: number }} offset An object that applies
    * an offset to the menu position.
+   * @param {Function} [anchorRectProvider] Returns the current anchor rectangle for
+   * scroll-follow repositioning, or `null` when the anchor is no longer rendered.
    * @fires Hooks#beforeDropdownMenuShow
    * @fires Hooks#afterDropdownMenuShow
    * @example
@@ -475,7 +496,8 @@ export class DropdownMenu extends BasePlugin {
    */
   open(
     position: Record<string, number> | Event,
-    offset: Record<string, number> = { above: 0, below: 0, left: 0, right: 0 }
+    offset: Record<string, number> = { above: 0, below: 0, left: 0, right: 0 },
+    anchorRectProvider?: MenuAnchorRectProvider,
   ): void {
     if (this.menu?.isOpened()) {
       return;
@@ -491,7 +513,7 @@ export class DropdownMenu extends BasePlugin {
     objectEach(offset, (value, key) => {
       this.menu?.setOffset(key as string, value as number);
     });
-    this.menu?.setPosition(position);
+    this.menu?.setPosition(position, anchorRectProvider);
   }
 
   /**
@@ -576,6 +598,10 @@ export class DropdownMenu extends BasePlugin {
     if (hasClass(target, BUTTON_CLASS_NAME)) {
       const offset = getDocumentOffsetByElement(this.menu?.container ?? this.hot.rootElement, this.hot.rootDocument);
       const buttonRect = this.#getButtonRect(target);
+      const th = target.closest('th');
+      const cellCoords = th ? this.hot.getCoords(th) : null;
+      const visualColumn = cellCoords?.col ?? null;
+      const headerRowIndex = cellCoords?.row ?? -1;
 
       event.stopPropagation();
       this.#isButtonClicked = false;
@@ -588,6 +614,11 @@ export class DropdownMenu extends BasePlugin {
         right: 0,
         above: 0,
         below: 3,
+      }, visualColumn === null ? undefined : () => {
+        const headerCell = this.hot.getCell(headerRowIndex, visualColumn, true);
+        const button = headerCell?.querySelector(`.${BUTTON_CLASS_NAME}`);
+
+        return button ? button.getBoundingClientRect() : null;
       });
     }
   }

--- a/handsontable/src/plugins/dropdownMenu/index.ts
+++ b/handsontable/src/plugins/dropdownMenu/index.ts
@@ -3,3 +3,5 @@ export {
   PLUGIN_PRIORITY,
   DropdownMenu,
 } from './dropdownMenu';
+
+export type { MenuAnchorRectProvider } from './dropdownMenu';

--- a/handsontable/src/plugins/filters/ui/select.ts
+++ b/handsontable/src/plugins/filters/ui/select.ts
@@ -205,12 +205,15 @@ export class SelectUI extends BaseUI {
 
     if (this.#menu) {
       this.#menu.open();
-      this.#menu.setPosition({
-        left: this.hot?.isLtr() ? rect.left - 5 : rect.left - 31,
-        top: rect.top - 1,
-        width: rect.width,
-        height: rect.height,
-      });
+      this.#menu.setPosition(
+        {
+          left: this.hot?.isLtr() ? rect.left - 5 : rect.left - 31,
+          top: rect.top - 1,
+          width: rect.width,
+          height: rect.height,
+        },
+        () => (el.isConnected ? el.getBoundingClientRect() : null),
+      );
       this.#menu?.getNavigator()?.toFirstItem();
       this.#menu?.getKeyboardShortcutsCtrl()?.addCustomShortcuts([{
         keys: [['Tab'], ['Shift', 'Tab']],

--- a/tests/e2e/menu-scroll.spec.ts
+++ b/tests/e2e/menu-scroll.spec.ts
@@ -1,0 +1,193 @@
+import { test, expect } from '../fixtures/test';
+import { MenuScrollPage } from '../fixtures/pages/MenuScrollPage';
+
+/**
+ * Issue #12719 (v2 — follow behavior): menus portal to document.body with
+ * once-at-open positioning. When an element OUTSIDE the menu scrolls, the menu
+ * must FOLLOW its anchor (header button / cell / parent item). It closes only
+ * when the anchor scrolls out of the rendered grid viewport. Page scroll and
+ * menu-internal scrolls change nothing.
+ */
+test.describe('menu follows its anchor on outside element scroll', () => {
+  let menuPage: MenuScrollPage;
+
+  test.beforeEach(async ({ page, theme }) => {
+    menuPage = new MenuScrollPage(page, theme);
+    await menuPage.goto();
+  });
+
+  test('dropdown menu follows its header button when an ancestor container is scrolled', async () => {
+    await menuPage.openDropdownMenu(0);
+    const buttonBefore = await menuPage.boundingBox(menuPage.headerButton(0));
+    const menuBefore = await menuPage.boundingBox(menuPage.dropdownMenu);
+
+    await menuPage.scrollContainerBy(100);
+    await menuPage.settleFrames();
+
+    await expect(menuPage.dropdownMenu).toBeVisible();
+    const buttonAfter = await menuPage.boundingBox(menuPage.headerButton(0));
+    const menuAfter = await menuPage.boundingBox(menuPage.dropdownMenu);
+
+    // The menu keeps the same offset to its anchor (allow 1px rounding).
+    expect(Math.abs((menuAfter.y - buttonAfter.y) - (menuBefore.y - buttonBefore.y))).toBeLessThanOrEqual(1);
+    expect(Math.abs((menuAfter.x - buttonAfter.x) - (menuBefore.x - buttonBefore.x))).toBeLessThanOrEqual(1);
+    // And it actually moved with the content.
+    expect(Math.abs((menuBefore.y - menuAfter.y) - 100)).toBeLessThanOrEqual(1);
+  });
+
+  test('context menu follows its cell when an ancestor container is scrolled', async () => {
+    await menuPage.openContextMenu(1, 1);
+    const cellBefore = await menuPage.boundingBox(menuPage.cell(1, 1));
+    const menuBefore = await menuPage.boundingBox(menuPage.contextMenu);
+
+    await menuPage.scrollContainerBy(80);
+    await menuPage.settleFrames();
+
+    await expect(menuPage.contextMenu).toBeVisible();
+    const cellAfter = await menuPage.boundingBox(menuPage.cell(1, 1));
+    const menuAfter = await menuPage.boundingBox(menuPage.contextMenu);
+
+    expect(Math.abs((menuAfter.y - cellAfter.y) - (menuBefore.y - cellBefore.y))).toBeLessThanOrEqual(1);
+    expect(Math.abs((menuAfter.x - cellAfter.x) - (menuBefore.x - cellBefore.x))).toBeLessThanOrEqual(1);
+  });
+
+  test('submenu follows together with its parent menu on container scroll', async () => {
+    await menuPage.openContextMenu(1, 1);
+    await menuPage.openAlignmentSubmenu();
+    const parentBefore = await menuPage.boundingBox(menuPage.contextMenu);
+    const subBefore = await menuPage.boundingBox(menuPage.submenu);
+
+    await menuPage.scrollContainerBy(60);
+    await menuPage.settleFrames();
+
+    await expect(menuPage.contextMenu).toBeVisible();
+    await expect(menuPage.submenu).toBeVisible();
+    const parentAfter = await menuPage.boundingBox(menuPage.contextMenu);
+    const subAfter = await menuPage.boundingBox(menuPage.submenu);
+
+    expect(Math.abs((subAfter.y - parentAfter.y) - (subBefore.y - parentBefore.y))).toBeLessThanOrEqual(1);
+    expect(Math.abs((parentBefore.y - parentAfter.y) - 60)).toBeLessThanOrEqual(1);
+  });
+
+  test('dropdown menu follows its column when the grid itself is scrolled horizontally', async () => {
+    await menuPage.openDropdownMenu(1);
+    const menuBefore = await menuPage.boundingBox(menuPage.dropdownMenu);
+
+    await menuPage.scrollGridHorizontallyBy(60);
+    await menuPage.settleFrames();
+
+    await expect(menuPage.dropdownMenu).toBeVisible();
+    const buttonAfter = await menuPage.boundingBox(menuPage.headerButton(1));
+    const menuAfter = await menuPage.boundingBox(menuPage.dropdownMenu);
+
+    // Menu moved left together with the column.
+    expect(Math.abs((menuBefore.x - menuAfter.x) - 60)).toBeLessThanOrEqual(1);
+    // Still attached to the (moved) button.
+    expect(menuAfter.x).toBeGreaterThanOrEqual(buttonAfter.x - menuBefore.width);
+  });
+
+  test('dropdown menu closes when its column is scrolled out of the grid viewport', async () => {
+    await menuPage.openDropdownMenu(0);
+    await menuPage.scrollGridHorizontallyBy(2000);
+    await expect(menuPage.dropdownMenu).toBeHidden();
+  });
+
+  test('dropdown menu does NOT move on vertical grid scroll (sticky header)', async () => {
+    await menuPage.openDropdownMenu(0);
+    const menuBefore = await menuPage.boundingBox(menuPage.dropdownMenu);
+
+    await menuPage.scrollGridVerticallyBy(60);
+    await menuPage.settleFrames();
+
+    await expect(menuPage.dropdownMenu).toBeVisible();
+    const menuAfter = await menuPage.boundingBox(menuPage.dropdownMenu);
+
+    expect(Math.abs(menuAfter.y - menuBefore.y)).toBeLessThanOrEqual(1);
+    expect(Math.abs(menuAfter.x - menuBefore.x)).toBeLessThanOrEqual(1);
+  });
+
+  test('context menu follows its cell on vertical grid scroll and closes when the cell derenders', async () => {
+    await menuPage.openContextMenu(1, 1);
+    const menuBefore = await menuPage.boundingBox(menuPage.contextMenu);
+
+    await menuPage.scrollGridVerticallyBy(40);
+    await menuPage.settleFrames();
+
+    await expect(menuPage.contextMenu).toBeVisible();
+    const menuAfter = await menuPage.boundingBox(menuPage.contextMenu);
+    expect(Math.abs((menuBefore.y - menuAfter.y) - 40)).toBeLessThanOrEqual(1);
+
+    await menuPage.scrollGridVerticallyBy(2000);
+    await expect(menuPage.contextMenu).toBeHidden();
+  });
+
+  test('scrolling the filter value list inside the menu changes nothing', async () => {
+    await menuPage.openDropdownMenu(0);
+    const menuBefore = await menuPage.boundingBox(menuPage.dropdownMenu);
+
+    await menuPage.scrollFilterValueListBy(40);
+    await menuPage.settleFrames();
+
+    await expect(menuPage.dropdownMenu).toBeVisible();
+    const menuAfter = await menuPage.boundingBox(menuPage.dropdownMenu);
+    expect(menuAfter.y).toBe(menuBefore.y);
+    expect(menuAfter.x).toBe(menuBefore.x);
+  });
+
+  test('page scroll keeps the menu open and correctly positioned', async () => {
+    await menuPage.openDropdownMenu(0);
+    const buttonBefore = await menuPage.boundingBox(menuPage.headerButton(0));
+    const menuBefore = await menuPage.boundingBox(menuPage.dropdownMenu);
+
+    await menuPage.scrollPageBy(100);
+    await menuPage.settleFrames();
+
+    await expect(menuPage.dropdownMenu).toBeVisible();
+    const buttonAfter = await menuPage.boundingBox(menuPage.headerButton(0));
+    const menuAfter = await menuPage.boundingBox(menuPage.dropdownMenu);
+
+    expect(Math.abs((menuAfter.y - buttonAfter.y) - (menuBefore.y - buttonBefore.y))).toBeLessThanOrEqual(1);
+  });
+
+  test('keyboard-opened context menu lands attached to its cell after the open-time viewport scroll', async () => {
+    await menuPage.cell(2, 1).click();
+    await menuPage.scrollGridVerticallyBy(30);
+    await menuPage.settleFrames();
+    await menuPage.page.keyboard.press('Shift+F10');
+
+    await expect(menuPage.contextMenu).toBeVisible();
+    await menuPage.settleFrames();
+    await expect(menuPage.contextMenu).toBeVisible();
+
+    const cellBox = await menuPage.boundingBox(menuPage.cell(2, 1));
+    const menuBox = await menuPage.boundingBox(menuPage.contextMenu);
+
+    // Menu top edge sits at/below the cell's top edge and within a cell-height of its bottom.
+    expect(menuBox.y).toBeGreaterThanOrEqual(cellBox.y - 1);
+    expect(menuBox.y).toBeLessThanOrEqual(cellBox.y + cellBox.height + 2);
+  });
+});
+
+test.describe('menu with uiContainer follows its container natively', () => {
+  let menuPage: MenuScrollPage;
+
+  test.beforeEach(async ({ page, theme }) => {
+    menuPage = new MenuScrollPage(page, theme);
+    await menuPage.goto({ uiContainer: true });
+  });
+
+  test('container scroll keeps the uiContainer menu attached (no double translation)', async () => {
+    await menuPage.openDropdownMenu(0);
+    const buttonBefore = await menuPage.boundingBox(menuPage.headerButton(0));
+    const menuBefore = await menuPage.boundingBox(menuPage.dropdownMenu);
+
+    await menuPage.scrollContainerBy(60);
+    await menuPage.settleFrames();
+
+    await expect(menuPage.dropdownMenu).toBeVisible();
+    const buttonAfter = await menuPage.boundingBox(menuPage.headerButton(0));
+    const menuAfter = await menuPage.boundingBox(menuPage.dropdownMenu);
+
+    expect(Math.abs((menuAfter.y - buttonAfter.y) - (menuBefore.y - buttonBefore.y))).toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/e2e/menu-scroll.spec.ts
+++ b/tests/e2e/menu-scroll.spec.ts
@@ -121,6 +121,44 @@ test.describe('menu follows its anchor on outside element scroll', () => {
     await expect(menuPage.contextMenu).toBeHidden();
   });
 
+  test('filter condition select menu stays open on vertical grid scroll (sticky header)', async () => {
+    await menuPage.openDropdownMenu(0);
+    await menuPage.openConditionSelectMenu();
+    const menuBefore = await menuPage.boundingBox(menuPage.conditionMenu);
+
+    await menuPage.scrollGridVerticallyBy(60);
+    await menuPage.settleFrames();
+
+    // The dropdown menu is anchored to the sticky header, so neither it nor the
+    // condition select menu moves — and neither may close.
+    await expect(menuPage.dropdownMenu).toBeVisible();
+    await expect(menuPage.conditionMenu).toBeVisible();
+    const menuAfter = await menuPage.boundingBox(menuPage.conditionMenu);
+
+    expect(Math.abs(menuAfter.y - menuBefore.y)).toBeLessThanOrEqual(1);
+    expect(Math.abs(menuAfter.x - menuBefore.x)).toBeLessThanOrEqual(1);
+  });
+
+  test('filter condition select menu follows its select element on container scroll', async () => {
+    await menuPage.openDropdownMenu(0);
+    await menuPage.openConditionSelectMenu();
+    const selectBefore = await menuPage.boundingBox(menuPage.conditionSelect());
+    const menuBefore = await menuPage.boundingBox(menuPage.conditionMenu);
+
+    await menuPage.scrollContainerBy(60);
+    await menuPage.settleFrames();
+
+    await expect(menuPage.conditionMenu).toBeVisible();
+    const selectAfter = await menuPage.boundingBox(menuPage.conditionSelect());
+    const menuAfter = await menuPage.boundingBox(menuPage.conditionMenu);
+
+    // The menu keeps the same offset to the select element (allow 1px rounding).
+    expect(Math.abs((menuAfter.y - selectAfter.y) - (menuBefore.y - selectBefore.y))).toBeLessThanOrEqual(1);
+    expect(Math.abs((menuAfter.x - selectAfter.x) - (menuBefore.x - selectBefore.x))).toBeLessThanOrEqual(1);
+    // And it actually moved with the content.
+    expect(Math.abs((menuBefore.y - menuAfter.y) - 60)).toBeLessThanOrEqual(1);
+  });
+
   test('scrolling the filter value list inside the menu changes nothing', async () => {
     await menuPage.openDropdownMenu(0);
     const menuBefore = await menuPage.boundingBox(menuPage.dropdownMenu);

--- a/tests/e2e/menu-scroll.spec.ts
+++ b/tests/e2e/menu-scroll.spec.ts
@@ -159,6 +159,35 @@ test.describe('menu follows its anchor on outside element scroll', () => {
     expect(Math.abs((menuBefore.y - menuAfter.y) - 60)).toBeLessThanOrEqual(1);
   });
 
+  test('filter condition select menu follows after the dropdown menu is reinitialized', async () => {
+    // First open builds the long-lived condition select menu; `updateSettings` then
+    // recreates the dropdown `Menu`. With construction-time scroll listeners the
+    // condition menu's listener would fire first and measure its anchor BEFORE the
+    // dropdown menu moved it (zero correction, menu stranded). Scroll listeners are
+    // registered per-open, so the dropdown menu (opened first) always repositions
+    // before the condition menu measures.
+    await menuPage.openDropdownMenu(0);
+    await menuPage.reinitializeDropdownMenu();
+
+    await menuPage.openDropdownMenu(0);
+    await menuPage.openConditionSelectMenu();
+    const selectBefore = await menuPage.boundingBox(menuPage.conditionSelect());
+    const menuBefore = await menuPage.boundingBox(menuPage.conditionMenu);
+
+    await menuPage.scrollContainerBy(60);
+    await menuPage.settleFrames();
+
+    await expect(menuPage.conditionMenu).toBeVisible();
+    const selectAfter = await menuPage.boundingBox(menuPage.conditionSelect());
+    const menuAfter = await menuPage.boundingBox(menuPage.conditionMenu);
+
+    // The menu keeps the same offset to the select element (allow 1px rounding).
+    expect(Math.abs((menuAfter.y - selectAfter.y) - (menuBefore.y - selectBefore.y))).toBeLessThanOrEqual(1);
+    expect(Math.abs((menuAfter.x - selectAfter.x) - (menuBefore.x - selectBefore.x))).toBeLessThanOrEqual(1);
+    // And it actually moved with the content.
+    expect(Math.abs((menuBefore.y - menuAfter.y) - 60)).toBeLessThanOrEqual(1);
+  });
+
   test('scrolling the filter value list inside the menu changes nothing', async () => {
     await menuPage.openDropdownMenu(0);
     const menuBefore = await menuPage.boundingBox(menuPage.dropdownMenu);

--- a/tests/fixtures/demo/menu-scroll.html
+++ b/tests/fixtures/demo/menu-scroll.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable menu-scroll e2e fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Active theme from the ?theme= query param, mapped through a fixed allowlist
+    // to a LITERAL (default main) — same sanitization as grid.html, no XSS.
+    window.htTheme = ({ horizon: 'horizon', classic: 'classic' })[new URLSearchParams(location.search).get('theme')] || 'main';
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+  </script>
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+    #scroll-container { height: 320px; overflow: auto; border: 1px solid #ccc; }
+    .spacer-top { height: 80px; }
+    .spacer-bottom { height: 800px; }
+    .page-spacer { height: 1500px; }
+  </style>
+</head>
+<body>
+  <!--
+    Reproduction layout for #12719: the grid sits inside a scrollable (overflow: auto)
+    container. Menus portal to document.body and follow the anchor cell when this
+    container scrolls; they close only when the anchor scrolls out of the rendered
+    viewport. The page spacer below makes the WINDOW scrollable too, testing whether
+    viewport scroll also triggers the follow-anchor behavior.
+  -->
+  <div id="scroll-container" data-testid="scroll-container">
+    <div class="spacer-top"></div>
+    <div id="grid" data-testid="grid"></div>
+    <div class="spacer-bottom"></div>
+  </div>
+  <div class="page-spacer"></div>
+
+  <script src="/handsontable/dist/handsontable.full.min.js"></script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const testIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    };
+
+    // `?uicontainer=1` renders the menus inside the scrollable container instead of the
+    // default body portal. Both cases follow the anchor; this flag only changes HOW
+    // the menu follows (natively with its container vs. repositioned by JS).
+    // Sanitized boolean check, same spirit as the theme allowlist above - no XSS.
+    const useUiContainer = new URLSearchParams(location.search).get('uicontainer') === '1';
+    const scrollContainer = document.getElementById('scroll-container');
+
+    // Wide + tall enough that the grid has BOTH of its own scrollbars, so the
+    // "grid's own wtHolder scroll closes the menu" cases are reachable.
+    window.hot = new Handsontable(container, {
+      data: Handsontable.helper.createSpreadsheetData(30, 30),
+      colHeaders: true,
+      rowHeaders: true,
+      dropdownMenu: useUiContainer ? { uiContainer: scrollContainer } : true,
+      filters: true,
+      contextMenu: useUiContainer ? { uiContainer: scrollContainer } : true,
+      colWidths: 120,
+      width: 600,
+      height: 200,
+      renderer: testIdRenderer,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/MenuScrollPage.ts
+++ b/tests/fixtures/pages/MenuScrollPage.ts
@@ -13,6 +13,7 @@ export class MenuScrollPage {
   readonly dropdownMenu: Locator;
   readonly contextMenu: Locator;
   readonly submenu: Locator;
+  readonly conditionMenu: Locator;
 
   constructor(page: Page, theme = 'main') {
     this.page = page;
@@ -23,6 +24,10 @@ export class MenuScrollPage {
     this.contextMenu = page.locator('.htContextMenu.handsontable:not([class*="Sub_"])');
     // Any submenu container regardless of parent menu kind.
     this.submenu = page.locator('.htMenu[class*="Sub_"]');
+    // The standalone menu opened by the "filter by condition" select. The component
+    // builds one (closed, empty) container per condition select — `[role="menu"]`
+    // narrows the match to the opened one.
+    this.conditionMenu = page.locator('.htFiltersConditionsMenu[role="menu"]');
   }
 
   /**
@@ -55,6 +60,17 @@ export class MenuScrollPage {
       .locator('.changeType')
       .click();
     await expect(this.dropdownMenu).toBeVisible();
+  }
+
+  /** The "filter by condition" select element inside the open dropdown menu. */
+  conditionSelect(): Locator {
+    return this.dropdownMenu.locator('.htUISelect').first();
+  }
+
+  /** Open the "filter by condition" select menu inside the open dropdown menu. */
+  async openConditionSelectMenu(): Promise<void> {
+    await this.conditionSelect().click();
+    await expect(this.conditionMenu).toBeVisible();
   }
 
   /** Open the context menu by right-clicking a cell. */

--- a/tests/fixtures/pages/MenuScrollPage.ts
+++ b/tests/fixtures/pages/MenuScrollPage.ts
@@ -73,6 +73,20 @@ export class MenuScrollPage {
     await expect(this.conditionMenu).toBeVisible();
   }
 
+  /**
+   * Recreate the dropdown menu plugin's `Menu` instance via `updateSettings`. The new
+   * instance is constructed AFTER any long-lived menu created earlier (e.g. the filters
+   * condition select menu) — the reordering that stranded the condition menu when
+   * scroll listeners were registered at construction time.
+   */
+  async reinitializeDropdownMenu(): Promise<void> {
+    await this.page.evaluate(() => {
+      const { hot } = window as Window & { hot: { updateSettings(settings: Record<string, unknown>): void } };
+
+      hot.updateSettings({ dropdownMenu: true });
+    });
+  }
+
   /** Open the context menu by right-clicking a cell. */
   async openContextMenu(row: number, col: number): Promise<void> {
     await this.cell(row, col).click({ button: 'right' });

--- a/tests/fixtures/pages/MenuScrollPage.ts
+++ b/tests/fixtures/pages/MenuScrollPage.ts
@@ -1,0 +1,139 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the menu-scroll fixture (issue #12719). Encapsulates opening
+ * the dropdown/context menus and performing element scrolls (container, grid
+ * holder, filter value list) and page scrolls. Waits are web-first assertions.
+ */
+export class MenuScrollPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly grid: Locator;
+  readonly scrollContainer: Locator;
+  readonly dropdownMenu: Locator;
+  readonly contextMenu: Locator;
+  readonly submenu: Locator;
+
+  constructor(page: Page, theme = 'main') {
+    this.page = page;
+    this.theme = theme;
+    this.grid = page.getByTestId('grid');
+    this.scrollContainer = page.getByTestId('scroll-container');
+    this.dropdownMenu = page.locator('.htDropdownMenu.handsontable:not([class*="Sub_"])');
+    this.contextMenu = page.locator('.htContextMenu.handsontable:not([class*="Sub_"])');
+    // Any submenu container regardless of parent menu kind.
+    this.submenu = page.locator('.htMenu[class*="Sub_"]');
+  }
+
+  /**
+   * Navigate to the fixture page.
+   *
+   * @param {object} [options] Navigation options.
+   * @param {boolean} [options.uiContainer] When `true`, renders the dropdown/context menus
+   * inside the scrollable container (the `uiContainer` workaround) instead of the default
+   * body portal.
+   */
+  async goto(options: { uiContainer?: boolean } = {}): Promise<void> {
+    const { uiContainer = false } = options;
+    const uiContainerParam = uiContainer ? '&uicontainer=1' : '';
+
+    await this.page.goto(`/tests/fixtures/demo/menu-scroll.html?theme=${this.theme}${uiContainerParam}`);
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /** A single data cell, by visual row/column, via its stable test id. */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /** Open the column dropdown menu by clicking the header button of `col`. */
+  async openDropdownMenu(col: number): Promise<void> {
+    // +1 skips the row-header corner TH.
+    await this.grid
+      .locator('.ht_clone_top thead th')
+      .nth(col + 1)
+      .locator('.changeType')
+      .click();
+    await expect(this.dropdownMenu).toBeVisible();
+  }
+
+  /** Open the context menu by right-clicking a cell. */
+  async openContextMenu(row: number, col: number): Promise<void> {
+    await this.cell(row, col).click({ button: 'right' });
+    await expect(this.contextMenu).toBeVisible();
+  }
+
+  /** Hover the "Alignment" item of the open context menu until its submenu shows. */
+  async openAlignmentSubmenu(): Promise<void> {
+    await this.contextMenu.getByText('Alignment', { exact: true }).hover();
+    await expect(this.submenu).toBeVisible();
+  }
+
+  /** Scroll the outer overflow:auto container (element scroll outside the menu). */
+  async scrollContainerBy(px: number): Promise<void> {
+    await this.scrollContainer.evaluate((el, delta) => {
+      el.scrollTop += delta;
+    }, px);
+  }
+
+  /** Scroll the grid's own viewport horizontally (the customer-reported case). */
+  async scrollGridHorizontallyBy(px: number): Promise<void> {
+    await this.grid.locator('.ht_master .wtHolder').evaluate((el, delta) => {
+      el.scrollLeft += delta;
+    }, px);
+  }
+
+  /** Scroll the grid's own viewport vertically. */
+  async scrollGridVerticallyBy(px: number): Promise<void> {
+    await this.grid.locator('.ht_master .wtHolder').evaluate((el, delta) => {
+      el.scrollTop += delta;
+    }, px);
+  }
+
+  /** Scroll the "filter by value" list INSIDE the open dropdown menu. */
+  async scrollFilterValueListBy(px: number): Promise<void> {
+    await this.dropdownMenu
+      .locator('.htUIMultipleSelectHot .ht_master .wtHolder')
+      .evaluate((el, delta) => {
+        el.scrollTop += delta;
+      }, px);
+  }
+
+  /** Scroll the window/page itself (must NOT close the menu). */
+  async scrollPageBy(px: number): Promise<void> {
+    await this.page.evaluate((delta) => {
+      window.scrollBy(0, delta);
+    }, px);
+  }
+
+  /**
+   * Let two rendering updates pass so any pending element `scroll` events have
+   * fired and been handled. Deterministic (rAF-based) — not a timeout.
+   */
+  async settleFrames(): Promise<void> {
+    await this.page.evaluate(
+      () => new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+    );
+  }
+
+  /** The dropdown button of column `col`'s header (row-header TH is index 0). */
+  headerButton(col: number): Locator {
+    return this.grid
+      .locator('.ht_clone_top thead th')
+      .nth(col + 1)
+      .locator('.changeType');
+  }
+
+  /** Bounding box of a locator, failing loudly instead of returning null. */
+  async boundingBox(locator: Locator): Promise<{ x: number; y: number; width: number; height: number }> {
+    const box = await locator.boundingBox();
+
+    if (!box) {
+      throw new Error('Expected element to have a bounding box (is it visible?)');
+    }
+
+    return box;
+  }
+}


### PR DESCRIPTION
### Context

The PR fixes menus (ContextMenu, DropdownMenu, Filters, and their submenus) staying stranded at their open-time screen position when an element outside the menu is scrolled. Menus render in a body-level portal positioned once at open time in document coordinates, so scrolling an ancestor `overflow: auto` container or the grid's own viewport left the menu detached from its column/cell, painted over unrelated UI (reported over fixed app headers/footers, and as the dropdown "following" the grid's horizontal scroll instead of staying with its column).

With this change, each plugin passes an anchor-rect provider (`() => DOMRect | null`) to the shared `Menu` class. A capture-phase document `scroll` listener re-derives the menu position from the anchor's fresh rectangle plus the offset captured at open. The reposition is self-correcting (computed from measured rects, applied as an increment to the inline styles), so it is correct in any containing block — a custom `uiContainer` needs no special case. The menu closes only when its anchor scrolls out of the rendered viewport (the provider returns `null` once the cell derenders). Page scroll and scrolls inside the menu (e.g. the Filters value list) behave as before.

Two implementation notes for reviewers:

- Repositioning the menu under a stationary pointer makes browsers recompute `:hover` and fire synthetic `mouseover` events, which would destroy open submenus through the hover→open-submenu path. A frame-armed, cancelable guard (`#suppressHoverSubMenuToggle`) suppresses hover-driven submenu toggling around repositions; the dropped-hover trade-off is documented in code. Verified on Chromium and on Playwright's bundled headless Firefox/WebKit (real-device verification not performed in this environment).
- The API delta is strictly additive: an optional trailing `anchorRectProvider` parameter on `ContextMenu#open`, `DropdownMenu#open`, and `Menu#setPosition`, plus the exported `MenuAnchorRectProvider` type (re-exported through the plugin barrels). No defaults changed, no options added, no breaking changes.

Known accepted gaps: the touch/mobile hover-submenu path has no test coverage (pre-existing), and the hidden-nested-placeholder keyboard-open scroll-follow scenario is untested (it degrades to closing on the first outside scroll; the intent is pinned by a code comment at the DropdownMenu keyboard site).

### How has this been tested?

- New Playwright E2E: `tests/e2e/menu-scroll.spec.ts` (11 tests × 3 theme projects) with a dedicated fixture (`tests/fixtures/demo/menu-scroll.html`) and page object. The tests pin the follow contract with ≤1px offset-delta assertions: container scroll (dropdown/context/submenu), grid horizontal/vertical scroll, derender-close on both axes, sticky-header no-move, Filters value-list scroll, page scroll, keyboard open, and `uiContainer` (no double translation). Run: `cd tests && npx playwright test menu-scroll`
- Legacy Jasmine E2E suites green: contextMenu (593), dropdownMenu (195), filters (283); expectations that asserted the stranded behavior were updated with `#12719` comments. Run: `npm run test:e2e --prefix handsontable -- --testPathPattern=contextMenu`
- Unit suite green (3266 tests), `test:types` clean, ESLint/Stylelint clean.
- Manual A/B verification of a demo page (scrollable flex container between fixed header/footer) comparing v18.0.0 (stranded) against this build (follows), including the customer's horizontal-scroll case.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #12719
2. HOT-15499

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/HOT-15499

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared menu positioning, document scroll handling, and submenu hover behavior across context menu, dropdown, and filters; API is additive but scroll-follow changes visible UX.
> 
> **Overview**
> Fixes **#12719**: context menus, dropdown menus, filter condition selects, and submenus no longer stay fixed at their open-time screen position when a scrollable ancestor or the grid viewport moves.
> 
> The shared **`Menu`** class now accepts an optional **`MenuAnchorRectProvider`** on **`setPosition`**. While open, capture-phase document **`scroll`** listeners re-apply the offset captured at open using measured rects (works for body portals and custom **`uiContainer`**). The menu **closes** when the provider returns **`null`** (anchor derendered). Scroll listeners register **per open** so nested menus (e.g. filters inside dropdown after **`updateSettings`**) reposition in open order.
> 
> **Context menu**, **dropdown menu**, and **filters** **`select`** wire providers from the right-clicked cell, header button (dropdown anchor coords fixed for hidden nested placeholders), keyboard shortcut, or select element. Repositioning arms a short **hover-submenu suppression** guard to avoid spurious **`mouseover`** toggling submenus.
> 
> Adds optional third param on **`ContextMenu#open`** / **`DropdownMenu#open`**, exports **`MenuAnchorRectProvider`**, changelog **12719**, updated Jasmine expectations, and Playwright **`menu-scroll`** E2E coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a871f8f3c38d23cc5fe19e34a6e80296f96d18bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->