### PR TITLE
DEV-2502: Fix full bundle crash on pages with an AMD loader present

### DIFF
--- a/.changelogs/13187.json
+++ b/.changelogs/13187.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the full bundle failing to load on pages with an AMD loader present (RequireJS, SharePoint).",
+  "type": "fixed",
+  "issueOrPR": 13187,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/.config/base.js
+++ b/handsontable/.config/base.js
@@ -8,6 +8,13 @@ const licenseBody = getLicenseBody();
 
 module.exports.create = function create(envArgs) {
   const config = {
+    // Keep rspack's AMD dependency parsing ON (webpack's default; rspack
+    // defaults it to `false`). Without it, a vendored dependency's UMD wrapper
+    // (regexp-to-ast inside the full bundle) survives verbatim and calls the
+    // host page's global `define` when an AMD loader (RequireJS, SharePoint)
+    // is present, leaving its exports empty and crashing the bundle at load
+    // time with `RegExpParser is not a constructor` (DEV-2502).
+    amd: {},
     devtool: false,
     entry: [],
     performance: {

--- a/tests/e2e/amd-loader.spec.ts
+++ b/tests/e2e/amd-loader.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '../fixtures/test';
+import { AmdLoaderGridPage } from '../fixtures/pages/AmdLoaderGridPage';
+
+/**
+ * Regression guard for hosting the UMD bundles on a page that already ships a
+ * RequireJS-style AMD loader (SharePoint, Dojo, RequireJS-based CMSes).
+ *
+ * The webpack→rspack migration (DEV-1418) silently flipped AMD dependency
+ * parsing off (rspack defaults `amd` to false, webpack enabled it), so the
+ * vendored regexp-to-ast UMD wrapper inside handsontable.full.min.js reached
+ * the page's global `define` at load time, left its `module.exports` empty,
+ * and the whole bundle threw `RegExpParser is not a constructor` (DEV-2502).
+ * The `amd: {}` entry in handsontable/.config/base.js is the fix this spec
+ * pins down; the `-min` legs of the matrix cover the full bundle where the
+ * vendored dependency lives.
+ */
+test.describe('bundle on a page with an AMD loader', () => {
+  test('loads and renders while a global define.amd is present', async ({ page, theme, bundle }) => {
+    const pageErrors: Error[] = [];
+
+    page.on('pageerror', (error) => {
+      pageErrors.push(error);
+    });
+
+    const grid = new AmdLoaderGridPage(page, theme, bundle);
+
+    await grid.goto();
+
+    // Load-time failure (the DEV-2502 regression) surfaces here with the
+    // exact thrown error, not as an opaque missing-cell timeout below.
+    expect(pageErrors).toEqual([]);
+
+    // The bundle must have registered through the page's AMD loader — proves
+    // the collision scenario was actually exercised, not silently skipped.
+    expect(await grid.amdRegistrationCount()).toBeGreaterThan(0);
+
+    await grid.expectCell(0, 0, 'A1');
+    await grid.expectCell(2, 2, 'C3');
+  });
+});

--- a/tests/fixtures/demo/amd-loader-grid.html
+++ b/tests/fixtures/demo/amd-loader-grid.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable e2e fixture — AMD loader collision</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back — a
+    // typo in the project config must be one red leg, never a silently
+    // mislabeled green one (nothing else asserts which file actually loaded).
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    // Written into <head> so the themed stylesheet is present before first render.
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    // 1:1 with the Puppeteer legs (umd = handsontable.js, full-min =
+    // handsontable.full.min.js, the exact file `test:production` loads).
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <script>
+    // A minimal RequireJS-style AMD loader present BEFORE the bundle loads —
+    // the SharePoint/Dojo/RequireJS hosting scenario. The bundle's own UMD
+    // wrapper detects `define.amd` and registers through it (named define),
+    // and the loader executes the module factory immediately, like a real
+    // loader would. Regression guard for the rspack `amd: false` default:
+    // with AMD parsing off, a vendored dependency's UMD wrapper (regexp-to-ast
+    // inside the full bundle) also reached this global `define`, left its
+    // `module.exports` empty, and the whole bundle threw
+    // `RegExpParser is not a constructor` at load time.
+    window.__amdRegistrations = [];
+    window.define = function() {
+      const factory = arguments[arguments.length - 1];
+
+      window.__amdRegistrations.push(typeof factory === 'function' ? factory() : factory);
+    };
+    window.define.amd = {};
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } </style>
+</head>
+<body>
+  <!--
+    E2E fixture. Cells are stamped with data-testid via a renderer so tests hook
+    into them unambiguously (data-testid="cell-<row>-<col>") instead of brittle
+    structural selectors. This mirrors the convention the authoring skill teaches.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The
+    // closing tag is split so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    // With `define.amd` present the UMD wrapper registers via the AMD loader
+    // instead of setting the global, so recover the export the loader captured
+    // (the Handsontable constructor is a function carrying `version`).
+    window.Handsontable = window.Handsontable
+      || window.__amdRegistrations.find(function(moduleExport) {
+        return typeof moduleExport === 'function' && typeof moduleExport.version === 'string';
+      });
+
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const testIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    };
+
+    new Handsontable(container, {
+      data: [
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+      ],
+      colHeaders: true,
+      rowHeaders: true,
+      renderer: testIdRenderer,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/AmdLoaderGridPage.ts
+++ b/tests/fixtures/pages/AmdLoaderGridPage.ts
@@ -1,0 +1,49 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the AMD-loader-collision fixture (`amd-loader-grid.html`).
+ *
+ * The fixture installs a RequireJS-style global `define` (with `define.amd`)
+ * BEFORE the Handsontable bundle loads — the SharePoint/Dojo/RequireJS hosting
+ * scenario. The page object exposes the grid cells plus the count of AMD
+ * registrations the fake loader captured, so a spec can prove the AMD code
+ * path was actually exercised and the bundle still initialized.
+ */
+export class AmdLoaderGridPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly grid: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.grid = page.getByTestId('grid');
+  }
+
+  /**
+   * Navigate to the fixture. Waits only for the document `load` event — the
+   * bundle and grid init are synchronous inline scripts, so any load-time
+   * failure (the regression this fixture guards) has already surfaced as a
+   * page error by then. Cell visibility is asserted separately by the spec.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(`/tests/fixtures/demo/amd-loader-grid.html?theme=${this.theme}&bundle=${this.bundle}`);
+  }
+
+  /** A single data cell, by visual row/column, via its stable test id. */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /** Assert a cell shows the expected text (web-first, auto-retrying). */
+  async expectCell(row: number, col: number, text: string): Promise<void> {
+    await expect(this.cell(row, col)).toHaveText(text);
+  }
+
+  /** How many modules registered through the page's fake AMD loader. */
+  async amdRegistrationCount(): Promise<number> {
+    return this.page.evaluate(() => (window as any).__amdRegistrations.length);
+  }
+}


### PR DESCRIPTION
### Context

The PR fixes `handsontable.full.min.js` (and `handsontable.full.js`) crashing at load time with `TypeError: T.RegExpParser is not a constructor` on pages that already ship a RequireJS-style AMD loader (SharePoint, Dojo, RequireJS-based CMSes).

The webpack→rspack migration (DEV-1418, first released in 17.1.0) silently flipped AMD dependency parsing off: webpack enables the `amd` option by default, while Rspack defaults it to `false`. With AMD parsing off, the UMD wrapper of the vendored `regexp-to-ast` dependency (used by Chevrotain, which HyperFormula bundles into the full build) survives verbatim into the bundle. Its wrapper checks AMD **first**, so on a page with a global `define.amd` it registers through the host page's loader instead of populating `module.exports`. Chevrotain then calls `new RegExpParser()` on an empty object and the whole bundle fails to initialize.

The fix restores webpack's behavior with a one-line build-config change: `amd: {}` in `handsontable/.config/base.js`. Rspack then rewrites the vendored wrapper's `define` call at build time so it never reaches the host page's loader. The `regexp-to-ast` dependency itself is unchanged.

Affected releases: 17.1.0 up to and including 18.0.0. Candidate for a cherry-pick to the active patch branches.

### How has this been tested?

- New Playwright regression spec `tests/e2e/amd-loader.spec.ts` with the `tests/fixtures/demo/amd-loader-grid.html` fixture, which installs a RequireJS-style global `define`/`define.amd` **before** the bundle loads, asserts zero page errors, asserts the bundle registered through the AMD loader, and asserts the grid renders. Before the fix it fails on the `-min` legs with the exact reported error (`RegExpParser is not a constructor`); after the fix it passes on all six theme × bundle legs:
  ```bash
  cd tests && npx playwright test e2e/amd-loader.spec.ts
  ```
- Full functional Playwright suite on both bundle legs — 86 passed, 0 failed:
  ```bash
  cd tests && npx playwright test --project=e2e-main --project=e2e-main-min
  ```
- Verified the rebuilt `dist/handsontable.full.min.js` no longer contains the vendored `define([], factory)` call nor the `regexpToAst` global fallback, and loads correctly with a hostile `define.amd` present.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2502

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2502

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core rspack bundling for all UMD outputs (small config change) with high impact on third-party hosting when AMD loaders are present; regression is covered by new e2e tests on full and plain bundles.
> 
> **Overview**
> Fixes **load-time crashes** of `handsontable.full.min.js` on pages that already expose a RequireJS-style global `define` (SharePoint, Dojo, etc.), where users saw `RegExpParser is not a constructor`.
> 
> The rspack migration left AMD dependency parsing disabled by default, so a vendored **regexp-to-ast** UMD wrapper in the full bundle could still call the host page’s `define` and leave `module.exports` empty. **Restores webpack behavior** by setting `amd: {}` in `handsontable/.config/base.js` so rspack rewrites those AMD calls at build time.
> 
> Adds a **Playwright regression**: `amd-loader-grid.html` installs a fake `define.amd` before the bundle loads, `amd-loader.spec.ts` asserts no page errors, AMD registration occurred, and the grid renders; plus changelog entry **13187**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b23273e75f5c2742d32aab0104edb1ddc04bafd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->