### PR TITLE
DEV-2198: Point PR preview links at demos.handsontable.com

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -121,9 +121,12 @@ jobs:
         if: env.HOT_PREBUILT == 'true'
         run: |
           tar -zxf dist.tar.gz ./handsontable/dist ./handsontable/styles && rm dist.tar.gz
-          rm -rf handsontable/tmp/dist handsontable/tmp/styles
+          rm -rf handsontable/tmp/dist
           cp -R handsontable/dist handsontable/tmp/dist
-          cp -R handsontable/styles handsontable/tmp/styles
+          # Merge the CSS into tmp/styles instead of replacing the directory —
+          # tmp/styles also holds the generated handsontableStyles.{js,mjs,d.ts}
+          # module that utils/stylesHandler imports at runtime.
+          cp -R handsontable/styles/. handsontable/tmp/styles/
       - name: Build wrapper packages (handsontable prebuilt)
         if: env.HOT_PREBUILT == 'true'
         run: npm run all build -- --e examples visual-tests handsontable
@@ -165,18 +168,18 @@ jobs:
 
             | Framework | Link |
             |-----------|------|
-            | Angular | [Open in CodeSandbox](https://handsontable.com/codesandbox-vm?example-dir=angular&handsontable-version=${{ github.event.pull_request.number }}) |
-            | Vanilla JS | [Open in CodeSandbox](https://handsontable.com/codesandbox-vm?example-dir=javascript&handsontable-version=${{ github.event.pull_request.number }}) |
-            | React TS | [Open in CodeSandbox](https://handsontable.com/codesandbox-vm?example-dir=react&handsontable-version=${{ github.event.pull_request.number }}) |
-            | React JS | [Open in CodeSandbox](https://handsontable.com/codesandbox-vm?example-dir=react-js&handsontable-version=${{ github.event.pull_request.number }}) |
-            | TypeScript | [Open in CodeSandbox](https://handsontable.com/codesandbox-vm?example-dir=typescript&handsontable-version=${{ github.event.pull_request.number }}) |
-            | Vue 3 | [Open in CodeSandbox](https://handsontable.com/codesandbox-vm?example-dir=vue&handsontable-version=${{ github.event.pull_request.number }}) |
+            | Angular | [Open live demo](https://demos.handsontable.com/?example=angular&v=${{ github.event.pull_request.number }}) |
+            | Vanilla JS | [Open live demo](https://demos.handsontable.com/?example=javascript&v=${{ github.event.pull_request.number }}) |
+            | React TS | [Open live demo](https://demos.handsontable.com/?example=react&v=${{ github.event.pull_request.number }}) |
+            | React JS | [Open live demo](https://demos.handsontable.com/?example=react-js&v=${{ github.event.pull_request.number }}) |
+            | TypeScript | [Open live demo](https://demos.handsontable.com/?example=typescript&v=${{ github.event.pull_request.number }}) |
+            | Vue 3 | [Open live demo](https://demos.handsontable.com/?example=vue&v=${{ github.event.pull_request.number }}) |
 
             **SSR Examples:**
 
             | Framework | Link |
             |-----------|------|
-            | Next.js | [Open in CodeSandbox](https://handsontable.com/codesandbox-vm?example-dir=next.js&handsontable-version=${{ github.event.pull_request.number }}) |
-            | Astro | [Open in CodeSandbox](https://handsontable.com/codesandbox-vm?example-dir=astro&handsontable-version=${{ github.event.pull_request.number }}) |
-            | Remix | [Open in CodeSandbox](https://handsontable.com/codesandbox-vm?example-dir=remix&handsontable-version=${{ github.event.pull_request.number }}) |
-            | Nuxt | [Open in CodeSandbox](https://handsontable.com/codesandbox-vm?example-dir=nuxt&handsontable-version=${{ github.event.pull_request.number }}) |
+            | Next.js | [Open live demo](https://demos.handsontable.com/?example=next.js&v=${{ github.event.pull_request.number }}) |
+            | Astro | [Open live demo](https://demos.handsontable.com/?example=astro&v=${{ github.event.pull_request.number }}) |
+            | Remix | [Open live demo](https://demos.handsontable.com/?example=remix&v=${{ github.event.pull_request.number }}) |
+            | Nuxt | [Open live demo](https://demos.handsontable.com/?example=nuxt&v=${{ github.event.pull_request.number }}) |


### PR DESCRIPTION
### Context

The PR changes the `## 📚 Examples` links in the PR preview comment (`.github/workflows/integration.yml`, the "Post PR preview comment" step) from CodeSandbox to our own demo runner at `demos.handsontable.com`.

All ten rows move together — six under `## 📚 Examples` and four under `**SSR Examples:**`:

```
https://handsontable.com/codesandbox-vm?example-dir=<DIR>&handsontable-version=<PR>
→ https://demos.handsontable.com/?example=<DIR>&v=<PR>
```

The link text changes from `Open in CodeSandbox` to `Open live demo`. The `## 📦 PR Preview Packages` block is untouched.

No runner-side change is needed. `?v=<PR_NUMBER>` — a bare numeric id — is already accepted and treated as a pkg.pr.new build ref, and every Handsontable dependency in the example's `package.json` is then pinned to `https://pkg.pr.new/<pkg>@<PR_NUMBER>` — core and the wrappers (`@handsontable/react-wrapper`, `@handsontable/vue3`, `@handsontable/angular-wrapper`). `@handsontable/pikaday` is deliberately never rewritten. All ten `example-dir` values exist in the runner catalog, so this is a 1:1 swap with no gaps.

#### Second change: the preview package was missing `styles/handsontableStyles`

Verifying the new links surfaced a **pre-existing bug** that made every PR preview package unusable, on the demo runner and in CodeSandbox alike. Loading an example failed with:

```
Could not find module in path: 'handsontable/styles/handsontableStyles'
relative to '/node_modules/handsontable/utils/stylesHandler.js'
```

The "Merge dist and styles into the preview package" step (the `HOT_PREBUILT` path) did:

```sh
rm -rf handsontable/tmp/dist handsontable/tmp/styles
cp -R handsontable/styles handsontable/tmp/styles
```

`handsontable/tmp/styles` holds the generated `handsontableStyles.{js,mjs,d.ts}` module that `utils/stylesHandler` imports at runtime, while `handsontable/styles/` holds only the compiled `.css` files. Deleting the directory and copying the CSS over it dropped the JS module from the published tarball. The fix stops removing `tmp/styles` and merges the CSS into it (`cp -R handsontable/styles/. handsontable/tmp/styles/`) so both survive.

Confirmed against real published artifacts:

| Package | `styles/handsontableStyles.*` |
|---|---|
| `handsontable@18.0.0` (npm, stable) | present |
| `https://pkg.pr.new/handsontable@13168` | **missing** |
| `https://pkg.pr.new/handsontable@13167` | **missing** |
| `https://pkg.pr.new/handsontable@13166` | **missing** |
| `https://pkg.pr.new/handsontable@13164` | **missing** |

### How has this been tested?

This is a CI workflow change, so there are no unit or E2E tests. Verified manually:

1. **YAML parses and the step renders as intended** — loaded `.github/workflows/integration.yml` with `js-yaml` and printed the resolved `Post PR preview comment` message and the `Merge dist and styles` script.
2. **No CodeSandbox references remain in this workflow:**
   ```sh
   grep -c codesandbox .github/workflows/integration.yml   # 0
   ```
   The remaining repo-wide hits are in `publish.yml` (release Slack notifications), which is out of scope here.
3. **Opened a generated URL by hand** against a live PR build — `https://demos.handsontable.com/?example=react&v=13168`. The runner resolved the bare PR number, and `package.json` in the file tree showed:
   ```json
   "@handsontable/react-wrapper": "https://pkg.pr.new/@handsontable/react-wrapper@13168",
   "handsontable": "https://pkg.pr.new/handsontable@13168"
   ```
   The install then failed with the `handsontableStyles` error above, which is what led to the second change.
4. **Verified the tarball gap** by downloading `https://pkg.pr.new/handsontable@<n>` for four recent PRs and the stable `handsontable@18.0.0` npm tarball and diffing `package/styles/` (table above).
5. **Simulated the fixed merge** against real local build output (`handsontable/tmp/styles` + `handsontable/styles`) and confirmed the resulting directory contains both `handsontableStyles.{js,mjs,d.ts}` and the `.css` files.

The end-to-end proof — a demo link on a PR whose preview package was built with the fixed step — can only happen once this merges, since it needs a pkg.pr.new build produced by the corrected workflow.

### Worth knowing

- **pkg.pr.new builds expire.** A demo link on an old PR will fail to install once the build is gone. This is the same behavior as the CodeSandbox links it replaces, not a regression.
- **First load can be slow.** `angular`, `next.js`, `astro`, `nuxt`, `remix`, `vue` and `react-js` run in a live container that installs dependencies on first boot. The runner streams the boot log so it does not look frozen. `javascript`, `typescript` and `react` are in-browser and start fast.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2198

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

CI tooling only — no package source code is changed. `[skip changelog]`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2198

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and PR comment content only; the styles merge fix restores expected preview package layout without touching runtime library code.
> 
> **Overview**
> PR preview comments now point **Examples** and **SSR Examples** at `demos.handsontable.com` (`?example=<dir>&v=<PR>`) instead of CodeSandbox, with link text **Open live demo**.
> 
> For **HOT_PREBUILT** preview publishes, the merge step no longer replaces `handsontable/tmp/styles` with only compiled CSS—it copies CSS into `tmp/styles` so generated **`handsontableStyles.{js,mjs,d.ts}`** (used by `stylesHandler`) stay in the published tarball.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 953a9ad45592dbde958af93893d947e7fff843dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->