### PR TITLE
DEV-2165: Fix mobile selection handles not being attached to the DOM

### DIFF
--- a/.changelogs/13185.json
+++ b/.changelogs/13185.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed mobile selection handles not being visible on touch devices.",
+  "type": "fixed",
+  "issueOrPR": 13185,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -376,6 +376,11 @@ class Border {
       handleStyleTarget.background = `color-mix(in srgb, ${cellMobileHandleBackgroundColor} ${cellMobileHandleBackgroundOpacity}%, transparent)`;
       handleStyleTarget.border = `${cellMobileHandleBorderWidth}px solid ${cellMobileHandleBorderColor}`;
     }
+
+    this.main!.appendChild(this.selectionHandles.top);
+    this.main!.appendChild(this.selectionHandles.bottom);
+    this.main!.appendChild(this.selectionHandles.topHitArea);
+    this.main!.appendChild(this.selectionHandles.bottomHitArea);
   }
 
   /**

--- a/tests/e2e/mobile-selection-handles.spec.ts
+++ b/tests/e2e/mobile-selection-handles.spec.ts
@@ -1,0 +1,46 @@
+import { devices } from '@playwright/test';
+import { test, expect } from '../fixtures/test';
+import { MobileHandlesPage } from '../fixtures/pages/MobileHandlesPage';
+
+/**
+ * Regression spec for DEV-2165: the mobile selection handles (the round
+ * grab-points on the corners of a selection) disappeared in 18.0 — the
+ * handle elements were created but never attached to the DOM.
+ *
+ * Handsontable creates the handles only when it detects a mobile browser at
+ * grid construction time, so the whole spec runs with iPhone emulation
+ * (touch + mobile user agent).
+ */
+test.use({
+  ...devices['iPhone 13'],
+  browserName: 'chromium',
+});
+
+test.describe('mobile selection handles', () => {
+  let mobileGrid: MobileHandlesPage;
+
+  test.beforeEach(async ({ page, theme }) => {
+    mobileGrid = new MobileHandlesPage(page, theme);
+    await mobileGrid.goto();
+  });
+
+  test('appear on the selection corners after tapping a cell', async () => {
+    await mobileGrid.tapCell(1, 1);
+
+    await mobileGrid.expectHandlesVisible();
+  });
+
+  test('follow the selection when another cell is tapped', async () => {
+    await mobileGrid.tapCell(1, 1);
+    await mobileGrid.expectHandlesVisible();
+
+    const firstBox = await mobileGrid.topHandle().boundingBox();
+
+    await mobileGrid.tapCell(3, 2);
+    await mobileGrid.expectHandlesVisible();
+
+    const secondBox = await mobileGrid.topHandle().boundingBox();
+
+    expect(secondBox).not.toEqual(firstBox);
+  });
+});

--- a/tests/fixtures/demo/mobile-handles.html
+++ b/tests/fixtures/demo/mobile-handles.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable mobile selection handles fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Active theme from the ?theme= query param set by the Playwright project.
+    // Mapped through a fixed allowlist to a LITERAL (default main), so a crafted
+    // ?theme= can never be reflected into the document — no XSS. Exposed as
+    // window.htTheme so the grid init below reuses the sanitized value.
+    window.htTheme = ({ horizon: 'horizon', classic: 'classic' })[new URLSearchParams(location.search).get('theme')] || 'main';
+    // Written into <head> so the themed stylesheet is present before first render.
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } </style>
+</head>
+<body>
+  <!--
+    Fixture for the mobile selection handles regression spec (DEV-2165). The
+    page must be visited with mobile emulation (touch + mobile user agent) —
+    Handsontable creates the selection handles only when it detects a mobile
+    browser at grid construction time.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script src="/handsontable/dist/handsontable.full.min.js"></script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const testIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    };
+
+    new Handsontable(container, {
+      data: [
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+        ['A4', 'B4', 'C4'],
+        ['A5', 'B5', 'C5'],
+      ],
+      colHeaders: true,
+      rowHeaders: true,
+      renderer: testIdRenderer,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/MobileHandlesPage.ts
+++ b/tests/fixtures/pages/MobileHandlesPage.ts
@@ -1,0 +1,76 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the mobile selection handles fixture (DEV-2165).
+ *
+ * The spec using this page object must run with touch + mobile user agent
+ * emulation (`test.use({ hasTouch: true, ... })`) — Handsontable decides
+ * whether to create the selection handles from the user agent at grid
+ * construction time.
+ */
+export class MobileHandlesPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly grid: Locator;
+
+  constructor(page: Page, theme = 'main') {
+    this.page = page;
+    this.theme = theme;
+    this.grid = page.getByTestId('grid');
+  }
+
+  /**
+   * Navigate to the fixture and wait for the grid to render.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(`/tests/fixtures/demo/mobile-handles.html?theme=${this.theme}`);
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /**
+   * A single data cell, by visual row/column, via its stable test id.
+   */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /**
+   * Tap a cell to select it with a touch gesture.
+   */
+  async tapCell(row: number, col: number): Promise<void> {
+    await this.cell(row, col).tap();
+  }
+
+  /**
+   * The top-left mobile selection handle of the focus selection, scoped to
+   * the master overlay.
+   */
+  topHandle(): Locator {
+    return this.page.locator('.ht_master .htBorders .topSelectionHandle').first();
+  }
+
+  /**
+   * The bottom-right mobile selection handle of the focus selection, scoped
+   * to the master overlay.
+   */
+  bottomHandle(): Locator {
+    return this.page.locator('.ht_master .htBorders .bottomSelectionHandle').first();
+  }
+
+  /**
+   * Assert both mobile selection handles are attached and visible with a
+   * non-zero rendered size.
+   */
+  async expectHandlesVisible(): Promise<void> {
+    await expect(this.topHandle()).toBeVisible();
+    await expect(this.bottomHandle()).toBeVisible();
+
+    for (const handle of [this.topHandle(), this.bottomHandle()]) {
+      const box = await handle.boundingBox();
+
+      expect(box).not.toBeNull();
+      expect(box!.width).toBeGreaterThan(0);
+      expect(box!.height).toBeGreaterThan(0);
+    }
+  }
+}


### PR DESCRIPTION
### Context

The PR fixes a regression where the mobile selection handles (the round grab-points on the corners of a selection) were no longer visible on touch devices since 18.0.

The TypeScript conversion (#12011) dropped the four `appendChild` calls at the end of `Border#createMultipleSelectorHandles`, so the handle elements were created and styled but never attached to the DOM. This PR restores the `appendChild` calls.

### How has this been tested?

- New Playwright regression spec that runs the grid under iPhone emulation (touch + mobile user agent), taps a cell, and asserts both handles are visible on the selection corners and follow the selection:
  ```bash
  cd tests && npx playwright test e2e/mobile-selection-handles.spec.ts
  ```
  Verified red against the unfixed build, green after the fix, across all three theme projects (main/horizon/classic).
- Manual check in Chrome with iPhone emulation: local build side by side with 17.1.0 from CDN — handles render 14×14 with 40×40 hit areas, matching 17.1 behavior.
- `npm run eslint --prefix handsontable` and `npm run test:types --prefix handsontable` pass.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2165

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2165

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted DOM attachment fix in mobile-only border code with new e2e coverage; no auth, data, or API surface changes.
> 
> **Overview**
> Restores **mobile selection corner handles** on touch devices by re-attaching the four handle elements (top/bottom visuals plus hit areas) to the border container in `createMultipleSelectorHandles`—they were still created and styled after 18.0 but never inserted into the DOM.
> 
> Adds a **Playwright regression** under iPhone emulation (fixture, page object, and specs) that taps cells and asserts handles are visible and move with the selection, plus a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5fe8a37b7a545ef56c605d988b2a50368bde07e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->