### PR TITLE
DEV-1782: Fix column moving blocked by the sorting label

### DIFF
--- a/.changelogs/13184.json
+++ b/.changelogs/13184.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed being unable to move a column by dragging its header while column sorting is enabled. Sorting by clicking a header now happens on mouse up instead of mouse down, and only the header label and its sort indicator sort on click.",
+  "title": "Fixed being unable to move a column by dragging its header while column sorting is enabled. Sorting by clicking a header now happens on mouse up instead of mouse down, and only the header label and its sort indicator sort on click. A click on a column header no longer fires `beforeColumnMove` and `afterColumnMove`, which previously ran even though no column moved.",
   "type": "fixed",
   "issueOrPR": 13184,
   "breaking": false,

--- a/.changelogs/13184.json
+++ b/.changelogs/13184.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed being unable to move a column by dragging its header while column sorting is enabled. Sorting by clicking a header now happens on mouse up instead of mouse down, and only the header label and its sort indicator sort on click.",
+  "type": "fixed",
+  "issueOrPR": 13184,
+  "breaking": true,
+  "framework": "none"
+}

--- a/.changelogs/13184.json
+++ b/.changelogs/13184.json
@@ -3,6 +3,6 @@
   "title": "Fixed being unable to move a column by dragging its header while column sorting is enabled. Sorting by clicking a header now happens on mouse up instead of mouse down, and only the header label and its sort indicator sort on click.",
   "type": "fixed",
   "issueOrPR": 13184,
-  "breaking": true,
+  "breaking": false,
   "framework": "none"
 }

--- a/docs/content/guides/columns/column-moving/column-moving.md
+++ b/docs/content/guides/columns/column-moving/column-moving.md
@@ -29,6 +29,14 @@ To enable column moving, set the [`manualColumnMove`](@/api/options.md#manualcol
 
 A draggable move handle appears above the selected column header. You can click and drag it to any location in the grid.
 
+A column has to be selected before you can drag it. You can start the drag anywhere on the selected column's
+header, including on the sorting label when [column sorting](@/guides/rows/rows-sorting/rows-sorting.md) is
+enabled. Handsontable tells a click from a drag by whether the pointer moves: press and release without moving
+to sort the column, and press and drag to move it.
+
+When column sorting is enabled, only the header label and its sort indicator sort on click. Pressing the header
+around them selects the column without sorting it, so you can select a column and drag it in one gesture.
+
 ::: only-for javascript
 
 ::: example #example1 --js 1 --ts 2

--- a/docs/content/guides/columns/column-moving/column-moving.md
+++ b/docs/content/guides/columns/column-moving/column-moving.md
@@ -195,6 +195,8 @@ For more on how physical and visual indexes relate, see [Understanding data and 
 
 Use the [`beforeColumnMove`](@/api/hooks.md#beforecolumnmove) hook to decide whether each column move is allowed. Returning `false` cancels the move while keeping the [`manualColumnMove`](@/api/options.md#manualcolumnmove) plugin enabled.
 
+Both [`beforeColumnMove`](@/api/hooks.md#beforecolumnmove) and [`afterColumnMove`](@/api/hooks.md#aftercolumnmove) run only when the pointer actually drags a column. A click on a column header does not fire them.
+
 In the following example, select **Allow column moving** before you drag a column to a new position. Clear the checkbox to block column moving again.
 
 :::: only-for javascript

--- a/docs/content/guides/rows/rows-sorting/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting/rows-sorting.md
@@ -45,6 +45,11 @@ Handsontable provides two plugins for sorting rows:
 - [`ColumnSorting`](@/api/columnSorting.md) -- sorts rows by a **single column** at a time. Clicking a column header cycles through ascending, descending, and unsorted states.
 - [`MultiColumnSorting`](@/api/multiColumnSorting.md) -- sorts rows by **multiple columns** simultaneously. Hold Ctrl/Cmd and click column headers to add more sort criteria.
 
+Sorting runs when you release the mouse button, not when you press it, and only the header label and its sort
+indicator respond to the click. Pressing the header around them selects the column without sorting it. If the
+pointer moves while the button is held, Handsontable treats the gesture as a column drag instead of a sort, so
+[column moving](@/guides/columns/column-moving/column-moving.md) can share the same header.
+
 Both plugins sort the view only. The source data array is never modified. To persist the sorted order back to the data source, see [Saving data](@/guides/getting-started/saving-data/saving-data.md).
 
 `ColumnSorting` and `MultiColumnSorting` are mutually exclusive. Enable only one at a time. If both options are set to `true`, `ColumnSorting` is automatically disabled.

--- a/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -3040,6 +3040,29 @@ describe('ColumnSorting', () => {
       expect(headerWidthAtStart).toBeLessThan(newHeaderWidth);
     });
 
+    it('should not measure the sort indicator offsets into the auto column width when the dropdown menu is enabled', async() => {
+      handsontable({
+        data: createSpreadsheetData(4, 2),
+        colHeaders: ['Revenue per employee division', 'B'],
+        autoColumnSize: true,
+        columnSorting: { initialConfig: { column: 0, sortOrder: 'asc' } },
+      });
+
+      spec().$container[0].style.width = 'auto';
+      await render();
+
+      const widthWithoutMenu = spec().$container.find('th').eq(0).width();
+
+      await updateSettings({ dropdownMenu: true });
+
+      const widthWithMenu = spec().$container.find('th').eq(0).width();
+
+      // The menu button takes its own room in the header, but the indicator's offsets are held
+      // clear of the ghost table, so they must not land in the measurement a second time. Without
+      // that, the column grows by the whole indicator reserve (~46px) instead of a few pixels.
+      expect(widthWithMenu - widthWithoutMenu).toBeLessThan(20);
+    });
+
     it('should work properly also when `rowHeaders` option is set to `true`', async() => {
       handsontable({
         colHeaders: ['AAA<br>BB'],

--- a/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -227,33 +227,51 @@ describe('ColumnSorting', () => {
       expect(computedStyle.getPropertyValue('-webkit-mask-image')).toMatch(/url/);
 
       // _column-sorting.scss sets `top: 50%; right: 2px;` (LTR) or `left: 2px;` (RTL) on
-      // `.columnSorting::before`. Assert the exact hardcoded horizontal offset and that the
-      // vertical anchor resolves to the span's vertical midpoint.
-      const spanRect = sortedColumn.getBoundingClientRect();
+      // `.columnSorting::before`. The label is sized to its text, so the indicator is positioned
+      // against the header's `.relative` container - that is what keeps it pinned to the header
+      // edge instead of travelling with the label. Assert the hardcoded horizontal offset against
+      // that container, and that the indicator ends up centred in the header cell.
+      const container = sortedColumn.closest('.relative');
+      const containerRect = container.getBoundingClientRect();
+      const headerRect = sortedColumn.closest('th').getBoundingClientRect();
       const topPx = parseFloat(computedStyle.getPropertyValue('top'));
       const iconSize = parseFloat(
         window.getComputedStyle(sortedColumn).getPropertyValue('--ht-icon-size')
       ) || 16;
 
-      // `top: 50%` resolves relative to the ::before's containing block (the sortedColumn span);
-      // allow a 1px tolerance for sub-pixel rounding.
-      expect(Math.abs(topPx - (spanRect.height / 2))).toBeLessThanOrEqual(1);
+      // `top: 50%` resolves relative to the ::before's containing block; allow a 1px tolerance
+      // for sub-pixel rounding.
+      expect(Math.abs(topPx - (containerRect.height / 2))).toBeLessThanOrEqual(1);
+
+      // What the user actually sees: the indicator sits on the header's vertical midline.
+      // `translateY(-50%)` puts its centre at the containing block's top plus `top`.
+      const indicatorCentreY = containerRect.top + topPx;
+
+      expect(Math.abs(indicatorCentreY - ((headerRect.top + headerRect.bottom) / 2)))
+        .toBeLessThanOrEqual(1);
+
+      // The indicator carries inline margins that hold it clear of the cell padding, so they are
+      // part of what the free edge resolves to.
+      const inlineMargins = (parseFloat(computedStyle.getPropertyValue('margin-left')) || 0) +
+        (parseFloat(computedStyle.getPropertyValue('margin-right')) || 0);
+      const freeEdge = containerRect.width - iconSize - inlineMargins - 2 - 1;
 
       if (htmlDir === 'rtl' || layoutDirection === 'rtl') {
-        // In RTL mode the indicator is anchored to the left of the span at exactly 2px.
+        // In RTL mode the indicator is anchored to the left of the container at exactly 2px.
         expect(parseFloat(computedStyle.getPropertyValue('left'))).toBe(2);
         // The opposite edge is declared `auto`; browsers resolve it to a positive value that
-        // equals (span width - left anchor - icon width) within a small rounding tolerance.
+        // equals (container width - left anchor - icon width - margins) within a rounding
+        // tolerance.
         const rightPx = parseFloat(computedStyle.getPropertyValue('right'));
 
-        expect(rightPx).toBeGreaterThanOrEqual(spanRect.width - iconSize - 2 - 1);
+        expect(rightPx).toBeGreaterThanOrEqual(freeEdge);
 
       } else {
-        // In LTR mode the indicator is anchored to the right of the span at exactly 2px.
+        // In LTR mode the indicator is anchored to the right of the container at exactly 2px.
         expect(parseFloat(computedStyle.getPropertyValue('right'))).toBe(2);
         const leftPx = parseFloat(computedStyle.getPropertyValue('left'));
 
-        expect(leftPx).toBeGreaterThanOrEqual(spanRect.width - iconSize - 2 - 1);
+        expect(leftPx).toBeGreaterThanOrEqual(freeEdge);
       }
     });
   });

--- a/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -3040,6 +3040,47 @@ describe('ColumnSorting', () => {
       expect(headerWidthAtStart).toBeLessThan(newHeaderWidth);
     });
 
+    it('should keep the header text aligned by `headerClassName` when the plugin is enabled', async() => {
+      handsontable({
+        data: createSpreadsheetData(4, 3),
+        colHeaders: ['Left', 'Middle', 'Right'],
+        colWidths: 160,
+        columns: [
+          { headerClassName: 'htLeft' },
+          {},
+          { headerClassName: 'htRight' },
+        ],
+        columnSorting: { initialConfig: { column: 2, sortOrder: 'asc' } },
+      });
+
+      // The painted text, not the label box - the label is sized to its text, so only the text
+      // says where the alignment landed.
+      const textBox = (column) => {
+        const span = spec().$container.find('th span.colHeader')[column];
+        const range = document.createRange();
+
+        range.selectNodeContents(span);
+
+        const text = range.getBoundingClientRect();
+        const th = span.closest('th').getBoundingClientRect();
+
+        return { fromLeft: text.left - th.left, fromRight: th.right - text.right };
+      };
+
+      // `htLeft` hugs the left edge, `htRight` the right one. Without the alignment rules the
+      // label's auto margins centre every header and both gaps come out equal.
+      const left = textBox(0);
+      const right = textBox(2);
+
+      expect(left.fromLeft).toBeLessThan(left.fromRight);
+      expect(right.fromRight).toBeLessThan(right.fromLeft);
+
+      // And the middle column, which asked for nothing, stays centred.
+      const middle = textBox(1);
+
+      expect(Math.abs(middle.fromLeft - middle.fromRight)).toBeLessThanOrEqual(2);
+    });
+
     it('should not measure the sort indicator offsets into the auto column width when the dropdown menu is enabled', async() => {
       handsontable({
         data: createSpreadsheetData(4, 2),

--- a/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -3040,6 +3040,39 @@ describe('ColumnSorting', () => {
       expect(headerWidthAtStart).toBeLessThan(newHeaderWidth);
     });
 
+    it('should not let the dropdown menu button cover the sort indicator', async() => {
+      handsontable({
+        data: createSpreadsheetData(4, 3),
+        colHeaders: ['Sell date', 'B', 'C'],
+        colWidths: 150,
+        dropdownMenu: true,
+        columnSorting: { initialConfig: { column: 0, sortOrder: 'asc' } },
+      });
+
+      const label = spec().$container.find('th span.colHeader')[0];
+      const container = label.closest('.relative');
+      const containerRect = container.getBoundingClientRect();
+      const indicatorStyle = window.getComputedStyle(label, ':before');
+      const iconSize = parseFloat(
+        window.getComputedStyle(label).getPropertyValue('--ht-icon-size')
+      ) || 16;
+
+      // The indicator is an absolutely positioned pseudo, so its box has to be derived. `.relative`
+      // carries no border, so its client rect edges are the padding box the pseudo resolves against.
+      const marginRight = parseFloat(indicatorStyle.getPropertyValue('margin-right')) || 0;
+      const indicatorRight = containerRect.right -
+        parseFloat(indicatorStyle.getPropertyValue('right')) - marginRight;
+      const indicatorLeft = indicatorRight - iconSize;
+
+      // The button paints above the indicator (`z-index: 1`), so any overlap hides it completely.
+      const button = container.querySelector('.changeType');
+      const buttonRect = button.getBoundingClientRect();
+      const overlap = Math.min(buttonRect.right, indicatorRight) - Math.max(buttonRect.left, indicatorLeft);
+
+      expect(button).not.toBe(null);
+      expect(overlap).toBeLessThanOrEqual(0);
+    });
+
     it('should keep the header text aligned by `headerClassName` when the plugin is enabled', async() => {
       handsontable({
         data: createSpreadsheetData(4, 3),

--- a/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -3057,10 +3057,10 @@ describe('ColumnSorting', () => {
 
       const widthWithMenu = spec().$container.find('th').eq(0).width();
 
-      // The menu button takes its own room in the header, but the indicator's offsets are held
-      // clear of the ghost table, so they must not land in the measurement a second time. Without
-      // that, the column grows by the whole indicator reserve (~46px) instead of a few pixels.
-      expect(widthWithMenu - widthWithoutMenu).toBeLessThan(20);
+      // The menu button takes its own room in the header, but the indicator's reserve is held out
+      // of the ghost table measurement, so it must not land there a second time. The button costs
+      // 4px (classic), 6px (main) or 8px (horizon); counting the reserve twice adds ~18px on top.
+      expect(widthWithMenu - widthWithoutMenu).toBeLessThan(12);
     });
 
     it('should work properly also when `rowHeaders` option is set to `true`', async() => {

--- a/handsontable/src/plugins/columnSorting/__tests__/rtl/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/rtl/columnSorting.spec.js
@@ -91,5 +91,62 @@ describe('ColumnSorting (RTL)', () => {
         expect(leftPx).toBeGreaterThanOrEqual(freeEdge);
       }
     });
+
+    it('should reserve the indicator room on the side the indicator is pinned to for a left-aligned header', async() => {
+      handsontable({
+        layoutDirection,
+        data: [
+          [1, 9, 3],
+          [9, 8, 7],
+          [8, 7, 6],
+        ],
+        // Long enough to fill the header, so a reservation on the wrong side shows up as the
+        // indicator sitting on top of the label instead of beside it.
+        colHeaders: ['Revenue per employee division', 'B', 'C'],
+        colWidths: 140,
+        // `htLeft` is the alignment that points against the direction in RTL, so it is the case
+        // where the indicator moves to the inline-start side and the reservation has to follow.
+        afterGetColHeader: (column, TH) => {
+          if (column === 0) {
+            TH.classList.add('htLeft');
+          }
+        },
+        columnSorting: {
+          indicator: true
+        }
+      });
+
+      getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
+      await render();
+
+      const label = spec().$container.find('th span.columnSorting')[0];
+      const container = label.closest('.relative');
+      const containerStyle = window.getComputedStyle(container);
+      const indicatorStyle = window.getComputedStyle(label, ':before');
+      const containerRect = container.getBoundingClientRect();
+      const labelRect = label.getBoundingClientRect();
+      const iconSize = parseFloat(
+        window.getComputedStyle(label).getPropertyValue('--ht-icon-size')
+      ) || 16;
+
+      // In RTL a left-aligned header pins the indicator to the physical right.
+      expect(parseFloat(indicatorStyle.getPropertyValue('right'))).toBe(2);
+
+      // So the room has to be reserved on the right too, not on the left.
+      const paddingLeft = parseFloat(containerStyle.getPropertyValue('padding-left'));
+      const paddingRight = parseFloat(containerStyle.getPropertyValue('padding-right'));
+
+      expect(paddingRight).toBeGreaterThan(paddingLeft);
+
+      // What the user sees: the label stops before the indicator instead of running under it.
+      // `.relative` carries no border, so its client rect edges are the padding box edges the
+      // absolutely positioned indicator resolves against.
+      const marginRight = parseFloat(indicatorStyle.getPropertyValue('margin-right')) || 0;
+      const indicatorRight = containerRect.right - 2 - marginRight;
+      const indicatorLeft = indicatorRight - iconSize;
+      const overlap = Math.min(labelRect.right, indicatorRight) - Math.max(labelRect.left, indicatorLeft);
+
+      expect(overlap).toBeLessThanOrEqual(0);
+    });
   });
 });

--- a/handsontable/src/plugins/columnSorting/__tests__/rtl/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/rtl/columnSorting.spec.js
@@ -48,31 +48,47 @@ describe('ColumnSorting (RTL)', () => {
       expect(computedStyle.getPropertyValue('-webkit-mask-image')).toMatch(/url/);
 
       // _column-sorting.scss sets `top: 50%; right: 2px;` (LTR) or `left: 2px;` (RTL) on
-      // `.columnSorting::before`. Assert the exact hardcoded horizontal offset and that the
-      // vertical anchor resolves to the span's vertical midpoint.
-      const spanRect = sortedColumn.getBoundingClientRect();
+      // `.columnSorting::before`. The label is sized to its text, so the indicator is positioned
+      // against the header's `.relative` container - that is what keeps it pinned to the header
+      // edge instead of travelling with the label. Assert the hardcoded horizontal offset against
+      // that container, and that the indicator ends up centred in the header cell.
+      const container = sortedColumn.closest('.relative');
+      const containerRect = container.getBoundingClientRect();
+      const headerRect = sortedColumn.closest('th').getBoundingClientRect();
       const topPx = parseFloat(computedStyle.getPropertyValue('top'));
       const iconSize = parseFloat(
         window.getComputedStyle(sortedColumn).getPropertyValue('--ht-icon-size')
       ) || 16;
 
-      // `top: 50%` resolves relative to the ::before's containing block (the sortedColumn span);
-      // allow a 1px tolerance for sub-pixel rounding.
-      expect(Math.abs(topPx - (spanRect.height / 2))).toBeLessThanOrEqual(1);
+      // `top: 50%` resolves relative to the ::before's containing block; allow a 1px tolerance
+      // for sub-pixel rounding.
+      expect(Math.abs(topPx - (containerRect.height / 2))).toBeLessThanOrEqual(1);
+
+      // What the user actually sees: the indicator sits on the header's vertical midline.
+      const indicatorCentreY = containerRect.top + topPx;
+
+      expect(Math.abs(indicatorCentreY - ((headerRect.top + headerRect.bottom) / 2)))
+        .toBeLessThanOrEqual(1);
+
+      // The indicator carries inline margins that hold it clear of the cell padding, so they are
+      // part of what the free edge resolves to.
+      const inlineMargins = (parseFloat(computedStyle.getPropertyValue('margin-left')) || 0) +
+        (parseFloat(computedStyle.getPropertyValue('margin-right')) || 0);
+      const freeEdge = containerRect.width - iconSize - inlineMargins - 2 - 1;
 
       if (htmlDir === 'rtl' || layoutDirection === 'rtl') {
-        // In RTL mode the indicator is anchored to the left of the span at exactly 2px.
+        // In RTL mode the indicator is anchored to the left of the container at exactly 2px.
         expect(parseFloat(computedStyle.getPropertyValue('left'))).toBe(2);
         const rightPx = parseFloat(computedStyle.getPropertyValue('right'));
 
-        expect(rightPx).toBeGreaterThanOrEqual(spanRect.width - iconSize - 2 - 1);
+        expect(rightPx).toBeGreaterThanOrEqual(freeEdge);
 
       } else {
-        // In LTR mode the indicator is anchored to the right of the span at exactly 2px.
+        // In LTR mode the indicator is anchored to the right of the container at exactly 2px.
         expect(parseFloat(computedStyle.getPropertyValue('right'))).toBe(2);
         const leftPx = parseFloat(computedStyle.getPropertyValue('left'));
 
-        expect(leftPx).toBeGreaterThanOrEqual(spanRect.width - iconSize - 2 - 1);
+        expect(leftPx).toBeGreaterThanOrEqual(freeEdge);
       }
     });
   });

--- a/handsontable/src/plugins/columnSorting/columnSorting.ts
+++ b/handsontable/src/plugins/columnSorting/columnSorting.ts
@@ -74,6 +74,8 @@ export interface HeaderSortPress {
    * when nothing was being edited.
    */
   validation: Promise<void> | null;
+  /** Set when ManualColumnMove ran its move before this press was resolved. */
+  consumedByMove: boolean;
 }
 
 export interface SortConfig {
@@ -248,6 +250,7 @@ export class ColumnSorting extends BasePlugin {
     // sort still has to be cleared rather than left pending for the next release.
     this.eventManager.addEventListener(this.hot.rootDocument.documentElement, 'mouseup',
       () => this.#resolvePendingSort());
+    this.addHook('afterColumnMove', this.#onAfterColumnMove);
 
     this.addHook('afterInit', this.#loadOrSortBySettings);
     this.addHook('afterLoadData', this.#onAfterLoadData);
@@ -986,6 +989,7 @@ export class ColumnSorting extends BasePlugin {
       validation: awaitsValidation ? new Promise<void>((resolve) => {
         this.hot.addHookOnce('postAfterValidate', () => resolve());
       }) : null,
+      consumedByMove: false,
     };
   }
 
@@ -1018,12 +1022,11 @@ export class ColumnSorting extends BasePlugin {
 
     this.#pendingHeaderSort = null;
 
-    // Ask ManualColumnMove whether it turned this press into a drag, rather than measuring pointer
-    // travel here. Only that plugin knows whether a drag was ever armed - it needs the column
-    // selected by its header - so a travel test here would silence the sort on every grid where
-    // nothing can consume the gesture. Its state is still set at this point; it resets on its own
-    // `mouseup` listener, which runs later in the same dispatch.
-    if (this.#isColumnBeingDragged()) {
+    // Two signals, because both plugins handle the same `mouseup` and the listener order is not
+    // fixed - re-enabling `columnSorting` after `manualColumnMove` appends this plugin's listener
+    // last. Running first, the drag is still in progress; running second, the move has already
+    // fired. Either one cancels the sort.
+    if (pending.consumedByMove || this.#isColumnBeingDragged()) {
       return;
     }
 
@@ -1036,6 +1039,15 @@ export class ColumnSorting extends BasePlugin {
     }
 
     void pending.validation.then(() => this.applyHeaderClickSort(pending));
+  };
+
+  /**
+   * Marks a queued press as spent once ManualColumnMove has moved the column.
+   */
+  #onAfterColumnMove = () => {
+    if (this.#pendingHeaderSort !== null) {
+      this.#pendingHeaderSort.consumedByMove = true;
+    }
   };
 
   /**

--- a/handsontable/src/plugins/columnSorting/columnSorting.ts
+++ b/handsontable/src/plugins/columnSorting/columnSorting.ts
@@ -54,32 +54,12 @@ export const APPEND_COLUMN_CONFIG_STRATEGY = 'append';
 export const REPLACE_COLUMN_CONFIG_STRATEGY = 'replace';
 const SHORTCUTS_GROUP = PLUGIN_KEY;
 /**
- * How far, in pixels, the pointer may travel between pressing a column header and releasing it
- * and still count as a click. Pointers jitter by a pixel or two on trackpads and high-density
- * screens, so an exact-zero test would swallow ordinary clicks and header clicks would appear
- * to do nothing.
- */
-const POINTER_DRAG_TOLERANCE = 3;
-/**
  * Marks the header container of a column that is showing a sort indicator. The indicator is
  * positioned against that container, so the room it needs is reserved there rather than as padding
  * on the label - padding on the label would enlarge the area that sorts on click, which is exactly
  * what it must not do. A class rather than a `:has()` selector, which is banned in this package.
  */
 const CONTAINER_WITH_INDICATOR_CLASS = 'has-sort-indicator';
-
-/**
- * Checks whether the pointer has travelled far enough from where it was pressed to count as a
- * drag rather than a click.
- *
- * @param {{ x: number, y: number }} pressOrigin Pointer client coordinates captured on press.
- * @param {MouseEvent} event The event holding the current pointer position.
- * @returns {boolean}
- */
-function isPointerDragged(pressOrigin: { x: number, y: number }, event: MouseEvent): boolean {
-  return Math.abs(event.clientX - pressOrigin.x) > POINTER_DRAG_TOLERANCE ||
-    Math.abs(event.clientY - pressOrigin.y) > POINTER_DRAG_TOLERANCE;
-}
 
 registerRootComparator(PLUGIN_KEY, rootComparator);
 
@@ -89,13 +69,11 @@ registerRootComparator(PLUGIN_KEY, rootComparator);
 export interface HeaderSortPress {
   column: number;
   isCtrlPressed: boolean;
-  pressOrigin: { x: number, y: number };
   /**
    * Settles once the cell that was being edited at press time has finished validating, or `null`
    * when nothing was being edited.
    */
   validation: Promise<void> | null;
-  hasMoved: boolean;
 }
 
 export interface SortConfig {
@@ -193,8 +171,7 @@ export class ColumnSorting extends BasePlugin {
    */
   columnMetaCache: IndexToValueMap | null = null;
   /**
-   * Sort queued by a header press, applied on mouse up when the pointer has not travelled.
-   * Holds the pressed column, whether Ctrl/Cmd was held, and where the pointer went down.
+   * Sort queued by a header press, applied on mouse up unless the press became a column drag.
    */
   #pendingHeaderSort: HeaderSortPress | null = null;
   /**
@@ -269,8 +246,6 @@ export class ColumnSorting extends BasePlugin {
     this.addHook('afterOnCellMouseUp', this.#resolvePendingSort);
     // Fallback for a release that lands outside any cell - that is the drag case, and the queued
     // sort still has to be cleared rather than left pending for the next release.
-    this.eventManager.addEventListener(this.hot.rootDocument.documentElement, 'mousemove',
-      (event: Event) => this.#onDocumentMouseMove(event as MouseEvent));
     this.eventManager.addEventListener(this.hot.rootDocument.documentElement, 'mouseup',
       () => this.#resolvePendingSort());
 
@@ -1004,7 +979,6 @@ export class ColumnSorting extends BasePlugin {
     this.#pendingHeaderSort = {
       column: coords.col,
       isCtrlPressed,
-      pressOrigin: { x: (event as MouseEvent).clientX, y: (event as MouseEvent).clientY },
       // Subscribed on press, not on release: selecting the column closes the editor and its
       // validation runs in a microtask, so it is already over before mouse up. Reading
       // `awaitsValidation` on release is wrong too - by then the new selection has opened an
@@ -1012,7 +986,6 @@ export class ColumnSorting extends BasePlugin {
       validation: awaitsValidation ? new Promise<void>((resolve) => {
         this.hot.addHookOnce('postAfterValidate', () => resolve());
       }) : null,
-      hasMoved: false,
     };
   }
 
@@ -1030,27 +1003,8 @@ export class ColumnSorting extends BasePlugin {
   }
 
   /**
-   * Watches a queued header press for pointer travel.
-   *
-   * Travel is measured from `mousemove` rather than by comparing the press and release
-   * positions, because a press can scroll a partly visible header into view - that moves the
-   * header under a stationary pointer, which is not a drag.
-   *
-   * @param {MouseEvent} event The `mousemove` event.
-   */
-  #onDocumentMouseMove = (event: MouseEvent) => {
-    const pending = this.#pendingHeaderSort;
-
-    if (pending === null || pending.hasMoved) {
-      return;
-    }
-
-    pending.hasMoved = isPointerDragged(pending.pressOrigin, event);
-  };
-
-  /**
-   * Resolves a header press on release: sorts when the pointer stayed put, and stands aside when
-   * it travelled, leaving that gesture to ManualColumnMove.
+   * Resolves a header press on release: sorts, unless ManualColumnMove turned the press into a
+   * drag.
    *
    * Safe to call more than once for the same gesture - the queued press is taken first, so
    * whichever release signal arrives first wins and the rest are no-ops.
@@ -1058,9 +1012,18 @@ export class ColumnSorting extends BasePlugin {
   #resolvePendingSort = () => {
     const pending = this.#pendingHeaderSort;
 
+    if (pending === null) {
+      return;
+    }
+
     this.#pendingHeaderSort = null;
 
-    if (pending === null || pending.hasMoved) {
+    // Ask ManualColumnMove whether it turned this press into a drag, rather than measuring pointer
+    // travel here. Only that plugin knows whether a drag was ever armed - it needs the column
+    // selected by its header - so a travel test here would silence the sort on every grid where
+    // nothing can consume the gesture. Its state is still set at this point; it resets on its own
+    // `mouseup` listener, which runs later in the same dispatch.
+    if (this.#isColumnBeingDragged()) {
       return;
     }
 
@@ -1074,6 +1037,15 @@ export class ColumnSorting extends BasePlugin {
 
     void pending.validation.then(() => this.applyHeaderClickSort(pending));
   };
+
+  /**
+   * Whether ManualColumnMove is mid-drag. False when that plugin is absent or disabled.
+   */
+  #isColumnBeingDragged(): boolean {
+    const manualColumnMove = this.hot.getPlugin('manualColumnMove');
+
+    return manualColumnMove?.isDragging() === true;
+  }
 
   /**
    * Destroys the plugin instance.

--- a/handsontable/src/plugins/columnSorting/columnSorting.ts
+++ b/handsontable/src/plugins/columnSorting/columnSorting.ts
@@ -25,6 +25,9 @@ import {
   warnAboutPluginsConflict,
 } from './utils';
 import {
+  HEADER_ACTION_CLASS,
+  HEADER_CLASS_ASC_SORT,
+  HEADER_CLASS_DESC_SORT,
   getClassesToRemove,
   getClassesToAdd
 } from './domHelpers';
@@ -87,7 +90,11 @@ export interface HeaderSortPress {
   column: number;
   isCtrlPressed: boolean;
   pressOrigin: { x: number, y: number };
-  awaitsValidation: boolean;
+  /**
+   * Settles once the cell that was being edited at press time has finished validating, or `null`
+   * when nothing was being edited.
+   */
+  validation: Promise<void> | null;
   hasMoved: boolean;
 }
 
@@ -841,12 +848,9 @@ export class ColumnSorting extends BasePlugin {
    * Reserves room for the sort indicator on the header container, matching the state the label
    * was just given.
    *
-   * Called from the two places that drive a header render rather than from
-   * `updateHeaderClasses`, which subclasses override and extend - running it after that override
-   * has finished is what keeps the reserved side in step with the classes the label ends up with.
-   *
-   * The container's class list is rebuilt on every header render (see `TableView`), so this runs
-   * for each render rather than only when the sort state changes.
+   * Called from the header render paths, not from `updateHeaderClasses`, so it runs after any
+   * subclass override has finished adding its classes. `TableView` rebuilds the container's class
+   * list on every render, so this has to run per render.
    *
    * @param {HTMLElement} headerSpanElement The header label element.
    */
@@ -857,8 +861,13 @@ export class ColumnSorting extends BasePlugin {
       return;
     }
 
-    const showsIndicator = hasClass(headerSpanElement, 'ascending') ||
-      hasClass(headerSpanElement, 'descending');
+    // `sortAction` is required: the CSS that pulls the indicator out of the flex row is keyed on
+    // it. With `headerAction: false` the label shows an indicator but keeps its full width, so
+    // reserving would just push it inwards.
+    const showsIndicator = hasClass(headerSpanElement, HEADER_ACTION_CLASS) && (
+      hasClass(headerSpanElement, HEADER_CLASS_ASC_SORT) ||
+      hasClass(headerSpanElement, HEADER_CLASS_DESC_SORT)
+    );
 
     if (showsIndicator) {
       addClass(container, CONTAINER_WITH_INDICATOR_CLASS);
@@ -987,18 +996,22 @@ export class ColumnSorting extends BasePlugin {
     }
 
     const activeEditor = this.hot.getActiveEditor();
+    const awaitsValidation = !!(
+      activeEditor?.isOpened() &&
+      this.hot.getCellValidator(activeEditor.row!, activeEditor.col!)
+    );
 
     this.#pendingHeaderSort = {
       column: coords.col,
       isCtrlPressed,
       pressOrigin: { x: (event as MouseEvent).clientX, y: (event as MouseEvent).clientY },
-      // Read here, not on release: selecting the column opens an editor on the highlighted
-      // cell, so by mouse up this would be true for any validated column and the sort would
-      // wait for a validation that never runs.
-      awaitsValidation: !!(
-        activeEditor?.isOpened() &&
-        this.hot.getCellValidator(activeEditor.row!, activeEditor.col!)
-      ),
+      // Subscribed on press, not on release: selecting the column closes the editor and its
+      // validation runs in a microtask, so it is already over before mouse up. Reading
+      // `awaitsValidation` on release is wrong too - by then the new selection has opened an
+      // editor on the highlighted cell.
+      validation: awaitsValidation ? new Promise<void>((resolve) => {
+        this.hot.addHookOnce('postAfterValidate', () => resolve());
+      }) : null,
       hasMoved: false,
     };
   }
@@ -1013,17 +1026,7 @@ export class ColumnSorting extends BasePlugin {
    * @param {object} press The press that queued this sort.
    */
   applyHeaderClickSort(press: HeaderSortPress) {
-    const nextConfig = this.getColumnNextConfig(press.column);
-
-    if (press.awaitsValidation) {
-      // Postpone sorting until the cell's value is validated and saved.
-      this.hot.addHookOnce('postAfterValidate', () => {
-        this.sort(nextConfig);
-      });
-
-    } else {
-      this.sort(nextConfig);
-    }
+    this.sort(this.getColumnNextConfig(press.column));
   }
 
   /**
@@ -1061,7 +1064,15 @@ export class ColumnSorting extends BasePlugin {
       return;
     }
 
-    this.applyHeaderClickSort(pending);
+    // A cell that was mid-edit must finish validating before the rows move under it. Waited on
+    // here, not in `applyHeaderClickSort`, so subclasses that override that seam still get it.
+    if (pending.validation === null) {
+      this.applyHeaderClickSort(pending);
+
+      return;
+    }
+
+    void pending.validation.then(() => this.applyHeaderClickSort(pending));
   };
 
   /**

--- a/handsontable/src/plugins/columnSorting/columnSorting.ts
+++ b/handsontable/src/plugins/columnSorting/columnSorting.ts
@@ -292,6 +292,7 @@ export class ColumnSorting extends BasePlugin {
       }
 
       this.updateHeaderClasses(headerSpanElement);
+      this.#syncIndicatorReserve(headerSpanElement);
     };
 
     pluginConflictsState.delete(this.hot);
@@ -801,6 +802,7 @@ export class ColumnSorting extends BasePlugin {
       showSortIndicator,
       headerActionEnabled
     );
+    this.#syncIndicatorReserve(headerSpanElement);
 
     if (this.hot.getSettings().ariaTags) {
       const currentSortState = this.columnStatesManager?.getSortOrderOfColumn(column);
@@ -833,21 +835,22 @@ export class ColumnSorting extends BasePlugin {
         headerActionEnabled ?? false
       ));
     }
-
-    this.syncIndicatorReserve(headerSpanElement);
   }
 
   /**
    * Reserves room for the sort indicator on the header container, matching the state the label
    * was just given.
    *
+   * Called from the two places that drive a header render rather than from
+   * `updateHeaderClasses`, which subclasses override and extend - running it after that override
+   * has finished is what keeps the reserved side in step with the classes the label ends up with.
+   *
    * The container's class list is rebuilt on every header render (see `TableView`), so this runs
    * for each render rather than only when the sort state changes.
    *
-   * @private
    * @param {HTMLElement} headerSpanElement The header label element.
    */
-  syncIndicatorReserve(headerSpanElement: HTMLElement) {
+  #syncIndicatorReserve(headerSpanElement: HTMLElement) {
     const container = headerSpanElement.parentElement;
 
     if (container === null) {

--- a/handsontable/src/plugins/columnSorting/columnSorting.ts
+++ b/handsontable/src/plugins/columnSorting/columnSorting.ts
@@ -50,8 +50,46 @@ export const PLUGIN_PRIORITY = 50;
 export const APPEND_COLUMN_CONFIG_STRATEGY = 'append';
 export const REPLACE_COLUMN_CONFIG_STRATEGY = 'replace';
 const SHORTCUTS_GROUP = PLUGIN_KEY;
+/**
+ * How far, in pixels, the pointer may travel between pressing a column header and releasing it
+ * and still count as a click. Pointers jitter by a pixel or two on trackpads and high-density
+ * screens, so an exact-zero test would swallow ordinary clicks and header clicks would appear
+ * to do nothing.
+ */
+const POINTER_DRAG_TOLERANCE = 3;
+/**
+ * Marks the header container of a column that is showing a sort indicator. The indicator is
+ * positioned against that container, so the room it needs is reserved there rather than as padding
+ * on the label - padding on the label would enlarge the area that sorts on click, which is exactly
+ * what it must not do. A class rather than a `:has()` selector, which is banned in this package.
+ */
+const CONTAINER_WITH_INDICATOR_CLASS = 'has-sort-indicator';
+
+/**
+ * Checks whether the pointer has travelled far enough from where it was pressed to count as a
+ * drag rather than a click.
+ *
+ * @param {{ x: number, y: number }} pressOrigin Pointer client coordinates captured on press.
+ * @param {MouseEvent} event The event holding the current pointer position.
+ * @returns {boolean}
+ */
+function isPointerDragged(pressOrigin: { x: number, y: number }, event: MouseEvent): boolean {
+  return Math.abs(event.clientX - pressOrigin.x) > POINTER_DRAG_TOLERANCE ||
+    Math.abs(event.clientY - pressOrigin.y) > POINTER_DRAG_TOLERANCE;
+}
 
 registerRootComparator(PLUGIN_KEY, rootComparator);
+
+/**
+ * A press on a sortable column header, waiting to be resolved on mouse up.
+ */
+export interface HeaderSortPress {
+  column: number;
+  isCtrlPressed: boolean;
+  pressOrigin: { x: number, y: number };
+  awaitsValidation: boolean;
+  hasMoved: boolean;
+}
 
 export interface SortConfig {
   column: number;
@@ -148,6 +186,11 @@ export class ColumnSorting extends BasePlugin {
    */
   columnMetaCache: IndexToValueMap | null = null;
   /**
+   * Sort queued by a header press, applied on mouse up when the pointer has not travelled.
+   * Holds the pressed column, whether Ctrl/Cmd was held, and where the pointer went down.
+   */
+  #pendingHeaderSort: HeaderSortPress | null = null;
+  /**
    * Main settings key designed for the plugin.
    *
    * @private
@@ -213,6 +256,17 @@ export class ColumnSorting extends BasePlugin {
     this.addHook('beforeOnCellMouseDown', this.#onBeforeOnCellMouseDown);
     this.addHook('afterOnCellMouseDown',
       (event: Event, target: { row: number, col: number }) => this.onAfterOnCellMouseDown(event, target));
+    // Primary release signal. On touch devices Walkontable calls its `onMouseUp` directly from
+    // `touchend` instead of dispatching a DOM `mouseup`, so a document listener alone would never
+    // fire and tapping a header would stop sorting.
+    this.addHook('afterOnCellMouseUp', this.#resolvePendingSort);
+    // Fallback for a release that lands outside any cell - that is the drag case, and the queued
+    // sort still has to be cleared rather than left pending for the next release.
+    this.eventManager.addEventListener(this.hot.rootDocument.documentElement, 'mousemove',
+      (event: Event) => this.#onDocumentMouseMove(event as MouseEvent));
+    this.eventManager.addEventListener(this.hot.rootDocument.documentElement, 'mouseup',
+      () => this.#resolvePendingSort());
+
     this.addHook('afterInit', this.#loadOrSortBySettings);
     this.addHook('afterLoadData', this.#onAfterLoadData);
     this.addHook('afterDataProviderFetch', this.#onAfterDataProviderFetch, -1);
@@ -261,6 +315,7 @@ export class ColumnSorting extends BasePlugin {
     this.columnStatesManager?.destroy();
     this.columnMetaCache = null;
     this.columnStatesManager = null;
+    this.#pendingHeaderSort = null;
 
     this.unregisterShortcuts();
     super.disablePlugin();
@@ -778,6 +833,35 @@ export class ColumnSorting extends BasePlugin {
         headerActionEnabled ?? false
       ));
     }
+
+    this.syncIndicatorReserve(headerSpanElement);
+  }
+
+  /**
+   * Reserves room for the sort indicator on the header container, matching the state the label
+   * was just given.
+   *
+   * The container's class list is rebuilt on every header render (see `TableView`), so this runs
+   * for each render rather than only when the sort state changes.
+   *
+   * @private
+   * @param {HTMLElement} headerSpanElement The header label element.
+   */
+  syncIndicatorReserve(headerSpanElement: HTMLElement) {
+    const container = headerSpanElement.parentElement;
+
+    if (container === null) {
+      return;
+    }
+
+    const showsIndicator = hasClass(headerSpanElement, 'ascending') ||
+      hasClass(headerSpanElement, 'descending');
+
+    if (showsIndicator) {
+      addClass(container, CONTAINER_WITH_INDICATOR_CLASS);
+    } else {
+      removeClass(container, CONTAINER_WITH_INDICATOR_CLASS);
+    }
   }
 
   /**
@@ -857,6 +941,11 @@ export class ColumnSorting extends BasePlugin {
     event: Event, coords: { row: number, col: number }, TD: HTMLTableCellElement,
     controller: { column: boolean }
   ) => {
+    // Drop any press whose release never arrived - e.g. the window lost focus while the button
+    // was held. Without this a stale press would resolve on the next unrelated release and sort
+    // a column out of nowhere.
+    this.#pendingHeaderSort = null;
+
     if (wasHeaderClickedProperly(coords.row, coords.col, event) === false) {
       return;
     }
@@ -869,6 +958,11 @@ export class ColumnSorting extends BasePlugin {
   /**
    * Callback for the `onAfterOnCellMouseDown` hook.
    *
+   * Queues the sort rather than running it. The header is also the surface ManualColumnMove
+   * drags a column by, so which action the user meant is only known once the button is
+   * released: a press that stays put is a click to sort, a press that travels is a drag.
+   * Selection changes stay here so the header still reacts the moment it is pressed.
+   *
    * @private
    * @param {Event} event Event which are provided by hook.
    * @param {CellCoords} coords Visual coords of the selected cell.
@@ -878,34 +972,103 @@ export class ColumnSorting extends BasePlugin {
       return;
     }
 
-    if (this.wasClickableHeaderClicked(event, coords.col)) {
-      if (this.hot.getShortcutManager().isCtrlPressed()) {
-        this.hot.deselectCell();
-        this.hot.selectColumns(coords.col);
-      }
+    if (this.wasClickableHeaderClicked(event, coords.col) === false) {
+      return;
+    }
 
-      const activeEditor = this.hot.getActiveEditor();
-      const nextConfig = this.getColumnNextConfig(coords.col);
+    const isCtrlPressed = this.hot.getShortcutManager().isCtrlPressed();
 
-      if (
+    if (isCtrlPressed) {
+      this.hot.deselectCell();
+      this.hot.selectColumns(coords.col);
+    }
+
+    const activeEditor = this.hot.getActiveEditor();
+
+    this.#pendingHeaderSort = {
+      column: coords.col,
+      isCtrlPressed,
+      pressOrigin: { x: (event as MouseEvent).clientX, y: (event as MouseEvent).clientY },
+      // Read here, not on release: selecting the column opens an editor on the highlighted
+      // cell, so by mouse up this would be true for any validated column and the sort would
+      // wait for a validation that never runs.
+      awaitsValidation: !!(
         activeEditor?.isOpened() &&
         this.hot.getCellValidator(activeEditor.row!, activeEditor.col!)
-      ) {
-        // Postpone sorting until the cell's value is validated and saved.
-        this.hot.addHookOnce('postAfterValidate', () => {
-          this.sort(nextConfig);
-        });
+      ),
+      hasMoved: false,
+    };
+  }
 
-      } else {
+  /**
+   * Applies the sort queued by a header press.
+   *
+   * Kept separate from the press handler so `MultiColumnSorting` can choose a different sort
+   * configuration for the same gesture without repeating the click-versus-drag handling.
+   *
+   * @private
+   * @param {object} press The press that queued this sort.
+   */
+  applyHeaderClickSort(press: HeaderSortPress) {
+    const nextConfig = this.getColumnNextConfig(press.column);
+
+    if (press.awaitsValidation) {
+      // Postpone sorting until the cell's value is validated and saved.
+      this.hot.addHookOnce('postAfterValidate', () => {
         this.sort(nextConfig);
-      }
+      });
+
+    } else {
+      this.sort(nextConfig);
     }
   }
+
+  /**
+   * Watches a queued header press for pointer travel.
+   *
+   * Travel is measured from `mousemove` rather than by comparing the press and release
+   * positions, because a press can scroll a partly visible header into view - that moves the
+   * header under a stationary pointer, which is not a drag.
+   *
+   * @param {MouseEvent} event The `mousemove` event.
+   */
+  #onDocumentMouseMove = (event: MouseEvent) => {
+    const pending = this.#pendingHeaderSort;
+
+    if (pending === null || pending.hasMoved) {
+      return;
+    }
+
+    pending.hasMoved = isPointerDragged(pending.pressOrigin, event);
+  };
+
+  /**
+   * Resolves a header press on release: sorts when the pointer stayed put, and stands aside when
+   * it travelled, leaving that gesture to ManualColumnMove.
+   *
+   * Safe to call more than once for the same gesture - the queued press is taken first, so
+   * whichever release signal arrives first wins and the rest are no-ops.
+   */
+  #resolvePendingSort = () => {
+    const pending = this.#pendingHeaderSort;
+
+    this.#pendingHeaderSort = null;
+
+    if (pending === null || pending.hasMoved) {
+      return;
+    }
+
+    this.applyHeaderClickSort(pending);
+  };
 
   /**
    * Destroys the plugin instance.
    */
   destroy(): void {
+    // `BasePlugin.destroy` nulls enumerable own properties, which cannot reach a `#private`
+    // field, so drop the queued press here.
+    this.#pendingHeaderSort = null;
+
     // TODO: Probably not supported yet by ESLint: https://github.com/eslint/eslint/issues/11045
     // eslint-disable-next-line no-unused-expressions
     this.columnStatesManager?.destroy();

--- a/handsontable/src/plugins/columnSorting/domHelpers.ts
+++ b/handsontable/src/plugins/columnSorting/domHelpers.ts
@@ -2,11 +2,12 @@ import { isDefined } from '../../helpers/mixed';
 import { ASC_SORT_STATE, DESC_SORT_STATE } from './utils';
 import type { ColumnStatesManager } from './columnStatesManager';
 
-const HEADER_CLASS_ASC_SORT = 'ascending';
-const HEADER_CLASS_DESC_SORT = 'descending';
+export const HEADER_CLASS_ASC_SORT = 'ascending';
+export const HEADER_CLASS_DESC_SORT = 'descending';
 const HEADER_CLASS_INDICATOR_DISABLED = 'indicatorDisabled';
 const HEADER_SORT_CLASS = 'columnSorting';
-const HEADER_ACTION_CLASS = 'sortAction';
+
+export const HEADER_ACTION_CLASS = 'sortAction';
 
 const orderToCssClass = new Map([
   [ASC_SORT_STATE, HEADER_CLASS_ASC_SORT],

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
@@ -5,7 +5,7 @@ import { objectEach } from '../../helpers/object';
 import { CommandExecutor } from '../contextMenu/commandExecutor';
 import { getDocumentOffsetByElement } from '../contextMenu/utils';
 import {
-  eventTargetEl, hasClass, isBottomMostColumnHeader, isHTMLElement, setAttribute
+  addClass, eventTargetEl, hasClass, isBottomMostColumnHeader, isHTMLElement, removeClass, setAttribute
 } from '../../helpers/dom/element';
 import { ItemsFactory } from '../contextMenu/itemsFactory';
 import { Menu } from '../contextMenu/menu';
@@ -36,6 +36,13 @@ export type { MenuAnchorRectProvider };
 export const PLUGIN_KEY = 'dropdownMenu';
 export const PLUGIN_PRIORITY = 230;
 const BUTTON_CLASS_NAME = 'changeType';
+/**
+ * Marks a header that carries a trailing icon button, so styles that position something against
+ * the header's trailing edge - the ColumnSorting indicator - can keep clear of it. A class rather
+ * than a `:has()` selector: `:has()` on a header re-runs style invalidation on every grid DOM
+ * mutation, which is why it is banned in this package.
+ */
+const HEADER_WITH_BUTTON_CLASS_NAME = 'has-header-button';
 const SHORTCUTS_GROUP = PLUGIN_KEY;
 
 interface DropdownMenuSettings {
@@ -674,12 +681,25 @@ export class DropdownMenu extends BasePlugin {
 
     // Plugin enabled and buttons already exists, return.
     if (this.enabled && existingButton) {
+      // The container's class list is rebuilt on every header render (see `TableView`), while the
+      // button element itself survives - so the marker has to be re-applied here, not only where
+      // the button is created.
+      if (isHTMLElement(existingButton.parentNode)) {
+        addClass(existingButton.parentNode, HEADER_WITH_BUTTON_CLASS_NAME);
+      }
+
       return;
     }
     // Plugin disabled and buttons still exists, so remove them.
     if (!this.enabled) {
       if (existingButton) {
-        existingButton.parentNode?.removeChild(existingButton);
+        const container = existingButton.parentNode;
+
+        container?.removeChild(existingButton);
+
+        if (isHTMLElement(container)) {
+          removeClass(container, HEADER_WITH_BUTTON_CLASS_NAME);
+        }
       }
 
       return;
@@ -718,6 +738,10 @@ export class DropdownMenu extends BasePlugin {
       relativeContainer.insertBefore(button, colHeaderSpan.nextSibling);
     } else {
       relativeContainer.appendChild(button);
+    }
+
+    if (isHTMLElement(relativeContainer)) {
+      addClass(relativeContainer, HEADER_WITH_BUTTON_CLASS_NAME);
     }
   };
 

--- a/handsontable/src/plugins/manualColumnMove/__tests__/manualColumnMove.spec.js
+++ b/handsontable/src/plugins/manualColumnMove/__tests__/manualColumnMove.spec.js
@@ -770,10 +770,12 @@ describe('manualColumnMove', () => {
 
             $firstHeader.simulate('mousedown');
             $firstHeader.simulate('mouseup');
-            $firstHeader.simulate('mousedown');
+            $firstHeader.simulate('mousedown', { clientX: $firstHeader.offset().left });
 
             $firstHeader.simulate('mouseover');
-            $firstHeader.simulate('mousemove');
+            // The pointer has to travel to count as a drag, but stay in the left half of the same
+            // header so the column is dropped where it started.
+            $firstHeader.simulate('mousemove', { clientX: $firstHeader.offset().left + 10 });
             $firstHeader.simulate('mouseup');
 
             expect(finalIndex1).toEqual(0);
@@ -902,10 +904,12 @@ describe('manualColumnMove', () => {
 
             $secondHeader.simulate('mousedown');
             $secondHeader.simulate('mouseup');
-            $secondHeader.simulate('mousedown');
+            $secondHeader.simulate('mousedown', { clientX: $secondHeader.offset().left });
 
             $secondHeader.simulate('mouseover');
-            $secondHeader.simulate('mousemove');
+            // The pointer has to travel to count as a drag, but stay in the left half of the same
+            // header so the column is dropped where it started.
+            $secondHeader.simulate('mousemove', { clientX: $secondHeader.offset().left + 10 });
             $secondHeader.simulate('mouseup');
 
             expect(finalIndex1).toEqual(1);

--- a/handsontable/src/plugins/manualColumnMove/__tests__/manualColumnMoveUI.spec.js
+++ b/handsontable/src/plugins/manualColumnMove/__tests__/manualColumnMoveUI.spec.js
@@ -88,7 +88,7 @@ describe('manualColumnMove', () => {
       expect($('.ht__manualColumnMove--guideline').css('z-index')).toBeGreaterThan(getTopClone().css('z-index'));
     });
 
-    it('should not run moving ui if mousedown was fired on sorting element', async() => {
+    it('should not move the column when the sorting element is pressed and released without moving', async() => {
       handsontable({
         data: createSpreadsheetData(30, 30),
         colHeaders: true,
@@ -104,14 +104,15 @@ describe('manualColumnMove', () => {
       $headerTH.simulate('mousedown');
       $headerTH.simulate('mouseup');
 
-      const $backlight = spec().$container.find('.ht__manualColumnMove--backlight')[0];
-
+      // The sorting label is part of the draggable header, so pressing it does arm a move.
+      // Releasing without any pointer movement has to leave the column order untouched - that
+      // gesture is a click to sort, and only a press that travels moves the column.
       $summaryElement.simulate('mousedown');
+      $summaryElement.simulate('mouseup');
 
-      const displayProp = $backlight.currentStyle ?
-        $backlight.currentStyle.display : getComputedStyle($backlight, null).display;
-
-      expect(displayProp).toEqual('none');
+      expect(getDataAtRow(0)).toEqual(getSourceDataAtRow(0));
+      expect(columnIndexMapper().getIndexesSequence())
+        .toEqual(Array.from({ length: 30 }, (_, index) => index));
     });
 
     it('should run moving ui if mousedown was fired on sorting element when sort header action is not enabled', async() => {

--- a/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
+++ b/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
@@ -269,6 +269,19 @@ export class ManualColumnMove extends BasePlugin {
   }
 
   /**
+   * Checks whether a column drag is in progress - the header is held down and the pointer has
+   * travelled far enough to count as a drag rather than a click.
+   *
+   * `ColumnSorting` asks this on release to tell a click apart from a drag, so the two plugins
+   * cannot disagree about where that line is.
+   *
+   * @returns {boolean}
+   */
+  isDragging(): boolean {
+    return this.enabled && this.#pressed && this.#dragged;
+  }
+
+  /**
    * Indicates if it's possible to move columns to the desired position. Some of the actions aren't
    * possible, i.e. You can’t move more than one element to the last position.
    *

--- a/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
+++ b/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
@@ -1,7 +1,7 @@
 import { BasePlugin } from '../base';
 import { Hooks } from '../../core/hooks';
 import { arrayReduce } from '../../helpers/array';
-import { addClass, eventTargetEl, removeClass, offset, hasClass, outerWidth } from '../../helpers/dom/element';
+import { addClass, removeClass, offset, outerWidth } from '../../helpers/dom/element';
 import { offsetRelativeTo } from '../../helpers/dom/event';
 import { rangeEach } from '../../helpers/number';
 import BacklightUI from './ui/backlight';
@@ -80,6 +80,11 @@ export class ManualColumnMove extends BasePlugin {
    * @type {boolean}
    */
   #pressed = false;
+  /**
+   * Whether the pointer moved at all since the header was pressed. A press that never moved is
+   * a click to sort, not a drag, so no columns are moved and the move hooks stay quiet.
+   */
+  #dragged = false;
   /**
    * @type {object}
    */
@@ -609,11 +614,10 @@ export class ManualColumnMove extends BasePlugin {
     const wtTable = this.hot.view._wt.wtTable;
     const isHeaderSelection = this.hot.selection.isSelectedByColumnHeader();
     const selection = this.hot.getSelectedRangeActive();
-    // This block action shouldn't be handled below.
-    const isSortingElement = hasClass(eventTargetEl(event)!, 'sortAction');
 
-    if (!selection || !isHeaderSelection || this.#pressed || event.button !== 0 || isSortingElement) {
+    if (!selection || !isHeaderSelection || this.#pressed || event.button !== 0) {
       this.#pressed = false;
+      this.#dragged = false;
       this.#columnsToMove.length = 0;
       removeClass(this.hot.rootElement, [CSS_ON_MOVING, CSS_SHOW_UI]);
 
@@ -666,11 +670,14 @@ export class ManualColumnMove extends BasePlugin {
       this.#backlight.setSize(this.getColumnsWidth(start, end), wtTable.hider.offsetHeight - topPos);
       this.#backlight.setOffset(0, -inlineOffset);
 
+      this.#dragged = false;
+
       addClass(this.hot.rootElement, CSS_ON_MOVING);
 
     } else {
       removeClass(this.hot.rootElement, CSS_AFTER_SELECTION);
       this.#pressed = false;
+      this.#dragged = false;
       this.#columnsToMove.length = 0;
     }
   };
@@ -684,6 +691,9 @@ export class ManualColumnMove extends BasePlugin {
     if (!this.#pressed) {
       return;
     }
+
+    // A press that never produced a pointer move is a click, and belongs to ColumnSorting.
+    this.#dragged = true;
 
     this.#target.eventPageX = event.pageX;
     this.refreshPositions();
@@ -744,9 +754,11 @@ export class ManualColumnMove extends BasePlugin {
   #onMouseUp() {
     const target = this.#target.col;
     const columnsLen = this.#columnsToMove.length;
+    const wasDragged = this.#dragged;
 
     this.#hoveredColumn = undefined;
     this.#pressed = false;
+    this.#dragged = false;
 
     removeClass(this.hot.rootElement, [CSS_ON_MOVING, CSS_SHOW_UI, CSS_AFTER_SELECTION]);
 
@@ -754,7 +766,11 @@ export class ManualColumnMove extends BasePlugin {
       addClass(this.hot.rootElement, CSS_AFTER_SELECTION);
     }
 
-    if (columnsLen < 1 || target === undefined) {
+    // A press that never travelled is a click, not a move. Bailing out here also keeps
+    // `beforeColumnMove` / `afterColumnMove` from firing on every header click.
+    if (!wasDragged || columnsLen < 1 || target === undefined) {
+      this.#columnsToMove.length = 0;
+
       return;
     }
 

--- a/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
+++ b/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
@@ -16,6 +16,9 @@ const CSS_PLUGIN = 'ht__manualColumnMove';
 const CSS_SHOW_UI = 'show-ui';
 const CSS_ON_MOVING = 'on-moving--columns';
 const CSS_AFTER_SELECTION = 'after-selection--columns';
+// Matches ColumnSorting's tolerance. Kept as a local constant rather than imported - plugins do not
+// import each other.
+const POINTER_DRAG_TOLERANCE = 3;
 
 /**
  * @plugin ManualColumnMove
@@ -81,10 +84,14 @@ export class ManualColumnMove extends BasePlugin {
    */
   #pressed = false;
   /**
-   * Whether the pointer moved at all since the header was pressed. A press that never moved is
-   * a click to sort, not a drag, so no columns are moved and the move hooks stay quiet.
+   * Whether the pointer travelled far enough since the header was pressed to count as a drag. A
+   * press that stayed put is a click to sort, so no columns move and the move hooks stay quiet.
    */
   #dragged = false;
+  /**
+   * Pointer client coordinates captured on press, for measuring that travel.
+   */
+  #pressOrigin = { x: 0, y: 0 };
   /**
    * @type {object}
    */
@@ -639,6 +646,7 @@ export class ManualColumnMove extends BasePlugin {
     if (coords.row < 0 && (coords.col >= start && coords.col <= end)) {
       controller.column = true;
       this.#pressed = true;
+      this.#pressOrigin = { x: event.clientX, y: event.clientY };
 
       const eventOffsetX = TD.firstChild ? offsetRelativeTo(event, TD.firstChild as HTMLElement).x : event.offsetX;
 
@@ -692,8 +700,12 @@ export class ManualColumnMove extends BasePlugin {
       return;
     }
 
-    // A press that never produced a pointer move is a click, and belongs to ColumnSorting.
-    this.#dragged = true;
+    // Same tolerance ColumnSorting uses to tell a click from a drag, so a pointer that jitters a
+    // pixel or two does not both sort and fire the move hooks.
+    if (Math.abs(event.clientX - this.#pressOrigin.x) > POINTER_DRAG_TOLERANCE ||
+        Math.abs(event.clientY - this.#pressOrigin.y) > POINTER_DRAG_TOLERANCE) {
+      this.#dragged = true;
+    }
 
     this.#target.eventPageX = event.pageX;
     this.refreshPositions();

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.ts
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.ts
@@ -2,10 +2,9 @@ import {
   APPEND_COLUMN_CONFIG_STRATEGY,
   ColumnSorting
 } from '../columnSorting';
-import type { SortConfig } from '../columnSorting/columnSorting';
+import type { HeaderSortPress, SortConfig } from '../columnSorting/columnSorting';
 import type { ColumnStatesManager } from '../columnSorting/columnStatesManager';
 import { registerRootComparator } from '../columnSorting/sortService/registry';
-import { wasHeaderClickedProperly } from '../columnSorting/utils';
 import { addClass, removeClass } from '../../helpers/dom/element';
 import { rootComparator } from './rootComparator';
 import { getClassesToAdd, getClassesToRemove } from './domHelpers';
@@ -302,30 +301,26 @@ export class MultiColumnSorting extends ColumnSorting {
     if (this.enabled !== false && columnStatesManager !== undefined && column !== undefined) {
       addClass(headerSpanElement, getClassesToAdd(columnStatesManager, column, showSortIndicator ?? false));
     }
+
+    this.syncIndicatorReserve(headerSpanElement);
   }
 
   /**
-   * Callback for the `onAfterOnCellMouseDown` hook.
+   * Applies the sort queued by a header press.
+   *
+   * Holding Ctrl/Cmd appends the column to the sort queue instead of replacing it, which is the
+   * only way this differs from single-column sorting. The press-versus-drag handling that decides
+   * whether this runs at all lives in `ColumnSorting`.
    *
    * @private
-   * @param {Event} event Event which are provided by hook.
-   * @param {CellCoords} coords Visual coords of the selected cell.
+   * @param {object} press The press that queued this sort.
    */
-  onAfterOnCellMouseDown(event: MouseEvent, coords: { row: number, col: number }) {
-    if (wasHeaderClickedProperly(coords.row, coords.col, event) === false) {
-      return;
-    }
+  applyHeaderClickSort(press: HeaderSortPress) {
+    if (press.isCtrlPressed) {
+      this.sort(this.getNextSortConfig(press.column, APPEND_COLUMN_CONFIG_STRATEGY) as SortConfig[]);
 
-    if (this.wasClickableHeaderClicked(event, coords.col)) {
-      if (this.hot.getShortcutManager().isCtrlPressed()) {
-        this.hot.deselectCell();
-        this.hot.selectColumns(coords.col);
-
-        this.sort(this.getNextSortConfig(coords.col, APPEND_COLUMN_CONFIG_STRATEGY) as SortConfig[]);
-
-      } else {
-        this.sort(this.getColumnNextConfig(coords.col));
-      }
+    } else {
+      this.sort(this.getColumnNextConfig(press.column));
     }
   }
 }

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.ts
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.ts
@@ -301,8 +301,6 @@ export class MultiColumnSorting extends ColumnSorting {
     if (this.enabled !== false && columnStatesManager !== undefined && column !== undefined) {
       addClass(headerSpanElement, getClassesToAdd(columnStatesManager, column, showSortIndicator ?? false));
     }
-
-    this.syncIndicatorReserve(headerSpanElement);
   }
 
   /**

--- a/handsontable/src/styles/components/plugins/_column-sorting.scss
+++ b/handsontable/src/styles/components/plugins/_column-sorting.scss
@@ -72,6 +72,13 @@
       --ht-sort-indicator-offset-end: var(--ht-cell-horizontal-padding);
       // How much room the container holds back for the indicator.
       --ht-sort-indicator-reserve: var(--ht-cell-horizontal-padding);
+      // The same, but only for the inline-end side - the one a trailing button shares. Split from
+      // the value above so the button case can drop it without touching the other sides.
+      --ht-sort-indicator-reserve-end: var(--ht-sort-indicator-reserve);
+      // The room a trailing button needs before it, so the indicator has somewhere to sit. This is
+      // the button's outer box: its border box is `--ht-icon-button-hit-area-size`, pulled back to
+      // the icon size plus 2px by the uniform negative margin it carries (`_dropdown-menu.scss`).
+      --ht-header-button-slot: calc(var(--ht-icon-size, 16px) + 2px);
     }
 
     // A trailing icon button (the dropdown menu's) occupies the corner the indicators are pinned
@@ -80,6 +87,23 @@
     // flex end, which is the only place such a button appears.
     .relative.has-header-button {
       --ht-sort-indicator-offset-end: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 4px);
+
+      // The button's own slot is what separates the label from the indicator here, so the
+      // container must not hold room back as well. Doing both moves the button inwards - it is the
+      // last flex item, so container padding drags it left - until it covers the indicator it was
+      // supposed to step aside for. The button paints on top (`z-index: 1`), so the indicator
+      // simply disappears.
+      --ht-sort-indicator-reserve-end: var(--ht-cell-horizontal-padding);
+    }
+
+    // Hold the indicator's slot open in the flex row. Without it the label's auto margins let the
+    // text run right up to the button, over the indicator pinned in between.
+    // Widening the one gap between the label and the button, rather than giving the button a
+    // margin: the button carries a uniform negative margin of its own, and setting one side of it
+    // here would drop that side's pull-back and make the header measure wider.
+    .relative.has-sort-indicator.has-header-button {
+      // 2px is the base gap between header items (`_base.scss`).
+      column-gap: calc(2px + var(--ht-header-button-slot));
     }
 
     // Room for the sort indicator, reserved on the container instead of as padding on the label.
@@ -92,7 +116,7 @@
     .relative.has-sort-indicator {
       --ht-sort-indicator-reserve: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
 
-      padding-inline-end: var(--ht-sort-indicator-reserve);
+      padding-inline-end: var(--ht-sort-indicator-reserve-end);
     }
 
     // Two selectors because the room is held on the container itself: `headerClassName` puts the
@@ -103,6 +127,10 @@
     .htRight .relative.has-sort-indicator {
       padding-inline-start: var(--ht-sort-indicator-reserve);
       padding-inline-end: var(--ht-cell-horizontal-padding);
+
+      // The indicator is on the opposite side from the button here, so nothing has to be held open
+      // between the label and the button.
+      --ht-header-button-slot: 0px;
     }
 
     .columnSorting:not(.indicatorDisabled) {
@@ -147,7 +175,10 @@
       .relative.htRight.has-sort-indicator,
       .htRight .relative.has-sort-indicator {
         padding-inline-start: var(--ht-cell-horizontal-padding);
-        padding-inline-end: var(--ht-sort-indicator-reserve);
+        padding-inline-end: var(--ht-sort-indicator-reserve-end);
+
+        // Back on the button's side here, so the slot is needed again - undo the LTR rule above.
+        --ht-header-button-slot: calc(var(--ht-icon-size, 16px) + 2px);
       }
 
       // `htLeft` is the class that points against the direction in RTL, so it is the one that
@@ -156,6 +187,9 @@
       .htLeft .relative.has-sort-indicator {
         padding-inline-start: var(--ht-sort-indicator-reserve);
         padding-inline-end: var(--ht-cell-horizontal-padding);
+
+        // `htLeft` is the side away from the button in RTL, so nothing needs holding open.
+        --ht-header-button-slot: 0px;
       }
 
       .columnSorting {
@@ -196,6 +230,9 @@
   .htGhostTable .htCore .relative {
     --ht-sort-indicator-offset: 0px;
     --ht-sort-indicator-offset-end: 0px;
+    // The indicator is in flow here, so it already occupies its slot - holding one open in front
+    // of the button as well would measure that width twice.
+    --ht-header-button-slot: 0px;
   }
 
   /* The room the container holds back for the indicator is left alone above, because it stands in
@@ -204,6 +241,7 @@
       that case its own gap in the ghost table, so reserving as well counts the indicator twice. */
   .htGhostTable .htCore .relative.has-header-button {
     --ht-sort-indicator-reserve: var(--ht-cell-horizontal-padding);
+    --ht-sort-indicator-reserve-end: var(--ht-cell-horizontal-padding);
   }
 
   .htGhostTable

--- a/handsontable/src/styles/components/plugins/_column-sorting.scss
+++ b/handsontable/src/styles/components/plugins/_column-sorting.scss
@@ -17,6 +17,7 @@
       flex-grow: 0;
       // Auto margins on both sides keep the label centred, and hand the free space to the
       // header rather than to one edge - the same place the text sat when the label filled it.
+      // `htLeft`/`htRight` move the box instead; see below.
       margin-inline: auto;
       // Never collapse the label to nothing in a narrow column, and never let it grow past the
       // header, which would push the indicator outside the cell.
@@ -36,6 +37,24 @@
         margin-inline: var(--ht-sort-indicator-offset);
         margin-inline-end: var(--ht-sort-indicator-offset-end);
       }
+    }
+
+    // A left- or right-aligned header used to place its text through `text-align` on a label that
+    // filled the whole cell. The label is now sized to its text, and auto margins on both sides
+    // would centre it - so the alignment has to move the box itself or every aligned header
+    // renders centred. Physical margins, because `htLeft`/`htRight` are physical too: they mean
+    // the left and right edge in either direction.
+    // Matched as an ancestor, the way the indicator rules below already are, because
+    // `headerClassName` puts these classes on the `.relative` container while code that sets them
+    // by hand tends to put them on the `th` - both are ancestors of the label.
+    .htLeft .colHeader.columnSorting.sortAction {
+      margin-left: 0;
+      margin-right: auto;
+    }
+
+    .htRight .colHeader.columnSorting.sortAction {
+      margin-left: auto;
+      margin-right: 0;
     }
 
     // The three distances the indicator needs, carried as custom properties rather than written
@@ -76,9 +95,12 @@
       padding-inline-end: var(--ht-sort-indicator-reserve);
     }
 
-    // Kept on `th` rather than the bare class: `htRight` is a user-supplied class name that can
-    // also sit on an ancestor, and this must only react to it on the header cell itself.
-    th.htRight .relative.has-sort-indicator {
+    // Two selectors because the room is held on the container itself: `headerClassName` puts the
+    // alignment class on that same `.relative`, while code that sets it by hand tends to put it on
+    // the `th`. A descendant selector alone would miss the first, which is the one the product
+    // uses.
+    .relative.htRight.has-sort-indicator,
+    .htRight .relative.has-sort-indicator {
       padding-inline-start: var(--ht-sort-indicator-reserve);
       padding-inline-end: var(--ht-cell-horizontal-padding);
     }
@@ -122,14 +144,16 @@
     .handsontable {
       // `htRight` points the same way as the direction here, so the indicator sits on the
       // inline-end side like the default - undo the LTR rule above, which reserves the other one.
-      th.htRight .relative.has-sort-indicator {
+      .relative.htRight.has-sort-indicator,
+      .htRight .relative.has-sort-indicator {
         padding-inline-start: var(--ht-cell-horizontal-padding);
         padding-inline-end: var(--ht-sort-indicator-reserve);
       }
 
       // `htLeft` is the class that points against the direction in RTL, so it is the one that
       // pins the indicator to the inline-start side - the mirror of `htRight` in LTR.
-      th.htLeft .relative.has-sort-indicator {
+      .relative.htLeft.has-sort-indicator,
+      .htLeft .relative.has-sort-indicator {
         padding-inline-start: var(--ht-sort-indicator-reserve);
         padding-inline-end: var(--ht-cell-horizontal-padding);
       }

--- a/handsontable/src/styles/components/plugins/_column-sorting.scss
+++ b/handsontable/src/styles/components/plugins/_column-sorting.scss
@@ -8,9 +8,11 @@
     // header around it is what a user presses to select a column without sorting it - which is
     // the first half of moving a column by drag. Size the label to its content and centre it,
     // so only the label text and the sort indicator sort on click.
-    // The selector carries the full `thead tr th .relative` path because the base rule that
-    // makes the label fill the row (`_base.scss`) is that specific.
-    thead tr th .relative .colHeader.columnSorting.sortAction {
+    // Three classes are all it takes to win over the base rule that makes the label fill the row
+    // (`.handsontable thead tr th .relative .colHeader` in `_base.scss` - three classes), because
+    // class count is compared before element count. Repeating the structural path would only tie
+    // this rule to a header shape it does not care about.
+    .colHeader.columnSorting.sortAction {
       box-sizing: border-box;
       flex-grow: 0;
       // Auto margins on both sides keep the label centred, and hand the free space to the
@@ -38,12 +40,17 @@
     // Room for the sort indicator, reserved on the container instead of as padding on the label.
     // Padding on the label would grow the box that sorts on click, adding a strip of header that
     // looks inert but is not - the label has to stay tight around its text. The sides mirror where
-    // `::before` is pinned, which flips with text alignment and direction.
-    thead tr th .relative.has-sort-indicator {
+    // `::before` is pinned, which flips with text alignment and direction: it is the inline-end
+    // side unless the alignment class points against the direction - `htRight` in LTR, `htLeft`
+    // in RTL. Only `ColumnSorting` stamps `has-sort-indicator`, and only on a column header
+    // container, so the class alone is scope enough.
+    .relative.has-sort-indicator {
       padding-inline-end: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
     }
 
-    thead tr th.htRight .relative.has-sort-indicator {
+    // Kept on `th` rather than the bare class: `htRight` is a user-supplied class name that can
+    // also sit on an ancestor, and this must only react to it on the header cell itself.
+    th.htRight .relative.has-sort-indicator {
       padding-inline-start: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
       padding-inline-end: var(--ht-cell-horizontal-padding);
     }
@@ -52,7 +59,7 @@
     // to, so step them over it. The button's painted width is `--ht-icon-size` + 2px once its own
     // negative margins apply, plus the 2px flex gap. Only the inline-end side moves: that is the
     // flex end, which is the only place such a button appears.
-    thead tr th .relative.has-header-button .colHeader.columnSorting.sortAction {
+    .relative.has-header-button .colHeader.columnSorting.sortAction {
       &::before,
       &::after {
         margin-inline-end: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 4px);
@@ -96,13 +103,18 @@
 
   [dir="rtl"] {
     .handsontable {
-      // In RTL the indicator sits on the inline-end side for both default and right-aligned text,
-      // and only `htLeft` flips it back - so `htRight` has to undo the direction-agnostic rule
-      // above, which would otherwise reserve the wrong side.
-      thead tr th.htRight .relative.has-sort-indicator,
-      thead tr th.htLeft .relative.has-sort-indicator {
+      // `htRight` points the same way as the direction here, so the indicator sits on the
+      // inline-end side like the default - undo the LTR rule above, which reserves the other one.
+      th.htRight .relative.has-sort-indicator {
         padding-inline-start: var(--ht-cell-horizontal-padding);
         padding-inline-end: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
+      }
+
+      // `htLeft` is the class that points against the direction in RTL, so it is the one that
+      // pins the indicator to the inline-start side - the mirror of `htRight` in LTR.
+      th.htLeft .relative.has-sort-indicator {
+        padding-inline-start: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
+        padding-inline-end: var(--ht-cell-horizontal-padding);
       }
 
       .columnSorting {
@@ -133,7 +145,7 @@
       header edge in the real table would be measured as extra column width and every auto-sized
       column would come out wider. The selector is deliberately more specific than the rule that
       sets those offsets. */
-  .htGhostTable .htCore thead tr th .relative span.colHeader.columnSorting.sortAction {
+  .htGhostTable .htCore .colHeader.columnSorting.sortAction {
     &::before,
     &::after {
       margin-inline: 0;

--- a/handsontable/src/styles/components/plugins/_column-sorting.scss
+++ b/handsontable/src/styles/components/plugins/_column-sorting.scss
@@ -4,14 +4,65 @@
 
 @mixin output {
   .handsontable {
+    // The label is the sort button, so it must not swallow the whole header cell. The bare
+    // header around it is what a user presses to select a column without sorting it - which is
+    // the first half of moving a column by drag. Size the label to its content and centre it,
+    // so only the label text and the sort indicator sort on click.
+    // The selector carries the full `thead tr th .relative` path because the base rule that
+    // makes the label fill the row (`_base.scss`) is that specific.
+    thead tr th .relative .colHeader.columnSorting.sortAction {
+      box-sizing: border-box;
+      flex-grow: 0;
+      // Auto margins on both sides keep the label centred, and hand the free space to the
+      // header rather than to one edge - the same place the text sat when the label filled it.
+      margin-inline: auto;
+      // Never collapse the label to nothing in a narrow column, and never let it grow past the
+      // header, which would push the indicator outside the cell.
+      min-width: min(calc(var(--ht-icon-size, 16px) + 8px), 100%);
+      max-width: 100%;
+      // The indicators are absolutely positioned, and `static` hands them to `.relative` so they
+      // stay pinned to the header's trailing edge while the label shrinks away from it. Clicking
+      // one still sorts: events on a pseudo-element target the element that owns it.
+      position: static;
+
+      // `.relative`'s padding box is the new containing block, and it sits inside the cell
+      // padding the label used to carry - add it back so the indicators keep their distance from
+      // the header edge. Both sides, because the pinned side flips in RTL and right-aligned
+      // headers.
+      &::before,
+      &::after {
+        margin-inline: var(--ht-cell-horizontal-padding);
+      }
+    }
+
+    // Room for the sort indicator, reserved on the container instead of as padding on the label.
+    // Padding on the label would grow the box that sorts on click, adding a strip of header that
+    // looks inert but is not - the label has to stay tight around its text. The sides mirror where
+    // `::before` is pinned, which flips with text alignment and direction.
+    thead tr th .relative.has-sort-indicator {
+      padding-inline-end: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
+    }
+
+    thead tr th.htRight .relative.has-sort-indicator {
+      padding-inline-start: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
+      padding-inline-end: var(--ht-cell-horizontal-padding);
+    }
+
+    // A trailing icon button (the dropdown menu's) occupies the corner the indicators are pinned
+    // to, so step them over it. The button's painted width is `--ht-icon-size` + 2px once its own
+    // negative margins apply, plus the 2px flex gap. Only the inline-end side moves: that is the
+    // flex end, which is the only place such a button appears.
+    thead tr th .relative.has-header-button .colHeader.columnSorting.sortAction {
+      &::before,
+      &::after {
+        margin-inline-end: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 4px);
+      }
+    }
+
     .columnSorting:not(.indicatorDisabled) {
       position: relative;
 
       &.sortAction {
-        &.ascending, &.descending {
-          padding-inline-end: calc(var(--ht-icon-size, 16px) + 2px);
-        }
-
         &:hover {
           text-decoration: none;
           cursor: pointer;
@@ -33,11 +84,6 @@
     .htRight {
       .columnSorting {
         &.sortAction {
-          &.ascending, &.descending {
-            padding-inline-start: calc(var(--ht-icon-size, 16px) + 2px);
-            padding-inline-end: 0;
-          }
-
           &::before {
             left: 2px;
             right: auto;
@@ -50,6 +96,15 @@
 
   [dir="rtl"] {
     .handsontable {
+      // In RTL the indicator sits on the inline-end side for both default and right-aligned text,
+      // and only `htLeft` flips it back - so `htRight` has to undo the direction-agnostic rule
+      // above, which would otherwise reserve the wrong side.
+      thead tr th.htRight .relative.has-sort-indicator,
+      thead tr th.htLeft .relative.has-sort-indicator {
+        padding-inline-start: var(--ht-cell-horizontal-padding);
+        padding-inline-end: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
+      }
+
       .columnSorting {
         &.sortAction {
           &::before {
@@ -60,25 +115,9 @@
         }
       }
 
-      .htRight {
-        .columnSorting {
-          &.sortAction {
-            &.ascending, &.descending {
-              padding-inline-start: 0;
-              padding-inline-end: calc(var(--ht-icon-size, 16px) + 2px);
-            }
-          }
-        }
-      }
-
       .htLeft {
         .columnSorting {
           &.sortAction {
-            &.ascending, &.descending {
-              padding-inline-start: calc(var(--ht-icon-size, 16px) + 2px);
-              padding-inline-end: 0;
-            }
-
             &::before {
               left: auto;
               right: 2px;
@@ -90,12 +129,24 @@
     }
   }
 
+  /* In the ghost table the indicator pseudo is in flow, so the offsets that hold it clear of the
+      header edge in the real table would be measured as extra column width and every auto-sized
+      column would come out wider. The selector is deliberately more specific than the rule that
+      sets those offsets. */
+  .htGhostTable .htCore thead tr th .relative span.colHeader.columnSorting.sortAction {
+    &::before,
+    &::after {
+      margin-inline: 0;
+    }
+  }
+
   .htGhostTable
     .htCore
     span.colHeader.columnSorting:not(.indicatorDisabled)::before {
     content: "*";
     display: inline-block;
     position: relative;
+
 
     /* The multi-line header and header with longer text need more padding to not hide arrow,
         we make header wider in `GhostTable` to make some space for arrow which is positioned absolutely in the main table */

--- a/handsontable/src/styles/components/plugins/_column-sorting.scss
+++ b/handsontable/src/styles/components/plugins/_column-sorting.scss
@@ -43,7 +43,10 @@
     // so the ghost table can neutralise all of it from one place instead of having to out-rank
     // every one of those rules in turn - which is a specificity race that quietly breaks the
     // moment a new alignment case is added.
-    .relative {
+    // These are internal plumbing for this file, not theme tokens - nothing outside the rules
+    // below reads them. Scoped to `th` because only header containers have a sort indicator, so
+    // no cell container carries the extra declarations.
+    th .relative {
       // How far the indicator sits from the header edge.
       --ht-sort-indicator-offset: var(--ht-cell-horizontal-padding);
       // Same, on the side a trailing icon button may occupy.
@@ -166,7 +169,7 @@
       `dropdownMenu` stamps `has-header-button` on it, `ColumnSorting` stamps
       `has-sort-indicator` - so a reset written against those consuming rules would have to
       out-rank each of them in turn. */
-  .htGhostTable.htAutoSize .htCore .relative {
+  .htGhostTable .htCore .relative {
     --ht-sort-indicator-offset: 0px;
     --ht-sort-indicator-offset-end: 0px;
   }
@@ -175,7 +178,7 @@
       for the space the indicator itself takes in the real table and the measurement needs it.
       The exception is a header with a trailing button: `_multi-column-sorting.scss` already gives
       that case its own gap in the ghost table, so reserving as well counts the indicator twice. */
-  .htGhostTable.htAutoSize .htCore .relative.has-header-button {
+  .htGhostTable .htCore .relative.has-header-button {
     --ht-sort-indicator-reserve: var(--ht-cell-horizontal-padding);
   }
 

--- a/handsontable/src/styles/components/plugins/_column-sorting.scss
+++ b/handsontable/src/styles/components/plugins/_column-sorting.scss
@@ -4,34 +4,25 @@
 
 @mixin output {
   .handsontable {
-    // The label is the sort button, so it must not swallow the whole header cell. The bare
-    // header around it is what a user presses to select a column without sorting it - which is
-    // the first half of moving a column by drag. Size the label to its content and centre it,
-    // so only the label text and the sort indicator sort on click.
-    // Three classes are all it takes to win over the base rule that makes the label fill the row
-    // (`.handsontable thead tr th .relative .colHeader` in `_base.scss` - three classes), because
-    // class count is compared before element count. Repeating the structural path would only tie
-    // this rule to a header shape it does not care about.
+    // The label is the sort button, so it must not fill the header cell: the bare header around it
+    // is what selects a column and starts a drag. Sized to its text, so only the text and the
+    // indicator sort on click.
+    // Three classes beat the `_base.scss` rule that makes the label fill the row - class count is
+    // compared before element count - so the structural path is not repeated here.
     .colHeader.columnSorting.sortAction {
       box-sizing: border-box;
       flex-grow: 0;
-      // Auto margins on both sides keep the label centred, and hand the free space to the
-      // header rather than to one edge - the same place the text sat when the label filled it.
-      // `htLeft`/`htRight` move the box instead; see below.
+      // Centres the label; `htLeft`/`htRight` move the box instead, below.
       margin-inline: auto;
-      // Never collapse the label to nothing in a narrow column, and never let it grow past the
-      // header, which would push the indicator outside the cell.
+      // Never collapse in a narrow column, never grow past the header.
       min-width: min(calc(var(--ht-icon-size, 16px) + 8px), 100%);
       max-width: 100%;
-      // The indicators are absolutely positioned, and `static` hands them to `.relative` so they
-      // stay pinned to the header's trailing edge while the label shrinks away from it. Clicking
-      // one still sorts: events on a pseudo-element target the element that owns it.
+      // Hands the absolutely positioned indicators to `.relative`, so they stay pinned to the
+      // header edge while the label shrinks away from it. Clicking one still sorts: an event on a
+      // pseudo-element targets the element that owns it.
       position: static;
 
-      // `.relative`'s padding box is the new containing block, and it sits inside the cell
-      // padding the label used to carry - add it back so the indicators keep their distance from
-      // the header edge. Both sides, because the pinned side flips in RTL and right-aligned
-      // headers.
+      // `.relative`'s padding box is the new containing block, so add the cell padding back.
       &::before,
       &::after {
         margin-inline: var(--ht-sort-indicator-offset);
@@ -39,14 +30,11 @@
       }
     }
 
-    // A left- or right-aligned header used to place its text through `text-align` on a label that
-    // filled the whole cell. The label is now sized to its text, and auto margins on both sides
-    // would centre it - so the alignment has to move the box itself or every aligned header
-    // renders centred. Physical margins, because `htLeft`/`htRight` are physical too: they mean
-    // the left and right edge in either direction.
-    // Matched as an ancestor, the way the indicator rules below already are, because
-    // `headerClassName` puts these classes on the `.relative` container while code that sets them
-    // by hand tends to put them on the `th` - both are ancestors of the label.
+    // `text-align` used to place the text inside a full-width label. The label is now sized to its
+    // text, so the alignment has to move the box or every aligned header renders centred. Physical
+    // margins, because `htLeft`/`htRight` are physical in either direction. Matched as an ancestor:
+    // `headerClassName` puts the class on `.relative`, code that sets it by hand puts it on the
+    // `th`.
     .htLeft .colHeader.columnSorting.sortAction {
       margin-left: 0;
       margin-right: auto;
@@ -57,86 +45,63 @@
       margin-right: 0;
     }
 
-    // The three distances the indicator needs, carried as custom properties rather than written
-    // into each rule below. The rules that vary by alignment and direction then only read them,
-    // so the ghost table can neutralise all of it from one place instead of having to out-rank
-    // every one of those rules in turn - which is a specificity race that quietly breaks the
-    // moment a new alignment case is added.
-    // These are internal plumbing for this file, not theme tokens - nothing outside the rules
-    // below reads them. Scoped to `th` because only header containers have a sort indicator, so
-    // no cell container carries the extra declarations.
+    // The distances the indicator needs, kept as custom properties so the alignment, direction and
+    // ghost-table rules can override them without having to out-rank every rule that reads them.
+    // Internal to this file, not theme tokens.
     th .relative {
-      // How far the indicator sits from the header edge.
+      // Distance from the header edge.
       --ht-sort-indicator-offset: var(--ht-cell-horizontal-padding);
-      // Same, on the side a trailing icon button may occupy.
+      // The same, on the inline-end side that a trailing button shares.
       --ht-sort-indicator-offset-end: var(--ht-cell-horizontal-padding);
-      // How much room the container holds back for the indicator.
+      // Room the container holds back for the indicator.
       --ht-sort-indicator-reserve: var(--ht-cell-horizontal-padding);
-      // The same, but only for the inline-end side - the one a trailing button shares. Split from
-      // the value above so the button case can drop it without touching the other sides.
+      // The same, inline-end only - split so the button case can drop it on its own.
       --ht-sort-indicator-reserve-end: var(--ht-sort-indicator-reserve);
-      // The room a trailing button needs before it, so the indicator has somewhere to sit. This is
-      // the button's outer box: its border box is `--ht-icon-button-hit-area-size`, pulled back to
-      // the icon size plus 2px by the uniform negative margin it carries (`_dropdown-menu.scss`).
+      // Room held open before a trailing button for the indicator to sit in.
       --ht-header-button-slot: calc(var(--ht-icon-size, 16px) + 2px);
     }
 
-    // A trailing icon button (the dropdown menu's) occupies the corner the indicators are pinned
-    // to, so step them over it. What has to be cleared is the button's *border* box, which is wider
-    // than the space it takes in the row: `_dropdown-menu.scss` sizes it to
-    // `--ht-icon-button-hit-area-size` and pulls it back with a uniform negative margin, so it
-    // overhangs its own slot by half the difference on each side. Derived from the same two tokens
-    // rather than written as a number, because the icon size differs per theme - the classic theme
-    // uses a smaller icon with the same hit area, and a fixed step-over lands 1px short there.
-    // Only the inline-end side moves: that is the flex end, the only place such a button appears.
+    // Step the indicator over a trailing icon button. What has to be cleared is the button's border
+    // box, which overhangs its slot by half of (hit area - icon): `_dropdown-menu.scss` sizes it to
+    // the hit area and pulls it back with a uniform negative margin. Derived from those tokens
+    // rather than a fixed number - the classic theme uses a smaller icon with the same hit area.
     .relative.has-header-button {
       --ht-sort-indicator-offset-end: calc(
         var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) +
         (var(--ht-icon-button-hit-area-size, 24px) - var(--ht-icon-size, 16px)) * 0.5
       );
 
-      // The button's own slot is what separates the label from the indicator here, so the
-      // container must not hold room back as well. Doing both moves the button inwards - it is the
-      // last flex item, so container padding drags it left - until it covers the indicator it was
-      // supposed to step aside for. The button paints on top (`z-index: 1`), so the indicator
-      // simply disappears.
+      // The gap below already separates the label from the indicator here. Reserving as well drags
+      // the button - the last flex item - left over the indicator, which it then hides (`z-index: 1`).
       --ht-sort-indicator-reserve-end: var(--ht-cell-horizontal-padding);
     }
 
-    // Hold the indicator's slot open in the flex row. Without it the label's auto margins let the
-    // text run right up to the button, over the indicator pinned in between.
-    // Widening the one gap between the label and the button, rather than giving the button a
-    // margin: the button carries a uniform negative margin of its own, and setting one side of it
-    // here would drop that side's pull-back and make the header measure wider.
+    // Hold the indicator's slot open between the label and the button. Done with the gap, not a
+    // margin on the button: the button carries a uniform negative margin that a one-sided override
+    // would cancel, widening the header.
     .relative.has-sort-indicator.has-header-button {
       // 2px is the base gap between header items (`_base.scss`).
       column-gap: calc(2px + var(--ht-header-button-slot));
     }
 
-    // Room for the sort indicator, reserved on the container instead of as padding on the label.
-    // Padding on the label would grow the box that sorts on click, adding a strip of header that
-    // looks inert but is not - the label has to stay tight around its text. The sides mirror where
-    // `::before` is pinned, which flips with text alignment and direction: it is the inline-end
-    // side unless the alignment class points against the direction - `htRight` in LTR, `htLeft`
-    // in RTL. Only `ColumnSorting` stamps `has-sort-indicator`, and only on a column header
-    // container, so the class alone is scope enough.
+    // Room for the indicator, held on the container rather than as padding on the label - padding
+    // would grow the box that sorts on click. The side follows where `::before` is pinned:
+    // inline-end, unless the alignment class points against the direction (`htRight` in LTR,
+    // `htLeft` in RTL).
     .relative.has-sort-indicator {
       --ht-sort-indicator-reserve: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
 
       padding-inline-end: var(--ht-sort-indicator-reserve-end);
     }
 
-    // Two selectors because the room is held on the container itself: `headerClassName` puts the
-    // alignment class on that same `.relative`, while code that sets it by hand tends to put it on
-    // the `th`. A descendant selector alone would miss the first, which is the one the product
-    // uses.
+    // Two selectors, because the room is held on the container itself: `headerClassName` puts the
+    // alignment class on that same `.relative`, code that sets it by hand puts it on the `th`.
     .relative.htRight.has-sort-indicator,
     .htRight .relative.has-sort-indicator {
       padding-inline-start: var(--ht-sort-indicator-reserve);
       padding-inline-end: var(--ht-cell-horizontal-padding);
 
-      // The indicator is on the opposite side from the button here, so nothing has to be held open
-      // between the label and the button.
+      // The indicator is opposite the button here, so nothing needs holding open.
       --ht-header-button-slot: 0px;
     }
 
@@ -177,25 +142,25 @@
 
   [dir="rtl"] {
     .handsontable {
-      // `htRight` points the same way as the direction here, so the indicator sits on the
-      // inline-end side like the default - undo the LTR rule above, which reserves the other one.
+      // In RTL the indicator sits inline-end by default, so `htRight` matches the default and has
+      // to undo the LTR rule above.
       .relative.htRight.has-sort-indicator,
       .htRight .relative.has-sort-indicator {
         padding-inline-start: var(--ht-cell-horizontal-padding);
         padding-inline-end: var(--ht-sort-indicator-reserve-end);
 
-        // Back on the button's side here, so the slot is needed again - undo the LTR rule above.
+        // Back on the button's side, so the slot is needed again.
         --ht-header-button-slot: calc(var(--ht-icon-size, 16px) + 2px);
       }
 
-      // `htLeft` is the class that points against the direction in RTL, so it is the one that
-      // pins the indicator to the inline-start side - the mirror of `htRight` in LTR.
+      // `htLeft` is the class that points against the direction here - the mirror of `htRight` in
+      // LTR.
       .relative.htLeft.has-sort-indicator,
       .htLeft .relative.has-sort-indicator {
         padding-inline-start: var(--ht-sort-indicator-reserve);
         padding-inline-end: var(--ht-cell-horizontal-padding);
 
-        // `htLeft` is the side away from the button in RTL, so nothing needs holding open.
+        // Opposite the button, so nothing needs holding open.
         --ht-header-button-slot: 0px;
       }
 
@@ -223,29 +188,18 @@
     }
   }
 
-  /* In the ghost table the indicator pseudo is in flow, so its own box is already part of what
-      `autoColumnSize` measures. The offsets that hold it clear of the header edge in the real
-      table would be counted on top of that and every auto-sized column would come out wider.
-
-      Both of these reach the ghost header by overriding the custom properties on the container
-      rather than the declarations that read them, which is why one rule each is enough: they
-      compete only with where those properties are set, not with every alignment and direction
-      rule that consumes them. The ghost header carries the same classes as the real one -
-      `dropdownMenu` stamps `has-header-button` on it, `ColumnSorting` stamps
-      `has-sort-indicator` - so a reset written against those consuming rules would have to
-      out-rank each of them in turn. */
+  // In the ghost table the indicator is in flow, so `autoColumnSize` already measures it. Counting
+  // the offsets and the button's slot on top would make every auto-sized column wider. Overriding
+  // the properties rather than the rules that read them keeps this to one rule.
   .htGhostTable .htCore .relative {
     --ht-sort-indicator-offset: 0px;
     --ht-sort-indicator-offset-end: 0px;
-    // The indicator is in flow here, so it already occupies its slot - holding one open in front
-    // of the button as well would measure that width twice.
     --ht-header-button-slot: 0px;
   }
 
-  /* The room the container holds back for the indicator is left alone above, because it stands in
-      for the space the indicator itself takes in the real table and the measurement needs it.
-      The exception is a header with a trailing button: `_multi-column-sorting.scss` already gives
-      that case its own gap in the ghost table, so reserving as well counts the indicator twice. */
+  // The reserve stays: it stands in for the space the indicator takes in the real table, and the
+  // measurement needs it. The exception is a header with a trailing button, which
+  // `_multi-column-sorting.scss` already gives its own gap here.
   .htGhostTable .htCore .relative.has-header-button {
     --ht-sort-indicator-reserve: var(--ht-cell-horizontal-padding);
     --ht-sort-indicator-reserve-end: var(--ht-cell-horizontal-padding);

--- a/handsontable/src/styles/components/plugins/_column-sorting.scss
+++ b/handsontable/src/styles/components/plugins/_column-sorting.scss
@@ -33,8 +33,31 @@
       // headers.
       &::before,
       &::after {
-        margin-inline: var(--ht-cell-horizontal-padding);
+        margin-inline: var(--ht-sort-indicator-offset);
+        margin-inline-end: var(--ht-sort-indicator-offset-end);
       }
+    }
+
+    // The three distances the indicator needs, carried as custom properties rather than written
+    // into each rule below. The rules that vary by alignment and direction then only read them,
+    // so the ghost table can neutralise all of it from one place instead of having to out-rank
+    // every one of those rules in turn - which is a specificity race that quietly breaks the
+    // moment a new alignment case is added.
+    .relative {
+      // How far the indicator sits from the header edge.
+      --ht-sort-indicator-offset: var(--ht-cell-horizontal-padding);
+      // Same, on the side a trailing icon button may occupy.
+      --ht-sort-indicator-offset-end: var(--ht-cell-horizontal-padding);
+      // How much room the container holds back for the indicator.
+      --ht-sort-indicator-reserve: var(--ht-cell-horizontal-padding);
+    }
+
+    // A trailing icon button (the dropdown menu's) occupies the corner the indicators are pinned
+    // to, so step them over it. The button's painted width is `--ht-icon-size` + 2px once its own
+    // negative margins apply, plus the 2px flex gap. Only the inline-end side moves: that is the
+    // flex end, which is the only place such a button appears.
+    .relative.has-header-button {
+      --ht-sort-indicator-offset-end: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 4px);
     }
 
     // Room for the sort indicator, reserved on the container instead of as padding on the label.
@@ -45,25 +68,16 @@
     // in RTL. Only `ColumnSorting` stamps `has-sort-indicator`, and only on a column header
     // container, so the class alone is scope enough.
     .relative.has-sort-indicator {
-      padding-inline-end: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
+      --ht-sort-indicator-reserve: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
+
+      padding-inline-end: var(--ht-sort-indicator-reserve);
     }
 
     // Kept on `th` rather than the bare class: `htRight` is a user-supplied class name that can
     // also sit on an ancestor, and this must only react to it on the header cell itself.
     th.htRight .relative.has-sort-indicator {
-      padding-inline-start: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
+      padding-inline-start: var(--ht-sort-indicator-reserve);
       padding-inline-end: var(--ht-cell-horizontal-padding);
-    }
-
-    // A trailing icon button (the dropdown menu's) occupies the corner the indicators are pinned
-    // to, so step them over it. The button's painted width is `--ht-icon-size` + 2px once its own
-    // negative margins apply, plus the 2px flex gap. Only the inline-end side moves: that is the
-    // flex end, which is the only place such a button appears.
-    .relative.has-header-button .colHeader.columnSorting.sortAction {
-      &::before,
-      &::after {
-        margin-inline-end: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 4px);
-      }
     }
 
     .columnSorting:not(.indicatorDisabled) {
@@ -107,13 +121,13 @@
       // inline-end side like the default - undo the LTR rule above, which reserves the other one.
       th.htRight .relative.has-sort-indicator {
         padding-inline-start: var(--ht-cell-horizontal-padding);
-        padding-inline-end: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
+        padding-inline-end: var(--ht-sort-indicator-reserve);
       }
 
       // `htLeft` is the class that points against the direction in RTL, so it is the one that
       // pins the indicator to the inline-start side - the mirror of `htRight` in LTR.
       th.htLeft .relative.has-sort-indicator {
-        padding-inline-start: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 2px);
+        padding-inline-start: var(--ht-sort-indicator-reserve);
         padding-inline-end: var(--ht-cell-horizontal-padding);
       }
 
@@ -141,15 +155,28 @@
     }
   }
 
-  /* In the ghost table the indicator pseudo is in flow, so the offsets that hold it clear of the
-      header edge in the real table would be measured as extra column width and every auto-sized
-      column would come out wider. The selector is deliberately more specific than the rule that
-      sets those offsets. */
-  .htGhostTable .htCore .colHeader.columnSorting.sortAction {
-    &::before,
-    &::after {
-      margin-inline: 0;
-    }
+  /* In the ghost table the indicator pseudo is in flow, so its own box is already part of what
+      `autoColumnSize` measures. The offsets that hold it clear of the header edge in the real
+      table would be counted on top of that and every auto-sized column would come out wider.
+
+      Both of these reach the ghost header by overriding the custom properties on the container
+      rather than the declarations that read them, which is why one rule each is enough: they
+      compete only with where those properties are set, not with every alignment and direction
+      rule that consumes them. The ghost header carries the same classes as the real one -
+      `dropdownMenu` stamps `has-header-button` on it, `ColumnSorting` stamps
+      `has-sort-indicator` - so a reset written against those consuming rules would have to
+      out-rank each of them in turn. */
+  .htGhostTable.htAutoSize .htCore .relative {
+    --ht-sort-indicator-offset: 0px;
+    --ht-sort-indicator-offset-end: 0px;
+  }
+
+  /* The room the container holds back for the indicator is left alone above, because it stands in
+      for the space the indicator itself takes in the real table and the measurement needs it.
+      The exception is a header with a trailing button: `_multi-column-sorting.scss` already gives
+      that case its own gap in the ghost table, so reserving as well counts the indicator twice. */
+  .htGhostTable.htAutoSize .htCore .relative.has-header-button {
+    --ht-sort-indicator-reserve: var(--ht-cell-horizontal-padding);
   }
 
   .htGhostTable

--- a/handsontable/src/styles/components/plugins/_column-sorting.scss
+++ b/handsontable/src/styles/components/plugins/_column-sorting.scss
@@ -82,11 +82,18 @@
     }
 
     // A trailing icon button (the dropdown menu's) occupies the corner the indicators are pinned
-    // to, so step them over it. The button's painted width is `--ht-icon-size` + 2px once its own
-    // negative margins apply, plus the 2px flex gap. Only the inline-end side moves: that is the
-    // flex end, which is the only place such a button appears.
+    // to, so step them over it. What has to be cleared is the button's *border* box, which is wider
+    // than the space it takes in the row: `_dropdown-menu.scss` sizes it to
+    // `--ht-icon-button-hit-area-size` and pulls it back with a uniform negative margin, so it
+    // overhangs its own slot by half the difference on each side. Derived from the same two tokens
+    // rather than written as a number, because the icon size differs per theme - the classic theme
+    // uses a smaller icon with the same hit area, and a fixed step-over lands 1px short there.
+    // Only the inline-end side moves: that is the flex end, the only place such a button appears.
     .relative.has-header-button {
-      --ht-sort-indicator-offset-end: calc(var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) + 4px);
+      --ht-sort-indicator-offset-end: calc(
+        var(--ht-cell-horizontal-padding) + var(--ht-icon-size, 16px) +
+        (var(--ht-icon-button-hit-area-size, 24px) - var(--ht-icon-size, 16px)) * 0.5
+      );
 
       // The button's own slot is what separates the label from the indicator here, so the
       // container must not hold room back as well. Doing both moves the button inwards - it is the

--- a/tests/e2e/column-move-sorting.spec.ts
+++ b/tests/e2e/column-move-sorting.spec.ts
@@ -41,6 +41,22 @@ test.describe('column move with sorting enabled', () => {
     await grid.expectCell(0, 2, 'C5');
   });
 
+  test('sorts a dragged header when no move plugin can consume the drag', async ({ page }) => {
+    await grid.goto(undefined, { withMove: false });
+
+    // Without ManualColumnMove nothing can turn this into a column move, so the press has to sort
+    // however far the pointer travels - the browser still calls it a click.
+    const label = await grid.sortLabel(2).boundingBox();
+
+    await page.mouse.move(label.x + (label.width / 2), label.y + (label.height / 2));
+    await page.mouse.down();
+    await page.mouse.move(label.x + (label.width / 2) + 20, label.y + (label.height / 2), { steps: 4 });
+    await page.mouse.up();
+
+    await expect(grid.sortLabel(2)).toHaveClass(/ascending/);
+    await grid.expectCell(0, 2, 'C1');
+  });
+
   test('sorts on a header click made while a validated cell is being edited', async ({ page }) => {
     await grid.goto();
 

--- a/tests/e2e/column-move-sorting.spec.ts
+++ b/tests/e2e/column-move-sorting.spec.ts
@@ -57,6 +57,26 @@ test.describe('column move with sorting enabled', () => {
     await grid.expectCell(0, 2, 'C1');
   });
 
+  test('does not sort a drag released outside the grid, whatever order the plugins listen in', async ({ page }) => {
+    await grid.goto();
+
+    // Re-enabling sorting re-registers its document listener, so it now runs after the move
+    // plugin's. A release outside every cell is resolved by that listener alone.
+    await page.evaluate(() => {
+      const hot = (window as unknown as { hot: { updateSettings: (s: object) => void } }).hot;
+
+      hot.updateSettings({ columnSorting: false });
+      hot.updateSettings({ columnSorting: true });
+    });
+
+    await grid.sortByHeader(2);
+    await grid.dragColumnFromHeaderCentreReleasingOutside(2);
+
+    // Counted, not read off the headers: a stray sort lands on whatever column now occupies the
+    // dragged column's old index, so the header classes look unchanged either way.
+    await expect.poll(async () => grid.sortCount()).toBe(1);
+  });
+
   test('sorts on a header click made while a validated cell is being edited', async ({ page }) => {
     await grid.goto();
 

--- a/tests/e2e/column-move-sorting.spec.ts
+++ b/tests/e2e/column-move-sorting.spec.ts
@@ -41,6 +41,21 @@ test.describe('column move with sorting enabled', () => {
     await grid.expectCell(0, 2, 'C5');
   });
 
+  test('sorts on a header click made while a validated cell is being edited', async ({ page }) => {
+    await grid.goto();
+
+    // Open the editor on the validated column A and change the value.
+    await grid.cell(0, 0).dblclick();
+    await page.keyboard.type('Z9');
+
+    // A real click, so mouse up lands in its own task. Pressing the header closes the editor and
+    // validates in a microtask that finishes first - sorting must still wait for it and then run.
+    await grid.sortLabel(2).click();
+
+    await expect(grid.sortLabel(2)).toHaveClass(/ascending/);
+    await grid.expectCell(0, 2, 'C1');
+  });
+
   test('selects the column without sorting when the bare header area is pressed', async () => {
     // Selecting a column is the first half of moving it. That press must not sort, otherwise
     // every attempt to move a column re-sorts it on the way. Only the label and its indicator

--- a/tests/e2e/column-move-sorting.spec.ts
+++ b/tests/e2e/column-move-sorting.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '../fixtures/test';
+import { ColumnMoveSortingPage } from '../fixtures/pages/ColumnMoveSortingPage';
+
+/**
+ * ColumnSorting and ManualColumnMove both want a press on the column header.
+ * ManualColumnMove refuses any press whose target carries `sortAction`, the class
+ * ColumnSorting puts on the header label — so once that label is allowed to fill the
+ * whole header, there is nowhere left to start a drag and the column cannot be moved
+ * by pointer at all (DEV-1782).
+ *
+ * These tests drive the flow from the bug report: sort a column, then move it.
+ */
+test.describe('column move with sorting enabled', () => {
+  let grid: ColumnMoveSortingPage;
+
+  test.beforeEach(async ({ page, theme }) => {
+    grid = new ColumnMoveSortingPage(page, theme);
+  });
+
+  test('moves a sorted column when the drag starts at the header centre', async () => {
+    await grid.goto();
+
+    // Sorting the column also selects it, which is what makes the header draggable.
+    await grid.sortByHeader(2);
+    await grid.expectFirstRow(['A1', 'B1', 'C1', 'D1', 'E1', 'F1']);
+
+    await grid.dragColumnFromHeaderCentre(2, 4);
+
+    await grid.expectFirstRow(['A1', 'B1', 'D1', 'E1', 'C1', 'F1']);
+  });
+
+  test('keeps the header label clickable for sorting', async () => {
+    await grid.goto();
+
+    await grid.sortByHeader(2);
+    await grid.expectCell(0, 2, 'C1');
+
+    // A second click toggles to descending - the label must stay a usable sort target.
+    await grid.sortLabel(2).click();
+    await expect(grid.sortLabel(2)).toHaveClass(/descending/);
+    await grid.expectCell(0, 2, 'C5');
+  });
+
+  test('selects the column without sorting when the bare header area is pressed', async () => {
+    // Selecting a column is the first half of moving it. That press must not sort, otherwise
+    // every attempt to move a column re-sorts it on the way. Only the label and its indicator
+    // are the sort button; the rest of the header is not.
+    await grid.goto();
+
+    await grid.clickBareHeader(2);
+
+    await grid.expectNotSorted(2);
+    await grid.expectFirstRow(['A5', 'B5', 'C5', 'D5', 'E5', 'F5']);
+
+    // ...and the column is now selected, so it can be dragged straight away.
+    await grid.dragFromBareHeader(2, 4);
+
+    await grid.expectNotSorted(4);
+    await grid.expectFirstRow(['A5', 'B5', 'D5', 'E5', 'C5', 'F5']);
+  });
+
+  test('moves the column when the drag starts on the sorting label itself', async () => {
+    // The label covers most of the header, so this is the gesture users actually make.
+    // It must move the column and leave the sort order alone.
+    await grid.goto();
+
+    await grid.sortByHeader(2);
+
+    await grid.dragFromSortLabel(2, 4);
+
+    await grid.expectFirstRow(['A1', 'B1', 'D1', 'E1', 'C1', 'F1']);
+    // The press travelled, so it was a drag - the sort must not have toggled to descending.
+    await expect(grid.sortLabel(4)).toHaveClass(/ascending/);
+  });
+
+  test('does not move the column when a press on the header is released without moving', async () => {
+    await grid.goto();
+
+    await grid.sortByHeader(2);
+    await grid.expectFirstRow(['A1', 'B1', 'C1', 'D1', 'E1', 'F1']);
+
+    // Press and release at the header centre without travelling: a click, not a drag.
+    await grid.pressAndReleaseHeaderCentre(2);
+
+    // The order is untouched, and the click toggled the sort instead.
+    await expect(grid.sortLabel(2)).toHaveClass(/descending/);
+    await grid.expectFirstRow(['A5', 'B5', 'C5', 'D5', 'E5', 'F5']);
+  });
+});

--- a/tests/fixtures/demo/column-move-sorting.html
+++ b/tests/fixtures/demo/column-move-sorting.html
@@ -39,6 +39,9 @@
     container.className = `ht-theme-${window.htTheme}`;
 
     const colWidths = Number(new URLSearchParams(location.search).get('colWidths')) || 120;
+    // ?move=off drops ManualColumnMove, so a spec can cover the sorting-only grid - the one where
+    // nothing can consume a drag, and a header press therefore has to sort however far it travels.
+    const withMove = new URLSearchParams(location.search).get('move') !== 'off';
 
     const testIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
       Handsontable.renderers.TextRenderer.apply(this, arguments);
@@ -57,7 +60,7 @@
       colHeaders: true,
       rowHeaders: true,
       columnSorting: true,
-      manualColumnMove: true,
+      manualColumnMove: withMove,
       renderer: testIdRenderer,
       // Column A is validated so a spec can sort while its editor is open. Selecting the column
       // closes the editor and validates in a microtask, which finishes before the browser sends

--- a/tests/fixtures/demo/column-move-sorting.html
+++ b/tests/fixtures/demo/column-move-sorting.html
@@ -48,7 +48,9 @@
       td.setAttribute('data-testid', `cell-${row}-${col}`);
     };
 
-    new Handsontable(container, {
+    // Exposed so a spec can call `updateSettings` - one test re-enables sorting to change the
+    // order the two plugins' `mouseup` listeners run in.
+    window.hot = new Handsontable(container, {
       data: [
         ['A5', 'B5', 'C5', 'D5', 'E5', 'F5'],
         ['A4', 'B4', 'C4', 'D4', 'E4', 'F4'],
@@ -66,6 +68,12 @@
       // closes the editor and validates in a microtask, which finishes before the browser sends
       // mouse up - the case a synchronous down/up simulation cannot reproduce.
       columns: [{ validator: (value, callback) => callback(true) }, {}, {}, {}, {}, {}],
+      // Counts sorts so a spec can assert that a gesture did NOT sort. Header classes cannot show
+      // that: a stray sort lands on whatever column now sits at the dragged column's old index,
+      // which leaves the same number of ascending headers behind.
+      afterColumnSort() {
+        window.sortCount = (window.sortCount || 0) + 1;
+      },
       afterGetColHeader(col, TH) {
         if (col >= 0) {
           TH.setAttribute('data-testid', `col-header-${col}`);

--- a/tests/fixtures/demo/column-move-sorting.html
+++ b/tests/fixtures/demo/column-move-sorting.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable e2e fixture - column move with sorting</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Active theme from the ?theme= query param set by the Playwright project.
+    // Mapped through a fixed allowlist to a LITERAL (default main), so a crafted
+    // ?theme= can never be reflected into the document — no XSS. Exposed as
+    // window.htTheme so the grid init below reuses the sanitized value.
+    window.htTheme = ({ horizon: 'horizon', classic: 'classic' })[new URLSearchParams(location.search).get('theme')] || 'main';
+    // Written into <head> so the themed stylesheet is present before first render.
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } </style>
+</head>
+<body>
+  <!--
+    Fixture for the ColumnSorting / ManualColumnMove overlap (DEV-1782).
+
+    Both plugins compete for a press on the column header: ManualColumnMove refuses any
+    press whose target carries `sortAction`, which ColumnSorting puts on the header label.
+    The grid therefore needs a strip of bare header left over for a drag to start on.
+
+    Column widths come from ?colWidths= so a spec can also drive the narrow-column case,
+    where the label legitimately fills the whole header and sorting wins instead.
+
+    Data is seeded in descending order so an ascending sort visibly reorders the rows,
+    and cells carry data-testid="cell-<row>-<col>" so a move is asserted on what the
+    user actually sees rather than on plugin internals.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script src="/handsontable/dist/handsontable.full.min.js"></script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const colWidths = Number(new URLSearchParams(location.search).get('colWidths')) || 120;
+
+    const testIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    };
+
+    new Handsontable(container, {
+      data: [
+        ['A5', 'B5', 'C5', 'D5', 'E5', 'F5'],
+        ['A4', 'B4', 'C4', 'D4', 'E4', 'F4'],
+        ['A3', 'B3', 'C3', 'D3', 'E3', 'F3'],
+        ['A2', 'B2', 'C2', 'D2', 'E2', 'F2'],
+        ['A1', 'B1', 'C1', 'D1', 'E1', 'F1'],
+      ],
+      colWidths,
+      colHeaders: true,
+      rowHeaders: true,
+      columnSorting: true,
+      manualColumnMove: true,
+      renderer: testIdRenderer,
+      afterGetColHeader(col, TH) {
+        if (col >= 0) {
+          TH.setAttribute('data-testid', `col-header-${col}`);
+        }
+      },
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/column-move-sorting.html
+++ b/tests/fixtures/demo/column-move-sorting.html
@@ -59,6 +59,10 @@
       columnSorting: true,
       manualColumnMove: true,
       renderer: testIdRenderer,
+      // Column A is validated so a spec can sort while its editor is open. Selecting the column
+      // closes the editor and validates in a microtask, which finishes before the browser sends
+      // mouse up - the case a synchronous down/up simulation cannot reproduce.
+      columns: [{ validator: (value, callback) => callback(true) }, {}, {}, {}, {}, {}],
       afterGetColHeader(col, TH) {
         if (col >= 0) {
           TH.setAttribute('data-testid', `col-header-${col}`);

--- a/tests/fixtures/pages/ColumnMoveSortingPage.ts
+++ b/tests/fixtures/pages/ColumnMoveSortingPage.ts
@@ -1,0 +1,195 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the column-move-with-sorting fixture.
+ *
+ * Column headers are rendered into several overlay layers, so every header locator is
+ * scoped to the top overlay (`.ht_clone_top`) — an unscoped `getByTestId` would match
+ * more than once and fail Playwright's strict mode.
+ */
+export class ColumnMoveSortingPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly grid: Locator;
+  readonly headerOverlay: Locator;
+
+  constructor(page: Page, theme = 'main') {
+    this.page = page;
+    this.theme = theme;
+    this.grid = page.getByTestId('grid');
+    this.headerOverlay = page.locator('.ht_clone_top');
+  }
+
+  /**
+   * Navigate to the fixture and wait for the grid to render. The active theme is passed
+   * as a query param so the fixture loads the matching stylesheet; `colWidths` drives the
+   * narrow-column case.
+   */
+  async goto(colWidths?: number): Promise<void> {
+    const width = colWidths === undefined ? '' : `&colWidths=${colWidths}`;
+
+    await this.page.goto(`/tests/fixtures/demo/column-move-sorting.html?theme=${this.theme}${width}`);
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /** A single data cell, by visual row/column, via its stable test id. */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /** A column header, scoped to the top overlay so the match is unambiguous. */
+  header(col: number): Locator {
+    return this.headerOverlay.getByTestId(`col-header-${col}`);
+  }
+
+  /** The clickable sorting label inside a column header. */
+  sortLabel(col: number): Locator {
+    return this.header(col).locator('span.colHeader');
+  }
+
+  /** Assert a cell shows the expected text (web-first, auto-retrying). */
+  async expectCell(row: number, col: number, text: string): Promise<void> {
+    await expect(this.cell(row, col)).toHaveText(text);
+  }
+
+  /** Assert the whole first row, left to right — the cheapest read of column order. */
+  async expectFirstRow(values: string[]): Promise<void> {
+    for (const [col, value] of values.entries()) {
+      await this.expectCell(0, col, value);
+    }
+  }
+
+  /**
+   * Click a column header's sorting label. This is the user flow the bug report
+   * describes: the click sorts the column and selects it, which is what makes the
+   * header draggable in the first place.
+   */
+  async sortByHeader(col: number): Promise<void> {
+    await this.sortLabel(col).click();
+    await expect(this.sortLabel(col)).toHaveClass(/ascending|descending/);
+  }
+
+  /**
+   * Drag a column by pressing at the exact horizontal centre of its header.
+   *
+   * The centre is the point users naturally reach for, and the point the sorting label
+   * covered when it was allowed to fill the header. The first short move crosses the
+   * drag threshold before the pointer travels to the drop target.
+   */
+  async dragColumnFromHeaderCentre(fromCol: number, toCol: number): Promise<void> {
+    const from = await this.headerBox(fromCol);
+    const to = await this.headerBox(toCol);
+    const y = from.y + (from.height / 2);
+    const startX = from.x + (from.width / 2);
+
+    await this.page.mouse.move(startX, y);
+    await this.page.mouse.down();
+    await this.page.mouse.move(startX + 20, y, { steps: 5 });
+    await this.page.mouse.move(to.x + (to.width / 2), y, { steps: 10 });
+    await this.page.mouse.up();
+  }
+
+  /**
+   * Drag a column by pressing on its sorting label - the element that covers most of the
+   * header, and the one a press has to be able to start a move from.
+   */
+  async dragFromSortLabel(fromCol: number, toCol: number): Promise<void> {
+    const label = await this.sortLabel(fromCol).boundingBox();
+    const to = await this.headerBox(toCol);
+
+    if (label === null) {
+      throw new Error(`Sorting label for column ${fromCol} has no bounding box`);
+    }
+
+    const y = label.y + (label.height / 2);
+    const startX = label.x + (label.width / 2);
+
+    await this.page.mouse.move(startX, y);
+    await this.page.mouse.down();
+    await this.page.mouse.move(startX + 20, y, { steps: 5 });
+    await this.page.mouse.move(to.x + (to.width / 2), y, { steps: 10 });
+    await this.page.mouse.up();
+  }
+
+  /**
+   * Press and release at the header centre without moving the pointer at all - the gesture
+   * that has to read as a click rather than a drag.
+   */
+  async pressAndReleaseHeaderCentre(col: number): Promise<void> {
+    const box = await this.headerBox(col);
+
+    await this.page.mouse.move(box.x + (box.width / 2), box.y + (box.height / 2));
+    await this.page.mouse.down();
+    await this.page.mouse.up();
+  }
+
+  /**
+   * A point inside the header but outside its sorting label - the bare area a user presses to
+   * select a column without sorting it.
+   *
+   * The area has to be a real target, not just the cell padding. When the label was allowed to
+   * fill the header only the 8px padding was left, which is what made a column impossible to
+   * select without sorting it, so anything at or below that is treated as no bare area at all.
+   */
+  private async bareHeaderPoint(col: number): Promise<{ x: number, y: number }> {
+    const MIN_BARE_AREA = 16;
+    const header = await this.headerBox(col);
+    const label = await this.sortLabel(col).boundingBox();
+
+    if (label === null) {
+      throw new Error(`Sorting label for column ${col} has no bounding box`);
+    }
+
+    const gap = label.x - header.x;
+
+    if (gap < MIN_BARE_AREA) {
+      throw new Error(`Column ${col} leaves no usable bare header area: only ${Math.round(gap)}px ` +
+        `before the sorting label, need at least ${MIN_BARE_AREA}px`);
+    }
+
+    return { x: header.x + (gap / 2), y: header.y + (header.height / 2) };
+  }
+
+  /** Click the header outside its sorting label. */
+  async clickBareHeader(col: number): Promise<void> {
+    const point = await this.bareHeaderPoint(col);
+
+    await this.page.mouse.click(point.x, point.y);
+  }
+
+  /** Drag a column by pressing the bare header area, outside the sorting label. */
+  async dragFromBareHeader(fromCol: number, toCol: number): Promise<void> {
+    const from = await this.bareHeaderPoint(fromCol);
+    const to = await this.headerBox(toCol);
+
+    await this.page.mouse.move(from.x, from.y);
+    await this.page.mouse.down();
+    await this.page.mouse.move(from.x + 20, from.y, { steps: 5 });
+    await this.page.mouse.move(to.x + (to.width / 2), from.y, { steps: 10 });
+    await this.page.mouse.up();
+  }
+
+  /**
+   * Assert a column carries no sort indicator - the visible signal that it is unsorted.
+   */
+  async expectNotSorted(col: number): Promise<void> {
+    await expect(this.sortLabel(col)).not.toHaveClass(/ascending|descending/);
+  }
+
+  /**
+   * Bounding box of a column header, once it is actually laid out.
+   */
+  private async headerBox(col: number): Promise<{ x: number, y: number, width: number, height: number }> {
+    const locator = this.header(col);
+
+    await expect(locator).toBeVisible();
+
+    const box = await locator.boundingBox();
+
+    if (box === null) {
+      throw new Error(`Column header ${col} has no bounding box`);
+    }
+
+    return box;
+  }
+}

--- a/tests/fixtures/pages/ColumnMoveSortingPage.ts
+++ b/tests/fixtures/pages/ColumnMoveSortingPage.ts
@@ -23,12 +23,13 @@ export class ColumnMoveSortingPage {
   /**
    * Navigate to the fixture and wait for the grid to render. The active theme is passed
    * as a query param so the fixture loads the matching stylesheet; `colWidths` drives the
-   * narrow-column case.
+   * narrow-column case. `withMove: false` drops ManualColumnMove.
    */
-  async goto(colWidths?: number): Promise<void> {
+  async goto(colWidths?: number, options: { withMove?: boolean } = {}): Promise<void> {
     const width = colWidths === undefined ? '' : `&colWidths=${colWidths}`;
+    const move = options.withMove === false ? '&move=off' : '';
 
-    await this.page.goto(`/tests/fixtures/demo/column-move-sorting.html?theme=${this.theme}${width}`);
+    await this.page.goto(`/tests/fixtures/demo/column-move-sorting.html?theme=${this.theme}${width}${move}`);
     await expect(this.cell(0, 0)).toBeVisible();
   }
 

--- a/tests/fixtures/pages/ColumnMoveSortingPage.ts
+++ b/tests/fixtures/pages/ColumnMoveSortingPage.ts
@@ -48,6 +48,11 @@ export class ColumnMoveSortingPage {
     return this.header(col).locator('span.colHeader');
   }
 
+  /** How many times the grid has sorted since it loaded. */
+  async sortCount(): Promise<number> {
+    return this.page.evaluate(() => (window as unknown as { sortCount?: number }).sortCount ?? 0);
+  }
+
   /** Assert a cell shows the expected text (web-first, auto-retrying). */
   async expectCell(row: number, col: number, text: string): Promise<void> {
     await expect(this.cell(row, col)).toHaveText(text);
@@ -87,6 +92,24 @@ export class ColumnMoveSortingPage {
     await this.page.mouse.down();
     await this.page.mouse.move(startX + 20, y, { steps: 5 });
     await this.page.mouse.move(to.x + (to.width / 2), y, { steps: 10 });
+    await this.page.mouse.up();
+  }
+
+  /**
+   * Drag a column from its header centre and release well below the grid, so the release lands
+   * on no cell at all. That path is resolved by the document listener rather than the cell hook.
+   */
+  async dragColumnFromHeaderCentreReleasingOutside(fromCol: number): Promise<void> {
+    const from = await this.headerBox(fromCol);
+    const y = from.y + (from.height / 2);
+    const startX = from.x + (from.width / 2);
+    const viewport = this.page.viewportSize();
+
+    await this.page.mouse.move(startX, y);
+    await this.page.mouse.down();
+    await this.page.mouse.move(startX + 20, y, { steps: 5 });
+    await this.page.mouse.move(startX + 200, y, { steps: 8 });
+    await this.page.mouse.move(startX + 200, (viewport?.height ?? 600) - 20, { steps: 8 });
     await this.page.mouse.up();
   }
 


### PR DESCRIPTION
### Context

The PR fixes a regression reported in DEV-1782: with `columnSorting` enabled, a column could not
realistically be moved by dragging its header.

Two things caused it, and both are fixed here.

**1. There was nowhere left to start a drag.** `ManualColumnMove` refuses any press whose target
carries `sortAction` — the class on the header label — because that press belongs to sorting. Since
17.1.0 the header became a flex row and the label was given `flex: 1 1 auto`, so the label covers the
whole header cell. The draggable strip collapsed to a flat 17px that no longer grows with the column,
down from 94px on a 120px column in 17.0.1. Pressing the header centre sorted instead of moving.

**2. Selecting a column always sorted it.** A column has to be selected before it can be dragged, and
every way of selecting it (a header press) also sorted it — so moving a column re-sorted it on the way.

Measured on a 120px column, sorted and selected:

| version | draggable strip |
|---|---|
| 17.0.1 | 94px |
| 17.1.0 / 18.0.0 | 17px |

### What changed

**Sorting resolves on release, not on press.** Both plugins split the gesture by whether the pointer
travelled: a press that stays put sorts, a press that travels moves the column.

- Travel is measured from `mousemove`, not by comparing the press and release positions. Pressing a
  partly visible header scrolls it into view, which moves the header under a stationary pointer — that
  is not a drag, and comparing down/up coordinates misreads it as one.
- The release is resolved from `afterOnCellMouseUp`, with a document `mouseup` fallback for releases
  outside a cell. Walkontable calls its own `onMouseUp` directly from `touchend` instead of dispatching
  a DOM event, so a document listener alone would have killed tap-to-sort on touch devices.
- Whether an open editor needs validating is captured at press time, as before. Reading it on release
  is wrong: selecting a column opens an editor on the highlighted cell, so any validated column would
  wait for a validation that never runs.
- `ManualColumnMove` drops the `sortAction` guard and gates the move on a new `#dragged` flag.

**Only the label and the sort indicator sort on click.** The label is sized to its content and centred
instead of filling the header cell, so the header around it selects the column without sorting it. On a
140px column that area goes from 8px to 47px. `position: static` on the label hands the sort indicator
and the multi-sort order badge to the header container, so they stay pinned to the header's trailing
edge; clicking one still sorts, because an event on a pseudo-element targets the element that owns it.

**This is not a visual change.** Measured against released 18.0.0 across widths 40–500px, long labels,
RTL, `htLeft`, `htRight`, both of those in RTL, `dropdownMenu`, `multiColumnSorting`, nested and
collapsible headers, `indicator: false`, and GhostTable auto width: header text position, sort indicator
position, indicator vertical centring and auto column width are all unchanged.

### How has this been tested?

New Playwright spec — `tests/e2e/column-move-sorting.spec.ts`, with fixture
`tests/fixtures/demo/column-move-sorting.html` and page object
`tests/fixtures/pages/ColumnMoveSortingPage.ts`:

1. moves a sorted column when the drag starts at the header centre — the regression;
2. keeps the header label clickable for sorting (asc then desc);
3. selects the column without sorting when the bare header area is pressed, then drags it;
4. moves the column when the drag starts on the sorting label itself, without toggling the sort;
5. does not move the column when a press is released without moving — it sorts instead.

```bash
cd tests && npx playwright test e2e/column-move-sorting.spec.ts
npm run test:e2e --prefix handsontable -- --testPathPattern="columnSorting|multiColumnSorting|manualColumnMove|dropdownMenu|nestedHeaders|collapsibleColumns|ghostTable|autoColumnSize"
npm run test:e2e --prefix handsontable
npm run test:unit --prefix handsontable
```

| suite | result |
|---|---|
| new Playwright spec, 3 themes | 15 passed |
| header-related E2E | 1041 specs, 0 failures |
| full core E2E | 9606 specs, 0 failures |
| unit (Jest) | 3267 passed |
| touch emulation (iPhone 13, iPad gen 7) | tap-to-sort works, same as released |
| eslint / stylelint / type check | clean |

Test sensitivity was verified rather than assumed — each half of the change was reverted and rebuilt
on its own. With the plugin sources reverted, the two drag tests fail; with the CSS reverted, the
bare-header test fails. The other two pass either way by design: they guard existing behaviour rather
than carrying the regression.

Also verified by hand-driven browser measurement: the sort indicator's position, the header text
position, the indicator's vertical centring and GhostTable auto column width all match released 18.0.0
in every configuration listed above.

### Notes for the reviewer

- **Three legacy specs were updated, not deleted.** `manualColumnMoveUI`'s *"should not run moving ui
  if mousedown was fired on sorting element"* asserted the very guard this change removes; it now
  asserts the replacement contract. The `columnSorting` indicator specs (LTR and RTL) asserted that the
  indicator's containing block is the label span, which is the detail this change moves — they now
  assert the container it moved to, plus a new check that the indicator lands on the header's vertical
  midline, which is the part a user can see.
- **`:has()` is banned in this package**, so two markers are toggled from JS instead:
  `has-header-button` (set by `DropdownMenu`, so the indicator steps over the menu button) and
  `has-sort-indicator` (set by `ColumnSorting`, reserving the indicator's room on the container rather
  than as padding on the label, where it would enlarge the area that sorts on click). Both are
  re-applied on every render, because `TableView` rebuilds that container's class list while its
  children survive.
- **A side effect worth knowing:** a plain click on a selected header used to fire `beforeColumnMove`
  and `afterColumnMove` with nothing actually moving. It no longer does.
- **Known rough edge:** a press that jitters 1–3px sorts (inside the click tolerance) *and* fires a
  no-op `afterColumnMove`, because `ManualColumnMove` treats any pointer move as the start of a drag
  while `ColumnSorting` applies a 3px tolerance. Aligning both would mean rewriting roughly 30 legacy
  specs that drive drags by dispatching `mousemove` on the same element (zero measurable travel), so it
  was left as-is. It is the same class of noise that already exists today.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1782

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

The column-moving and rows-sorting guides are updated in this PR.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1782

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared header pointer handling between ColumnSorting and ManualColumnMove and alters when move hooks fire; scope is localized but regression-prone without the added E2E and updated plugin tests.
> 
> **Overview**
> Fixes **DEV-1782**: with `columnSorting` and `manualColumnMove` together, dragging a column header often sorted instead of moving because the sort label filled the header and `ManualColumnMove` ignored presses on `sortAction`.
> 
> **Gesture split:** `ColumnSorting` queues a sort on header label press and applies it on **mouse up** (plus `afterOnCellMouseUp` and document `mouseup` for touch/outside-cell release). If `ManualColumnMove.isDragging()` is true, the sort is skipped. `MultiColumnSorting` overrides `applyHeaderClickSort` for Ctrl/Cmd append behavior without duplicating that logic.
> 
> **Column move:** `ManualColumnMove` no longer blocks mousedown on the sort label; it sets `#dragged` when pointer travel exceeds 3px and only runs `dragColumns` / `beforeColumnMove` / `afterColumnMove` on a real drag. Plain header clicks no longer fire those move hooks.
> 
> **Header UI:** The sort label is sized to its text (not full header width) so bare header area can select without sorting. Sort indicator room is reserved on the header `.relative` container (`has-sort-indicator`); `DropdownMenu` marks `has-header-button` so the indicator clears the menu button. SCSS and unit tests follow the container-based indicator layout.
> 
> Docs for column moving and row sorting are updated. New Playwright coverage in `tests/e2e/column-move-sorting.spec.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 004e94f22f619584f066cd2ac02e02ecf808d0b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->