### PR TITLE
Cherry-pick #13109 and #13183 to prod-docs/18.0

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -423,6 +423,36 @@ Use the `@` prefix with `.md` extension for all internal links:
 
 Do not use relative paths (`../`) for internal links.
 
+### Template variables in links
+
+Never hardcode a branch name in a GitHub link. Five template variables resolve at
+build time - production builds point at the frozen branch for the docs version,
+every other build points at the development branch. All five are declared and
+substituted in `src/plugins/template-variables.mjs`, the sole registry:
+
+| Variable | Production | Otherwise | Use for |
+|---|---|---|---|
+| `{{$examplesBranch}}` | `prod-examples/<major>` | `master` | `handsontable/examples` starter sources |
+| `{{$currentMinorVersion}}` | `prod-docs/<major>.<minor>` | `develop` | `handsontable/handsontable` sources |
+| `{{$currentVersion}}` | package.json version | `0.0.0-next-<sha>-<date>` | version strings, runner links |
+| `{{$latestChangelogVersion}}` | highest `changelog-N` major | same | links to the newest changelog page |
+| `{{$basePath}}` | `''` | `''` | root-relative asset paths |
+
+Three pipelines substitute them and all three go through that module: the content
+loader (`src/plugins/framework-loader.mjs`), the Vite pre-transform
+(`src/plugins/vuepress-preprocessor.mjs`), and the `_md` route generator in
+`astro.config.mjs` that backs Copy Markdown. Add a variable in one place only.
+The exception is `{{$basePath}}` inside **embedded example source files**, which
+`framework-loader.mjs` substitutes with `/docs` rather than `''`.
+
+A hardcoded `tree/master` link sends a reader on older docs to a starter that no
+longer matches their version (DEV-2214).
+
+Exception: the `server-side-*` recipes keep `tree/master/server-examples/...`.
+`server-examples/` is not in the runner's `frameworks.json`, is not bucketed per
+major, and receives no per-major repair, so a `prod-examples/<major>` copy of it
+would be a frozen unmaintained snapshot.
+
 ---
 
 ## 2.8 Trademark Notices

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -7,6 +7,7 @@ import sitemap from '@astrojs/sitemap';
 import { pluginLineNumbers } from '@expressive-code/plugin-line-numbers';
 import { pluginCollapsibleSections } from '@expressive-code/plugin-collapsible-sections';
 import { vuepressPreprocessor } from './src/plugins/vuepress-preprocessor.mjs';
+import { replaceTemplateVariables } from './src/plugins/template-variables.mjs';
 import { rehypeTableWrapper } from './src/plugins/rehype-table-wrapper.mjs';
 import { rehypeMigrationSteps } from './src/plugins/rehype-migration-steps.mjs';
 import { replaceHasSelectors } from './src/plugins/replace-has-selectors.mjs';
@@ -556,6 +557,20 @@ function markdownRoutesIntegration() {
   const publicMdDir = resolve(__dirname, 'public', '_md');
   const PREFIXES = ['javascript-data-grid', 'react-data-grid', 'angular-data-grid'];
 
+  /**
+   * Assembles one output file: an H1 from the frontmatter title, then the body
+   * with its template variables resolved. Without the substitution a reader
+   * copying the Markdown of a page gets a literal `{{$examplesBranch}}` (or
+   * `{{$currentMinorVersion}}`) instead of a working link.
+   *
+   * @param {string} title The page title from frontmatter.
+   * @param {string} content The page body, frontmatter already stripped.
+   * @returns {string}
+   */
+  function buildMarkdown(title, content) {
+    return replaceTemplateVariables(`# ${title}\n\n${content.trim()}`);
+  }
+
   function buildRouteMap() {
     const routeMap = new Map();
 
@@ -585,14 +600,14 @@ function markdownRoutesIntegration() {
         const rel = relative(contentDir, full);
 
         if (rel === 'index.md') {
-          routeMap.set('index.md', `# ${data.title}\n\n${content.trim()}`);
+          routeMap.set('index.md', buildMarkdown(data.title, content));
           continue;
         }
 
         if (!data.permalink) continue;
 
         const slug = data.permalink.replace(/^\//, '').replace(/\/$/, '') || 'index';
-        const md = `# ${data.title}\n\n${content.trim()}`;
+        const md = buildMarkdown(data.title, content);
 
         for (const prefix of PREFIXES) {
           routeMap.set(`${prefix}/${slug}.md`, md);

--- a/docs/content/guides/formulas/installation/installation.md
+++ b/docs/content/guides/formulas/installation/installation.md
@@ -1,0 +1,208 @@
+---
+type: how-to
+title: Installation
+metaTitle: Install HyperFormula - JavaScript Data Grid | Handsontable
+description: Install HyperFormula as a separate dependency, license it, and import it to power the Formulas plugin in Handsontable 18.0 and later.
+permalink: /formulas-installation
+canonicalUrl: /formulas-installation
+tags:
+  - formulas
+  - hyperformula
+  - installation
+  - license
+react:
+  metaTitle: Install HyperFormula - React Data Grid | Handsontable
+angular:
+  metaTitle: Install HyperFormula - Angular Data Grid | Handsontable
+vue:
+  metaTitle: Install HyperFormula - Vue Data Grid | Handsontable
+searchCategory: Guides
+category: Formulas
+menuTag: new
+---
+
+The [`Formulas`](@/api/formulas.md) plugin runs on [HyperFormula](https://hyperformula.handsontable.com/),
+a calculation engine that you install separately. This guide shows how to install, license, and
+import HyperFormula so you can enable the plugin.
+
+Starting with Handsontable 18.0, HyperFormula is not bundled with Handsontable. You add it to your
+project yourself. In earlier versions, HyperFormula shipped as a Handsontable dependency and
+required no separate installation.
+
+[[toc]]
+
+## Prerequisites
+
+- Handsontable is installed in your project. See [Installation](@/guides/getting-started/installation/installation.md).
+
+## Install HyperFormula
+
+Install HyperFormula with your package manager:
+
+<code-group>
+  <code-block title="npm">
+
+  ```bash
+  npm install hyperformula
+  ```
+
+  </code-block>
+  <code-block title="Yarn">
+
+  ```bash
+  yarn add hyperformula
+  ```
+
+  </code-block>
+  <code-block title="pnpm">
+
+  ```bash
+  pnpm add hyperformula
+  ```
+
+  </code-block>
+</code-group>
+
+Install the HyperFormula version that matches your Handsontable version. For the compatible
+versions, see [HyperFormula version support](@/guides/formulas/formula-calculation/formula-calculation.md#hyperformula-version-support).
+
+To load HyperFormula from a CDN or as a UMD bundle instead, see the
+[HyperFormula installation docs](https://handsontable.github.io/hyperformula/guide/client-side-installation.html).
+
+## Import HyperFormula
+
+Import the `HyperFormula` class into the file where you configure the grid:
+
+```js
+import { HyperFormula } from 'hyperformula';
+```
+
+## License HyperFormula
+
+HyperFormula requires a license key. When HyperFormula runs inside Handsontable, use the
+`'internal-use-in-handsontable'` key. This key is free and covers any HyperFormula instance that is
+connected to a Handsontable instance.
+
+How you apply the key depends on how you create the engine:
+
+- If you pass the `HyperFormula` class to the `formulas.engine` option, Handsontable builds the
+  engine and applies the `'internal-use-in-handsontable'` key for you.
+- If you build the engine yourself with `HyperFormula.buildEmpty()`, set the key in the
+  configuration:
+
+```js
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  licenseKey: 'internal-use-in-handsontable',
+});
+```
+
+To run HyperFormula on its own, outside a Handsontable instance (for example, on a server), you
+need a dedicated [HyperFormula license key](https://hyperformula.handsontable.com/guide/license-key.html).
+For details, [contact our Sales Team](https://handsontable.com/get-a-quote).
+
+## Enable the Formulas plugin
+
+Pass the `HyperFormula` class to the `formulas.engine` option. Handsontable builds the engine and
+applies the license key for you.
+
+```js
+import Handsontable from 'handsontable';
+import { HyperFormula } from 'hyperformula';
+
+const container = document.querySelector('#example');
+
+const hot = new Handsontable(container, {
+  data: [
+    ['Product', 'Price', 'Quantity', 'Total'],
+    ['Wireless mouse', 25, 4, '=B2*C2'],
+    ['Mechanical keyboard', 89, 2, '=B3*C3'],
+    ['USB-C hub', 45, 3, '=B4*C4'],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  formulas: {
+    engine: HyperFormula,
+  },
+  licenseKey: 'non-commercial-and-evaluation', // for non-commercial use only
+});
+```
+
+This example passes the `HyperFormula` class, which is one of several ways to connect the engine.
+
+## Ways to pass HyperFormula
+
+You can connect HyperFormula to Handsontable in more than one way. The `formulas.engine` option
+accepts the `HyperFormula` class, a pre-built HyperFormula instance, or an engine configuration
+object. Choose the approach that fits your setup.
+
+### Pass the `HyperFormula` class
+This is the shortest path, shown above. You import the class and
+pass it to `formulas.engine`. Handsontable builds the engine, applies the
+`'internal-use-in-handsontable'` license key, and manages the engine's lifecycle for you. Use this
+for a single grid, or for grids that each work on their own data.
+
+```js
+import { HyperFormula } from 'hyperformula';
+
+const hot = new Handsontable(container, {
+  formulas: {
+    engine: HyperFormula,
+  },
+  licenseKey: 'non-commercial-and-evaluation', // for non-commercial use only
+});
+```
+
+### Build a `HyperFormula` instance first, then pass it
+Create the engine yourself with
+`HyperFormula.buildEmpty()`, set the license key, and pass the instance to `formulas.engine`. This
+gives you direct access to the engine's API. It also lets several Handsontable instances share one
+engine, so formulas can reference cells across grids with cross-sheet references.
+
+```js
+import { HyperFormula } from 'hyperformula';
+
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  licenseKey: 'internal-use-in-handsontable',
+});
+
+const hot = new Handsontable(container, {
+  formulas: {
+    engine: hyperformulaInstance,
+  },
+  licenseKey: 'non-commercial-and-evaluation', // for non-commercial use only
+});
+```
+
+### Pass an engine configuration object
+Instead of the bare class, pass an object with a
+`hyperformula` field (the class or an instance) alongside HyperFormula configuration options, such
+as `leapYear1900`. Use this to customize how the engine behaves.
+
+```js
+import { HyperFormula } from 'hyperformula';
+
+const hot = new Handsontable(container, {
+  formulas: {
+    engine: {
+      hyperformula: HyperFormula, // or a pre-built HyperFormula instance
+      leapYear1900: false,
+    },
+  },
+  licenseKey: 'non-commercial-and-evaluation', // for non-commercial use only
+});
+```
+
+For complete, framework-specific examples of each approach - including shared and external engines
+across multiple grids - see [Initialization methods](@/guides/formulas/formula-calculation/formula-calculation.md#initialization-methods).
+
+## Result
+
+HyperFormula is installed, licensed, and connected to Handsontable. The `Formulas` plugin evaluates
+any cell whose value starts with `=`, and it recalculates dependent cells as your data changes.
+
+## Related
+
+- [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) - use formulas, named expressions, custom functions, and cross-sheet references
+- [Installation](@/guides/getting-started/installation/installation.md) - install Handsontable
+- [`Formulas` plugin API](@/api/formulas.md)
+- [`formulas` option](@/api/options.md#formulas)

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -109,6 +109,7 @@ const cellTypesItems = [
 ];
 
 const formulasItems = [
+  { path: 'guides/formulas/installation/installation' },
   { path: 'guides/formulas/formula-calculation/formula-calculation' },
 ];
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -1152,7 +1152,7 @@ The **Formulas** plugin uses [HyperFormula](https://hyperformula.handsontable.co
 1. Install HyperFormula in your project (e.g. `npm install hyperformula`).
 2. Import HyperFormula and pass it to the Formulas plugin with `licenseKey: 'internal-use-in-handsontable'`.
 
-See the [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) guide for configuration details.
+See the [Formulas installation](@/guides/formulas/installation/installation.md) guide to install and license HyperFormula, and the [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) guide for configuration details.
 
 ## Summary of breaking changes
 

--- a/docs/content/recipes/themes/ant-design/ant-design.md
+++ b/docs/content/recipes/themes/ant-design/ant-design.md
@@ -37,11 +37,11 @@ In this tutorial, you will integrate Handsontable into a React app that uses Ant
 ></iframe>
 
 [**Open in sandbox**](https://demos.handsontable.com/?example=ant-design&v={{$currentVersion}})
-[**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/ant-design)
+[**View source on GitHub**](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/ant-design)
 
 ## Overview
 
-This recipe uses the official [handsontable/examples Ant Design demo](https://github.com/handsontable/examples/tree/master/examples/ant-design) as the live reference implementation. It shows how to integrate Handsontable into a React app that uses [Ant Design](https://ant.design/) by registering a custom theme and mapping Handsontable theme colors and tokens to Ant Design table-like styles.
+This recipe uses the official [handsontable/examples Ant Design demo](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/ant-design) as the live reference implementation. It shows how to integrate Handsontable into a React app that uses [Ant Design](https://ant.design/) by registering a custom theme and mapping Handsontable theme colors and tokens to Ant Design table-like styles.
 
 **Difficulty:** Beginner
 **Time:** ~15 minutes

--- a/docs/content/recipes/themes/base-theme/base-theme.md
+++ b/docs/content/recipes/themes/base-theme/base-theme.md
@@ -38,7 +38,7 @@ This tutorial shows you how to integrate Handsontable into a React app that uses
 ></iframe>
 
 [**Open in sandbox**](https://demos.handsontable.com/?example=base-web&v={{$currentVersion}})
-[**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/base-web)
+[**View source on GitHub**](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/base-web)
 
 ## Overview
 

--- a/docs/content/recipes/themes/custom-theme/custom-theme.md
+++ b/docs/content/recipes/themes/custom-theme/custom-theme.md
@@ -38,7 +38,7 @@ This tutorial shows you how to integrate Handsontable into a Next.js app that us
    ></iframe>
 
 [**Open in sandbox**](https://demos.handsontable.com/?example=next-shadcn.js&v={{$currentVersion}})
-[**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/next-shadcn.js)
+[**View source on GitHub**](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/next-shadcn.js)
 
 ## Overview
 

--- a/docs/content/recipes/themes/fluent-ui/fluent-ui.md
+++ b/docs/content/recipes/themes/fluent-ui/fluent-ui.md
@@ -32,7 +32,7 @@ In this tutorial, you will integrate Handsontable into a React app with Fluent U
 ></iframe>
 
 [**Open in sandbox**](https://demos.handsontable.com/?example=fluent-ui&v={{$currentVersion}})
-[**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/fluent-ui)
+[**View source on GitHub**](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/fluent-ui)
 
 ## Overview
 

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -39,7 +39,7 @@ This tutorial shows you how to integrate Handsontable into a React app that uses
 ></iframe>
 
 [**Open in sandbox**](https://demos.handsontable.com/?example=mui&v={{$currentVersion}})
-[**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/mui)
+[**View source on GitHub**](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/mui)
 
 ## Overview
 

--- a/docs/src/plugins/__tests__/docs-version.test.mjs
+++ b/docs/src/plugins/__tests__/docs-version.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { deriveExamplesBranch, CURRENT_EXAMPLES_BRANCH } from '../docs-version.mjs';
+
+test('a production build derives the prod-examples branch for its major', () => {
+  assert.equal(deriveExamplesBranch('18.0.2', true), 'prod-examples/18');
+  assert.equal(deriveExamplesBranch('15.3.0', true), 'prod-examples/15');
+  assert.equal(deriveExamplesBranch('19.0.0-beta.1', true), 'prod-examples/19');
+});
+
+test('a non-production build always resolves to the examples repo master branch', () => {
+  // master, not develop: handsontable/examples has no develop branch.
+  assert.equal(deriveExamplesBranch('0.0.0-next-abc1234-20260812', false), 'master');
+  assert.equal(deriveExamplesBranch('18.0.2', false), 'master');
+});
+
+test('a version with no released major never derives a prod-examples/0 branch', () => {
+  // The staging/dev placeholder reaching a production build must not produce a
+  // link to prod-examples/0, which does not exist.
+  assert.equal(deriveExamplesBranch('0.0.0-next-abc1234-20260812', true), 'master');
+  assert.equal(deriveExamplesBranch('next', true), 'master');
+  assert.equal(deriveExamplesBranch('', true), 'master');
+  assert.equal(deriveExamplesBranch(undefined, true), 'master');
+});
+
+test('CURRENT_EXAMPLES_BRANCH resolves to a branch that exists in handsontable/examples', () => {
+  assert.match(CURRENT_EXAMPLES_BRANCH, /^(master|prod-examples\/\d+)$/);
+  assert.doesNotMatch(CURRENT_EXAMPLES_BRANCH, /prod-examples\/0$/);
+});

--- a/docs/src/plugins/__tests__/framework-loader.test.mjs
+++ b/docs/src/plugins/__tests__/framework-loader.test.mjs
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { frameworkLoader } from '../framework-loader.mjs';
 import { LATEST_CHANGELOG_MAJOR } from '../changelog-parser.mjs';
-import { CURRENT_DOCS_VERSION } from '../docs-version.mjs';
+import { CURRENT_DOCS_VERSION, CURRENT_EXAMPLES_BRANCH } from '../docs-version.mjs';
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -555,6 +555,46 @@ test('{{$latestChangelogVersion}} placeholder resolves to the latest changelog p
     // Regression guard: if the placeholder were substituted after (or never),
     // the literal "{{" would leak into the link or the fallback path.
     assert.ok(!html.includes('{{'), 'no unresolved {{$latestChangelogVersion}} placeholder should remain');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('{{$examplesBranch}} placeholder resolves to the matching handsontable/examples branch', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'hot-loader-examples-branch-'));
+  const contentDir = join(root, 'content');
+  const recipeDir = join(contentDir, 'recipes', 'themes', 'mui-theme');
+
+  mkdirSync(recipeDir, { recursive: true });
+  writeFileSync(join(contentDir, 'index.md'), '---\ntitle: Home\n---\n\nWelcome.\n');
+  writeFileSync(
+    join(recipeDir, 'mui-theme.md'),
+    [
+      '---',
+      'title: MUI theme',
+      'permalink: /mui-theme',
+      '---',
+      '',
+      '[**View source on GitHub**](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/mui)',
+      '',
+    ].join('\n')
+  );
+
+  try {
+    const { ctx, store } = createContext();
+
+    await frameworkLoader({ contentDir }).load(ctx);
+
+    const html = renderedHtmlOf(store, 'javascript-data-grid/mui-theme');
+
+    assert.ok(
+      html.includes(`https://github.com/handsontable/examples/tree/${CURRENT_EXAMPLES_BRANCH}/examples/mui`),
+      `expected the starter link to point at ${CURRENT_EXAMPLES_BRANCH}`
+    );
+
+    // DEV-2214: a hardcoded tree/master link sends a reader on older docs to a
+    // starter that no longer matches their version.
+    assert.ok(!html.includes('{{'), 'no unresolved {{$examplesBranch}} placeholder should remain');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/docs/src/plugins/__tests__/template-variables.test.mjs
+++ b/docs/src/plugins/__tests__/template-variables.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { replaceTemplateVariables } from '../template-variables.mjs';
+import {
+  CURRENT_DOCS_VERSION,
+  CURRENT_DOCS_MINOR_VERSION,
+  CURRENT_EXAMPLES_BRANCH,
+} from '../docs-version.mjs';
+import { LATEST_CHANGELOG_MAJOR } from '../changelog-parser.mjs';
+
+const values = {
+  basePath: '/docs',
+  version: '18.0.2',
+  minorVersion: 'prod-docs/18.0',
+  examplesBranch: 'prod-examples/18',
+};
+
+test('resolves every supported template variable', () => {
+  const md = [
+    '![shot]({{$basePath}}/img/pages/shot.png)',
+    'Install handsontable@{{$currentVersion}}.',
+    '[source](https://github.com/handsontable/handsontable/tree/{{$currentMinorVersion}}/docs)',
+    '[starter](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/mui)',
+  ].join('\n');
+
+  const result = replaceTemplateVariables(md, values);
+
+  assert.ok(result.includes('![shot](/docs/img/pages/shot.png)'));
+  assert.ok(result.includes('handsontable@18.0.2'));
+  assert.ok(result.includes('handsontable/tree/prod-docs/18.0/docs'));
+  assert.ok(result.includes('examples/tree/prod-examples/18/examples/mui'));
+  assert.ok(!result.includes('{{'), 'no unresolved template variable should remain');
+});
+
+test('tolerates whitespace inside the braces', () => {
+  const result = replaceTemplateVariables(
+    'a {{ $examplesBranch }} b {{  $currentVersion  }}',
+    values
+  );
+
+  assert.equal(result, 'a prod-examples/18 b 18.0.2');
+});
+
+test('replaces every occurrence, not only the first', () => {
+  const result = replaceTemplateVariables(
+    '{{$examplesBranch}} {{$examplesBranch}} {{$examplesBranch}}',
+    values
+  );
+
+  assert.equal(result, 'prod-examples/18 prod-examples/18 prod-examples/18');
+});
+
+test('{{$basePath}} defaults to an empty string so page paths stay root-relative', () => {
+  assert.equal(
+    replaceTemplateVariables('![shot]({{$basePath}}/img/pages/shot.png)'),
+    '![shot](/img/pages/shot.png)'
+  );
+});
+
+test('defaults come from the resolved build constants', () => {
+  const result = replaceTemplateVariables(
+    '{{$currentVersion}}|{{$currentMinorVersion}}|{{$examplesBranch}}'
+  );
+
+  assert.equal(
+    result,
+    `${CURRENT_DOCS_VERSION}|${CURRENT_DOCS_MINOR_VERSION}|${CURRENT_EXAMPLES_BRANCH}`
+  );
+});
+
+test('a $ in a replacement value is not read as a replacement pattern', () => {
+  const result = replaceTemplateVariables('v{{$currentVersion}}', {
+    ...values,
+    version: '18.0.0-$&-$1',
+  });
+
+  assert.equal(result, 'v18.0.0-$&-$1');
+});
+
+test('resolves {{$latestChangelogVersion}} to the highest existing changelog major', () => {
+  assert.equal(
+    replaceTemplateVariables('changelog-{{$latestChangelogVersion}}'),
+    `changelog-${LATEST_CHANGELOG_MAJOR}`
+  );
+  assert.equal(
+    replaceTemplateVariables('changelog-{{$latestChangelogVersion}}', { latestChangelogVersion: 42 }),
+    'changelog-42'
+  );
+});
+
+test('leaves unknown variables untouched', () => {
+  assert.equal(replaceTemplateVariables('{{$notAVariable}}', values), '{{$notAVariable}}');
+});

--- a/docs/src/plugins/__tests__/vuepress-preprocessor.test.mjs
+++ b/docs/src/plugins/__tests__/vuepress-preprocessor.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { vuepressPreprocessor } from '../vuepress-preprocessor.mjs';
+import {
+  CURRENT_DOCS_VERSION,
+  CURRENT_DOCS_MINOR_VERSION,
+  CURRENT_EXAMPLES_BRANCH,
+} from '../docs-version.mjs';
+
+const plugin = vuepressPreprocessor({ framework: 'javascript' });
+
+/**
+ * Runs markdown through the plugin's transform hook the way Vite would.
+ *
+ * @param {string} md
+ * @returns {string}
+ */
+function transform(md) {
+  return plugin.transform(md, '/docs/content/recipes/themes/mui-theme/mui-theme.md').code;
+}
+
+test('resolves the template variables this pipeline shares with the content loader', () => {
+  // The two pipelines are separate: a variable wired into framework-loader.mjs
+  // alone stays a literal here. Guard both.
+  const result = transform([
+    '[starter](https://github.com/handsontable/examples/tree/{{$examplesBranch}}/examples/mui)',
+    '[source](https://github.com/handsontable/handsontable/tree/{{$currentMinorVersion}}/docs)',
+    'Install handsontable@{{$currentVersion}}.',
+    '![shot]({{$basePath}}/img/pages/shot.png)',
+  ].join('\n'));
+
+  assert.ok(result.includes(`examples/tree/${CURRENT_EXAMPLES_BRANCH}/examples/mui`));
+  assert.ok(result.includes(`handsontable/tree/${CURRENT_DOCS_MINOR_VERSION}/docs`));
+  assert.ok(result.includes(`handsontable@${CURRENT_DOCS_VERSION}`));
+  assert.ok(result.includes('![shot](/img/pages/shot.png)'));
+  assert.ok(!result.includes('{{'), 'no unresolved template variable should remain');
+});
+
+test('skips files that are not markdown', () => {
+  assert.equal(plugin.transform('{{$examplesBranch}}', '/docs/src/app.ts'), null);
+});

--- a/docs/src/plugins/docs-version.mjs
+++ b/docs/src/plugins/docs-version.mjs
@@ -129,3 +129,46 @@ export const CURRENT_DOCS_MINOR_VERSION = (() => {
 
   return 'develop';
 })();
+
+/**
+ * Derives the `handsontable/examples` branch that matches a docs version.
+ *
+ * Production builds produce `prod-examples/<major>` (e.g. `prod-examples/18`),
+ * matching the per-major starter snapshot branches in the examples repository.
+ * The snapshots are cut per major only, so the major is the right granularity.
+ *
+ * Every other build falls back to `master`, the sole development branch of the
+ * examples repository. It is `master` rather than `develop` because that repo
+ * has no `develop` branch.
+ *
+ * A version that carries no released major - an unparsable string, or the
+ * `0.0.0-next-<sha>-<date>` placeholder reaching a production build - also falls
+ * back to `master`. There is no `prod-examples/0` branch, so a derived link
+ * would 404.
+ *
+ * @param {string} version The docs version string to derive the branch from.
+ * @param {boolean} isProduction Whether this is a production docs build.
+ * @returns {string}
+ */
+export function deriveExamplesBranch(version, isProduction) {
+  if (!isProduction) {
+    return 'master';
+  }
+
+  const major = String(version ?? '').match(/^(\d+)\./)?.[1];
+
+  return major && major !== '0' ? `prod-examples/${major}` : 'master';
+}
+
+/**
+ * The `handsontable/examples` branch used for starter source links in
+ * documentation pages.
+ *
+ * Evaluated once at module load time so all imports share the same value.
+ *
+ * @type {string}
+ */
+export const CURRENT_EXAMPLES_BRANCH = deriveExamplesBranch(
+  CURRENT_DOCS_VERSION,
+  process.env.BUILD_MODE === 'production'
+);

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -10,8 +10,8 @@
 import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
 import { join, relative, dirname } from 'path';
 import matter from 'gray-matter';
-import { CURRENT_DOCS_VERSION, CURRENT_DOCS_MINOR_VERSION } from './docs-version.mjs';
-import { LATEST_CHANGELOG_MAJOR } from './changelog-parser.mjs';
+import { CURRENT_DOCS_VERSION } from './docs-version.mjs';
+import { replaceTemplateVariables } from './template-variables.mjs';
 import { convertAsideBodyMarkdown } from './aside-inline-markdown.mjs';
 import { loadVersionHighlights } from './version-highlights-loader.mjs';
 
@@ -1154,25 +1154,12 @@ function applyVuepressPreprocessing(content, prefix, contentDir) {
   // Fix $withBase('/path') → /path
   result = result.replace(/\$withBase\s*\(\s*['"]?([^'")\s]+)['"]?\s*\)/g, '$1');
 
-  // Fix {{$basePath}} → '' (VuePress versioned-base template variable)
-  result = result.replace(/\{\{\s*\$basePath\s*\}\}/g, '');
-
-  // Fix {{$currentVersion}} → resolved Handsontable version string.
-  // Production builds use the package.json version (e.g. "17.0.1").
-  // Staging/dev builds use "0.0.0-next-{shortSHA}-{YYYYMMDD}" so that
-  // CodeSandbox links resolve to the correct in-progress build artifact.
-  result = result.replace(/\{\{\s*\$currentVersion\s*\}\}/g, CURRENT_DOCS_VERSION);
-
-  // Fix {{$currentMinorVersion}} → GitHub branch path for source-code links.
-  // Production builds produce "prod-docs/X.Y" (e.g. "prod-docs/17.1").
-  // Staging/dev builds resolve to "develop" (no prod-docs/ prefix, since
-  // the prod-docs/develop branch does not exist).
-  result = result.replace(/\{\{\s*\$currentMinorVersion\s*\}\}/g, CURRENT_DOCS_MINOR_VERSION);
-
-  // Fix {{$latestChangelogVersion}} → highest existing changelog-N major version.
-  // Keeps the Introduction page's "Changelog" link current without manual edits
-  // on every major release.
-  result = result.replace(/\{\{\s*\$latestChangelogVersion\s*\}\}/g, String(LATEST_CHANGELOG_MAJOR));
+  // Resolve every template variable ({{$basePath}}, {{$currentVersion}},
+  // {{$currentMinorVersion}}, {{$examplesBranch}}, {{$latestChangelogVersion}}).
+  // See template-variables.mjs for what each one resolves to and why. This must
+  // stay above the @/...md link resolution below - {{$latestChangelogVersion}} is
+  // used inside such a link, which cannot resolve while it is still a placeholder.
+  result = replaceTemplateVariables(result);
 
   // Transform @/framework/path.md links to absolute Starlight URLs using permalinks.
   // When prefix/contentDir are available (framework pages), do full permalink resolution.

--- a/docs/src/plugins/template-variables.mjs
+++ b/docs/src/plugins/template-variables.mjs
@@ -1,0 +1,72 @@
+/**
+ * Substitutes the VuePress-style template variables used in documentation
+ * markdown.
+ *
+ * Two separate pipelines render page markdown - the Astro content-layer loader
+ * (`framework-loader.mjs`) and the Vite pre-transform (`vuepress-preprocessor.mjs`) -
+ * and the `_md` route generator in `astro.config.mjs` writes a third,
+ * plain-markdown output. A variable resolved in only one of them silently
+ * survives as a literal `{{$name}}` in the others, so the regexes live here
+ * rather than being copied per call site.
+ *
+ * Supported variables:
+ *
+ * - `{{$basePath}}` - the VuePress versioned-base prefix. Astro resolves public
+ *   assets relative to the site root, so page markdown drops it entirely and the
+ *   root-relative path (e.g. `/img/pages/...`) stays correct. Embedded example
+ *   source files need `/docs` instead, which is why `basePath` is an option.
+ * - `{{$currentVersion}}` - the resolved Handsontable version string. Production
+ *   builds use the `handsontable/package.json` version (e.g. `18.0.2`);
+ *   staging/dev builds use `0.0.0-next-<shortSHA>-<YYYYMMDD>` so runner links
+ *   resolve to the in-progress build artifact.
+ * - `{{$currentMinorVersion}}` - the `handsontable/handsontable` branch for
+ *   source-code links: `prod-docs/<major>.<minor>` in production, `develop`
+ *   otherwise.
+ * - `{{$examplesBranch}}` - the `handsontable/examples` branch for starter
+ *   source links: `prod-examples/<major>` in production, `master` otherwise.
+ * - `{{$latestChangelogVersion}}` - the highest existing `changelog-N` major, so
+ *   a "Changelog" link stays current without a manual edit every major release.
+ *   Callers that resolve `@/...md` links must substitute before doing so, or the
+ *   link lands on a page that does not exist.
+ */
+
+import {
+  CURRENT_DOCS_VERSION,
+  CURRENT_DOCS_MINOR_VERSION,
+  CURRENT_EXAMPLES_BRANCH,
+} from './docs-version.mjs';
+import { LATEST_CHANGELOG_MAJOR } from './changelog-parser.mjs';
+
+/**
+ * Replaces every supported `{{$name}}` template variable in a string.
+ *
+ * The values default to the constants resolved for this build; pass them
+ * explicitly to test both the production and the development mapping without
+ * reloading `docs-version.mjs` (its constants are computed once at module load).
+ *
+ * @param {string} text The markdown or source text to transform.
+ * @param {object} [options]
+ * @param {string} [options.basePath] Replacement for `{{$basePath}}`.
+ * @param {string} [options.version] Replacement for `{{$currentVersion}}`.
+ * @param {string} [options.minorVersion] Replacement for `{{$currentMinorVersion}}`.
+ * @param {string} [options.examplesBranch] Replacement for `{{$examplesBranch}}`.
+ * @param {string|number} [options.latestChangelogVersion] Replacement for
+ *   `{{$latestChangelogVersion}}`.
+ * @returns {string}
+ */
+export function replaceTemplateVariables(text, {
+  basePath = '',
+  version = CURRENT_DOCS_VERSION,
+  minorVersion = CURRENT_DOCS_MINOR_VERSION,
+  examplesBranch = CURRENT_EXAMPLES_BRANCH,
+  latestChangelogVersion = LATEST_CHANGELOG_MAJOR,
+} = {}) {
+  // The replacements are passed as functions so a `$` in a value (`$&`, `$1`)
+  // cannot be read as a replacement pattern.
+  return text
+    .replace(/\{\{\s*\$basePath\s*\}\}/g, () => basePath)
+    .replace(/\{\{\s*\$currentVersion\s*\}\}/g, () => version)
+    .replace(/\{\{\s*\$currentMinorVersion\s*\}\}/g, () => minorVersion)
+    .replace(/\{\{\s*\$examplesBranch\s*\}\}/g, () => examplesBranch)
+    .replace(/\{\{\s*\$latestChangelogVersion\s*\}\}/g, () => String(latestChangelogVersion));
+}

--- a/docs/src/plugins/vuepress-preprocessor.mjs
+++ b/docs/src/plugins/vuepress-preprocessor.mjs
@@ -13,11 +13,12 @@
  * - $withBase('/path') → /path
  * - {{$currentVersion}} → resolved Handsontable version string (full semver, e.g. "17.1.0")
  * - {{$currentMinorVersion}} → GitHub branch path for source-code links (e.g. "prod-docs/17.1" or "develop")
+ * - {{$examplesBranch}} → handsontable/examples branch for starter links (e.g. "prod-examples/18" or "master")
  * - @/framework/path links  → /path (cross-framework alias)
  * - <div class="boxes-list"> ... </div>  → Starlight-styled card grid HTML
  */
 
-import { CURRENT_DOCS_VERSION, CURRENT_DOCS_MINOR_VERSION } from './docs-version.mjs';
+import { replaceTemplateVariables } from './template-variables.mjs';
 import { convertAsideInlineMarkdown } from './aside-inline-markdown.mjs';
 
 /**
@@ -81,23 +82,10 @@ function preprocessMarkdown(content, framework) {
   // 6. Fix $withBase('/path') → /path in image srcs and link hrefs
   result = result.replace(/\$withBase\s*\(\s*['"]?([^'")\s]+)['"]?\s*\)/g, '$1');
 
-  // 6b. Fix {{$basePath}} → '' (VuePress versioned-base template variable)
-  //     In Astro, public assets are resolved relative to the site root so the
-  //     base prefix is added automatically; dropping the placeholder preserves
-  //     the correct root-relative path (e.g. /img/pages/... or /cert.pdf).
-  result = result.replace(/\{\{\s*\$basePath\s*\}\}/g, '');
-
-  // 6c. Fix {{$currentVersion}} → resolved Handsontable version string.
-  //     Production builds use the package.json version (e.g. "17.0.1").
-  //     Staging/dev builds use "0.0.0-next-{shortSHA}-{YYYYMMDD}" so that
-  //     CodeSandbox links resolve to the correct in-progress build artifact.
-  result = result.replace(/\{\{\s*\$currentVersion\s*\}\}/g, CURRENT_DOCS_VERSION);
-
-  // 6d. Fix {{$currentMinorVersion}} → GitHub branch path for source-code links.
-  //     Production builds produce "prod-docs/X.Y" (e.g. "prod-docs/17.1").
-  //     Staging/dev builds resolve to "develop" (no prod-docs/ prefix, since
-  //     the prod-docs/develop branch does not exist).
-  result = result.replace(/\{\{\s*\$currentMinorVersion\s*\}\}/g, CURRENT_DOCS_MINOR_VERSION);
+  // 6b. Resolve the {{$basePath}}, {{$currentVersion}}, {{$currentMinorVersion}}
+  //     and {{$examplesBranch}} template variables. See template-variables.mjs
+  //     for what each one resolves to and why.
+  result = replaceTemplateVariables(result);
 
   // 7. Transform @/framework/... cross-framework alias links to absolute paths.
   //    e.g. @/react/guides/foo/foo.md → /guides/foo/foo


### PR DESCRIPTION
### Context

The PR cherry-picks two documentation changes from `develop` to `prod-docs/18.0` so they are included in the production docs deployment:

- #13109 – Adds the HyperFormula installation guide to the Formulas section (new `guides/formulas/installation` page, sidebar entry, and the `template-variables` / `docs-version` plugins with tests that support it).
- #13183 – Points the docs starter links (theme recipes and the 17.0 migration guide) at the examples branch matching the docs version, so StackBlitz starters open the correct code for the released version.

Both commits are clean cherry-picks with no conflicts.

[skip changelog]

### How has this been tested?

- Cherry-picked commits were already reviewed, tested, and merged to `develop` in #13109 and #13183.
- `npm --prefix docs run docs:test:plugins` – all 164 docs plugin unit tests pass on this branch, including the new `template-variables`, `docs-version`, `framework-loader`, and `vuepress-preprocessor` tests.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #13109
2. #13183

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and build-plugin changes only; behavior is covered by new plugin tests and does not touch grid runtime code.
> 
> **Overview**
> Cherry-picks documentation work onto **prod-docs/18.0**: a new **HyperFormula installation** how-to (sidebar entry, migration guide cross-link) and fixes so GitHub “view source” links match the docs version readers are on.
> 
> **Version-aware links:** Theme recipe pages no longer hardcode `tree/master` on `handsontable/examples`. They use `{{$examplesBranch}}`, which resolves to `prod-examples/<major>` in production and `master` otherwise. Substitution is centralized in `template-variables.mjs` and shared by the content loader, Vite preprocessor, and Copy Markdown output so placeholders do not leak into copied Markdown. `AGENTS.md` documents the five template variables and the rule against hardcoded branch names (DEV-2214).
> 
> **Tests:** Plugin unit tests cover `deriveExamplesBranch`, `replaceTemplateVariables`, and `{{$examplesBranch}}` resolution in the loader and preprocessor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fd351ee2b146d8c2c007c626f98e766953dfefa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->