### PR TITLE
DEV-2202: Fix the theme CSS file path in the theme customization guide

### DIFF
--- a/docs/content/guides/styling/theme-customization/theme-customization.md
+++ b/docs/content/guides/styling/theme-customization/theme-customization.md
@@ -229,7 +229,7 @@ The Theme Generator transforms JSON tokens exported from Figma into properly for
 
 For full control over your theme, you can override CSS variables directly. Follow these [steps](@/guides/styling/themes/themes.md#use-a-theme) to apply a theme, then override the variables for your chosen theme.
 
-You can also directly modify the CSS theme files located in `handsontable/dist/styles/themes/`. This gives you immediate access to all CSS variables and allows for quick iterations.
+You can also open the CSS theme files in `handsontable/styles/` to see every CSS variable a theme defines. Copy the variables you need into your own stylesheet - edits made inside `node_modules` are lost on the next install.
 
 Here's an example for `.ht-theme-main`:
 


### PR DESCRIPTION
### Context

The PR fixes a broken file path in the **Theme customization** guide.

The guide told readers the CSS theme files live in `handsontable/dist/styles/themes/`. That directory does not exist in the published `handsontable` package - `dist/` ships JavaScript only (the sole CSS file there is `dist/pikaday/pikaday.css`). The built theme files land in a **flat** `handsontable/styles/` directory: `.config/themes-css-development.js` and `.config/themes-css-production.js` emit to `../styles/[name].css`, and `handsontable.copy` in `handsontable/package.json` copies `styles` as a top-level directory into the published package.

The page contradicted itself, too: every example on it already imports `handsontable/styles/ht-theme-main.css`.

**Note for review:** the reported task suggests `handsontable/styles/themes/`, which is also wrong - there is no `themes/` subdirectory in the published package. The `themes/` segment exists only in source (`handsontable/src/styles/themes/*.scss`), which is not published. The correct path is `handsontable/styles/`.

The sentence also advised editing files inside `node_modules`, which are build output overwritten on the next install. The replacement keeps the useful part (the theme files are the full list of CSS variables) and points readers to copy what they need into their own stylesheet.

The source line sits outside any `::: only-for` block, so the single edit corrects the JavaScript, React, Angular, and Vue versions of the page.

### How has this been tested?

Docs-only prose change, verified by inspection:

```bash
# No stale path remains in the docs source
git grep -n 'dist/styles' -- docs/content   # no hits

# The published layout is flat, and dist/styles does not exist
ls handsontable/styles/                     # ht-theme-main.css, ht-theme-horizon.css, ...
ls handsontable/dist/styles                 # No such file or directory
```

Cross-checked against the emit targets in `handsontable/.config/themes-css-development.js` and `themes-css-production.js`, and against the imports in this page's own examples (`docs/content/guides/styling/theme-customization/{javascript,react,angular,vue}/example1.*`).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2202

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog] - documentation-only change.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2202

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only prose change with no runtime or API impact.
> 
> **Overview**
> Fixes **Option 3: Override CSS variables** in the Theme customization guide so it matches the published `handsontable` package and the page’s own examples.
> 
> The guide no longer points readers to **`handsontable/dist/styles/themes/`** (that path is not shipped). It now says theme CSS lives in **`handsontable/styles/`** and can be used as a reference for every variable a theme defines.
> 
> It also stops recommending **editing theme files under `node_modules`**. Readers are told to **copy the variables they need into their own stylesheet**, since package installs overwrite changes in `node_modules`.
> 
> Because this paragraph is shared across framework variants, one edit updates the JS, React, Angular, and Vue versions of the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce7ef1a37a50ba25113afcf576b4fc40c67e660f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->