### PR TITLE
DEV-1161: Add preserveNumericLiteral option to keep numeric editor input

### DIFF
--- a/.changelogs/13170.json
+++ b/.changelogs/13170.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added the `preserveNumericLiteral` option to the numeric cell type, which keeps the exact value you type in the cell editor (preserving trailing decimal zeros and large-number precision).",
+  "type": "added",
+  "issueOrPR": 13170,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -405,7 +405,9 @@ you edit a numeric cell:
   zero such as `9.0`, or a value whose magnitude exceeds the safe-integer limit
   (`9007199254740991`) -- Handsontable keeps the literal you typed, so the editor shows it exactly.
   Values that convert without loss (such as `9.5`) are still stored as numbers, so sorting,
-  filtering, and formulas are unaffected. This option is `false` by default.
+  filtering, and formulas are unaffected. A preserved literal still behaves like a number in those
+  features: sorting and filter conditions compare it numerically, and the formulas engine parses it
+  as a number, so functions such as `SUM` still include the cell. This option is `false` by default.
 
 ## Validate numbers
 

--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -407,7 +407,9 @@ you edit a numeric cell:
   Values that convert without loss (such as `9.5`) are still stored as numbers, so sorting,
   filtering, and formulas are unaffected. A preserved literal still behaves like a number in those
   features: sorting and filter conditions compare it numerically, and the formulas engine parses it
-  as a number, so functions such as `SUM` still include the cell. This option is `false` by default.
+  as a number, so functions such as `SUM` still include the cell. One exception: the filter menu's
+  "Filter by value" checkbox list compares values strictly, so a preserved literal (`9.0`) and its
+  plain number (`9`) appear as two separate entries. This option is `false` by default.
 
 ## Validate numbers
 

--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -398,6 +398,14 @@ you edit a numeric cell:
   these as `7000` and `7000.25` respectively. For other locales, the thousands separator is added
   automatically after editing, based on your [`numericFormat`](@/api/options.md#numericformat)
   configuration.
+- By default, entering `9.0` stores the number `9`, so the editor shows `9` the next time you open
+  it, and very large numbers lose precision. To keep the exact text you typed, set the
+  [`preserveNumericLiteral`](@/api/options.md#preservenumericliteral) option to `true`. Then, only
+  when converting your entry to a JavaScript number would lose information -- a trailing decimal
+  zero such as `9.0`, or a value whose magnitude exceeds the safe-integer limit
+  (`9007199254740991`) -- Handsontable keeps the literal you typed, so the editor shows it exactly.
+  Values that convert without loss (such as `9.5`) are still stored as numbers, so sorting,
+  filtering, and formulas are unaffected. This option is `false` by default.
 
 ## Validate numbers
 

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -187,6 +187,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   nestedRows: true,
   noWordWrapClassName: 'foo',
   numericFormat: numericIntlFormatOptions,
+  preserveNumericLiteral: true,
   observeDOMVisibility: true,
   outsideClickDeselects: oneOf(true, (target: HTMLElement) => false),
   pagination: oneOf(true, {

--- a/handsontable/src/cellTypes/numericType/__tests__/numericType.unit.ts
+++ b/handsontable/src/cellTypes/numericType/__tests__/numericType.unit.ts
@@ -172,6 +172,29 @@ describe('NumericCellType', () => {
       expect(valueSetter('1e-7', 0, 0, on)).toBe(1e-7);
     });
 
+    it('should not throw and not preserve input with an exponent far beyond the double range', () => {
+      const on = { preserveNumericLiteral: true };
+
+      expect(() => valueSetter('1e999999999', 0, 0, on)).not.toThrow();
+      expect(valueSetter('1e999999999', 0, 0, on)).toBe(Infinity);
+      expect(valueSetter('1e-999999999', 0, 0, on)).toBe(0);
+    });
+
+    it('should not preserve literals that overflow or underflow the finite double range', () => {
+      const on = { preserveNumericLiteral: true };
+
+      expect(valueSetter('1e400', 0, 0, on)).toBe(Infinity);
+      expect(valueSetter('-1e400', 0, 0, on)).toBe(-Infinity);
+      expect(valueSetter('1e-400', 0, 0, on)).toBe(0);
+    });
+
+    it('should store `-0` as the number `-0`, not as a preserved string', () => {
+      // `toBe` uses `Object.is`, so this asserts the negative zero exactly.
+      expect(valueSetter('-0', 0, 0, { preserveNumericLiteral: true })).toBe(-0);
+      // A trailing fractional zero on a negative zero is still preserved.
+      expect(valueSetter('-0.0', 0, 0, { preserveNumericLiteral: true })).toBe('-0.0');
+    });
+
     it('should treat hexadecimal input the same with and without the option (never preserved)', () => {
       // `parseFloat('0x1A')` stops at the `x`, so hex has always parsed to `0` here — the
       // option must not change that, and must not keep the raw hex string either.

--- a/handsontable/src/cellTypes/numericType/__tests__/numericType.unit.ts
+++ b/handsontable/src/cellTypes/numericType/__tests__/numericType.unit.ts
@@ -162,5 +162,21 @@ describe('NumericCellType', () => {
       expect(valueSetter('1,000', 0, 0, { ...on, locale: 'en-US' })).toBe(1000);
       expect(valueSetter('7.000', 0, 0, { ...on, locale: 'de-DE' })).toBe(7000);
     });
+
+    it('should not preserve scientific-notation input that parses without loss', () => {
+      const on = { preserveNumericLiteral: true };
+
+      expect(valueSetter('1e2', 0, 0, on)).toBe(100);
+      expect(valueSetter('1.5e3', 0, 0, on)).toBe(1500);
+      expect(valueSetter('0.0000001', 0, 0, on)).toBe(1e-7);
+      expect(valueSetter('1e-7', 0, 0, on)).toBe(1e-7);
+    });
+
+    it('should treat hexadecimal input the same with and without the option (never preserved)', () => {
+      // `parseFloat('0x1A')` stops at the `x`, so hex has always parsed to `0` here — the
+      // option must not change that, and must not keep the raw hex string either.
+      expect(valueSetter('0x1A', 0, 0, { preserveNumericLiteral: true })).toBe(0);
+      expect(valueSetter('0x1A', 0, 0, {})).toBe(0);
+    });
   });
 });

--- a/handsontable/src/cellTypes/numericType/__tests__/numericType.unit.ts
+++ b/handsontable/src/cellTypes/numericType/__tests__/numericType.unit.ts
@@ -188,6 +188,10 @@ describe('NumericCellType', () => {
       expect(valueSetter('1e-400', 0, 0, on)).toBe(0);
     });
 
+    it('should not preserve a very long leading-zero literal (leading zeros are cosmetic)', () => {
+      expect(valueSetter(`${'0'.repeat(1200)}5`, 0, 0, { preserveNumericLiteral: true })).toBe(5);
+    });
+
     it('should store `-0` as the number `-0`, not as a preserved string', () => {
       // `toBe` uses `Object.is`, so this asserts the negative zero exactly.
       expect(valueSetter('-0', 0, 0, { preserveNumericLiteral: true })).toBe(-0);

--- a/handsontable/src/cellTypes/numericType/__tests__/numericType.unit.ts
+++ b/handsontable/src/cellTypes/numericType/__tests__/numericType.unit.ts
@@ -105,5 +105,62 @@ describe('NumericCellType', () => {
       expect(valueSetter('0,100', 0, 0, meta)).toBe(0.1);
       expect(valueSetter('0,010', 0, 0, meta)).toBe(0.01);
     });
+
+    it('should return a number for lossless conversions regardless of the option', () => {
+      const on = { preserveNumericLiteral: true };
+
+      expect(valueSetter('9', 0, 0, on)).toBe(9);
+      expect(valueSetter('9.5', 0, 0, on)).toBe(9.5);
+      expect(valueSetter('1000', 0, 0, on)).toBe(1000);
+      expect(valueSetter('-123.456', 0, 0, on)).toBe(-123.456);
+      expect(valueSetter('09', 0, 0, on)).toBe(9);
+    });
+
+    it('should keep the old behavior (parse to number) by default, without the option', () => {
+      expect(valueSetter('9.0', 0, 0, {})).toBe(9);
+      expect(valueSetter('9.50', 0, 0, {})).toBe(9.5);
+      expect(valueSetter('12345678901234567.8', 0, 0, {})).toBe(12345678901234568);
+      expect(valueSetter('9.0', 0, 0, { preserveNumericLiteral: false })).toBe(9);
+    });
+
+    it('should preserve the original literal when a trailing fractional zero would be lost', () => {
+      const on = { preserveNumericLiteral: true };
+
+      expect(valueSetter('9.0', 0, 0, on)).toBe('9.0');
+      expect(valueSetter('9.50', 0, 0, on)).toBe('9.50');
+      expect(valueSetter('0.0', 0, 0, on)).toBe('0.0');
+      expect(valueSetter('1000.0', 0, 0, on)).toBe('1000.0');
+      expect(valueSetter('-9.0', 0, 0, on)).toBe('-9.0');
+    });
+
+    it('should preserve the original literal when precision beyond MAX_SAFE_INTEGER would be lost', () => {
+      const on = { preserveNumericLiteral: true };
+
+      expect(valueSetter('12345678901234567.8', 0, 0, on)).toBe('12345678901234567.8');
+      expect(valueSetter('9007199254740989.00', 0, 0, on)).toBe('9007199254740989.00');
+    });
+
+    it('should trim surrounding whitespace on a preserved literal', () => {
+      expect(valueSetter('  9.0  ', 0, 0, { preserveNumericLiteral: true })).toBe('9.0');
+    });
+
+    it('should be idempotent on a preserved literal', () => {
+      const on = { preserveNumericLiteral: true };
+      const preserved = valueSetter('9.0', 0, 0, on);
+
+      expect(valueSetter(preserved, 0, 0, on)).toBe('9.0');
+    });
+
+    it('should not preserve comma-bearing literals even with the option on (guard limited to dot-decimal)', () => {
+      expect(valueSetter('9,0', 0, 0, { locale: 'de-DE', preserveNumericLiteral: true })).toBe(9);
+      expect(valueSetter('0,100', 0, 0, { locale: 'en-US', preserveNumericLiteral: true })).toBe(0.1);
+    });
+
+    it('should not preserve when grouping removal changes the string (not information loss)', () => {
+      const on = { preserveNumericLiteral: true };
+
+      expect(valueSetter('1,000', 0, 0, { ...on, locale: 'en-US' })).toBe(1000);
+      expect(valueSetter('7.000', 0, 0, { ...on, locale: 'de-DE' })).toBe(7000);
+    });
   });
 });

--- a/handsontable/src/cellTypes/numericType/accessors/valueSetter.ts
+++ b/handsontable/src/cellTypes/numericType/accessors/valueSetter.ts
@@ -2,6 +2,8 @@ import {
   isCommaThousandsGroupedInteger,
   isDotThousandsGroupedInteger,
   isDotThousandsGroupedFloat,
+  isLossyNumericConversion,
+  isNumeric,
   isNumericLike,
   getParsedNumber,
 } from '../../../helpers/number';
@@ -67,18 +69,38 @@ export function valueSetter(newValue: unknown, _row: number, _column: number, ce
   }
 
   const decimalSeparator = getCellDecimalSeparator(cellMeta);
+  const isCommaGrouped = isCommaThousandsGroupedInteger(newValue, decimalSeparator);
+  const isDotGroupedInteger = isDotThousandsGroupedInteger(newValue, decimalSeparator);
+  const isDotGroupedFloat = isDotThousandsGroupedFloat(newValue, decimalSeparator);
 
-  if (
-    isNumericLike(newValue) ||
-    isCommaThousandsGroupedInteger(newValue, decimalSeparator) ||
-    isDotThousandsGroupedInteger(newValue, decimalSeparator) ||
-    isDotThousandsGroupedFloat(newValue, decimalSeparator)
-  ) {
+  if (isNumericLike(newValue) || isCommaGrouped || isDotGroupedInteger || isDotGroupedFloat) {
     const parsedNumber = getParsedNumber(newValue, {
       decimalSeparator,
     });
 
-    return isNullish(parsedNumber) ? newValue : parsedNumber;
+    if (isNullish(parsedNumber)) {
+      return newValue;
+    }
+
+    const isGrouped = isCommaGrouped || isDotGroupedInteger || isDotGroupedFloat;
+
+    // Opt-in: keep the original literal when parsing to a JS number would lose information
+    // (trailing fractional zeros like `9.0`, or precision beyond Number.MAX_SAFE_INTEGER). This
+    // preserves what the user typed in the editor, matching spreadsheet behavior. Gated behind
+    // `preserveNumericLiteral` (default `false`) so existing configurations are unchanged. The
+    // guard is limited to plain, dot-decimal literals (`isNumeric`): grouping removal
+    // (e.g. `7.000` → 7000) is intended, and preserving a comma-bearing literal (`9,0`, `0,100`)
+    // would break numeric rendering and validation, which do not accept a comma decimal separator.
+    if (
+      cellMeta.preserveNumericLiteral === true &&
+      !isGrouped &&
+      isNumeric(newValue) &&
+      isLossyNumericConversion(newValue, parsedNumber)
+    ) {
+      return newValue.trim();
+    }
+
+    return parsedNumber;
   }
 
   return newValue;

--- a/handsontable/src/cellTypes/numericType/accessors/valueSetter.ts
+++ b/handsontable/src/cellTypes/numericType/accessors/valueSetter.ts
@@ -87,6 +87,14 @@ export function valueSetter(newValue: unknown, _row: number, _column: number, ce
     // with `parseFloat`, which stops at the `x` — that mismatch is a parser artifact, not
     // information loss, so hex input must never be preserved.
     const isHexLiteral = /^[+-]?0x/i.test(newValue.trim());
+    // Literals outside the finite double range (`1e400` → `Infinity`) and non-zero literals that
+    // underflow to zero (`1e-400` → `0`) overflow the number's magnitude rather than losing
+    // trailing zeros or integer precision, so they are stored as the parsed number like any
+    // other input. The underflow check reads only mantissa digits — exponent digits must not
+    // make a genuine zero literal (`0.0e-5`) look non-zero.
+    const mantissaDigits = newValue.trim().replace(/e[+-]?\d+$/i, '');
+    const isMagnitudeOverflow = !Number.isFinite(parsedNumber) ||
+      (parsedNumber === 0 && /[1-9]/.test(mantissaDigits));
 
     // Opt-in: keep the original literal when parsing to a JS number would lose information
     // (trailing fractional zeros like `9.0`, or precision beyond Number.MAX_SAFE_INTEGER). This
@@ -99,6 +107,7 @@ export function valueSetter(newValue: unknown, _row: number, _column: number, ce
       cellMeta.preserveNumericLiteral === true &&
       !isGrouped &&
       !isHexLiteral &&
+      !isMagnitudeOverflow &&
       isNumeric(newValue) &&
       isLossyNumericConversion(newValue, parsedNumber)
     ) {

--- a/handsontable/src/cellTypes/numericType/accessors/valueSetter.ts
+++ b/handsontable/src/cellTypes/numericType/accessors/valueSetter.ts
@@ -83,6 +83,10 @@ export function valueSetter(newValue: unknown, _row: number, _column: number, ce
     }
 
     const isGrouped = isCommaGrouped || isDotGroupedInteger || isDotGroupedFloat;
+    // `isNumeric` also accepts hexadecimal literals (`0x1A`), but `getParsedNumber` reads them
+    // with `parseFloat`, which stops at the `x` — that mismatch is a parser artifact, not
+    // information loss, so hex input must never be preserved.
+    const isHexLiteral = /^[+-]?0x/i.test(newValue.trim());
 
     // Opt-in: keep the original literal when parsing to a JS number would lose information
     // (trailing fractional zeros like `9.0`, or precision beyond Number.MAX_SAFE_INTEGER). This
@@ -94,6 +98,7 @@ export function valueSetter(newValue: unknown, _row: number, _column: number, ce
     if (
       cellMeta.preserveNumericLiteral === true &&
       !isGrouped &&
+      !isHexLiteral &&
       isNumeric(newValue) &&
       isLossyNumericConversion(newValue, parsedNumber)
     ) {

--- a/handsontable/src/core/settings.ts
+++ b/handsontable/src/core/settings.ts
@@ -214,6 +214,7 @@ export interface GridSettings {
   locale?: string;
   language?: string;
   numericFormat?: object;
+  preserveNumericLiteral?: boolean;
   selectOptions?: string[] | number[] | object[] | Record<string, string>
     | ((visualRow: number, visualColumn: number, prop: string | number) => string[] | Record<string, string>);
   strict?: boolean;

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -4704,7 +4704,10 @@ export default (): Record<string, unknown> => {
      * string instead of the number. This preserves trailing decimal zeros (`9.0`, `9.50`) and the
      * full precision of large numbers in the cell editor, matching spreadsheet software. Values
      * that convert without loss (for example `9`, `9.5`, `1000`) are still stored as numbers, so
-     * sorting, filtering, and formula calculations are unaffected. The cell renderer still formats
+     * sorting, filtering, and formula calculations are unaffected. A preserved literal also keeps
+     * behaving like a number in those features: column sorting and filter conditions compare it
+     * numerically, and the [`Formulas`](@/api/formulas.md) engine parses the literal as a number,
+     * so functions such as `SUM` still include the cell. The cell renderer still formats
      * the value according to [`numericFormat`](@/api/options.md#numericformat); only the editor
      * shows the preserved literal.
      *

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -4709,7 +4709,9 @@ export default (): Record<string, unknown> => {
      * numerically, and the [`Formulas`](@/api/formulas.md) engine parses the literal as a number,
      * so functions such as `SUM` still include the cell. The cell renderer still formats
      * the value according to [`numericFormat`](@/api/options.md#numericformat); only the editor
-     * shows the preserved literal.
+     * shows the preserved literal. One exception: the filter menu's "Filter by value" checkbox
+     * list compares values strictly, so a preserved literal (`'9.0'`) and its plain number (`9`)
+     * appear as two separate entries.
      *
      * The default is `false` so existing configurations keep their current behavior.
      *

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -4692,6 +4692,44 @@ export default (): Record<string, unknown> => {
     numericFormat: undefined,
 
     /**
+     * Controls whether a [`numeric`](@/guides/cell-types/numeric-cell-type/numeric-cell-type.md)
+     * cell keeps the exact text you typed when converting it to a JavaScript number would lose
+     * information.
+     *
+     * By default (`false`), a numeric cell always stores the parsed JavaScript number, so a value
+     * like `9.0` is stored as `9` and the editor shows `9` the next time you open it. Numbers whose
+     * magnitude exceeds the safe-integer limit (`9007199254740991`) also lose precision.
+     *
+     * When set to `true`, and only when parsing would be lossy, the cell keeps the original literal
+     * string instead of the number. This preserves trailing decimal zeros (`9.0`, `9.50`) and the
+     * full precision of large numbers in the cell editor, matching spreadsheet software. Values
+     * that convert without loss (for example `9`, `9.5`, `1000`) are still stored as numbers, so
+     * sorting, filtering, and formula calculations are unaffected. The cell renderer still formats
+     * the value according to [`numericFormat`](@/api/options.md#numericformat); only the editor
+     * shows the preserved literal.
+     *
+     * The default is `false` so existing configurations keep their current behavior.
+     *
+     * @memberof Options#
+     * @since 18.1.0
+     * @type {boolean}
+     * @default false
+     * @category Core
+     *
+     * @example
+     * ```js
+     * columns: [
+     *   {
+     *     type: 'numeric',
+     *     // keep `9.0` and very large numbers as typed in the editor
+     *     preserveNumericLiteral: true,
+     *   }
+     * ],
+     * ```
+     */
+    preserveNumericLiteral: false,
+
+    /**
      * If the `observeDOMVisibility` option is set to `true`,
      * Handsontable rerenders every time it detects that the grid was made visible in the DOM.
      *

--- a/handsontable/src/helpers/__tests__/number.unit.ts
+++ b/handsontable/src/helpers/__tests__/number.unit.ts
@@ -10,6 +10,7 @@ import {
   clamp,
   isUnsignedNumber,
   getParsedNumber,
+  isLossyNumericConversion,
 } from 'handsontable/helpers/number';
 
 describe('Number helper', () => {
@@ -512,6 +513,45 @@ describe('Number helper', () => {
       expect(getParsedNumber('100,000', dotDecimal)).toBe(100000);
       expect(getParsedNumber('1,234,567', dotDecimal)).toBe(1234567);
       expect(getParsedNumber('-12,345', dotDecimal)).toBe(-12345);
+    });
+  });
+
+  //
+  // Handsontable.helper.isLossyNumericConversion
+  //
+  describe('isLossyNumericConversion', () => {
+    it('should return false when the string round-trips to its parsed number without loss', () => {
+      expect(isLossyNumericConversion('9', 9)).toBe(false);
+      expect(isLossyNumericConversion('9.5', 9.5)).toBe(false);
+      expect(isLossyNumericConversion('1000', 1000)).toBe(false);
+      expect(isLossyNumericConversion('-123.456', -123.456)).toBe(false);
+      expect(isLossyNumericConversion('0', 0)).toBe(false);
+    });
+
+    it('should return false when only leading zeros or a leading plus differ (cosmetic, not information)', () => {
+      expect(isLossyNumericConversion('09', 9)).toBe(false);
+      expect(isLossyNumericConversion('+9', 9)).toBe(false);
+      expect(isLossyNumericConversion('007', 7)).toBe(false);
+      expect(isLossyNumericConversion('.5', 0.5)).toBe(false);
+      expect(isLossyNumericConversion('5.', 5)).toBe(false);
+    });
+
+    it('should return true when trailing fractional zeros would be lost', () => {
+      expect(isLossyNumericConversion('9.0', 9)).toBe(true);
+      expect(isLossyNumericConversion('9.50', 9.5)).toBe(true);
+      expect(isLossyNumericConversion('0.0', 0)).toBe(true);
+      expect(isLossyNumericConversion('1000.0', 1000)).toBe(true);
+      expect(isLossyNumericConversion('-9.0', -9)).toBe(true);
+    });
+
+    it('should return true when precision beyond Number.MAX_SAFE_INTEGER would be lost', () => {
+      expect(isLossyNumericConversion('12345678901234567.8', 12345678901234568)).toBe(true);
+      expect(isLossyNumericConversion('9007199254740989.00', 9007199254740989)).toBe(true);
+    });
+
+    it('should handle whitespace-padded input by trimming before comparison', () => {
+      expect(isLossyNumericConversion('  9.0  ', 9)).toBe(true);
+      expect(isLossyNumericConversion('  9  ', 9)).toBe(false);
     });
   });
 });

--- a/handsontable/src/helpers/__tests__/number.unit.ts
+++ b/handsontable/src/helpers/__tests__/number.unit.ts
@@ -592,6 +592,15 @@ describe('Number helper', () => {
       expect(isLossyNumericConversion('1e-999999999', 0)).toBe(true);
     });
 
+    it('should still normalize very long leading-zero literals (only the exponent is bounded)', () => {
+      // A 1200-digit leading-zero integer needs no expansion at all — it must keep
+      // normalizing to `5` instead of tripping the exponent bound and reading as lossy.
+      expect(isLossyNumericConversion(`${'0'.repeat(1200)}5`, 5)).toBe(false);
+      expect(isLossyNumericConversion(`${'0'.repeat(1200)}5.0`, 5)).toBe(true);
+      // An in-range exponent on a long literal still expands correctly.
+      expect(isLossyNumericConversion(`${'0'.repeat(1200)}5e1`, 50)).toBe(false);
+    });
+
     it('should not treat mantissa trailing zeros shifted onto integer positions as loss', () => {
       // 1.0e2 === 100 and 1.10e2 === 110 exactly: the mantissa zero becomes an integer
       // digit of the parsed value, so no typed digit disappears — same class as `1e2`.

--- a/handsontable/src/helpers/__tests__/number.unit.ts
+++ b/handsontable/src/helpers/__tests__/number.unit.ts
@@ -574,6 +574,24 @@ describe('Number helper', () => {
       expect(isLossyNumericConversion('1.10e1', 11)).toBe(true);
     });
 
+    it('should not treat a plain `-0` as loss (the parsed number keeps the sign)', () => {
+      expect(isLossyNumericConversion('-0', -0)).toBe(false);
+      expect(isLossyNumericConversion('-0e0', -0)).toBe(false);
+      // The trailing fractional zero is still real information loss.
+      expect(isLossyNumericConversion('-0.0', -0)).toBe(true);
+    });
+
+    it('should not throw on exponents far beyond the finite double range', () => {
+      // Without the `pointIndex` bound these threw `RangeError: Invalid string length`
+      // in `padEnd`/`repeat` while expanding the decimal form.
+      expect(() => isLossyNumericConversion('1e999999999', Infinity)).not.toThrow();
+      expect(() => isLossyNumericConversion('1e-999999999', 0)).not.toThrow();
+      expect(() => isLossyNumericConversion('1e100000000', Infinity)).not.toThrow();
+
+      expect(isLossyNumericConversion('1e999999999', Infinity)).toBe(true);
+      expect(isLossyNumericConversion('1e-999999999', 0)).toBe(true);
+    });
+
     it('should not treat mantissa trailing zeros shifted onto integer positions as loss', () => {
       // 1.0e2 === 100 and 1.10e2 === 110 exactly: the mantissa zero becomes an integer
       // digit of the parsed value, so no typed digit disappears — same class as `1e2`.

--- a/handsontable/src/helpers/__tests__/number.unit.ts
+++ b/handsontable/src/helpers/__tests__/number.unit.ts
@@ -553,5 +553,23 @@ describe('Number helper', () => {
       expect(isLossyNumericConversion('  9.0  ', 9)).toBe(true);
       expect(isLossyNumericConversion('  9  ', 9)).toBe(false);
     });
+
+    it('should return false when only scientific notation differs on either side (not information loss)', () => {
+      // `String(parsedNumber)` uses scientific notation for these exact values.
+      expect(isLossyNumericConversion('0.0000001', 1e-7)).toBe(false);
+      expect(isLossyNumericConversion('0.000000015', 1.5e-8)).toBe(false);
+      expect(isLossyNumericConversion('-0.0000001', -1e-7)).toBe(false);
+
+      // Scientific notation in the input parses to the same exact value.
+      expect(isLossyNumericConversion('1e2', 100)).toBe(false);
+      expect(isLossyNumericConversion('1.5e3', 1500)).toBe(false);
+      expect(isLossyNumericConversion('1e-7', 1e-7)).toBe(false);
+      expect(isLossyNumericConversion('-1.5E3', -1500)).toBe(false);
+    });
+
+    it('should still detect trailing fractional zeros written in scientific notation', () => {
+      // 1.230e2 === 123 exactly, but the trailing zero of the mantissa is dropped on parse.
+      expect(isLossyNumericConversion('1.2300e2', 123)).toBe(true);
+    });
   });
 });

--- a/handsontable/src/helpers/__tests__/number.unit.ts
+++ b/handsontable/src/helpers/__tests__/number.unit.ts
@@ -570,6 +570,15 @@ describe('Number helper', () => {
     it('should still detect trailing fractional zeros written in scientific notation', () => {
       // 1.230e2 === 123 exactly, but the trailing zero of the mantissa is dropped on parse.
       expect(isLossyNumericConversion('1.2300e2', 123)).toBe(true);
+      // The mantissa zero of 1.10e1 stays fractional after the shift (11.0) and is dropped.
+      expect(isLossyNumericConversion('1.10e1', 11)).toBe(true);
+    });
+
+    it('should not treat mantissa trailing zeros shifted onto integer positions as loss', () => {
+      // 1.0e2 === 100 and 1.10e2 === 110 exactly: the mantissa zero becomes an integer
+      // digit of the parsed value, so no typed digit disappears — same class as `1e2`.
+      expect(isLossyNumericConversion('1.0e2', 100)).toBe(false);
+      expect(isLossyNumericConversion('1.10e2', 110)).toBe(false);
     });
   });
 });

--- a/handsontable/src/helpers/number.ts
+++ b/handsontable/src/helpers/number.ts
@@ -289,7 +289,10 @@ function toPlainDecimalString(numericText: string): string {
  * Both the input and `String(parsedNumber)` are normalized to plain decimal notation before
  * comparing, so purely cosmetic differences (leading zeros, a leading `+`, `.5`/`5.`, and
  * scientific notation on either side — `1e2` vs `100`, `0.0000001` vs `1e-7`) are not treated
- * as loss.
+ * as loss. A mantissa trailing zero that a positive exponent shifts onto or left of the
+ * decimal point (`1.0e2` → `100`, `1.10e2` → `110`) survives as an integer digit of the exact
+ * value, so it is not loss either; only zeros that stay fractional after the shift
+ * (`1.10e1` → `11.0`) are dropped by parsing and count as lossy.
  *
  * Intended only for the plain float path. Thousands-grouped inputs (e.g. `7.000`) are resolved
  * by the caller before this runs and must not be passed here.

--- a/handsontable/src/helpers/number.ts
+++ b/handsontable/src/helpers/number.ts
@@ -266,6 +266,13 @@ function toPlainDecimalString(numericText: string): string {
   let digits = `${integerDigits}${fractionDigits}`;
   let pointIndex = integerDigits.length + exponent;
 
+  // A double tops out near 1e308, so a decimal point shifted this far can never describe
+  // a finite number. Without this bound, the two expansions below allocate an enormous
+  // string or throw `RangeError: Invalid string length` for inputs like `1e999999999`.
+  if (Math.abs(pointIndex) > 1000) {
+    return numericText.trim();
+  }
+
   if (pointIndex > digits.length) {
     digits = digits.padEnd(pointIndex, '0');
   }
@@ -289,7 +296,8 @@ function toPlainDecimalString(numericText: string): string {
  * Both the input and `String(parsedNumber)` are normalized to plain decimal notation before
  * comparing, so purely cosmetic differences (leading zeros, a leading `+`, `.5`/`5.`, and
  * scientific notation on either side — `1e2` vs `100`, `0.0000001` vs `1e-7`) are not treated
- * as loss. A mantissa trailing zero that a positive exponent shifts onto or left of the
+ * as loss. A plain `-0` is not loss either — the parsed number `-0` keeps the sign even though
+ * `String(-0)` drops it. A mantissa trailing zero that a positive exponent shifts onto or left of the
  * decimal point (`1.0e2` → `100`, `1.10e2` → `110`) survives as an integer digit of the exact
  * value, so it is not loss either; only zeros that stay fractional after the shift
  * (`1.10e1` → `11.0`) are dropped by parsing and count as lossy.
@@ -302,7 +310,11 @@ function toPlainDecimalString(numericText: string): string {
  * @returns {boolean}
  */
 export function isLossyNumericConversion(rawInput: string, parsedNumber: number): boolean {
-  return toPlainDecimalString(rawInput.replace(',', '.')) !== toPlainDecimalString(String(parsedNumber));
+  // `String(-0)` drops the sign (`"0"`), but the number `-0` stores the sign exactly, so a
+  // plain `-0` input round-trips without loss and must not read as lossy.
+  const parsedNumberText = Object.is(parsedNumber, -0) ? '-0' : String(parsedNumber);
+
+  return toPlainDecimalString(rawInput.replace(',', '.')) !== toPlainDecimalString(parsedNumberText);
 }
 
 /**

--- a/handsontable/src/helpers/number.ts
+++ b/handsontable/src/helpers/number.ts
@@ -263,15 +263,19 @@ function toPlainDecimalString(numericText: string): string {
   const integerDigits = match[2];
   const fractionDigits = match[3] ?? '';
   const exponent = Number.parseInt(match[4] ?? '0', 10);
-  let digits = `${integerDigits}${fractionDigits}`;
-  let pointIndex = integerDigits.length + exponent;
 
-  // A double tops out near 1e308, so a decimal point shifted this far can never describe
-  // a finite number. Without this bound, the two expansions below allocate an enormous
-  // string or throw `RangeError: Invalid string length` for inputs like `1e999999999`.
-  if (Math.abs(pointIndex) > 1000) {
+  // A double tops out near 1e308, so an exponent this large can never describe a finite
+  // number. The exponent is also the only unbounded driver of the two expansions below
+  // (the digits themselves only ever shrink or keep the string length): without this bound
+  // they allocate an enormous string or throw `RangeError: Invalid string length` for
+  // inputs like `1e999999999`. Bounding the exponent alone — not the digit count — keeps
+  // long leading-zero literals (`000…0005`) normalizing, so they do not read as lossy.
+  if (Math.abs(exponent) > 1000) {
     return numericText.trim();
   }
+
+  let digits = `${integerDigits}${fractionDigits}`;
+  let pointIndex = integerDigits.length + exponent;
 
   if (pointIndex > digits.length) {
     digits = digits.padEnd(pointIndex, '0');

--- a/handsontable/src/helpers/number.ts
+++ b/handsontable/src/helpers/number.ts
@@ -243,6 +243,42 @@ export function getParsedNumber(numericData: string, options: { decimalSeparator
 }
 
 /**
+ * Whether converting a plain numeric string to its parsed JS number loses information.
+ * Two situations count as lossy: trailing fractional zeros (e.g. `9.0` → `9`) and precision
+ * beyond `Number.MAX_SAFE_INTEGER` (e.g. `12345678901234567.8` → `12345678901234568`).
+ *
+ * It compares a canonicalized form of the input (leading zeros and a leading sign normalized,
+ * decimal separator unified to `.`, but trailing zeros and all significant digits kept) against
+ * `String(parsedNumber)`. Purely cosmetic differences (leading zeros, a leading `+`, `.5`/`5.`)
+ * are not treated as loss.
+ *
+ * Intended only for the plain float path. Thousands-grouped inputs (e.g. `7.000`) are resolved
+ * by the caller before this runs and must not be passed here.
+ *
+ * @param {string} rawInput The raw user input string.
+ * @param {number} parsedNumber The number produced from `rawInput` by `getParsedNumber`.
+ * @returns {boolean}
+ */
+export function isLossyNumericConversion(rawInput: string, parsedNumber: number): boolean {
+  const negative = /^\s*-/.test(rawInput);
+  let normalized = rawInput.trim().replace(',', '.').replace(/^[+-]/, '');
+
+  normalized = normalized.replace(/^0+(?=\d)/, '');
+
+  if (normalized.startsWith('.')) {
+    normalized = `0${normalized}`;
+  }
+
+  if (normalized.endsWith('.')) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  const canonical = `${negative ? '-' : ''}${normalized}`;
+
+  return canonical !== String(parsedNumber);
+}
+
+/**
  * Check if the provided argument is an unsigned number.
  *
  * @param {*} value Value to check.

--- a/handsontable/src/helpers/number.ts
+++ b/handsontable/src/helpers/number.ts
@@ -243,14 +243,53 @@ export function getParsedNumber(numericData: string, options: { decimalSeparator
 }
 
 /**
+ * Converts a decimal or scientific-notation numeric string to its plain decimal form
+ * (`1e2` → `100`, `1e-7` → `0.0000001`). Leading zeros and a leading `+` are dropped, and the
+ * `.5`/`5.` shorthands gain the missing digit. Trailing fractional zeros are kept — they carry
+ * the information [[isLossyNumericConversion]] detects. A string that does not match the plain
+ * number grammar is returned trimmed but otherwise unchanged.
+ *
+ * @param {string} numericText The numeric string to normalize.
+ * @returns {string}
+ */
+function toPlainDecimalString(numericText: string): string {
+  const match = /^([+-]?)(\d*)(?:\.(\d*))?(?:e([+-]?\d+))?$/i.exec(numericText.trim());
+
+  if (match === null || (match[2] === '' && (match[3] ?? '') === '')) {
+    return numericText.trim();
+  }
+
+  const sign = match[1] === '-' ? '-' : '';
+  const integerDigits = match[2];
+  const fractionDigits = match[3] ?? '';
+  const exponent = Number.parseInt(match[4] ?? '0', 10);
+  let digits = `${integerDigits}${fractionDigits}`;
+  let pointIndex = integerDigits.length + exponent;
+
+  if (pointIndex > digits.length) {
+    digits = digits.padEnd(pointIndex, '0');
+  }
+
+  if (pointIndex < 1) {
+    digits = `${'0'.repeat(1 - pointIndex)}${digits}`;
+    pointIndex = 1;
+  }
+
+  const integerPart = digits.slice(0, pointIndex).replace(/^0+(?=\d)/, '');
+  const fractionPart = digits.slice(pointIndex);
+
+  return `${sign}${integerPart}${fractionPart.length > 0 ? `.${fractionPart}` : ''}`;
+}
+
+/**
  * Whether converting a plain numeric string to its parsed JS number loses information.
  * Two situations count as lossy: trailing fractional zeros (e.g. `9.0` → `9`) and precision
  * beyond `Number.MAX_SAFE_INTEGER` (e.g. `12345678901234567.8` → `12345678901234568`).
  *
- * It compares a canonicalized form of the input (leading zeros and a leading sign normalized,
- * decimal separator unified to `.`, but trailing zeros and all significant digits kept) against
- * `String(parsedNumber)`. Purely cosmetic differences (leading zeros, a leading `+`, `.5`/`5.`)
- * are not treated as loss.
+ * Both the input and `String(parsedNumber)` are normalized to plain decimal notation before
+ * comparing, so purely cosmetic differences (leading zeros, a leading `+`, `.5`/`5.`, and
+ * scientific notation on either side — `1e2` vs `100`, `0.0000001` vs `1e-7`) are not treated
+ * as loss.
  *
  * Intended only for the plain float path. Thousands-grouped inputs (e.g. `7.000`) are resolved
  * by the caller before this runs and must not be passed here.
@@ -260,22 +299,7 @@ export function getParsedNumber(numericData: string, options: { decimalSeparator
  * @returns {boolean}
  */
 export function isLossyNumericConversion(rawInput: string, parsedNumber: number): boolean {
-  const negative = /^\s*-/.test(rawInput);
-  let normalized = rawInput.trim().replace(',', '.').replace(/^[+-]/, '');
-
-  normalized = normalized.replace(/^0+(?=\d)/, '');
-
-  if (normalized.startsWith('.')) {
-    normalized = `0${normalized}`;
-  }
-
-  if (normalized.endsWith('.')) {
-    normalized = normalized.slice(0, -1);
-  }
-
-  const canonical = `${negative ? '-' : ''}${normalized}`;
-
-  return canonical !== String(parsedNumber);
+  return toPlainDecimalString(rawInput.replace(',', '.')) !== toPlainDecimalString(String(parsedNumber));
 }
 
 /**

--- a/handsontable/src/plugins/filters/__tests__/condition/equal.unit.ts
+++ b/handsontable/src/plugins/filters/__tests__/condition/equal.unit.ts
@@ -40,8 +40,9 @@ describe('Filters condition (`eq`)', () => {
     expect(condition(data(true), ['e'])).toBe(false);
   });
 
-  it('should compare numeric-typed cells numerically, so a preserved literal matches its number', () => {
-    const data = dateRowFactory({ type: 'numeric' });
+  it('should compare numeric-typed cells numerically when `preserveNumericLiteral` is enabled, ' +
+     'so a preserved literal matches its number', () => {
+    const data = dateRowFactory({ type: 'numeric', preserveNumericLiteral: true });
 
     expect(condition(data('9.0'), [9])).toBe(true);
     expect(condition(data('9.0'), ['9'])).toBe(true);
@@ -51,8 +52,21 @@ describe('Filters condition (`eq`)', () => {
     expect(condition(data('9.0'), [10])).toBe(false);
   });
 
-  it('should fall back to string comparison for numeric-typed cells holding non-numeric values', () => {
+  it('should keep the historical string comparison for numeric-typed cells without ' +
+     '`preserveNumericLiteral`', () => {
     const data = dateRowFactory({ type: 'numeric' });
+
+    expect(condition(data(100), ['1e2'])).toBe(false);
+    expect(condition(data(0.5), ['.5'])).toBe(false);
+    expect(condition(data(16), ['0x10'])).toBe(false);
+    expect(condition(data(0), ['-0'])).toBe(false);
+    expect(condition(data(9), ['9.0'])).toBe(false);
+    expect(condition(data(9), [9])).toBe(true);
+    expect(condition(data(9), ['9'])).toBe(true);
+  });
+
+  it('should fall back to string comparison for numeric-typed cells holding non-numeric values', () => {
+    const data = dateRowFactory({ type: 'numeric', preserveNumericLiteral: true });
 
     expect(condition(data(null), [''])).toBe(true);
     expect(condition(data('abc'), ['abc'])).toBe(true);

--- a/handsontable/src/plugins/filters/__tests__/condition/equal.unit.ts
+++ b/handsontable/src/plugins/filters/__tests__/condition/equal.unit.ts
@@ -40,6 +40,25 @@ describe('Filters condition (`eq`)', () => {
     expect(condition(data(true), ['e'])).toBe(false);
   });
 
+  it('should compare numeric-typed cells numerically, so a preserved literal matches its number', () => {
+    const data = dateRowFactory({ type: 'numeric' });
+
+    expect(condition(data('9.0'), [9])).toBe(true);
+    expect(condition(data('9.0'), ['9'])).toBe(true);
+    expect(condition(data(9), ['9.0'])).toBe(true);
+    expect(condition(data(9.5), ['9.5'])).toBe(true);
+    expect(condition(data('9.0'), ['9.5'])).toBe(false);
+    expect(condition(data('9.0'), [10])).toBe(false);
+  });
+
+  it('should fall back to string comparison for numeric-typed cells holding non-numeric values', () => {
+    const data = dateRowFactory({ type: 'numeric' });
+
+    expect(condition(data(null), [''])).toBe(true);
+    expect(condition(data('abc'), ['abc'])).toBe(true);
+    expect(condition(data('abc'), [9])).toBe(false);
+  });
+
   it('should handle locales properly', () => {
     const data = dateRowFactory({ locale: 'tr-TR' });
 

--- a/handsontable/src/plugins/filters/__tests__/condition/notEqual.unit.ts
+++ b/handsontable/src/plugins/filters/__tests__/condition/notEqual.unit.ts
@@ -40,12 +40,22 @@ describe('Filters condition (`neq`)', () => {
     expect(condition(data(null), [undefined])).toBe(false);
   });
 
-  it('should compare numeric-typed cells numerically, so a preserved literal matches its number', () => {
-    const data = dateRowFactory({ type: 'numeric' });
+  it('should compare numeric-typed cells numerically when `preserveNumericLiteral` is enabled, ' +
+     'so a preserved literal matches its number', () => {
+    const data = dateRowFactory({ type: 'numeric', preserveNumericLiteral: true });
 
     expect(condition(data('9.0'), [9])).toBe(false);
     expect(condition(data('9.0'), ['9'])).toBe(false);
     expect(condition(data('9.0'), ['9.5'])).toBe(true);
     expect(condition(data('9.0'), [10])).toBe(true);
+  });
+
+  it('should keep the historical string comparison for numeric-typed cells without ' +
+     '`preserveNumericLiteral`', () => {
+    const data = dateRowFactory({ type: 'numeric' });
+
+    expect(condition(data(100), ['1e2'])).toBe(true);
+    expect(condition(data(9), ['9.0'])).toBe(true);
+    expect(condition(data(9), ['9'])).toBe(false);
   });
 });

--- a/handsontable/src/plugins/filters/__tests__/condition/notEqual.unit.ts
+++ b/handsontable/src/plugins/filters/__tests__/condition/notEqual.unit.ts
@@ -39,4 +39,13 @@ describe('Filters condition (`neq`)', () => {
     expect(condition(data(null), [''])).toBe(false);
     expect(condition(data(null), [undefined])).toBe(false);
   });
+
+  it('should compare numeric-typed cells numerically, so a preserved literal matches its number', () => {
+    const data = dateRowFactory({ type: 'numeric' });
+
+    expect(condition(data('9.0'), [9])).toBe(false);
+    expect(condition(data('9.0'), ['9'])).toBe(false);
+    expect(condition(data('9.0'), ['9.5'])).toBe(true);
+    expect(condition(data('9.0'), [10])).toBe(true);
+  });
 });

--- a/handsontable/src/plugins/filters/condition/equal.ts
+++ b/handsontable/src/plugins/filters/condition/equal.ts
@@ -1,5 +1,6 @@
 import * as C from '../../../i18n/constants';
 import { stringify } from '../../../helpers/mixed';
+import { isNumeric } from '../../../helpers/number';
 import { localeLowerCase } from '../../../helpers/string';
 import { registerCondition } from '../conditionRegisterer';
 
@@ -17,12 +18,20 @@ type DataRow = {
 };
 
 /**
+ * Numeric-typed cells compare by numeric value (like `gt`/`lt`/`between`), so a preserved
+ * literal string such as `9.0` still matches a filter input of `9`. All other cells compare
+ * by locale-lowercased string equality.
+ *
  * @param {object} dataRow The object which holds and describes the single cell value.
  * @param {Array} inputValues An array of values to compare with.
  * @param {Array} inputValues."0" Value to check if it same as row's data.
  * @returns {boolean}
  */
 export function condition(dataRow: DataRow, [value]: unknown[]) {
+  if (dataRow.meta.type === 'numeric' && isNumeric(dataRow.value) && isNumeric(value)) {
+    return Number(dataRow.value) === Number(value);
+  }
+
   return localeLowerCase(stringify(dataRow.value), dataRow.meta.locale) === stringify(value);
 }
 

--- a/handsontable/src/plugins/filters/condition/equal.ts
+++ b/handsontable/src/plugins/filters/condition/equal.ts
@@ -13,14 +13,17 @@ type DataRow = {
     locale?: string;
     dateFormat?: Intl.DateTimeFormatOptions;
     instance?: unknown;
+    preserveNumericLiteral?: boolean;
     [key: string]: unknown
   };
 };
 
 /**
- * Numeric-typed cells compare by numeric value (like `gt`/`lt`/`between`), so a preserved
- * literal string such as `9.0` still matches a filter input of `9`. All other cells compare
- * by locale-lowercased string equality.
+ * Numeric-typed cells with [`preserveNumericLiteral`](@/api/options.md#preservenumericliteral)
+ * enabled compare by numeric value (like `gt`/`lt`/`between`), so a preserved literal string
+ * such as `9.0` still matches a filter input of `9`. The numeric branch is gated by the option
+ * so that columns which never opt in keep the historical string comparison (`1e2` does not
+ * match `100`). All other cells compare by locale-lowercased string equality.
  *
  * @param {object} dataRow The object which holds and describes the single cell value.
  * @param {Array} inputValues An array of values to compare with.
@@ -28,7 +31,12 @@ type DataRow = {
  * @returns {boolean}
  */
 export function condition(dataRow: DataRow, [value]: unknown[]) {
-  if (dataRow.meta.type === 'numeric' && isNumeric(dataRow.value) && isNumeric(value)) {
+  if (
+    dataRow.meta.preserveNumericLiteral === true &&
+    dataRow.meta.type === 'numeric' &&
+    isNumeric(dataRow.value) &&
+    isNumeric(value)
+  ) {
     return Number(dataRow.value) === Number(value);
   }
 

--- a/tests/e2e/numeric-editor.spec.ts
+++ b/tests/e2e/numeric-editor.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '../fixtures/test';
+import { NumericGridPage } from '../fixtures/pages/NumericGridPage';
+
+/**
+ * Regression coverage for DEV-1161 / HOT-9714: a numeric cell used to lose the
+ * user's literal when it was parsed to a JS number on save. Editing `9.0` showed
+ * `9` in the editor, and large numbers lost precision. With the opt-in
+ * `preserveNumericLiteral` option enabled (set in the fixture), the numeric
+ * valueSetter keeps the original literal whenever converting it to a number would
+ * lose information, so the editor shows exactly what the user typed. The cell
+ * itself stays numerically formatted — only the editor preserves the literal, and
+ * a preserved literal still sorts numerically.
+ */
+test.describe('numeric cell editor precision', () => {
+  let grid: NumericGridPage;
+
+  test.beforeEach(async ({ page, theme }) => {
+    grid = new NumericGridPage(page, theme);
+    await grid.goto();
+  });
+
+  test('keeps a trailing fractional zero in the editor after editing', async () => {
+    await grid.editCell(0, 0, '9.0');
+
+    // The cell renders the numerically formatted value...
+    await grid.expectCell(0, 0, '9');
+
+    // ...but reopening the editor shows the exact literal the user typed.
+    await grid.openEditor(0, 0);
+    await expect(grid.editor).toHaveValue('9.0');
+  });
+
+  test('keeps large-number precision in the editor after editing', async () => {
+    const largeNumber = '12345678901234567.8';
+
+    await grid.editCell(0, 0, largeNumber);
+    await grid.openEditor(0, 0);
+
+    await expect(grid.editor).toHaveValue(largeNumber);
+  });
+
+  test('leaves ordinary numeric values untouched (no regression)', async () => {
+    await grid.editCell(0, 0, '9.5');
+    await grid.expectCell(0, 0, '9.5');
+
+    await grid.openEditor(0, 0);
+    await expect(grid.editor).toHaveValue('9.5');
+  });
+
+  test('sorts a preserved literal numerically, not lexicographically', async () => {
+    // Seed data is [100, 2, 42]. Turn the first cell into a preserved literal ("9.0").
+    await grid.editCell(0, 0, '9.0');
+
+    // Ascending sort must order by numeric value (2, 9, 42) — a lexicographic sort
+    // of the rendered text would misorder them.
+    await grid.sortColumn();
+
+    await grid.expectCell(0, 0, '2');
+    await grid.expectCell(1, 0, '9');
+    await grid.expectCell(2, 0, '42');
+  });
+});

--- a/tests/e2e/numeric-editor.spec.ts
+++ b/tests/e2e/numeric-editor.spec.ts
@@ -47,6 +47,18 @@ test.describe('numeric cell editor precision', () => {
     await expect(grid.editor).toHaveValue('9.5');
   });
 
+  test('filters a preserved literal numerically with the "Is equal to" condition', async () => {
+    // Seed data is [100, 2, 42]. Turn the first cell into a preserved literal ("9.0").
+    await grid.editCell(0, 0, '9.0');
+
+    // An equality filter for `9` must match the cell that holds the string "9.0":
+    // the `eq` condition compares numeric-typed cells by value, not by text.
+    await grid.filterByCondition('Is equal to', '9');
+
+    await expect(grid.rows).toHaveCount(1);
+    await grid.expectCell(0, 0, '9');
+  });
+
   test('sorts a preserved literal numerically, not lexicographically', async () => {
     // Seed data is [100, 2, 42]. Turn the first cell into a preserved literal ("9.0").
     await grid.editCell(0, 0, '9.0');

--- a/tests/e2e/numeric-formulas.spec.ts
+++ b/tests/e2e/numeric-formulas.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '../fixtures/test';
+import { NumericGridPage } from '../fixtures/pages/NumericGridPage';
+
+/**
+ * Formulas coverage for DEV-1161: with `preserveNumericLiteral` enabled, a lossy
+ * entry such as `9.0` is stored as the literal string. The Formulas plugin passes
+ * that raw content to HyperFormula, which parses numeric-looking strings as
+ * numbers — so formula calculations (for example SUM) still include the cell.
+ * The stored literal itself is untouched by the round-trip: the editor keeps
+ * showing exactly what the user typed.
+ */
+test.describe('numeric preserved literal with formulas', () => {
+  let grid: NumericGridPage;
+
+  test.beforeEach(async ({ page, theme }) => {
+    grid = new NumericGridPage(page, theme, 'numeric-formulas');
+    await grid.goto();
+  });
+
+  test('SUM includes a preserved literal as its numeric value', async () => {
+    // Seed data is [100, 2, 42] with B1 = SUM(A1:A3).
+    await grid.expectCell(0, 1, '144');
+
+    await grid.editCell(0, 0, '9.0');
+
+    // The engine parses the preserved literal "9.0" as the number 9: 9 + 2 + 42.
+    await grid.expectCell(0, 1, '53');
+  });
+
+  test('the editor keeps the preserved literal when the Formulas plugin is enabled', async () => {
+    await grid.editCell(0, 0, '9.0');
+
+    await grid.openEditor(0, 0);
+    await expect(grid.editor).toHaveValue('9.0');
+  });
+});

--- a/tests/fixtures/demo/numeric-formulas.html
+++ b/tests/fixtures/demo/numeric-formulas.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable numeric + formulas e2e fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Active theme from the ?theme= query param set by the Playwright project.
+    // Mapped through a fixed allowlist to a LITERAL (default main), so a crafted
+    // ?theme= can never be reflected into the document — no XSS.
+    window.htTheme = ({ horizon: 'horizon', classic: 'classic' })[new URLSearchParams(location.search).get('theme')] || 'main';
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } </style>
+</head>
+<body>
+  <!--
+    Numeric-cell + Formulas E2E fixture. Column A is numeric-typed with the opt-in
+    `preserveNumericLiteral` option enabled; column B holds a SUM over column A.
+    Specs verify that a preserved literal string (for example "9.0") is parsed as
+    a number by the formula engine — SUM still includes the cell — and that the
+    literal survives the Formulas round-trip in the editor. Cells carry
+    data-testid="cell-<row>-<col>" so specs hook in unambiguously.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script src="/handsontable/dist/handsontable.full.min.js"></script>
+  <script src="/handsontable/dist/hyperformula/hyperformula.full.min.js"></script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const numericTestIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    };
+
+    new Handsontable(container, {
+      data: [[100, '=SUM(A1:A3)'], [2, null], [42, null]],
+      colHeaders: ['Amount', 'Total'],
+      rowHeaders: true,
+      columns: [
+        { type: 'numeric', preserveNumericLiteral: true, renderer: numericTestIdRenderer },
+        { renderer: numericTestIdRenderer },
+      ],
+      formulas: {
+        engine: HyperFormula,
+      },
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/numeric.html
+++ b/tests/fixtures/demo/numeric.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable numeric e2e fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Active theme from the ?theme= query param set by the Playwright project.
+    // Mapped through a fixed allowlist to a LITERAL (default main), so a crafted
+    // ?theme= can never be reflected into the document — no XSS.
+    window.htTheme = ({ horizon: 'horizon', classic: 'classic' })[new URLSearchParams(location.search).get('theme')] || 'main';
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } </style>
+</head>
+<body>
+  <!--
+    Numeric-cell E2E fixture. A single numeric-typed column with the opt-in
+    `preserveNumericLiteral` option enabled exercises the numeric editor /
+    valueSetter path. Column sorting and filters are on so specs can verify that
+    a preserved literal string still sorts and filters numerically. Cells carry
+    data-testid="cell-<row>-<col>" so specs hook in unambiguously.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script src="/handsontable/dist/handsontable.full.min.js"></script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const numericTestIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    };
+
+    new Handsontable(container, {
+      data: [[100], [2], [42]],
+      colHeaders: ['Amount'],
+      rowHeaders: true,
+      columns: [
+        { type: 'numeric', preserveNumericLiteral: true, renderer: numericTestIdRenderer },
+      ],
+      columnSorting: true,
+      dropdownMenu: true,
+      filters: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/NumericGridPage.ts
+++ b/tests/fixtures/pages/NumericGridPage.ts
@@ -1,0 +1,63 @@
+import type { Page, Locator } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+/**
+ * Page Object for the numeric-cell E2E fixture.
+ *
+ * Encapsulates the selectors and interactions used to exercise the numeric
+ * editor / valueSetter path: editing a cell, reopening its editor, and reading
+ * back what the editor textarea shows. Specs express intent; the DOM mechanics
+ * live here. Cells are addressed by stable `data-testid`; waits are web-first.
+ */
+export class NumericGridPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly grid: Locator;
+  readonly editor: Locator;
+  readonly columnHeader: Locator;
+
+  constructor(page: Page, theme = 'main') {
+    this.page = page;
+    this.theme = theme;
+    this.grid = page.getByTestId('grid');
+    this.editor = page.locator('.handsontableInput');
+    this.columnHeader = page.locator('.ht_clone_top thead th').filter({ hasText: 'Amount' });
+  }
+
+  /**
+   * Navigate to the fixture and wait for the grid to render. The active theme is
+   * passed as a query param so the fixture loads the matching stylesheet.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(`/tests/fixtures/demo/numeric.html?theme=${this.theme}`);
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /** A single data cell, by visual row/column, via its stable test id. */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /** Assert a cell shows the expected text (web-first, auto-retrying). */
+  async expectCell(row: number, col: number, text: string): Promise<void> {
+    await expect(this.cell(row, col)).toHaveText(text);
+  }
+
+  /** Open a cell's editor, replace its content with a value, and commit it. */
+  async editCell(row: number, col: number, value: string): Promise<void> {
+    await this.openEditor(row, col);
+    await this.editor.fill(value);
+    await this.editor.press('Enter');
+  }
+
+  /** Open a cell's editor in full-edit mode and wait until it is visible. */
+  async openEditor(row: number, col: number): Promise<void> {
+    await this.cell(row, col).dblclick();
+    await expect(this.editor).toBeVisible();
+  }
+
+  /** Click the "Amount" column header to toggle column sorting. */
+  async sortColumn(): Promise<void> {
+    await this.columnHeader.click();
+  }
+}

--- a/tests/fixtures/pages/NumericGridPage.ts
+++ b/tests/fixtures/pages/NumericGridPage.ts
@@ -12,16 +12,22 @@ import { expect } from '@playwright/test';
 export class NumericGridPage {
   readonly page: Page;
   readonly theme: string;
+  readonly fixture: string;
   readonly grid: Locator;
   readonly editor: Locator;
   readonly columnHeader: Locator;
+  readonly rows: Locator;
+  readonly dropdownMenu: Locator;
 
-  constructor(page: Page, theme = 'main') {
+  constructor(page: Page, theme = 'main', fixture = 'numeric') {
     this.page = page;
     this.theme = theme;
+    this.fixture = fixture;
     this.grid = page.getByTestId('grid');
     this.editor = page.locator('.handsontableInput');
     this.columnHeader = page.locator('.ht_clone_top thead th').filter({ hasText: 'Amount' });
+    this.rows = page.locator('.ht_master tbody tr');
+    this.dropdownMenu = page.locator('.htDropdownMenu');
   }
 
   /**
@@ -29,7 +35,7 @@ export class NumericGridPage {
    * passed as a query param so the fixture loads the matching stylesheet.
    */
   async goto(): Promise<void> {
-    await this.page.goto(`/tests/fixtures/demo/numeric.html?theme=${this.theme}`);
+    await this.page.goto(`/tests/fixtures/demo/${this.fixture}.html?theme=${this.theme}`);
     await expect(this.cell(0, 0)).toBeVisible();
   }
 
@@ -59,5 +65,31 @@ export class NumericGridPage {
   /** Click the "Amount" column header to toggle column sorting. */
   async sortColumn(): Promise<void> {
     await this.columnHeader.click();
+  }
+
+  /**
+   * Filter the "Amount" column through the dropdown-menu filter UI: open the menu,
+   * pick a by-condition entry by its visible label (for example "Is equal to"),
+   * type the condition value, and apply. Every step waits web-first on the element
+   * it is about to use.
+   */
+  async filterByCondition(conditionLabel: string, value: string): Promise<void> {
+    await this.columnHeader.locator('.changeType').click();
+    await expect(this.dropdownMenu).toBeVisible();
+
+    await this.dropdownMenu.locator('.htUISelect').first().click();
+
+    // Two condition menus exist in the DOM (first and second by-condition selects);
+    // only the one just opened is visible.
+    const conditionsMenu = this.page.locator('.htFiltersConditionsMenu:visible');
+
+    await expect(conditionsMenu).toBeVisible();
+    await conditionsMenu.getByText(conditionLabel, { exact: true }).click();
+
+    const valueInput = this.dropdownMenu.locator('.htFiltersMenuCondition input[type="text"]').first();
+
+    await valueInput.fill(value);
+    await this.dropdownMenu.locator('.htUIButtonOK input').click();
+    await expect(this.dropdownMenu).toBeHidden();
   }
 }


### PR DESCRIPTION
### Context

The PR fixes a numeric cell losing the user's exact input when it is parsed to a JavaScript number on save. Two symptoms were reported: editing `9.0` shows `9` in the cell editor (the trailing `.0` is dropped), and large numbers lose precision on paste/edit (e.g. `12345678901234567.8` becomes a rounded integer). Both come from the numeric `valueSetter`, which eagerly runs `parseFloat` and discards the original text.

Because JavaScript stores all numbers as IEEE-754 doubles, `9.0 === 9` and values above `Number.MAX_SAFE_INTEGER` cannot be represented exactly — so the literal can only survive if it is kept as text.

This is implemented as an **opt-in** option, `preserveNumericLiteral` (default `false`), so existing configurations are completely unchanged. When enabled, and only when converting the input to a number would lose information (trailing fractional zeros, or magnitude beyond the safe-integer limit), the cell keeps the original trimmed literal string; otherwise it stores the parsed number exactly as before. The guard is limited to plain dot-decimal literals (`isNumeric`), so grouped values (`7.000`) and comma-decimal literals (`9,0`) are unaffected. Values that convert without loss (`9`, `9.5`, `1000`) are always stored as numbers, so sorting, filtering, and formulas are unaffected.

Scope is editor-focused; there are no `numericRenderer` changes. As a verified bonus, because `Intl.NumberFormat.format()` accepts a decimal string, a preserved large-number literal also renders at full precision in the cell.

### How has this been tested?

New and updated automated tests, plus manual verification in a real browser (both grids of an ON/OFF demo, plus sorting and filtering).

- Unit — number helper and the setter:
  - `npm run test:unit --prefix handsontable --testPathPattern=number.unit`
  - `npm run test:unit --prefix handsontable --testPathPattern=numericType.unit`
  - Covers: lossless values stay numbers; `9.0`, `0.0`, `-9.0`, `12345678901234567.8` are preserved only with the option on; default (option off) keeps the old parse-to-number behavior; comma-decimal and grouped inputs are never preserved; idempotence.
- Type test — `handsontable/src/__tests__/core/settings.types.ts` updated for the new option; `npm run test:types --prefix handsontable`.
- E2E (Playwright, new) — `tests/e2e/numeric-editor.spec.ts` with fixture `numeric.html` + `NumericGridPage`:
  - `cd tests && npx playwright test --project=e2e-main e2e/numeric-editor.spec.ts`
  - Verifies the editor shows the preserved literal for `9.0` and a large number, that ordinary values are untouched, and that a preserved literal still sorts numerically (not lexicographically). Sorting and filters are enabled in the fixture.
- Full unit suite: `npm run test:unit --prefix handsontable` — 3279 passing.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1161

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1161

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core numeric value storage and filter equality for opted-in columns; default-off limits blast radius, but mixed string/number cell values can affect sort, filter-by-value, and downstream consumers.
> 
> **Overview**
> Adds an opt-in **`preserveNumericLiteral`** option (default `false`) on numeric cells so the editor can keep what you typed when parsing to a JavaScript number would drop trailing fractional zeros (e.g. `9.0` → `9`) or precision beyond `Number.MAX_SAFE_INTEGER`.
> 
> When enabled, the numeric **`valueSetter`** uses new **`isLossyNumericConversion`** logic (with **`toPlainDecimalString`** normalization) to store the trimmed literal string only for plain dot-decimal input that would lose information; lossless values still become numbers. Grouped thousands, comma-decimal literals, hex, and overflow/underflow cases are excluded from preservation.
> 
> **Equal** / **not equal** filter conditions compare numeric cells with this option numerically so `9.0` matches `9`, while columns without the option keep string equality. Docs, meta schema, unit tests, and Playwright E2E (editor, sort, filter, formulas) cover the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1334a2137db9da5ed7110ac50e48ead7f491e655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->