### PR TITLE
DEV-2223: Remove the private dev-handsontable link from the pikaday recipe

### DIFF
--- a/docs/content/recipes/cell-types/pikaday/javascript/example1.js
+++ b/docs/content/recipes/cell-types/pikaday/javascript/example1.js
@@ -237,7 +237,6 @@ const cellDefinition = {
       editor.parentDestroyed = false;
       // create the input element on init. This is a text input that color picker will be attached to.
       editor.input = editor.hot.rootDocument.createElement('INPUT');
-      // editor.showDatepicker = (editor, event) => {
       editor.datePicker = editor.container;
       /**
        * Prevent recognizing clicking on datepicker as clicking outside of table.
@@ -247,13 +246,7 @@ const cellDefinition = {
           editor.hideDatepicker(editor);
         }
       });
-      // TODO: fix this https://github.com/handsontable/dev-handsontable/issues/3004
-      // @ts-ignore
-      // editor.hot.rootPortalElement.appendChild(editor.datePicker);
     },
-    // afterInit(editor) {
-    //   editor.pickaday = new Pikaday(editor.getDatePickerConfig(editor));
-    // },
     getDatePickerConfig(editor) {
       const htInput = editor.input;
       const options = {};

--- a/docs/content/recipes/cell-types/pikaday/javascript/example1.ts
+++ b/docs/content/recipes/cell-types/pikaday/javascript/example1.ts
@@ -278,7 +278,6 @@ const cellDefinition: Pick<
         "INPUT",
       ) as HTMLInputElement;
 
-      //editor.showDatepicker = (editor, event) => {
       editor.datePicker = editor.container;
 
       /**
@@ -292,14 +291,7 @@ const cellDefinition: Pick<
           editor.hideDatepicker(editor);
         }
       });
-
-      // TODO: fix this https://github.com/handsontable/dev-handsontable/issues/3004
-      // @ts-ignore
-      // editor.hot.rootPortalElement.appendChild(editor.datePicker);
     },
-    // afterInit(editor) {
-    //   editor.pickaday = new Pikaday(editor.getDatePickerConfig(editor));
-    // },
     getDatePickerConfig(editor) {
       const htInput = editor.input;
       const options: Pikaday.PikadayOptions = {};


### PR DESCRIPTION
### Context

The PR removes a link to the private `handsontable/dev-handsontable` repository from the public pikaday recipe example.

The example carried a commented-out `// TODO` block pointing at `https://github.com/handsontable/dev-handsontable/issues/3004`. `pikaday.md` embeds `javascript/example1.js` and `example1.ts` through the `::: example` directive, so Expressive Code printed that comment in the code block readers see on the page. The link 404s for anyone outside the org and advertises an internal repository.

All three lines of the block were already commented out, so this is a text deletion with no behavior change. Two sibling dead-comment blocks in the same `init` went with it, since `docs/CLAUDE.md` §2.5 bans stray `// TODO` / `// ...` comments in published examples:

- the `// TODO` block itself (the private link),
- a commented-out `// afterInit(editor) { ... }`,
- a stray unmatched opener, `// editor.showDatepicker = (editor, event) => {`.

Net diff: 15 deletions across 2 files, no insertions.

Nothing to do in `handsontable/examples`. Its `runner/apps/authoring/public/docs-examples/{next,18.0}/recipes__cell-types__pikaday__javascript__example1.{js,ts}.json` are generated and overwritten on the next docs import. `normalizeDocsBranch()` in that repo accepts only `develop` (bucket `next`) or `prod-docs/<major>.<minor>`, so this PR against `develop` feeds the `next` bucket. No `prod-docs/18.0` cherry-pick — the 18.0 bucket picks it up at the next release-branch cut.

### How has this been tested?

Docs-only comment removal, so verification focused on proving the rendered page lost the comments while the live code stayed intact.

- Link gate: `git grep -n "dev-handsontable" -- docs/` returns no matches.
- Served page under `astro dev` (`/javascript-data-grid/recipes/cell-types/pikaday`): 0 occurrences of `dev-handsontable`, `TODO: fix this`, and `afterInit(editor)`. The real `showDatepicker` and `getDatePickerConfig` methods are still present (16 hits each across framework variants), confirming a comment was removed and not a live method.
- Grid still renders on the recipe page.
- `BASE_URL=http://localhost:4325/docs npx playwright test recipeConsoleErrors.spec.ts -g pikaday` — passes, no new console errors.
- Syntax: `node --check` on a `.mjs` copy of `example1.js` passes; `npx tsc --noEmit --skipLibCheck --target esnext --module esnext --moduleResolution bundler content/recipes/cell-types/pikaday/javascript/example1.ts` reports no `TS1xxx` syntax-class errors.
- ESLint does not cover these files: `docs/.eslintrc.js` `ignorePatterns` includes `**/recipes/**/*.js` and `**/recipes/**/*.ts`, so `docs:lint` skips them. Hence the direct syntax checks above.
- Files were hand-edited. `docs:code-examples:generate-js` was deliberately not run, since it reformats the whole file and would turn a 15-line deletion into a whole-file diff.

Pre-existing failure, not caused by this change: `npx playwright test pikadayRecipe.spec.ts` under `astro dev` times out on `.pika-single` for `javascript-data-grid` and `react-data-grid` (angular passes). The identical two failures reproduce with these edits stashed on clean `develop`. The console shows `pageerror: You need to define the shortcut's group.` plus a Vite `504 (Outdated Optimize Dep)`. There is no CI baseline to compare against - `docs-visual-tests.yml` runs the docs specs only on PRs carrying the `run-docs-visual` label, against the Cloudflare preview, never on a `develop` push. Worth a separate ticket if it also reproduces on a production build.

Reproduce:

```bash
npm --prefix docs run dev            # note the port it picks
git grep -n "dev-handsontable" -- docs/
cd docs && BASE_URL=http://localhost:<port>/docs npx playwright test recipeConsoleErrors.spec.ts -g pikaday
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2223

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation content only (`docs/content/recipes/`). No package source touched.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation. (This PR *is* the documentation change.)

[skip changelog] - docs-only change, no package source affected.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2223

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only deletion of already-commented code with no runtime or package behavior change.
> 
> **Overview**
> Removes dead commented-out blocks from the public pikaday recipe (`example1.js` / `example1.ts`), including a `TODO` that linked to the private `dev-handsontable` repo.
> 
> No live editor logic changes—only stray comments that were rendering in the published docs code block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 680a36ce6540af70bd47b61da7f4bc7a9537f9fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->