### PR TITLE
DEV-2208: Move the theme-customization examples to the theme object API

### DIFF
--- a/docs/content/guides/styling/theme-customization/angular/example1.html
+++ b/docs/content/guides/styling/theme-customization/angular/example1.html
@@ -1,5 +1,7 @@
 <style>
   .override-theme .ht-theme-main {
+    /* This demo hardcodes light colors, so keep the grid light whatever the reader's system preference is. */
+    color-scheme: light;
     --ht-accent-color: #2c78d4;
     --ht-foreground-color: #1a2533;
     --ht-background-color: #f8f9fa;

--- a/docs/content/guides/styling/theme-customization/angular/example1.ts
+++ b/docs/content/guides/styling/theme-customization/angular/example1.ts
@@ -1,7 +1,9 @@
 /* file: app.component.ts */
 import { Component } from '@angular/core';
 import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
-import 'handsontable/styles/ht-theme-main.css';
+import { mainTheme, registerTheme } from 'handsontable/themes';
+
+const myTheme = registerTheme(mainTheme);
 
 @Component({
   selector: 'example1-demo',
@@ -21,7 +23,7 @@ export class AppComponent {
   ];
 
   readonly gridSettings: GridSettings = {
-    theme: 'ht-theme-main',
+    theme: myTheme,
     colHeaders: ['Name', 'Email', 'City', 'Age', 'Position'],
     columns: [
       { data: 0, type: 'text' },

--- a/docs/content/guides/styling/theme-customization/javascript/example1.html
+++ b/docs/content/guides/styling/theme-customization/javascript/example1.html
@@ -1,5 +1,7 @@
 <style>
 .override-theme .ht-theme-main {
+  /* This demo hardcodes light colors, so keep the grid light whatever the reader's system preference is. */
+  color-scheme: light;
   --ht-accent-color: #2c78d4;
   --ht-foreground-color: #1a2533;
   --ht-background-color: #f8f9fa;

--- a/docs/content/guides/styling/theme-customization/javascript/example1.js
+++ b/docs/content/guides/styling/theme-customization/javascript/example1.js
@@ -1,14 +1,16 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import 'handsontable/styles/ht-theme-main.css';
+import { mainTheme, registerTheme } from 'handsontable/themes';
 
 // Register all Handsontable's modules.
 registerAllModules();
 
+const myTheme = registerTheme(mainTheme);
+
 const container = document.querySelector('#example1');
 
 new Handsontable(container, {
-  theme: 'ht-theme-main',
+  theme: myTheme,
   data: [
     ['John Doe', 'johndoe@example.com', 'New York', 32, 'Engineer'],
     ['Jane Smith', 'janesmith@example.com', 'Los Angeles', 29, 'Designer'],

--- a/docs/content/guides/styling/theme-customization/javascript/example1.ts
+++ b/docs/content/guides/styling/theme-customization/javascript/example1.ts
@@ -1,14 +1,16 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import 'handsontable/styles/ht-theme-main.css';
+import { mainTheme, registerTheme } from 'handsontable/themes';
 
 // Register all Handsontable's modules.
 registerAllModules();
 
+const myTheme = registerTheme(mainTheme);
+
 const container = document.querySelector('#example1')!;
 
 new Handsontable(container, {
-  theme: 'ht-theme-main',
+  theme: myTheme,
   data: [
     ['John Doe', 'johndoe@example.com', 'New York', 32, 'Engineer'],
     ['Jane Smith', 'janesmith@example.com', 'Los Angeles', 29, 'Designer'],

--- a/docs/content/guides/styling/theme-customization/react/example1.jsx
+++ b/docs/content/guides/styling/theme-customization/react/example1.jsx
@@ -1,15 +1,19 @@
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
-import 'handsontable/styles/ht-theme-main.css';
+import { mainTheme, registerTheme } from 'handsontable/themes';
 
 // register Handsontable's modules
 registerAllModules();
 
+const myTheme = registerTheme(mainTheme);
+
 const ExampleComponent = () => {
   return (
-    <>
+    <div className="override-theme">
       <style>{`
-        .ht-theme-main {
+        .override-theme .ht-theme-main {
+          /* This demo hardcodes light colors, so keep the grid light whatever the reader's system preference is. */
+          color-scheme: light;
           --ht-accent-color: #2c78d4;
           --ht-foreground-color: #1a2533;
           --ht-background-color: #f8f9fa;
@@ -24,7 +28,7 @@ const ExampleComponent = () => {
       `}</style>
 
       <HotTable
-        themeName="ht-theme-main"
+        theme={myTheme}
         data={[
           ['John Doe', 'johndoe@example.com', 'New York', 32, 'Engineer'],
           ['Jane Smith', 'janesmith@example.com', 'Los Angeles', 29, 'Designer'],
@@ -45,7 +49,7 @@ const ExampleComponent = () => {
         height="auto"
         licenseKey="non-commercial-and-evaluation"
       />
-    </>
+    </div>
   );
 };
 

--- a/docs/content/guides/styling/theme-customization/react/example1.tsx
+++ b/docs/content/guides/styling/theme-customization/react/example1.tsx
@@ -1,15 +1,19 @@
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
-import 'handsontable/styles/ht-theme-main.css';
+import { mainTheme, registerTheme } from 'handsontable/themes';
 
 // register Handsontable's modules
 registerAllModules();
 
+const myTheme = registerTheme(mainTheme);
+
 const ExampleComponent = () => {
   return (
-    <>
+    <div className="override-theme">
       <style>{`
-        .ht-theme-main {
+        .override-theme .ht-theme-main {
+          /* This demo hardcodes light colors, so keep the grid light whatever the reader's system preference is. */
+          color-scheme: light;
           --ht-accent-color: #2c78d4;
           --ht-foreground-color: #1a2533;
           --ht-background-color: #f8f9fa;
@@ -24,7 +28,7 @@ const ExampleComponent = () => {
       `}</style>
 
       <HotTable
-        themeName="ht-theme-main"
+        theme={myTheme}
         data={[
           ['John Doe', 'johndoe@example.com', 'New York', 32, 'Engineer'],
           ['Jane Smith', 'janesmith@example.com', 'Los Angeles', 29, 'Designer'],
@@ -45,7 +49,7 @@ const ExampleComponent = () => {
         height="auto"
         licenseKey="non-commercial-and-evaluation"
       />
-    </>
+    </div>
   );
 };
 

--- a/docs/content/guides/styling/theme-customization/theme-customization.md
+++ b/docs/content/guides/styling/theme-customization/theme-customization.md
@@ -231,6 +231,8 @@ For full control over your theme, you can override CSS variables directly. Follo
 
 You can also directly modify the CSS theme files located in `handsontable/dist/styles/themes/`. This gives you immediate access to all CSS variables and allows for quick iterations.
 
+The applied theme puts its own class on the grid's root element -- the `main` theme puts `ht-theme-main` there. Scope your overrides to the class of the theme you use.
+
 Here's an example for `.ht-theme-main`:
 
 ::: only-for javascript

--- a/docs/content/guides/styling/theme-customization/vue/example1.vue
+++ b/docs/content/guides/styling/theme-customization/vue/example1.vue
@@ -2,13 +2,15 @@
 import { computed } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
-import 'handsontable/styles/ht-theme-main.css';
+import { mainTheme, registerTheme } from 'handsontable/themes';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
+const myTheme = registerTheme(mainTheme);
+
 const hotSettings = computed<GridSettings>(() => ({
-  theme: 'ht-theme-main',
+  theme: myTheme,
   data: [
     ['John Doe', 'johndoe@example.com', 'New York', 32, 'Engineer'],
     ['Jane Smith', 'janesmith@example.com', 'Los Angeles', 29, 'Designer'],
@@ -38,7 +40,9 @@ const hotSettings = computed<GridSettings>(() => ({
 </template>
 
 <style>
-.ht-theme-main {
+.override-theme .ht-theme-main {
+  /* This demo hardcodes light colors, so keep the grid light whatever the reader's system preference is. */
+  color-scheme: light;
   --ht-accent-color: #2c78d4;
   --ht-foreground-color: #1a2533;
   --ht-background-color: #f8f9fa;


### PR DESCRIPTION
### Context

The PR removes the last manual Handsontable stylesheet imports from the docs examples. The five `theme-customization` `example1` variants (six files -- `react/example1.jsx` was missed in the original inventory) each opened with:

```js
import 'handsontable/styles/ht-theme-main.css';
```

That line is the first thing a reader sees in the snippet, so it reads as the recommended way to set a grid up, and no other example under `docs/content/guides/` still does it.

The import could not simply be deleted. These examples set a *string* theme (`theme: 'ht-theme-main'`, React `themeName="ht-theme-main"`), and with a string theme core injects no theme tokens. The docs site only loads the structural `handsontable.min.css` globally, so dropping the import alone renders the grid unthemed and logs `The "ht-theme-main" theme is enabled, but its stylesheets are missing or not imported correctly.` The examples therefore move to the `theme:` object API, which makes the stylesheet unnecessary because `ThemeManager` injects the `--ht-*` tokens itself:

```js
import { mainTheme, registerTheme } from 'handsontable/themes';

const myTheme = registerTheme(mainTheme);
// theme: myTheme   /   React: theme={myTheme}
```

This is also the shape the page's own "Option 1: Theme API" prose and the `example2` variants already use, so the page is now internally consistent.

**Second fix in the same change -- `color-scheme`.** The static `ht-theme-main.css` pins `.ht-theme-main { color-scheme: light }`, while the injected theme style emits `color-scheme: light dark` (the theme builder defaults to `auto`) and the token values use `light-dark()`. These four demos hardcode light colors (`#f8f9fa` background, `#1a2533` text) inside `.disable-auto-theme` containers, which deliberately opt out of the docs light/dark sync. Without the static file, a reader whose system prefers dark would get a half-dark grid wearing a light palette. Each override block now pins `color-scheme: light` at `.override-theme .ht-theme-main` (specificity 0,2,0, so it beats the injected 0,1,0 rule regardless of source order). The React variant gained an `.override-theme` wrapper element and the Vue variant had its selector scoped so the rule reaches them.

One sentence was added to the "Option 3: Override CSS variables" section explaining that the `.ht-theme-main` class comes from the applied theme, so the override selector is no longer unexplained.

### How has this been tested?

Manually in the docs dev server, for all four frameworks (`/docs/{javascript,react,vue,angular}-data-grid/theme-customization/`):

```bash
npm run build --prefix handsontable      # examples resolve handsontable/themes from tmp/
npm run dev --prefix docs
```

- With `prefers-color-scheme: dark` emulated, `example1`'s grid keeps its light override palette in every framework: computed `color-scheme: light`, `--ht-accent-color: #2c78d4`, cell background `rgb(248, 249, 250)`, `--ht-border-radius: 8px`. Repeated with light emulation. This is the check that catches the regression described above -- a light-only pass hides it.
- `--ht-line-height` resolves to `20px`, which is the value the missing-stylesheet warning tests, so the warning does not fire.
- Console is clean on all four pages. The only remaining entry is a dev-server 504 on `astro/runtime/client/dev-toolbar/entrypoint.js`, unrelated to the examples.
- `example2` on the same page still renders its customized horizon theme, so the two grids coexist.
- Dumped the matching CSS rules in the browser to confirm the new `.override-theme .ht-theme-main { color-scheme: light }` rule wins over the injected `.ht-theme-main { color-scheme: light dark }`.

Type-check:

```bash
SKIP_LATEST=1 npm run typecheck --prefix docs/angular-type-check
```

`angular/example1.ts` passes. The run reports 4 pre-existing errors in files this PR does not touch -- `guides/accessories-and-menus/context-menu/angular/example3.ts:45` and `recipes/cell-types/moment-date/angular/example1.ts:62,68`.

The page is covered by the docs visual tests (`docs/tests/paths.js`), so a screenshot diff is expected for review. The computed theme values are identical before and after; the only structural change is the React variant's fragment becoming a wrapper `<div>`.

### Notes for the reviewer

Two findings surfaced while verifying this, both left out of scope:

1. **Core double-registers a plain theme object.** `initializeThemeManager()` is called twice with no already-initialized guard -- once at the constructor tail (`handsontable/src/core.ts:6573`) and once in `this.init` (`core.ts:1591`). For a plain theme object the second call reaches `registerTheme()` again and logs `Theme "main" is already registered. Registration skipped.` Passing a `ThemeBuilder` skips that branch, which is why this PR registers the theme first. The plain-object form is what several guides teach in prose (`styling/themes/themes.md`, `styling/legacy-style/legacy-style.md`, the 16.2-to-17.0 migration guide), so readers copying those snippets see the warning. Worth its own task.
2. **The `theme` option is missing from the TypeScript types.** `handsontable/src/core/settings.ts` declares only `themeName?: string`; `theme` type-checks purely through the interface's `[key: string]: any` index signature.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2208

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog] -- docs-only change.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2208

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and live examples only; no runtime library or API changes.
> 
> **Overview**
> Updates the **Option 3** `example1` demos on the theme-customization guide so they no longer import `handsontable/styles/ht-theme-main.css` or pass a string theme (`'ht-theme-main'` / `themeName`). They now use **`registerTheme(mainTheme)`** and pass the registered **`theme`** object, matching the Theme API pattern used elsewhere on the page.
> 
> Because theme injection defaults to **`color-scheme: light dark`**, the hardcoded light CSS variable overrides are scoped under **`.override-theme .ht-theme-main`** with **`color-scheme: light`** so the demo stays light when the OS prefers dark. React examples wrap the grid in an **`override-theme`** container; Vue uses the same scoped selector.
> 
> The guide adds a short note that the active theme’s class (e.g. **`ht-theme-main`**) is applied on the grid root for override selectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 853b37ad776fc7f4b7c5002d76a37a335fa0f92c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->