### PR TITLE
DEV-2214: Point docs starter links at the matching examples branch

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -425,6 +425,36 @@ Use the `@` prefix with `.md` extension for all internal links:
 
 Do not use relative paths (`../`) for internal links.
 
+### Template variables in links
+
+Never hardcode a branch name in a GitHub link. Five template variables resolve at
+build time - production builds point at the frozen branch for the docs version,
+every other build points at the development branch. All five are declared and
+substituted in `src/plugins/template-variables.mjs`, the sole registry:
+
+| Variable | Production | Otherwise | Use for |
+|---|---|---|---|
+| `{{$examplesBranch}}` | `prod-examples/<major>` | `master` | `handsontable/examples` starter sources |
+| `{{$currentMinorVersion}}` | `prod-docs/<major>.<minor>` | `develop` | `handsontable/handsontable` sources |
+| `{{$currentVersion}}` | package.json version | `0.0.0-next-<sha>-<date>` | version strings, runner links |
+| `{{$latestChangelogVersion}}` | highest `changelog-N` major | same | links to the newest changelog page |
+| `{{$basePath}}` | `''` | `''` | root-relative asset paths |
+
+Three pipelines substitute them and all three go through that module: the content
+loader (`src/plugins/framework-loader.mjs`), the Vite pre-transform
+(`src/plugins/vuepress-preprocessor.mjs`), and the `_md` route generator in
+`astro.config.mjs` that backs Copy Markdown. Add a variable in one place only.
+The exception is `{{$basePath}}` inside **embedded example source files**, which
+`framework-loader.mjs` substitutes with `/docs` rather than `''`.
+
+A hardcoded `tree/master` link sends a reader on older docs to a starter that no
+longer matches their version (DEV-2214).
+
+Exception: the `server-side-*` recipes keep `tree/master/server-examples/...`.
+`server-examples/` is not in the runner's `frameworks.json`, is not bucketed per
+major, and receives no per-major repair, so a `prod-examples/<major>` copy of it
+would be a frozen unmaintained snapshot.
+
 ---
 
 ## 2.8 Trademark Notices

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -8,6 +8,7 @@ import sitemap from '@astrojs/sitemap';
 import { pluginLineNumbers } from '@expressive-code/plugin-line-numbers';
 import { pluginCollapsibleSections } from '@expressive-code/plugin-collapsible-sections';
 import { vuepressPreprocessor } from './src/plugins/vuepress-preprocessor.mjs';
+import { replaceTemplateVariables } from './src/plugins/template-variables.mjs';
 import { rehypeTableWrapper } from './src/plugins/rehype-table-wrapper.mjs';
 import { rehypeMigrationSteps } from './src/plugins/rehype-migration-steps.mjs';
 import { replaceHasSelectors } from './src/plugins/replace-has-selectors.mjs';
@@ -579,6 +580,20 @@ function markdownRoutesIntegration() {
   const publicMdDir = resolve(__dirname, 'public', '_md');
   const PREFIXES = ['javascript-data-grid', 'react-data-grid', 'angular-data-grid'];
 
+  /**
+   * Assembles one output file: an H1 from the frontmatter title, then the body
+   * with its template variables resolved. Without the substitution a reader
+   * copying the Markdown of a page gets a literal `{{$examplesBranch}}` (or
+   * `{{$currentMinorVersion}}`) instead of a working link.
+   *
+   * @param {string} title The page title from frontmatter.
+   * @param {string} content The page body, frontmatter already stripped.
+   * @returns {string}
+   */
+  function buildMarkdown(title, content) {
+    return replaceTemplateVariables(`# ${title}\n\n${content.trim()}`);
+  }
+
   function buildRouteMap() {
     const routeMap = new Map();
 
@@ -608,14 +623,14 @@ function markdownRoutesIntegration() {
         const rel = relative(contentDir, full);
 
         if (rel === 'index.md') {
-          routeMap.set('index.md', `# ${data.title}\n\n${content.trim()}`);
+          routeMap.set('index.md', buildMarkdown(data.title, content));
           continue;
         }
 
         if (!data.permalink) continue;
 
         const slug = data.permalink.replace(/^\//, '').replace(/\/$/, '') || 'index';
-        const md = `# ${data.title}\n\n${content.trim()}`;
+        const md = buildMarkdown(data.title, content);
 
         for (const prefix of PREFIXES) {
           routeMap.set(`${prefix}/${slug}.md`, md);

--- a/docs/content/recipes/themes/ant-design/ant-design.md
+++ b/docs/content/recipes/themes/ant-design/ant-design.md
@@ -33,11 +33,11 @@ In this tutorial, you will integrate Handsontable into a React app that uses Ant
 ></iframe>
 
 [**Open in sandbox**](https://demos.handsontable.com/?example=ant-design&v={{$currentVersion}})
-[**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/ant-design)
+[**View source on GitHub**](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/ant-design)
 
 ## Overview
 
-This recipe uses the official [handsontable/examples Ant Design demo](https://github.com/handsontable/examples/tree/master/examples/ant-design) as the live reference implementation. It shows how to integrate Handsontable into a React app that uses [Ant Design](https://ant.design/) by registering a custom theme and mapping Handsontable theme colors and tokens to Ant Design table-like styles.
+This recipe uses the official [handsontable/examples Ant Design demo](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/ant-design) as the live reference implementation. It shows how to integrate Handsontable into a React app that uses [Ant Design](https://ant.design/) by registering a custom theme and mapping Handsontable theme colors and tokens to Ant Design table-like styles.
 
 **Difficulty:** Beginner
 **Time:** ~15 minutes

--- a/docs/content/recipes/themes/base-theme/base-theme.md
+++ b/docs/content/recipes/themes/base-theme/base-theme.md
@@ -34,7 +34,7 @@ This tutorial shows you how to integrate Handsontable into a React app that uses
 ></iframe>
 
 [**Open in sandbox**](https://demos.handsontable.com/?example=base-web&v={{$currentVersion}})
-[**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/base-web)
+[**View source on GitHub**](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/base-web)
 
 ## Overview
 

--- a/docs/content/recipes/themes/custom-theme/custom-theme.md
+++ b/docs/content/recipes/themes/custom-theme/custom-theme.md
@@ -34,7 +34,7 @@ This tutorial shows you how to integrate Handsontable into a Next.js app that us
    ></iframe>
 
 [**Open in sandbox**](https://demos.handsontable.com/?example=next-shadcn.js&v={{$currentVersion}})
-[**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/next-shadcn.js)
+[**View source on GitHub**](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/next-shadcn.js)
 
 ## Overview
 

--- a/docs/content/recipes/themes/fluent-ui/fluent-ui.md
+++ b/docs/content/recipes/themes/fluent-ui/fluent-ui.md
@@ -30,7 +30,7 @@ In this tutorial, you will integrate Handsontable into a React app with Fluent U
 ></iframe>
 
 [**Open in sandbox**](https://demos.handsontable.com/?example=fluent-ui&v={{$currentVersion}})
-[**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/fluent-ui)
+[**View source on GitHub**](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/fluent-ui)
 
 ## Overview
 

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -35,7 +35,7 @@ This tutorial shows you how to integrate Handsontable into a React app that uses
 ></iframe>
 
 [**Open in sandbox**](https://demos.handsontable.com/?example=mui&v={{$currentVersion}})
-[**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/mui)
+[**View source on GitHub**](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/mui)
 
 ## Overview
 

--- a/docs/src/plugins/__tests__/docs-version.test.mjs
+++ b/docs/src/plugins/__tests__/docs-version.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { deriveExamplesBranch, CURRENT_EXAMPLES_BRANCH } from '../docs-version.mjs';
+
+test('a production build derives the prod-examples branch for its major', () => {
+  assert.equal(deriveExamplesBranch('18.0.2', true), 'prod-examples/18');
+  assert.equal(deriveExamplesBranch('15.3.0', true), 'prod-examples/15');
+  assert.equal(deriveExamplesBranch('19.0.0-beta.1', true), 'prod-examples/19');
+});
+
+test('a non-production build always resolves to the examples repo master branch', () => {
+  // master, not develop: handsontable/examples has no develop branch.
+  assert.equal(deriveExamplesBranch('0.0.0-next-abc1234-20260812', false), 'master');
+  assert.equal(deriveExamplesBranch('18.0.2', false), 'master');
+});
+
+test('a version with no released major never derives a prod-examples/0 branch', () => {
+  // The staging/dev placeholder reaching a production build must not produce a
+  // link to prod-examples/0, which does not exist.
+  assert.equal(deriveExamplesBranch('0.0.0-next-abc1234-20260812', true), 'master');
+  assert.equal(deriveExamplesBranch('next', true), 'master');
+  assert.equal(deriveExamplesBranch('', true), 'master');
+  assert.equal(deriveExamplesBranch(undefined, true), 'master');
+});
+
+test('CURRENT_EXAMPLES_BRANCH resolves to a branch that exists in handsontable/examples', () => {
+  assert.match(CURRENT_EXAMPLES_BRANCH, /^(master|prod-examples\/\d+)$/);
+  assert.doesNotMatch(CURRENT_EXAMPLES_BRANCH, /prod-examples\/0$/);
+});

--- a/docs/src/plugins/__tests__/framework-loader.test.mjs
+++ b/docs/src/plugins/__tests__/framework-loader.test.mjs
@@ -7,7 +7,7 @@ import { join } from 'node:path';
 import { frameworkLoader } from '../framework-loader.mjs';
 import { setRenderedHtmlDirForTests, readRenderedHtml } from '../rendered-html-store.mjs';
 import { LATEST_CHANGELOG_MAJOR } from '../changelog-parser.mjs';
-import { CURRENT_DOCS_VERSION } from '../docs-version.mjs';
+import { CURRENT_DOCS_VERSION, CURRENT_EXAMPLES_BRANCH } from '../docs-version.mjs';
 
 // The loader writes each entry's rendered HTML to a file and stores only a
 // marker in the data store (see rendered-html-store.mjs) — keep test writes
@@ -612,6 +612,46 @@ test('{{$latestChangelogVersion}} placeholder resolves to the latest changelog p
     // Regression guard: if the placeholder were substituted after (or never),
     // the literal "{{" would leak into the link or the fallback path.
     assert.ok(!html.includes('{{'), 'no unresolved {{$latestChangelogVersion}} placeholder should remain');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('{{$examplesBranch}} placeholder resolves to the matching handsontable/examples branch', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'hot-loader-examples-branch-'));
+  const contentDir = join(root, 'content');
+  const recipeDir = join(contentDir, 'recipes', 'themes', 'mui-theme');
+
+  mkdirSync(recipeDir, { recursive: true });
+  writeFileSync(join(contentDir, 'index.md'), '---\ntitle: Home\n---\n\nWelcome.\n');
+  writeFileSync(
+    join(recipeDir, 'mui-theme.md'),
+    [
+      '---',
+      'title: MUI theme',
+      'permalink: /mui-theme',
+      '---',
+      '',
+      '[**View source on GitHub**](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/mui)',
+      '',
+    ].join('\n')
+  );
+
+  try {
+    const { ctx, store } = createContext();
+
+    await frameworkLoader({ contentDir }).load(ctx);
+
+    const html = renderedHtmlOf(store, 'javascript-data-grid/mui-theme');
+
+    assert.ok(
+      html.includes(`https://github.com/handsontable/examples/tree/${CURRENT_EXAMPLES_BRANCH}/examples/mui`),
+      `expected the starter link to point at ${CURRENT_EXAMPLES_BRANCH}`
+    );
+
+    // DEV-2214: a hardcoded tree/master link sends a reader on older docs to a
+    // starter that no longer matches their version.
+    assert.ok(!html.includes('{{'), 'no unresolved {{$examplesBranch}} placeholder should remain');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/docs/src/plugins/__tests__/template-variables.test.mjs
+++ b/docs/src/plugins/__tests__/template-variables.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { replaceTemplateVariables } from '../template-variables.mjs';
+import {
+  CURRENT_DOCS_VERSION,
+  CURRENT_DOCS_MINOR_VERSION,
+  CURRENT_EXAMPLES_BRANCH,
+} from '../docs-version.mjs';
+import { LATEST_CHANGELOG_MAJOR } from '../changelog-parser.mjs';
+
+const values = {
+  basePath: '/docs',
+  version: '18.0.2',
+  minorVersion: 'prod-docs/18.0',
+  examplesBranch: 'prod-examples/18',
+};
+
+test('resolves every supported template variable', () => {
+  const md = [
+    '![shot]({{$basePath}}/img/pages/shot.png)',
+    'Install handsontable@{{$currentVersion}}.',
+    '[source](https://github.com/handsontable/handsontable/tree/{{$currentMinorVersion}}/docs)',
+    '[starter](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/mui)',
+  ].join('\n');
+
+  const result = replaceTemplateVariables(md, values);
+
+  assert.ok(result.includes('![shot](/docs/img/pages/shot.png)'));
+  assert.ok(result.includes('handsontable@18.0.2'));
+  assert.ok(result.includes('handsontable/tree/prod-docs/18.0/docs'));
+  assert.ok(result.includes('examples/tree/prod-examples/18/examples/mui'));
+  assert.ok(!result.includes('{{'), 'no unresolved template variable should remain');
+});
+
+test('tolerates whitespace inside the braces', () => {
+  const result = replaceTemplateVariables(
+    'a {{ $examplesBranch }} b {{  $currentVersion  }}',
+    values
+  );
+
+  assert.equal(result, 'a prod-examples/18 b 18.0.2');
+});
+
+test('replaces every occurrence, not only the first', () => {
+  const result = replaceTemplateVariables(
+    '{{$examplesBranch}} {{$examplesBranch}} {{$examplesBranch}}',
+    values
+  );
+
+  assert.equal(result, 'prod-examples/18 prod-examples/18 prod-examples/18');
+});
+
+test('{{$basePath}} defaults to an empty string so page paths stay root-relative', () => {
+  assert.equal(
+    replaceTemplateVariables('![shot]({{$basePath}}/img/pages/shot.png)'),
+    '![shot](/img/pages/shot.png)'
+  );
+});
+
+test('defaults come from the resolved build constants', () => {
+  const result = replaceTemplateVariables(
+    '{{$currentVersion}}|{{$currentMinorVersion}}|{{$examplesBranch}}'
+  );
+
+  assert.equal(
+    result,
+    `${CURRENT_DOCS_VERSION}|${CURRENT_DOCS_MINOR_VERSION}|${CURRENT_EXAMPLES_BRANCH}`
+  );
+});
+
+test('a $ in a replacement value is not read as a replacement pattern', () => {
+  const result = replaceTemplateVariables('v{{$currentVersion}}', {
+    ...values,
+    version: '18.0.0-$&-$1',
+  });
+
+  assert.equal(result, 'v18.0.0-$&-$1');
+});
+
+test('resolves {{$latestChangelogVersion}} to the highest existing changelog major', () => {
+  assert.equal(
+    replaceTemplateVariables('changelog-{{$latestChangelogVersion}}'),
+    `changelog-${LATEST_CHANGELOG_MAJOR}`
+  );
+  assert.equal(
+    replaceTemplateVariables('changelog-{{$latestChangelogVersion}}', { latestChangelogVersion: 42 }),
+    'changelog-42'
+  );
+});
+
+test('leaves unknown variables untouched', () => {
+  assert.equal(replaceTemplateVariables('{{$notAVariable}}', values), '{{$notAVariable}}');
+});

--- a/docs/src/plugins/__tests__/vuepress-preprocessor.test.mjs
+++ b/docs/src/plugins/__tests__/vuepress-preprocessor.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { vuepressPreprocessor } from '../vuepress-preprocessor.mjs';
+import {
+  CURRENT_DOCS_VERSION,
+  CURRENT_DOCS_MINOR_VERSION,
+  CURRENT_EXAMPLES_BRANCH,
+} from '../docs-version.mjs';
+
+const plugin = vuepressPreprocessor({ framework: 'javascript' });
+
+/**
+ * Runs markdown through the plugin's transform hook the way Vite would.
+ *
+ * @param {string} md
+ * @returns {string}
+ */
+function transform(md) {
+  return plugin.transform(md, '/docs/content/recipes/themes/mui-theme/mui-theme.md').code;
+}
+
+test('resolves the template variables this pipeline shares with the content loader', () => {
+  // The two pipelines are separate: a variable wired into framework-loader.mjs
+  // alone stays a literal here. Guard both.
+  const result = transform([
+    '[starter](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/mui)',
+    '[source](https://github.com/handsontable/handsontable/tree/{{$currentMinorVersion}}/docs)',
+    'Install handsontable@{{$currentVersion}}.',
+    '![shot]({{$basePath}}/img/pages/shot.png)',
+  ].join('\n'));
+
+  assert.ok(result.includes(`examples/tree/${CURRENT_EXAMPLES_BRANCH}/examples/mui`));
+  assert.ok(result.includes(`handsontable/tree/${CURRENT_DOCS_MINOR_VERSION}/docs`));
+  assert.ok(result.includes(`handsontable@${CURRENT_DOCS_VERSION}`));
+  assert.ok(result.includes('![shot](/img/pages/shot.png)'));
+  assert.ok(!result.includes('{{'), 'no unresolved template variable should remain');
+});
+
+test('skips files that are not markdown', () => {
+  assert.equal(plugin.transform('{{$examplesBranch}}', '/docs/src/app.ts'), null);
+});

--- a/docs/src/plugins/docs-version.mjs
+++ b/docs/src/plugins/docs-version.mjs
@@ -129,3 +129,46 @@ export const CURRENT_DOCS_MINOR_VERSION = (() => {
 
   return 'develop';
 })();
+
+/**
+ * Derives the `handsontable/examples` branch that matches a docs version.
+ *
+ * Production builds produce `prod-examples/<major>` (e.g. `prod-examples/18`),
+ * matching the per-major starter snapshot branches in the examples repository.
+ * The snapshots are cut per major only, so the major is the right granularity.
+ *
+ * Every other build falls back to `master`, the sole development branch of the
+ * examples repository. It is `master` rather than `develop` because that repo
+ * has no `develop` branch.
+ *
+ * A version that carries no released major - an unparsable string, or the
+ * `0.0.0-next-<sha>-<date>` placeholder reaching a production build - also falls
+ * back to `master`. There is no `prod-examples/0` branch, so a derived link
+ * would 404.
+ *
+ * @param {string} version The docs version string to derive the branch from.
+ * @param {boolean} isProduction Whether this is a production docs build.
+ * @returns {string}
+ */
+export function deriveExamplesBranch(version, isProduction) {
+  if (!isProduction) {
+    return 'master';
+  }
+
+  const major = String(version ?? '').match(/^(\d+)\./)?.[1];
+
+  return major && major !== '0' ? `prod-examples/${major}` : 'master';
+}
+
+/**
+ * The `handsontable/examples` branch used for starter source links in
+ * documentation pages.
+ *
+ * Evaluated once at module load time so all imports share the same value.
+ *
+ * @type {string}
+ */
+export const CURRENT_EXAMPLES_BRANCH = deriveExamplesBranch(
+  CURRENT_DOCS_VERSION,
+  process.env.BUILD_MODE === 'production'
+);

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -10,8 +10,8 @@
 import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
 import { join, relative, dirname } from 'path';
 import matter from 'gray-matter';
-import { CURRENT_DOCS_VERSION, CURRENT_DOCS_MINOR_VERSION } from './docs-version.mjs';
-import { LATEST_CHANGELOG_MAJOR } from './changelog-parser.mjs';
+import { CURRENT_DOCS_VERSION } from './docs-version.mjs';
+import { replaceTemplateVariables } from './template-variables.mjs';
 import { convertAsideBodyMarkdown } from './aside-inline-markdown.mjs';
 import { internEcTokenStyles } from './ec-token-styles.mjs';
 import { writeRenderedHtml } from './rendered-html-store.mjs';
@@ -1171,25 +1171,12 @@ function applyVuepressPreprocessing(content, prefix, contentDir) {
   // Fix $withBase('/path') → /path
   result = result.replace(/\$withBase\s*\(\s*['"]?([^'")\s]+)['"]?\s*\)/g, '$1');
 
-  // Fix {{$basePath}} → '' (VuePress versioned-base template variable)
-  result = result.replace(/\{\{\s*\$basePath\s*\}\}/g, '');
-
-  // Fix {{$currentVersion}} → resolved Handsontable version string.
-  // Production builds use the package.json version (e.g. "17.0.1").
-  // Staging/dev builds use "0.0.0-next-{shortSHA}-{YYYYMMDD}" so that
-  // CodeSandbox links resolve to the correct in-progress build artifact.
-  result = result.replace(/\{\{\s*\$currentVersion\s*\}\}/g, CURRENT_DOCS_VERSION);
-
-  // Fix {{$currentMinorVersion}} → GitHub branch path for source-code links.
-  // Production builds produce "prod-docs/X.Y" (e.g. "prod-docs/17.1").
-  // Staging/dev builds resolve to "develop" (no prod-docs/ prefix, since
-  // the prod-docs/develop branch does not exist).
-  result = result.replace(/\{\{\s*\$currentMinorVersion\s*\}\}/g, CURRENT_DOCS_MINOR_VERSION);
-
-  // Fix {{$latestChangelogVersion}} → highest existing changelog-N major version.
-  // Keeps the Introduction page's "Changelog" link current without manual edits
-  // on every major release.
-  result = result.replace(/\{\{\s*\$latestChangelogVersion\s*\}\}/g, String(LATEST_CHANGELOG_MAJOR));
+  // Resolve every template variable ({{$basePath}}, {{$currentVersion}},
+  // {{$currentMinorVersion}}, {{$examplesBranch}}, {{$latestChangelogVersion}}).
+  // See template-variables.mjs for what each one resolves to and why. This must
+  // stay above the @/...md link resolution below - {{$latestChangelogVersion}} is
+  // used inside such a link, which cannot resolve while it is still a placeholder.
+  result = replaceTemplateVariables(result);
 
   // Transform @/framework/path.md links to absolute Starlight URLs using permalinks.
   // When prefix/contentDir are available (framework pages), do full permalink resolution.

--- a/docs/src/plugins/template-variables.mjs
+++ b/docs/src/plugins/template-variables.mjs
@@ -1,0 +1,72 @@
+/**
+ * Substitutes the VuePress-style template variables used in documentation
+ * markdown.
+ *
+ * Two separate pipelines render page markdown - the Astro content-layer loader
+ * (`framework-loader.mjs`) and the Vite pre-transform (`vuepress-preprocessor.mjs`) -
+ * and the `_md` route generator in `astro.config.mjs` writes a third,
+ * plain-markdown output. A variable resolved in only one of them silently
+ * survives as a literal `{{$name}}` in the others, so the regexes live here
+ * rather than being copied per call site.
+ *
+ * Supported variables:
+ *
+ * - `{{$basePath}}` - the VuePress versioned-base prefix. Astro resolves public
+ *   assets relative to the site root, so page markdown drops it entirely and the
+ *   root-relative path (e.g. `/img/pages/...`) stays correct. Embedded example
+ *   source files need `/docs` instead, which is why `basePath` is an option.
+ * - `{{$currentVersion}}` - the resolved Handsontable version string. Production
+ *   builds use the `handsontable/package.json` version (e.g. `18.0.2`);
+ *   staging/dev builds use `0.0.0-next-<shortSHA>-<YYYYMMDD>` so runner links
+ *   resolve to the in-progress build artifact.
+ * - `{{$currentMinorVersion}}` - the `handsontable/handsontable` branch for
+ *   source-code links: `prod-docs/<major>.<minor>` in production, `develop`
+ *   otherwise.
+ * - `{{$examplesBranch}}` - the `handsontable/examples` branch for starter
+ *   source links: `prod-examples/<major>` in production, `master` otherwise.
+ * - `{{$latestChangelogVersion}}` - the highest existing `changelog-N` major, so
+ *   a "Changelog" link stays current without a manual edit every major release.
+ *   Callers that resolve `@/...md` links must substitute before doing so, or the
+ *   link lands on a page that does not exist.
+ */
+
+import {
+  CURRENT_DOCS_VERSION,
+  CURRENT_DOCS_MINOR_VERSION,
+  CURRENT_EXAMPLES_BRANCH,
+} from './docs-version.mjs';
+import { LATEST_CHANGELOG_MAJOR } from './changelog-parser.mjs';
+
+/**
+ * Replaces every supported `{{$name}}` template variable in a string.
+ *
+ * The values default to the constants resolved for this build; pass them
+ * explicitly to test both the production and the development mapping without
+ * reloading `docs-version.mjs` (its constants are computed once at module load).
+ *
+ * @param {string} text The markdown or source text to transform.
+ * @param {object} [options]
+ * @param {string} [options.basePath] Replacement for `{{$basePath}}`.
+ * @param {string} [options.version] Replacement for `{{$currentVersion}}`.
+ * @param {string} [options.minorVersion] Replacement for `{{$currentMinorVersion}}`.
+ * @param {string} [options.examplesBranch] Replacement for `{{$examplesBranch}}`.
+ * @param {string|number} [options.latestChangelogVersion] Replacement for
+ *   `{{$latestChangelogVersion}}`.
+ * @returns {string}
+ */
+export function replaceTemplateVariables(text, {
+  basePath = '',
+  version = CURRENT_DOCS_VERSION,
+  minorVersion = CURRENT_DOCS_MINOR_VERSION,
+  examplesBranch = CURRENT_EXAMPLES_BRANCH,
+  latestChangelogVersion = LATEST_CHANGELOG_MAJOR,
+} = {}) {
+  // The replacements are passed as functions so a `$` in a value (`$&`, `$1`)
+  // cannot be read as a replacement pattern.
+  return text
+    .replace(/\{\{\s*\$basePath\s*\}\}/g, () => basePath)
+    .replace(/\{\{\s*\$currentVersion\s*\}\}/g, () => version)
+    .replace(/\{\{\s*\$currentMinorVersion\s*\}\}/g, () => minorVersion)
+    .replace(/\{\{\s*\$examplesBranch\s*\}\}/g, () => examplesBranch)
+    .replace(/\{\{\s*\$latestChangelogVersion\s*\}\}/g, () => String(latestChangelogVersion));
+}

--- a/docs/src/plugins/vuepress-preprocessor.mjs
+++ b/docs/src/plugins/vuepress-preprocessor.mjs
@@ -13,11 +13,12 @@
  * - $withBase('/path') → /path
  * - {{$currentVersion}} → resolved Handsontable version string (full semver, e.g. "17.1.0")
  * - {{$currentMinorVersion}} → GitHub branch path for source-code links (e.g. "prod-docs/17.1" or "develop")
+ * - {{$examplesBranch}} → handsontable/examples branch for starter links (e.g. "prod-examples/18" or "master")
  * - @/framework/path links  → /path (cross-framework alias)
  * - <div class="boxes-list"> ... </div>  → Starlight-styled card grid HTML
  */
 
-import { CURRENT_DOCS_VERSION, CURRENT_DOCS_MINOR_VERSION } from './docs-version.mjs';
+import { replaceTemplateVariables } from './template-variables.mjs';
 import { convertAsideInlineMarkdown } from './aside-inline-markdown.mjs';
 
 /**
@@ -81,23 +82,10 @@ function preprocessMarkdown(content, framework) {
   // 6. Fix $withBase('/path') → /path in image srcs and link hrefs
   result = result.replace(/\$withBase\s*\(\s*['"]?([^'")\s]+)['"]?\s*\)/g, '$1');
 
-  // 6b. Fix {{$basePath}} → '' (VuePress versioned-base template variable)
-  //     In Astro, public assets are resolved relative to the site root so the
-  //     base prefix is added automatically; dropping the placeholder preserves
-  //     the correct root-relative path (e.g. /img/pages/... or /cert.pdf).
-  result = result.replace(/\{\{\s*\$basePath\s*\}\}/g, '');
-
-  // 6c. Fix {{$currentVersion}} → resolved Handsontable version string.
-  //     Production builds use the package.json version (e.g. "17.0.1").
-  //     Staging/dev builds use "0.0.0-next-{shortSHA}-{YYYYMMDD}" so that
-  //     CodeSandbox links resolve to the correct in-progress build artifact.
-  result = result.replace(/\{\{\s*\$currentVersion\s*\}\}/g, CURRENT_DOCS_VERSION);
-
-  // 6d. Fix {{$currentMinorVersion}} → GitHub branch path for source-code links.
-  //     Production builds produce "prod-docs/X.Y" (e.g. "prod-docs/17.1").
-  //     Staging/dev builds resolve to "develop" (no prod-docs/ prefix, since
-  //     the prod-docs/develop branch does not exist).
-  result = result.replace(/\{\{\s*\$currentMinorVersion\s*\}\}/g, CURRENT_DOCS_MINOR_VERSION);
+  // 6b. Resolve the {{$basePath}}, {{$currentVersion}}, {{$currentMinorVersion}}
+  //     and {{$examplesBranch}} template variables. See template-variables.mjs
+  //     for what each one resolves to and why.
+  result = replaceTemplateVariables(result);
 
   // 7. Transform @/framework/... cross-framework alias links to absolute paths.
   //    e.g. @/react/guides/foo/foo.md → /guides/foo/foo


### PR DESCRIPTION
### Context

The PR changes the docs starter-source links so they point at the `handsontable/examples` branch matching the docs version, instead of a hardcoded `master`.

Now that `prod-examples/15`, `/16`, `/17` and `/18` exist in `handsontable/examples`, a `tree/master` link on `/docs/16.0/` sends a reader to a starter that no longer matches their Handsontable version. Six "View source on GitHub" links in the theme recipes had the branch hardcoded.

The fix adds a `{{$examplesBranch}}` template variable, resolved at build time next to the existing `{{$currentMinorVersion}}`:

| Build | `{{$examplesBranch}}` |
|---|---|
| `BUILD_MODE=production` | `prod-examples/<major>` (e.g. `prod-examples/18`) |
| anything else | `master` |

A version with no released major - the `0.0.0-next-<sha>-<date>` placeholder reaching a production build - also falls back to `master`, because there is no `prod-examples/0` branch to link to.

**Three pipelines, one registry.** Page markdown is substituted in two separate places (`framework-loader.mjs` for content-collection entries, `vuepress-preprocessor.mjs` for everything outside the content layer), and the `_md` route generator in `astro.config.mjs` produced a third output that substituted nothing at all. A variable wired into one of them stays a literal `{{$name}}` in the others. The regexes now live in one module, `src/plugins/template-variables.mjs`, and all three call it.

Fixing the `_md` generator was required, not optional: `PageSidebar.astro` is a global Starlight override, so the theme recipe pages expose Copy Markdown and the Docs Assistant page context. Without it, this PR would have turned six working links into a literal `{{$examplesBranch}}`. The same gap was already leaking `{{$currentMinorVersion}}` and `{{$latestChangelogVersion}}` into six `_md` files, so `{{$latestChangelogVersion}}` moved into the shared module too and those leaks are gone.

**Decisions taken**

- The seven `server-side-*` recipe links stay on `master`. `server-examples/` is not in the runner's `frameworks.json`, is not bucketed per major, and receives no per-major repair, so a `prod-examples/<major>` copy of it would be a frozen unmaintained snapshot.
- No known-majors allowlist. Cutting `prod-examples/<major>` is part of the major-release chore.
- `runner/apps/authoring/src/App.tsx` ("Fork this starter on GitHub", also hardcoded to `tree/master`) is out of scope here - it lives in a different repository and needs its own PR.

Published docs build from `prod-docs/<major>.<minor>`, so this change has no effect on the live site until it is cherry-picked to `prod-docs/18.0`. That pick was pre-flighted: the full 15-file patch applies cleanly to `origin/prod-docs/18.0`.

### How has this been tested?

New test files for two modules that had no coverage at all (`docs-version.mjs`, `vuepress-preprocessor.mjs`), plus the new shared module, plus a rendered-HTML case in the existing loader suite.

```shell
npm --prefix docs run docs:test:plugins   # 243 pass, 0 fail
npx --prefix docs eslint --ext .js,.mjs,.ts,.astro src content   # exit 0
```

- Red check: removing the `$examplesBranch` substitution turns six tests red across all three pipelines; restoring it turns them green.
- Production mapping through the real loader:

  ```shell
  cd docs && BUILD_MODE=production node --test src/plugins/__tests__/*.test.mjs
  ```

  The loader test asserts the rendered HTML contains the resolved branch, which is `prod-examples/18` in that mode.

- `_md` output, production mode (`BUILD_MODE=production npx astro dev`):
  - theme recipes: `examples/tree/prod-examples/18/examples/{ant-design,base-web,next-shadcn.js,fluent-ui,mui}`
  - `server-side-*` recipes: `examples/tree/master/server-examples/...` (unchanged)
  - no `{{$...}}` docs variable left anywhere under `public/_md/` - the remaining `{{` occurrences are Angular/Vue interpolation inside code examples
- Dev mode resolves every starter link to `tree/master`.
- All five starter directories confirmed present on `prod-examples/18` via the GitHub API, so none of the produced URLs 404.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2214

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation only (`docs/`).

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

`docs/AGENTS.md` section 2.7 now documents all five template variables, the one-registry rule, and the `server-examples/` exception.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2214

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all three docs markdown pipelines and link generation, so a substitution miss could leak placeholders or break starter links, but the change is docs-only and covered by new tests.
> 
> **Overview**
> **Fixes version-mismatched starter links** by replacing hardcoded `tree/master` GitHub URLs in five theme recipes with a new `{{$examplesBranch}}` variable. Production builds resolve to `prod-examples/<major>`; other builds fall back to `master`.
> 
> **Centralizes template substitution** into `template-variables.mjs`, shared by the content loader, Vite preprocessor, and Copy Markdown (`_md`) generator. That also stops existing variables like `{{$currentMinorVersion}}` from leaking into copied markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a72cea2b481fa1bc0e7feede8361af266dd45830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->