### PR TITLE
fix: autocomplete dropdown should be at least as wide as the column when trimDropdown is false

### DIFF
--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -540,7 +540,18 @@ export class AutocompleteEditor extends HandsontableEditor {
       }
     }
 
-    return this.htEditor.getColWidth(0) + borderCompensation;
+    const dropdownWidth = this.htEditor.getColWidth(0) + borderCompensation;
+
+    // When trimDropdown is set to false, ensure the dropdown width is at least
+    // the width of the column in the main table. This prevents the dropdown
+    // from being narrower than the column when the list items are short.
+    if (this.cellProperties.trimDropdown === false) {
+      const columnWidth = this.hot.getColWidth(this.col) ?? 0;
+
+      return Math.max(dropdownWidth, columnWidth);
+    }
+
+    return dropdownWidth;
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?

Fixes the critical bug where the autocomplete/dropdown editor renders with a width **smaller** than the column width when `trimDropdown: false` is set and the list items are short.

### Why is this a problem?

When `trimDropdown: false`, the internal dropdown Handsontable uses `autoColumnSize`, so the dropdown width is computed from the content of the list items. With short items, the dropdown shrinks below the column width, which makes it look broken and harder to use.

### How does this fix work?

`getTargetEditorWidth()` now takes the main column width into account when `trimDropdown` is `false`:

- The dropdown width is computed as before (`htEditor.getColWidth(0) + borderCompensation`).
- When `trimDropdown === false`, the returned width is `Math.max(dropdownWidth, columnWidth)`, where `columnWidth` is the width of the edited column in the main table.

This ensures the dropdown is never narrower than the column it belongs to, matching the expected behavior of `trimDropdown: false`.

**Fixes #13180**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sizing logic in the autocomplete editor with no auth, data, or API surface changes.
> 
> **Overview**
> Fixes autocomplete/dropdown lists appearing **narrower than the edited column** when `trimDropdown: false` and option labels are short.
> 
> `getTargetEditorWidth()` still derives width from the internal list table (`htEditor.getColWidth(0)` plus border compensation). When `trimDropdown === false`, it now returns **`Math.max(dropdownWidth, hot.getColWidth(col))`**, so the popup is never smaller than the main grid column while still growing for longer options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 869265208e3ccde7c753e6ee6dd3e1835242e1f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->