### PR TITLE
PRO-1312: Document the automated CLA process

### DIFF
--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -57,7 +57,7 @@ The repository has a PR template at `.github/PULL_REQUEST_TEMPLATE.md`. Fill in 
 - **Types of changes** -- Check the box that applies: bug fix, new feature, breaking change, or translation.
 - **Related issue(s)** -- Link GitHub issues with `#xxx`. Include ClickUp task IDs (e.g. `DEV-627`) so they auto-link.
 - **Affected project(s)** -- Check every package your change touches: `handsontable`, `@handsontable/react-wrapper`, `@handsontable/angular-wrapper`, `@handsontable/vue3`.
-- **Checklist** -- Confirm code style, CLA signature, and whether documentation needs updating.
+- **Checklist** -- Confirm code style, CLA signature, and whether documentation needs updating. The CLA is checked automatically by the required `cla/signed` status check; one signature covers Handsontable and HyperFormula. See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md#contributor-license-agreement).
 
 ## 4. Target Branch
 
@@ -134,7 +134,7 @@ The body file template (write this with the Write tool, backticks and all, no es
 ### Checklist:
 
 - [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
-- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
+- [x] I have signed the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
 - [ ] My change requires a change to the documentation.
 
 ClickUp task: https://app.clickup.com/t/9015210959/DEV-xxx

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -134,7 +134,7 @@ The body file template (write this with the Write tool, backticks and all, no es
 ### Checklist:
 
 - [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
-- [x] I have signed the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
+- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
 - [ ] My change requires a change to the documentation.
 
 ClickUp task: https://app.clickup.com/t/9015210959/DEV-xxx

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,6 +48,6 @@ any HTML comment — here, inside a comment, it is inert.
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
-- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
+- [ ] I have signed the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
 - [ ] My change requires a change to the documentation.
 - [ ] This change needs a manual QA pass — <!-- describe WHAT to check and why automation can't; a reviewer (not the author) signs off by commenting `/manual-qa passed`, then re-run the "[CHECK] Manual QA" job -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,6 +48,6 @@ any HTML comment — here, inside a comment, it is inert.
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
-- [ ] I have signed the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
+- [ ] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
 - [ ] My change requires a change to the documentation.
 - [ ] This change needs a manual QA pass — <!-- describe WHAT to check and why automation can't; a reviewer (not the author) signs off by commenting `/manual-qa passed`, then re-run the "[CHECK] Manual QA" job -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. Changel
 - Strict XSS prevention in user-facing cell content.
 - Input sanitization on custom formulas and cell scripts.
 - Safe plugin architecture to minimize attack surfaces.
-- CLA must be signed before merging external contributions. This is enforced automatically: a GitHub App sets the required `cla/signed` status check on every PR, so an unsigned PR cannot be merged — never work around a red CLA check. One signature covers both Handsontable and HyperFormula (it is recorded per GitHub account, not per repository). Process and signing page: <https://cla-gate.handsontable-sandbox.workers.dev/>; contributor-facing summary in [`CONTRIBUTING.md`](CONTRIBUTING.md#contributor-license-agreement).
+- CLA must be signed before merging external contributions. This is enforced automatically: a GitHub App sets the required `cla/signed` status check on every PR, so an unsigned PR cannot be merged — never work around a red CLA check. One signature covers both Handsontable and HyperFormula (it is recorded per GitHub account, not per repository). Process and signing page: <https://cla.handsontable.com/>; contributor-facing summary in [`CONTRIBUTING.md`](CONTRIBUTING.md#contributor-license-agreement).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. Changel
 - Strict XSS prevention in user-facing cell content.
 - Input sanitization on custom formulas and cell scripts.
 - Safe plugin architecture to minimize attack surfaces.
-- CLA must be signed before merging external contributions.
+- CLA must be signed before merging external contributions. This is enforced automatically: a GitHub App sets the required `cla/signed` status check on every PR, so an unsigned PR cannot be merged — never work around a red CLA check. One signature covers both Handsontable and HyperFormula (it is recorded per GitHub account, not per repository). Process and signing page: <https://cla-gate.handsontable-sandbox.workers.dev/>; contributor-facing summary in [`CONTRIBUTING.md`](CONTRIBUTING.md#contributor-license-agreement).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Handsoncode publishes the code it merges — in open-source releases and in comm
 
 **Sign it once, for every project.** The signature is recorded against your GitHub account, not against a repository, and covers both [Handsontable](https://github.com/handsontable/handsontable) and [HyperFormula](https://github.com/handsontable/hyperformula). If you have already signed for either one, you are done.
 
-**Sign here: [cla-gate.handsontable-sandbox.workers.dev/sign](https://cla-gate.handsontable-sandbox.workers.dev/sign)** — the [process is explained in full](https://cla-gate.handsontable-sandbox.workers.dev/) on the same site.
+**Sign here: [cla.handsontable.com/sign](https://cla.handsontable.com/sign)** — the [process is explained in full](https://cla.handsontable.com/) on the same site.
 
 How it works on your pull request:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Your contribution to Handsontable's codebase is most welcome. To fix a bug or pr
 
 To speed up the process of merging your changes, follow these rules:
 
-1. Sign the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2), to let us publish your changes. This applies to all code you submit, including AI-assisted contributions (see [AI-assisted contributions](#ai-assisted-contributions)).
+1. Sign the [Contributor License Agreement](#contributor-license-agreement), to let us publish your changes. This applies to all code you submit, including AI-assisted contributions (see [AI-assisted contributions](#ai-assisted-contributions)).
 2. Make your changes on a separate branch. This speeds up the merging process.
 3. Always target your PR at the `develop` branch, not the `master` branch.
 4. Make changes to the right project:
@@ -41,6 +41,27 @@ To speed up the process of merging your changes, follow these rules:
 10. In your PR, add a thorough description of all the changes, and fill in the test-evidence section of the PR template.
 
 Thank you for your contribution!
+
+## Contributor License Agreement
+
+Handsoncode publishes the code it merges — in open-source releases and in commercial products. Doing that requires the right to use, relicense, and distribute your contribution, and the Contributor License Agreement (CLA) is the record of that permission. You keep the copyright to your work; the CLA grants Handsoncode a licence to it.
+
+**Sign it once, for every project.** The signature is recorded against your GitHub account, not against a repository, and covers both [Handsontable](https://github.com/handsontable/handsontable) and [HyperFormula](https://github.com/handsontable/hyperformula). If you have already signed for either one, you are done.
+
+**Sign here: [cla-gate.handsontable-sandbox.workers.dev/sign](https://cla-gate.handsontable-sandbox.workers.dev/sign)** — the [process is explained in full](https://cla-gate.handsontable-sandbox.workers.dev/) on the same site.
+
+How it works on your pull request:
+
+1. You open a PR. A GitHub App looks up your GitHub login and sets the `cla/signed` status check.
+2. If you have not signed, the check fails and a bot comments with your signing link.
+3. Open the link, authenticate with GitHub, read the agreement, and submit the form.
+4. The check turns green — on this PR and on any other open PR of yours, in either repository.
+
+`cla/signed` is a **required check**, so an unsigned PR cannot be merged. Members of the `handsontable` GitHub organization and known bots are exempt.
+
+Signature records are stored in Cloudflare D1 in the EU. For a correction to your record or an erasure request, email [support@handsontable.com](mailto:support@handsontable.com).
+
+> **Reviewers:** there is nothing to verify by hand — the required check is the verification. Never merge a PR whose `cla/signed` check is red, and do not work around it.
 
 ## Definition of done (local enforcement)
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ If you're using Handsontable in a project that supports commercial activities, y
 
 ## 🙌 Contributing
 
-Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
+Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign).
 
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ If you're using Handsontable in a project that supports commercial activities, y
 
 ## 🙌 Contributing
 
-Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign).
+Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla.handsontable.com/sign).
 
 <br>
 <br>

--- a/handsontable/README.md
+++ b/handsontable/README.md
@@ -237,7 +237,7 @@ If you're using Handsontable in a project that supports commercial activities, y
 
 ## 🙌 Contributing
 
-Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
+Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign).
 
 <br>
 <br>

--- a/handsontable/README.md
+++ b/handsontable/README.md
@@ -237,7 +237,7 @@ If you're using Handsontable in a project that supports commercial activities, y
 
 ## 🙌 Contributing
 
-Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign).
+Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla.handsontable.com/sign).
 
 <br>
 <br>

--- a/wrappers/angular-wrapper/README.md
+++ b/wrappers/angular-wrapper/README.md
@@ -229,7 +229,7 @@ If you're using Handsontable in a project that supports commercial activities, y
 
 ## 🙌 Contributing
 
-Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
+Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign).
 
 <br>
 <br>

--- a/wrappers/angular-wrapper/README.md
+++ b/wrappers/angular-wrapper/README.md
@@ -229,7 +229,7 @@ If you're using Handsontable in a project that supports commercial activities, y
 
 ## 🙌 Contributing
 
-Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign).
+Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla.handsontable.com/sign).
 
 <br>
 <br>

--- a/wrappers/react-wrapper/README.md
+++ b/wrappers/react-wrapper/README.md
@@ -217,7 +217,7 @@ If you're using Handsontable in a project that supports commercial activities, y
 
 ## 🙌 Contributing
 
-Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
+Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign).
 
 <br>
 <br>

--- a/wrappers/react-wrapper/README.md
+++ b/wrappers/react-wrapper/README.md
@@ -217,7 +217,7 @@ If you're using Handsontable in a project that supports commercial activities, y
 
 ## 🙌 Contributing
 
-Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign).
+Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla.handsontable.com/sign).
 
 <br>
 <br>

--- a/wrappers/vue3/README.md
+++ b/wrappers/vue3/README.md
@@ -231,7 +231,7 @@ If you're using Handsontable in a project that supports commercial activities, y
 
 ## 🙌 Contributing
 
-Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign).
+Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla.handsontable.com/sign).
 
 <br>
 <br>

--- a/wrappers/vue3/README.md
+++ b/wrappers/vue3/README.md
@@ -231,7 +231,7 @@ If you're using Handsontable in a project that supports commercial activities, y
 
 ## 🙌 Contributing
 
-Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
+Contributions are welcome, but before you make them, please read the [Contributing Guide](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md) and accept the [Contributor License Agreement](https://cla-gate.handsontable-sandbox.workers.dev/sign).
 
 <br>
 <br>


### PR DESCRIPTION
### Context

The PR documents the Contributor License Agreement process, which until now was mentioned in passing and pointed contributors at a Google Form.

The requirement existed in `CONTRIBUTING.md` and the PR template, but nothing explained **why** the CLA is needed, **what** it covers, **where** signature records live, or **how** a reviewer verifies one before merging. PRO-1312 asks for that explanation in one place.

Alongside this, the CLA is now enforced automatically by a GitHub App that sets a required `cla/signed` status check, and the same signature covers Handsontable and HyperFormula — the record is keyed to a GitHub account, not a repository. Neither fact was written down anywhere contributors would look.

What changed:

- **`CONTRIBUTING.md`** — new `Contributor License Agreement` section: why the CLA is required, that one signature covers both Handsontable and HyperFormula, the four steps a contributor actually sees, that `cla/signed` is a required check, where records are stored, and a note telling reviewers the check *is* the verification (nothing to confirm by hand, never merge around a red check).
- **`.github/PULL_REQUEST_TEMPLATE.md`** — the CLA checkbox points at the signing page instead of the retired Google Form.
- **READMEs** (root, `handsontable/`, all three wrappers) — same link replacement.
- **`AGENTS.md`** — states the enforcement so agents do not try to work around a red CLA check.
- **`.claude/skills/pr-creation/SKILL.md`** — updates the template it hands to agents.

The signing page and the full process description are served by the CLA gate worker, which is a separate repository; the HyperFormula counterpart to this PR is linked below. Generated output under `wrappers/angular-wrapper/dist/` still carries the old link and is deliberately left untouched — it is rebuilt from source.

### How has this been tested?

Documentation-only change; no runtime code is touched.

- Verified no `goo.gl/forms` or Google Form reference survives outside generated `dist/` output:
  ```bash
  grep -rn "goo.gl/forms" --include="*.md" . | grep -v node_modules | grep -v dist/
  ```
- Confirmed the in-page anchor `#contributor-license-agreement` resolves to the new heading in `CONTRIBUTING.md`.
- Confirmed both linked pages return HTTP 200 and render the expected content (process page headings, signing form).
- Checked the enforcement gates classify this as a non-source change, so neither the test-presence gate (`.github/scripts/lib/presence-gate.mjs` matches only `.ts/.js/.tsx` under source trees) nor the changelog gate (excludes `/\.md$/i`) applies. `[skip changelog]`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)
- [x] Documentation

### Related issue(s):

1. PRO-1312
2. HyperFormula counterpart: handsontable/hyperformula#1725

### Affected project(s):

- [x] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [x] `@handsontable/vue3`

(READMEs only — no source code in any package is touched.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

### Before merging

Two operational steps must land first, or contributors get a worse experience than today:

1. **Import the historical signatures** into the gate's database, so the ~150 people who signed the Google Form are not asked to sign again. An importer and instructions ship in the CLA gate repository.
2. **Add `cla/signed` as a required check** on `develop` in both repositories, so it actually blocks a merge. The App itself now covers both repos, and the check has been verified green on a HyperFormula PR.

`[skip changelog]`

ClickUp task: https://app.clickup.com/t/9015210959/PRO-1312

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and contributor guidance only; no runtime, auth, or merge-gate code changes in this diff.
> 
> **Overview**
> Documents the **Contributor License Agreement** end-to-end and retires the old Google Form links in contributor-facing docs.
> 
> **`CONTRIBUTING.md`** gains a dedicated **Contributor License Agreement** section: why signing is required, one GitHub-account signature for **Handsontable** and **HyperFormula**, the PR flow via the **`cla/signed`** required check, where records live, and reviewer guidance not to merge around a failed check. Rule #1 now links to that section instead of an external form.
> 
> **`.github/PULL_REQUEST_TEMPLATE.md`**, **`AGENTS.md`**, and **`.claude/skills/pr-creation/SKILL.md`** align the CLA checklist with **`cla.handsontable.com/sign`** and the automated **`cla/signed`** gate. Root and package **READMEs** use the same signing URL instead of **`goo.gl`** shortcuts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6d0489a51fc6e07e685a6b85bfd00087a254627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->