### PR TITLE
DEV-1619: Make the grid work inside Shadow DOM and Salesforce LWS

### DIFF
--- a/.changelogs/13194.json
+++ b/.changelogs/13194.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed grid interactions inside Shadow DOM and sandboxed hosts such as Salesforce Lightning Web Components: the cell editor no longer closes when clicked, copy and paste work, focus is released when it leaves the grid, outside clicks clear the selection, and the grid's internal z-index values no longer paint above the host page UI.",
+  "type": "fixed",
+  "issueOrPR": 13194,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -152,6 +152,7 @@ const buildingAndToolingItems = [
   { path: 'guides/tools-and-building/typescript-types/typescript-types' },
   { path: 'guides/tools-and-building/custom-plugins/custom-plugins' },
   { path: 'guides/tools-and-building/custom-builds/custom-builds' },
+  { path: 'guides/tools-and-building/shadow-dom/shadow-dom' },
   { path: 'guides/tools-and-building/testing/testing' },
 ];
 

--- a/docs/content/guides/tools-and-building/shadow-dom/shadow-dom.md
+++ b/docs/content/guides/tools-and-building/shadow-dom/shadow-dom.md
@@ -88,11 +88,12 @@ The class also applies `isolation: isolate` to the wrapper. Without it, the grid
 
 Some platforms wrap the DOM APIs in a security sandbox. Salesforce Lightning Web Security (LWS) filters `Event#composedPath()` and limits `document.activeElement` resolution for the sandboxed code. Handsontable falls back to signals that stay reliable in such environments: per-listener event targets and focus tracking within its own DOM tree. Cell editing, selection, keyboard handling, and copy and paste work under LWS without wrapper-side workarounds.
 
+Salesforce Lightning Experience renders Lightning Web Components with its synthetic Shadow DOM polyfill by default. Handsontable works in that default mode. It also works with the native opt-in (`static shadowSupportMode = 'native'`), with one requirement: Salesforce's `loadStyle` injects CSS into the document head, which a native shadow root ignores. Inject both Handsontable stylesheets into the component's shadow tree instead - for example, append the `<link>` elements inside the `lwc:dom="manual"` container and wait for their `load` events before you create the grid.
+
 ## Known limitations
 
 - The `ht-shadow-dom` class is set only when the instance is created. If you move a live grid into or out of a shadow root, destroy the instance and create it again.
 - The cell editor doesn't leave the grid's stacking context. In a tight layout, an editor that overflows the grid's wrapper can paint under the host page content that creates its own stacking context.
-- The synthetic Shadow DOM polyfill (used by some older Salesforce Lightning experiences) is not covered by Handsontable's test suite.
 
 ## Related guides
 

--- a/docs/content/guides/tools-and-building/shadow-dom/shadow-dom.md
+++ b/docs/content/guides/tools-and-building/shadow-dom/shadow-dom.md
@@ -94,7 +94,7 @@ Salesforce Lightning Experience renders Lightning Web Components with its synthe
 
 ## Known limitations
 
-- The `ht-shadow-dom` class is set only when the instance is created. If you move a live grid into or out of a shadow root, destroy the instance and create it again.
+- Handsontable checks the container's root node only when the instance is created. The check controls the `ht-shadow-dom` class and the shadow-root clipboard listeners that copy and paste rely on in sandboxed hosts. If you move a live grid into or out of a shadow root, destroy the instance and create it again.
 - The cell editor doesn't leave the grid's stacking context. In a tight layout, an editor that overflows the grid's wrapper can paint under the host page content that creates its own stacking context.
 
 ## Related guides

--- a/docs/content/guides/tools-and-building/shadow-dom/shadow-dom.md
+++ b/docs/content/guides/tools-and-building/shadow-dom/shadow-dom.md
@@ -78,6 +78,8 @@ customElements.define('data-grid-element', DataGridElement);
 
 If you skip the base stylesheet, the grid renders but interactive elements such as the cell editor appear in wrong positions. If you create the grid before the stylesheets finish loading, Handsontable warns that the theme stylesheets are missing and measures cell sizes against unstyled elements.
 
+Handsontable also injects its core styles into the document head (the [`injectCoreCss`](@/api/options.md#injectcorecss) option). Keep that default when the grid renders in a shadow root: the stylesheets inside the shadow root style the grid, and the document-head copy styles the elements that Handsontable renders outside the shadow root - the context menu and other dropdowns. Setting `injectCoreCss: false` removes the head copy only until the first menu opens, because the menus restore it for their own rendering.
+
 ## The `ht-shadow-dom` class
 
 Handsontable checks the container's root node once, when the instance is created. If the container sits inside a shadow root, the root wrapper element receives the `ht-shadow-dom` class. You can use the class in your own stylesheets to target grids that render inside a Shadow DOM tree.

--- a/docs/content/guides/tools-and-building/shadow-dom/shadow-dom.md
+++ b/docs/content/guides/tools-and-building/shadow-dom/shadow-dom.md
@@ -1,0 +1,104 @@
+---
+type: how-to
+title: Shadow DOM
+metaTitle: Shadow DOM - JavaScript Data Grid | Handsontable
+description: Run Handsontable inside a Shadow DOM tree, in web components, and on sandboxed platforms such as Salesforce Lightning Web Components.
+permalink: /shadow-dom
+canonicalUrl: /shadow-dom
+tags:
+  - shadow dom
+  - web components
+  - custom elements
+  - salesforce
+  - lightning web components
+  - lwc
+react:
+  metaTitle: Shadow DOM - React Data Grid | Handsontable
+angular:
+  metaTitle: Shadow DOM - Angular Data Grid | Handsontable
+vue:
+  metaTitle: Shadow DOM - Vue Data Grid | Handsontable
+searchCategory: Guides
+category: Tools and building
+menuTag: new
+---
+
+Handsontable works inside a Shadow DOM tree. You can render the grid in a web component, a custom element, or a sandboxed component platform such as Salesforce Lightning Web Components.
+
+[[toc]]
+
+## Overview
+
+When you attach the grid's container to a shadow root, Handsontable detects the boundary and adjusts its behavior:
+
+- Mouse, focus, and clipboard events are resolved through the shadow boundary, so cell selection, the cell editors, and copy and paste work the same way as in the regular DOM.
+- Handsontable adds the `ht-shadow-dom` CSS class to its root wrapper element. The class creates an isolated stacking context (`isolation: isolate`), which keeps the grid's internal z-index values from competing with the host page UI.
+
+## Load the styles inside the shadow root
+
+Styles don't cross the shadow boundary. Load both the base stylesheet and a theme stylesheet inside the shadow root that hosts the grid, and create the grid after the stylesheets finish loading. The web component below shows the full setup:
+
+```js
+class DataGridElement extends HTMLElement {
+  connectedCallback() {
+    const shadowRoot = this.attachShadow({ mode: 'open' });
+
+    const loadStylesheet = (href) => new Promise((resolve) => {
+      const link = document.createElement('link');
+
+      link.rel = 'stylesheet';
+      link.href = href;
+      link.onload = resolve;
+      shadowRoot.appendChild(link);
+    });
+
+    const container = document.createElement('div');
+
+    shadowRoot.appendChild(container);
+
+    Promise.all([
+      loadStylesheet('styles/handsontable.min.css'),
+      loadStylesheet('styles/ht-theme-main.min.css'),
+    ]).then(() => {
+      this.hot = new Handsontable(container, {
+        themeName: 'ht-theme-main',
+        licenseKey: 'non-commercial-and-evaluation',
+        // your configuration
+      });
+    });
+  }
+
+  disconnectedCallback() {
+    this.hot?.destroy();
+  }
+}
+
+customElements.define('data-grid-element', DataGridElement);
+```
+
+If you skip the base stylesheet, the grid renders but interactive elements such as the cell editor appear in wrong positions. If you create the grid before the stylesheets finish loading, Handsontable warns that the theme stylesheets are missing and measures cell sizes against unstyled elements.
+
+## The `ht-shadow-dom` class
+
+Handsontable checks the container's root node once, when the instance is created. If the container sits inside a shadow root, the root wrapper element receives the `ht-shadow-dom` class. You can use the class in your own stylesheets to target grids that render inside a Shadow DOM tree.
+
+The class also applies `isolation: isolate` to the wrapper. Without it, the grid's internal z-index values (up to 200) would compete with the host page's UI - for example, frozen headers of a scrolled grid could paint above the host application's navigation. Grids that render in the regular DOM keep their previous stacking behavior.
+
+## Sandboxed platforms
+
+Some platforms wrap the DOM APIs in a security sandbox. Salesforce Lightning Web Security (LWS) filters `Event#composedPath()` and limits `document.activeElement` resolution for the sandboxed code. Handsontable falls back to signals that stay reliable in such environments: per-listener event targets and focus tracking within its own DOM tree. Cell editing, selection, keyboard handling, and copy and paste work under LWS without wrapper-side workarounds.
+
+## Known limitations
+
+- The `ht-shadow-dom` class is set only when the instance is created. If you move a live grid into or out of a shadow root, destroy the instance and create it again.
+- The cell editor doesn't leave the grid's stacking context. In a tight layout, an editor that overflows the grid's wrapper can paint under the host page content that creates its own stacking context.
+- The synthetic Shadow DOM polyfill (used by some older Salesforce Lightning experiences) is not covered by Handsontable's test suite.
+
+## Related guides
+
+<div class="boxes-list">
+
+- [Custom builds](@/guides/tools-and-building/custom-builds/custom-builds.md)
+- [Themes](@/guides/styling/themes/themes.md)
+
+</div>

--- a/handsontable/AGENTS.md
+++ b/handsontable/AGENTS.md
@@ -7,6 +7,7 @@ This is the core data grid package. **TypeScript** - source files in `src/` are 
 - Use `throwWithCause()` from `src/helpers/errors.ts`, never `throw new Error()`
 - No barrel imports from `plugins/index`, `editors/index`, `renderers/index`, `validators/index`, `cellTypes/index`, `i18n/index` - import from specific submodule paths. Only exception: `src/registry.ts`
 - No global `window`, `document`, `console` - use `this.hot.rootWindow`, `this.hot.rootDocument`, and helpers from `src/helpers/console.ts`
+- **Shadow DOM / sandboxed hosts:** never decide "is the focus / this click inside the grid" from raw `document.activeElement` or a `parentNode` walk — both lie when the grid renders inside a shadow root, and Salesforce Lightning Web Security additionally filters `composedPath()` down to the host chain and collapses `activeElement` to the outermost shadow host. Use `getDeepActiveElement()` and `getShadowHostChain()` from `src/helpers/dom/element.ts`, `event.composedPath()` (checking for `ShadowRoot` entries to detect a filtered path), and `getFocusManager().hasBrowserFocus()` / `.isForeignFocusTarget()` — see `tableView.ts` outside-click handling and the `focusManager` for the reference patterns.
 - Private fields use `#` prefix, not `@private` JSDoc
 - **Required**: Plugin hook callbacks must be arrow function class fields — `#onAfterX = (arg1, arg2) => { ... }` — and passed directly: `this.addHook('afterX', this.#onAfterX)`. Never wrap in `(args) => this.#onX(args)` or use `.bind(this)`.
 - Cognitive complexity: keep each function at 15 or below

--- a/handsontable/src/3rdparty/walkontable/src/event.ts
+++ b/handsontable/src/3rdparty/walkontable/src/event.ts
@@ -4,6 +4,7 @@ import type { EngineContext } from './wire';
 import {
   closestDown,
   eventTargetEl,
+  getDeepActiveElement,
   hasClass,
   isChildOf,
   getParent,
@@ -289,7 +290,7 @@ class Event {
    * @param {MouseEvent} event The mouse event object.
    */
   onMouseDown(event: MouseEvent | TouchEvent) {
-    const activeElement = this.#deps.rootDocument.activeElement;
+    const activeElement = getDeepActiveElement(this.#deps.rootDocument);
     const targetEl = eventTargetEl(event)!;
     const getParentNode = (level: number) => getParent(targetEl, level);
     const realTarget = eventTargetEl(event);

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -1,4 +1,4 @@
-import { addClass, empty, observeVisibilityChangeOnce, removeClass } from './helpers/dom/element';
+import { addClass, empty, isShadowRoot, observeVisibilityChangeOnce, removeClass } from './helpers/dom/element';
 import { isFunction } from './helpers/function';
 import { isDefined, isUndefined, isRegExp, isEmpty } from './helpers/mixed';
 import { isMobileBrowser, isIpadOS } from './helpers/browser';
@@ -384,6 +384,10 @@ export default function Core(
 
     addClass(this.rootElement, ['ht-wrapper', 'handsontable']);
     addClass(this.rootWrapperElement, 'ht-root-wrapper');
+
+    if (isShadowRoot(this.rootContainer.getRootNode())) {
+      addClass(this.rootWrapperElement, 'ht-shadow-dom');
+    }
     addClass(this.rootSlotTopElement, 'ht-slot-top');
     addClass(this.rootGridElement, 'ht-grid');
     addClass(this.rootGridContentElement, 'ht-grid-content');

--- a/handsontable/src/editors/multiSelectEditor/multiSelectEditor.ts
+++ b/handsontable/src/editors/multiSelectEditor/multiSelectEditor.ts
@@ -4,7 +4,7 @@ import { BaseEditor } from '../baseEditor';
 import EventManager from '../../eventManager';
 import { DropdownController, type DropdownEntry } from './controllers/dropdownController';
 import { SelectedItemsController } from './controllers/selectedItemsController';
-import { addClass, setAttribute } from '../../helpers/dom/element';
+import { addClass, getDeepActiveElement, setAttribute } from '../../helpers/dom/element';
 import { isPrintableChar } from '../../helpers/unicode';
 import { localeLowerCase } from '../../helpers/string';
 import { A11Y_LABEL, A11Y_GROUP } from '../../helpers/a11y';
@@ -296,7 +296,7 @@ export class MultiSelectEditor extends BaseEditor {
     }, {
       keys: [['ArrowDown']],
       callback: () => {
-        if (this.hot.rootDocument.activeElement === this.getInputElement()) {
+        if (getDeepActiveElement(this.hot.rootDocument) === this.getInputElement()) {
           this.dropdownController!.focusFirstItem();
         } else {
           this.dropdownController!.focusNextItem();
@@ -310,7 +310,7 @@ export class MultiSelectEditor extends BaseEditor {
       keys: [['enter'], ['shift', 'enter'], ['control/meta', 'enter'], ['control/meta', 'shift', 'enter']],
       runOnlyIf: () => !this.#getEditorSetting('enterCommits'),
       callback: (event: Event) => {
-        const activeElement = this.hot.rootDocument.activeElement;
+        const activeElement = getDeepActiveElement(this.hot.rootDocument);
 
         if (activeElement instanceof HTMLInputElement && activeElement.type === 'checkbox') {
           activeElement.checked = !activeElement.checked;

--- a/handsontable/src/editors/textEditor/textEditor.ts
+++ b/handsontable/src/editors/textEditor/textEditor.ts
@@ -5,6 +5,7 @@ import EventManager from '../../eventManager';
 import { isEdge, isIOS } from '../../helpers/browser';
 import {
   addClass,
+  getDeepActiveElement,
   isInternalElement,
   setCaretPosition,
   hasClass,
@@ -136,7 +137,7 @@ export class TextEditor extends BaseEditor {
     this._opened = false;
     this.autoResize.unObserve();
 
-    if (isInternalElement(this.hot.rootDocument.activeElement as HTMLElement, this.hot.rootElement)) {
+    if (isInternalElement(getDeepActiveElement(this.hot.rootDocument) as HTMLElement, this.hot.rootElement)) {
       this.hot.listen(); // don't refocus the table if user focused some cell outside of HT on purpose
     }
 

--- a/handsontable/src/eventManager.ts
+++ b/handsontable/src/eventManager.ts
@@ -1,7 +1,7 @@
 import { stopImmediatePropagation as _stopImmediatePropagation } from './helpers/dom/event';
 
 interface EventListenerEntry {
-  element: Element | Document | Window;
+  element: Element | Document | Window | ShadowRoot;
   event: string;
   callback: (event: Event) => void;
   callbackProxy: (event: Event) => void;
@@ -50,7 +50,7 @@ class EventManager {
    * @returns {Function} Returns function which you can easily call to remove that event.
    */
   addEventListener<E extends Event = Event>(
-    element: Element | Document | Window, eventName: string,
+    element: Element | Document | Window | ShadowRoot, eventName: string,
     callback: (event: E) => void, options: boolean | AddEventListenerOptions = false
   ): () => void {
     if (!this.context) {
@@ -93,7 +93,8 @@ class EventManager {
    * @param {boolean} [onlyOwnEvents] Whether whould remove only events registered using this instance of EventManager.
    */
   removeEventListener(
-    element: Element | Document | Window, eventName: string, callback: (event: Event) => void, onlyOwnEvents = false
+    element: Element | Document | Window | ShadowRoot, eventName: string,
+    callback: (event: Event) => void, onlyOwnEvents = false
   ): void {
     if (!this.context) {
       return;

--- a/handsontable/src/focusManager/grid.ts
+++ b/handsontable/src/focusManager/grid.ts
@@ -1,6 +1,13 @@
 import type { HotInstance } from '../core/types';
+import EventManager from '../eventManager';
 import { warn } from '../helpers/console';
-import { isHTMLElement, isOutsideInput } from '../helpers/dom/element';
+import {
+  getDeepActiveElement,
+  getShadowHostChain,
+  isHTMLElement,
+  isInternalElement,
+  isOutsideInput,
+} from '../helpers/dom/element';
 import { debounce } from '../helpers/function';
 
 /**
@@ -38,6 +45,21 @@ export class FocusGridManager {
    * The Handsontable instance.
    */
   #hot: HotInstance;
+  /**
+   * Event manager used for the DOM listeners that track the browser focus within the grid.
+   *
+   * @type {EventManager}
+   */
+  #eventManager: EventManager | null = null;
+  /**
+   * Tracks whether the browser focus currently sits inside the grid's root wrapper or portal.
+   * Maintained by `focusin`/`focusout` listeners bound within the grid's own DOM tree, where
+   * sandboxed hosts (e.g. Salesforce Lightning Web Security) still report true event targets -
+   * unlike `document.activeElement`, which such hosts collapse to the outermost shadow host.
+   *
+   * @type {boolean}
+   */
+  #hasBrowserFocus = false;
   /**
    * The currently enabled focus mode.
    * Can be either:
@@ -106,6 +128,64 @@ export class FocusGridManager {
     this.#hot.addHook('afterSelectionFocusSet', (...args: unknown[]) => this.#onAfterSelectionChange());
     this.#hot.addHook('afterSelectionEnd', (...args: unknown[]) => this.#focusEditorElement());
     this.#hot.addHook('afterRender', (...args: unknown[]) => this.#onAfterRender());
+
+    this.#eventManager = new EventManager(this.#hot);
+
+    const focusRootElements = [this.#hot.rootWrapperElement ?? this.#hot.rootElement, this.#hot.rootPortalElement]
+      .filter(element => element instanceof HTMLElement);
+
+    focusRootElements.forEach((focusRootElement) => {
+      this.#eventManager!.addEventListener(focusRootElement, 'focusin', () => {
+        this.#hasBrowserFocus = true;
+      });
+
+      this.#eventManager!.addEventListener(focusRootElement, 'focusout', (event) => {
+        const relatedTarget = (event as FocusEvent).relatedTarget;
+
+        this.#hasBrowserFocus = relatedTarget instanceof Node &&
+          focusRootElements.some(focusRoot => focusRoot.contains(relatedTarget));
+      });
+    });
+  }
+
+  /**
+   * Checks whether the browser focus currently sits inside the grid's root wrapper or portal.
+   * The state comes from focus events observed within the grid's own DOM tree, so it stays
+   * correct in environments where `document.activeElement` cannot be resolved through foreign
+   * shadow boundaries.
+   *
+   * @returns {boolean}
+   */
+  hasBrowserFocus(): boolean {
+    return this.#hasBrowserFocus;
+  }
+
+  /**
+   * Checks whether the given focused element proves that the browser focus left the grid.
+   * Focus counts as foreign when the element is focusable, holds the browser focus, and is
+   * neither a part of the grid or its portal, nor one of the shadow hosts the grid is rendered
+   * within, nor the document body (a click on a non-focusable area keeps the focus where it
+   * was). Sandboxed hosts (e.g. Salesforce Lightning Web Security) hide the real focused
+   * element behind the host chain, so a focused ancestor host cannot prove the focus left the
+   * grid - only an unrelated element can.
+   *
+   * @param {HTMLElement | null} element The deepest reachable focused element.
+   * @returns {boolean}
+   */
+  isForeignFocusTarget(element: HTMLElement | null): boolean {
+    const { rootElement, rootPortalElement, rootDocument } = this.#hot;
+
+    if (
+      element === null ||
+      element === rootDocument.body ||
+      element === rootDocument.documentElement ||
+      isInternalElement(element, rootElement) ||
+      (rootPortalElement && rootPortalElement.contains(element))
+    ) {
+      return false;
+    }
+
+    return !getShadowHostChain(rootElement).includes(element);
   }
 
   /**
@@ -319,7 +399,8 @@ export class FocusGridManager {
     const suspended = this.#isSuspended;
 
     this.#getSelectedCell((selectedCell) => {
-      const activeElement = this.#hot.rootDocument.activeElement as HTMLElement | null;
+      const deepActiveElement = getDeepActiveElement(this.#hot.rootDocument);
+      const activeElement = isHTMLElement(deepActiveElement) ? deepActiveElement : null;
 
       // When focus management is suspended and an external focusable element (outside Handsontable)
       // currently owns the browser focus, keep it - do not blur and do not move focus to the cell.
@@ -351,7 +432,8 @@ export class FocusGridManager {
     // owns focus, fall through so the default `imeFastEdit` behavior still moves focus to the
     // editor textarea (existing per-editor IME support tests rely on this). See #10038.
     if (this.#isSuspended) {
-      const activeElement = this.#hot.rootDocument.activeElement as HTMLElement | null;
+      const deepActiveElement = getDeepActiveElement(this.#hot.rootDocument);
+      const activeElement = isHTMLElement(deepActiveElement) ? deepActiveElement : null;
 
       if (activeElement && isOutsideInput(activeElement)) {
         return;

--- a/handsontable/src/focusManager/grid.ts
+++ b/handsontable/src/focusManager/grid.ts
@@ -132,7 +132,7 @@ export class FocusGridManager {
     this.#eventManager = new EventManager(this.#hot);
 
     const focusRootElements = [this.#hot.rootWrapperElement ?? this.#hot.rootElement, this.#hot.rootPortalElement]
-      .filter(element => element instanceof HTMLElement);
+      .filter(element => isHTMLElement(element));
 
     focusRootElements.forEach((focusRootElement) => {
       this.#eventManager!.addEventListener(focusRootElement, 'focusin', () => {
@@ -142,7 +142,7 @@ export class FocusGridManager {
       this.#eventManager!.addEventListener(focusRootElement, 'focusout', (event) => {
         const relatedTarget = (event as FocusEvent).relatedTarget;
 
-        this.#hasBrowserFocus = relatedTarget instanceof Node &&
+        this.#hasBrowserFocus = isHTMLElement(relatedTarget) &&
           focusRootElements.some(focusRoot => focusRoot.contains(relatedTarget));
       });
     });

--- a/handsontable/src/focusManager/grid.ts
+++ b/handsontable/src/focusManager/grid.ts
@@ -169,6 +169,12 @@ export class FocusGridManager {
    * element behind the host chain, so a focused ancestor host cannot prove the focus left the
    * grid - only an unrelated element can.
    *
+   * The check mirrors the scope-deactivation rule in the focus scope manager (`scopeManager`
+   * unlistens when a focus event lands outside every scope). Sandboxed hosts retarget the
+   * window-level focus events that rule depends on, so the mouseup path re-applies the same
+   * rule from the deepest reachable focused element. On a regular page both mechanisms agree -
+   * this adds no behavior that the scope manager does not already provide there.
+   *
    * @param {HTMLElement | null} element The deepest reachable focused element.
    * @returns {boolean}
    */

--- a/handsontable/src/focusManager/scopeManager.ts
+++ b/handsontable/src/focusManager/scopeManager.ts
@@ -4,7 +4,7 @@ import { throwWithCause } from '../helpers/errors';
 import { createFocusScope } from './scope';
 import { useEventListener } from './eventListener';
 import { FOCUS_SOURCES } from './constants';
-import { eventTargetEl, isVisible } from '../helpers/dom/element';
+import { eventTargetEl, getDeepActiveElement, isVisible } from '../helpers/dom/element';
 
 type FocusScopeType = 'modal' | 'inline';
 type FocusScopeActivationSource = 'unknown' | 'click' | 'tab_from_above' | 'tab_from_below';
@@ -244,7 +244,7 @@ export function createFocusScopeManager(hotInstance: HotInstance): FocusScopeMan
       }
 
       if (scope === activeScope) {
-        if (scope.contains(hotInstance.rootDocument.activeElement as HTMLElement)) {
+        if (scope.contains(getDeepActiveElement(hotInstance.rootDocument) as HTMLElement)) {
           scope.deactivateFocusCatchers();
         } else {
           scope.activateFocusCatchers();

--- a/handsontable/src/helpers/dom/__tests__/element.unit.ts
+++ b/handsontable/src/helpers/dom/__tests__/element.unit.ts
@@ -19,6 +19,8 @@ import {
   isHTMLInputElement,
   isHTMLTableCellElement,
   isShadowRoot,
+  getDeepActiveElement,
+  getShadowHostChain,
   outerHeight,
   outerWidth,
   getTrimmingContainer,
@@ -1031,6 +1033,98 @@ describe('DomElement helper', () => {
       expect(isShadowRoot(shadow)).toBe(true);
 
       host.remove();
+    });
+  });
+
+  // Handsontable.helper.getShadowHostChain
+  //
+  describe('getShadowHostChain', () => {
+    it('should return an empty array for an element in the light DOM', () => {
+      const div = document.createElement('div');
+
+      document.body.appendChild(div);
+
+      expect(getShadowHostChain(div)).toEqual([]);
+
+      div.remove();
+    });
+
+    it('should return the host chain from the closest host outward', () => {
+      const outerHost = document.createElement('div');
+
+      document.body.appendChild(outerHost);
+
+      const outerShadow = outerHost.attachShadow({ mode: 'open' });
+      const innerHost = document.createElement('div');
+
+      outerShadow.appendChild(innerHost);
+
+      const innerShadow = innerHost.attachShadow({ mode: 'open' });
+      const leaf = document.createElement('span');
+
+      innerShadow.appendChild(leaf);
+
+      expect(getShadowHostChain(leaf)).toEqual([innerHost, outerHost]);
+
+      outerHost.remove();
+    });
+  });
+
+  // Handsontable.helper.getDeepActiveElement
+  //
+  describe('getDeepActiveElement', () => {
+    it('should return the document active element when no shadow DOM is involved', () => {
+      const input = document.createElement('input');
+
+      document.body.appendChild(input);
+      input.focus();
+
+      expect(getDeepActiveElement(document)).toBe(input);
+
+      input.remove();
+    });
+
+    it('should return `document.body` when nothing is focused', () => {
+      expect(getDeepActiveElement(document)).toBe(document.body);
+    });
+
+    it('should pierce an open shadow root and return the inner focused element', () => {
+      const host = document.createElement('div');
+
+      document.body.appendChild(host);
+
+      const shadow = host.attachShadow({ mode: 'open' });
+      const input = document.createElement('input');
+
+      shadow.appendChild(input);
+      input.focus();
+
+      expect(document.activeElement).toBe(host);
+      expect(getDeepActiveElement(document)).toBe(input);
+
+      host.remove();
+    });
+
+    it('should pierce nested shadow roots', () => {
+      const outerHost = document.createElement('div');
+
+      document.body.appendChild(outerHost);
+
+      const outerShadow = outerHost.attachShadow({ mode: 'open' });
+      const innerHost = document.createElement('div');
+
+      outerShadow.appendChild(innerHost);
+
+      const innerShadow = innerHost.attachShadow({ mode: 'open' });
+      const textarea = document.createElement('textarea');
+
+      innerShadow.appendChild(textarea);
+      textarea.focus();
+
+      expect(document.activeElement).toBe(outerHost);
+      expect(getDeepActiveElement(document)).toBe(textarea);
+
+      outerHost.remove();
     });
   });
 

--- a/handsontable/src/helpers/dom/element.ts
+++ b/handsontable/src/helpers/dom/element.ts
@@ -1351,7 +1351,7 @@ export function isOutsideInput(element: HTMLElement): boolean {
  * @param {HTMLElement} element - DOM element.
  */
 export function selectElementIfAllowed(element: HTMLElement): void {
-  const activeElement = element.ownerDocument.activeElement;
+  const activeElement = getDeepActiveElement(element.ownerDocument);
 
   if (isHTMLElement(activeElement) && !isOutsideInput(activeElement) &&
       (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement)) {
@@ -1509,6 +1509,50 @@ export function isHTMLInputElement(element: HTMLElement): element is HTMLInputEl
  */
 export function isShadowRoot(node: Node): node is ShadowRoot {
   return node.nodeType === Node.DOCUMENT_FRAGMENT_NODE && 'host' in node;
+}
+
+/**
+ * Gets the chain of shadow host elements the node is rendered within, ordered from the
+ * closest host outward to the host attached to the document.
+ *
+ * @param {Node} node The node to read the host chain from.
+ * @returns {HTMLElement[]} The shadow host elements; empty when the node is not in a Shadow DOM tree.
+ */
+export function getShadowHostChain(node: Node): HTMLElement[] {
+  const hosts: HTMLElement[] = [];
+  let rootNode = node.getRootNode();
+
+  while (isShadowRoot(rootNode)) {
+    const { host } = rootNode;
+
+    if (!isHTMLElement(host)) {
+      break;
+    }
+
+    hosts.push(host);
+    rootNode = host.getRootNode();
+  }
+
+  return hosts;
+}
+
+/**
+ * Gets the deepest active (focused) element in the document. When the focus is inside
+ * a Shadow DOM tree, `document.activeElement` points at the shadow host instead of the
+ * focused element. This helper descends through the open shadow roots and returns
+ * the element that actually holds the focus.
+ *
+ * @param {Document} rootDocument The document to read the active element from.
+ * @returns {Element|null} The deepest focused element, or `null` when nothing is focused.
+ */
+export function getDeepActiveElement(rootDocument: Document): Element | null {
+  let element = rootDocument.activeElement;
+
+  while (element?.shadowRoot?.activeElement) {
+    element = element.shadowRoot.activeElement;
+  }
+
+  return element;
 }
 
 /**

--- a/handsontable/src/helpers/dom/element.ts
+++ b/handsontable/src/helpers/dom/element.ts
@@ -1504,11 +1504,15 @@ export function isHTMLInputElement(element: HTMLElement): element is HTMLInputEl
 /**
  * Check if the node is a ShadowRoot (a document fragment attached to a host element).
  *
- * @param {Node} node Node to check.
+ * @param {Node|EventTarget} node Node to check.
  * @returns {boolean} `true` if the node is a ShadowRoot.
  */
-export function isShadowRoot(node: Node): node is ShadowRoot {
-  return node.nodeType === Node.DOCUMENT_FRAGMENT_NODE && 'host' in node;
+export function isShadowRoot(node: Node | EventTarget): node is ShadowRoot {
+  if (typeof node !== 'object' || node === null) {
+    return false;
+  }
+
+  return 'nodeType' in node && node.nodeType === Node.DOCUMENT_FRAGMENT_NODE && 'host' in node;
 }
 
 /**

--- a/handsontable/src/helpers/dom/element.ts
+++ b/handsontable/src/helpers/dom/element.ts
@@ -1547,7 +1547,9 @@ export function getShadowHostChain(node: Node): HTMLElement[] {
  * the element that actually holds the focus.
  *
  * @param {Document} rootDocument The document to read the active element from.
- * @returns {Element|null} The deepest focused element, or `null` when nothing is focused.
+ * @returns {Element|null} The deepest focused element. The browser reports `document.body`
+ * when no other element holds the focus; `null` appears only in edge cases such as
+ * a document with no body.
  */
 export function getDeepActiveElement(rootDocument: Document): Element | null {
   let element = rootDocument.activeElement;

--- a/handsontable/src/plugins/comments/commentEditor.ts
+++ b/handsontable/src/plugins/comments/commentEditor.ts
@@ -1,4 +1,4 @@
-import { addClass, outerWidth, outerHeight } from '../../helpers/dom/element';
+import { addClass, getDeepActiveElement, outerWidth, outerHeight } from '../../helpers/dom/element';
 import { mixin } from '../../helpers/object';
 import localHooks from '../../mixins/localHooks';
 import { EditorResizeObserver } from './editorResizeObserver';
@@ -224,7 +224,7 @@ class CommentEditor {
    * @returns {boolean}
    */
   isFocused() {
-    return this.#rootDocument.activeElement === this.getInputElement();
+    return getDeepActiveElement(this.#rootDocument) === this.getInputElement();
   }
 
   /**

--- a/handsontable/src/plugins/copyPaste/copyPaste.ts
+++ b/handsontable/src/plugins/copyPaste/copyPaste.ts
@@ -740,24 +740,29 @@ export class CopyPaste extends BasePlugin {
   }
 
   /**
-   * Resolves the element the clipboard event originated from. The initial element of
-   * `composedPath()` is preferred, but when the event's own `target` points inside the grid,
-   * the target wins. Sandboxed hosts (e.g. Salesforce Lightning Web Security) filter
-   * `composedPath()` down to the shadow host chain while still retargeting `event.target`
-   * correctly for listeners bound within the grid's shadow tree - the retargeted `target` is
-   * the only reference to the real source element in such environments.
+   * Resolves the element the clipboard event originated from. A complete path (one that
+   * crosses shadow boundaries and therefore contains ShadowRoot entries) is trusted as-is -
+   * its initial element is the real source, e.g. a node inside a web component that a custom
+   * renderer put in a cell. A path without ShadowRoot entries either involves no shadow tree
+   * at all (then `target` equals the path's initial element) or was filtered by a sandboxed
+   * host (e.g. Salesforce Lightning Web Security) that collapses `composedPath()` to the
+   * shadow host chain while still retargeting `event.target` correctly for listeners bound
+   * within the grid's shadow tree - in both cases the retargeted `target` is the deepest
+   * reliable reference to the source element.
    *
    * @param {ClipboardEvent | PasteEvent} event The clipboard event to resolve.
    * @returns {unknown} The deepest known event source element.
    */
   #resolveClipboardEventTarget(event: ClipboardEvent | PasteEvent): unknown {
-    const target = 'target' in event ? event.target : null;
+    const eventPath = event.composedPath();
 
-    if (isHTMLElement(target) && isInternalElement(target, this.hot.rootElement)) {
-      return target;
+    if (eventPath.some(entry => isShadowRoot(entry))) {
+      return eventPath[0];
     }
 
-    return event.composedPath()[0];
+    const target = 'target' in event ? event.target : null;
+
+    return target ?? eventPath[0];
   }
 
   /**

--- a/handsontable/src/plugins/copyPaste/copyPaste.ts
+++ b/handsontable/src/plugins/copyPaste/copyPaste.ts
@@ -11,6 +11,7 @@ import {
   makeElementContentEditableAndSelectItsContent,
   isHTMLElement,
   isInternalElement,
+  isShadowRoot,
   SANITIZER_WARN_KEY,
 } from '../../helpers/dom/element';
 import { isSafari } from '../../helpers/browser';
@@ -191,6 +192,14 @@ export class CopyPaste extends BasePlugin {
    */
   #copyMode = 'cells-only';
   /**
+   * Registry of the clipboard events that were already processed. When the grid lives inside
+   * a Shadow DOM tree, the clipboard listeners are bound both to the document and to the
+   * grid's shadow root, so the same event instance can reach the plugin twice.
+   *
+   * @type {WeakSet<object>}
+   */
+  #processedClipboardEvents: WeakSet<object> = new WeakSet();
+  /**
    * Flag that is used to prevent copying when the native shortcut was not pressed.
    *
    * @type {boolean}
@@ -265,9 +274,31 @@ export class CopyPaste extends BasePlugin {
 
     // Events are attached to the document, not the root table element - as it should,
     // for Chrome 133 and lower to copy/paste/cut work properly (#dev-2277).
-    this.eventManager.addEventListener(this.hot.rootDocument, 'copy', (e: ClipboardEvent) => this.onCopy(e));
-    this.eventManager.addEventListener(this.hot.rootDocument, 'cut', (e: ClipboardEvent) => this.onCut(e));
-    this.eventManager.addEventListener(this.hot.rootDocument, 'paste', (e: ClipboardEvent) => this.onPaste(e));
+    const dedupe = (handler: (event: ClipboardEvent) => void) => (event: ClipboardEvent) => {
+      if (this.#processedClipboardEvents.has(event)) {
+        return;
+      }
+      this.#processedClipboardEvents.add(event);
+      handler(event);
+    };
+
+    this.eventManager.addEventListener(this.hot.rootDocument, 'copy', dedupe((e: ClipboardEvent) => this.onCopy(e)));
+    this.eventManager.addEventListener(this.hot.rootDocument, 'cut', dedupe((e: ClipboardEvent) => this.onCut(e)));
+    this.eventManager.addEventListener(this.hot.rootDocument, 'paste', dedupe((e: ClipboardEvent) => this.onPaste(e)));
+
+    const rootNode = this.hot.rootElement.getRootNode();
+
+    // When the grid lives inside a Shadow DOM tree, the same listeners are attached to the
+    // grid's shadow root as well. Sandboxed hosts (e.g. Salesforce Lightning Web Security)
+    // retarget events observed at the document level, which hides the grid internals from
+    // the document listeners above. Listeners bound inside the grid's own shadow tree still
+    // receive the untouched event path. The `#processedClipboardEvents` registry prevents
+    // double handling when both listeners receive the same event.
+    if (isShadowRoot(rootNode)) {
+      this.eventManager.addEventListener(rootNode, 'copy', dedupe((e: ClipboardEvent) => this.onCopy(e)));
+      this.eventManager.addEventListener(rootNode, 'cut', dedupe((e: ClipboardEvent) => this.onCut(e)));
+      this.eventManager.addEventListener(rootNode, 'paste', dedupe((e: ClipboardEvent) => this.onPaste(e)));
+    }
 
     // Without this workaround Safari (tested on Safari@16.5.2) does allow copying/cutting from the browser menu.
     if (isSafari()) {
@@ -709,13 +740,34 @@ export class CopyPaste extends BasePlugin {
   }
 
   /**
+   * Resolves the element the clipboard event originated from. The initial element of
+   * `composedPath()` is preferred, but when the event's own `target` points inside the grid,
+   * the target wins. Sandboxed hosts (e.g. Salesforce Lightning Web Security) filter
+   * `composedPath()` down to the shadow host chain while still retargeting `event.target`
+   * correctly for listeners bound within the grid's shadow tree - the retargeted `target` is
+   * the only reference to the real source element in such environments.
+   *
+   * @param {ClipboardEvent | PasteEvent} event The clipboard event to resolve.
+   * @returns {unknown} The deepest known event source element.
+   */
+  #resolveClipboardEventTarget(event: ClipboardEvent | PasteEvent): unknown {
+    const target = 'target' in event ? event.target : null;
+
+    if (isHTMLElement(target) && isInternalElement(target, this.hot.rootElement)) {
+      return target;
+    }
+
+    return event.composedPath()[0];
+  }
+
+  /**
    * `copy` event callback on textarea element.
    *
    * @param {Event} event ClipboardEvent.
    * @private
    */
   onCopy(event: ClipboardEvent) {
-    const eventTarget = event.composedPath()[0];
+    const eventTarget = this.#resolveClipboardEventTarget(event);
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = isHTMLElement(eventTarget) && 'hotInput' in eventTarget.dataset;
 
@@ -759,7 +811,7 @@ export class CopyPaste extends BasePlugin {
    * @private
    */
   onCut(event: ClipboardEvent) {
-    const eventTarget = event.composedPath()[0];
+    const eventTarget = this.#resolveClipboardEventTarget(event);
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = isHTMLElement(eventTarget) && 'hotInput' in eventTarget.dataset;
 
@@ -800,7 +852,7 @@ export class CopyPaste extends BasePlugin {
    * @private
    */
   onPaste(event: ClipboardEvent | PasteEvent) {
-    const eventTarget = event.composedPath()[0];
+    const eventTarget = this.#resolveClipboardEventTarget(event);
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = isHTMLElement(eventTarget) && 'hotInput' in eventTarget.dataset;
 

--- a/handsontable/src/plugins/copyPaste/pasteEvent.ts
+++ b/handsontable/src/plugins/copyPaste/pasteEvent.ts
@@ -22,7 +22,7 @@ export default class PasteEvent {
   /**
    * Returns an empty array as a stub for the composed path of this synthetic event.
    */
-  composedPath(): unknown[] {
+  composedPath(): EventTarget[] {
     return [];
   }
 }

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -12,6 +12,14 @@
     flex-direction: column;
     height: 100%;
 
+    // The `ht-shadow-dom` class is stamped by the core when the grid renders inside a Shadow DOM
+    // tree. The isolated stacking context keeps the internal z-indexes (overlay clones, editors)
+    // from competing with the host page UI, which typically layers its own chrome above the
+    // embedded component (e.g. Salesforce Lightning navigation over a scrolled grid).
+    &.ht-shadow-dom {
+      isolation: isolate;
+    }
+
     // The `ht-slot-*-filled` classes are kept in sync by the `LayoutManager` (they mean "the slot
     // has at least one `.ht-slot-element` child"). Selecting on `:has()` here instead makes every
     // grid DOM mutation trigger a style invalidation scaled to the whole host page.

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -451,7 +451,8 @@ class TableView {
       }
 
       if (!wasOutsideClickHandled && activeHTMLElement !== null &&
-          isFocusLostToOutside && selection.isSelected()) {
+          isFocusLostToOutside && selection.isSelected() &&
+          !this.#isPathWithinGrid(eventPath) && !isRightClick(event)) {
         const clickTarget = eventPath.length > 0 ? eventPath[0] : event.target;
         const clickTargetElement = isHTMLElement(clickTarget) ? clickTarget : activeHTMLElement;
         const outsideClickDeselects = typeof this.settings.outsideClickDeselects === 'function' ?

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -446,7 +446,7 @@ class TableView {
 
       if (isOutsideInputElement || isFocusLostToOutside ||
           (!selection.isSelected() && !selection.isSelectedByAnyHeader() &&
-          !this.#isPathWithinGrid(event.composedPath()) && !isRightClick(event))) {
+          !this.#isPathWithinGrid(eventPath) && !isRightClick(event))) {
         this.hot.unlisten();
       }
 

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -1534,10 +1534,12 @@ class TableView {
 
   /**
    * Checks whether the event path points into the grid. The path counts as internal when it
-   * contains the grid's root element, its portal element, or any shadow host the grid is
-   * rendered within. The host chain check matters for sandboxed hosts (e.g. Salesforce
-   * Lightning Web Security) that retarget events observed at the document level to the
-   * nearest visible shadow host, hiding the grid internals from the path.
+   * contains the grid's root element or its portal element. A complete path (one that crosses
+   * shadow boundaries and therefore contains ShadowRoot entries) is trusted as-is - a miss
+   * means a genuine outside click, even when the path shares the grid's shadow hosts. Only a
+   * filtered path (no ShadowRoot entries) falls back to the shadow host chain check, which
+   * matters for sandboxed hosts (e.g. Salesforce Lightning Web Security) that collapse paths
+   * observed at the document level to the visible host chain, hiding the grid internals.
    *
    * @param {EventTarget[]} eventPath The event propagation path (`event.composedPath()`).
    * @private
@@ -1546,9 +1548,16 @@ class TableView {
   #isPathWithinGrid(eventPath: EventTarget[]): boolean {
     const { rootElement, rootPortalElement } = this.hot;
 
-    return eventPath.includes(rootElement) ||
-      (!!rootPortalElement && eventPath.includes(rootPortalElement)) ||
-      getShadowHostChain(rootElement).some(host => eventPath.includes(host));
+    if (eventPath.includes(rootElement) ||
+        (!!rootPortalElement && eventPath.includes(rootPortalElement))) {
+      return true;
+    }
+
+    if (eventPath.some(entry => isShadowRoot(entry))) {
+      return false;
+    }
+
+    return getShadowHostChain(rootElement).some(host => eventPath.includes(host));
   }
 
   /**

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -147,6 +147,14 @@ class TableView {
    */
   #mouseDown: boolean = false;
   /**
+   * Tracks whether the document-level mousedown handler already classified the current click
+   * cycle as an outside click and consulted the `outsideClickDeselects` setting. The mouseup
+   * handler skips its own deselect pass then, so the setting's callback fires once per click.
+   *
+   * @type {boolean}
+   */
+  #outsideClickHandled: boolean = false;
+  /**
    * Main <TABLE> element.
    *
    * @type {HTMLTableElement}
@@ -412,8 +420,10 @@ class TableView {
       }
 
       const wasInsideGridClick = this.#mouseDown;
+      const wasOutsideClickHandled = this.#outsideClickHandled;
 
       this.#mouseDown = false;
+      this.#outsideClickHandled = false;
 
       // Ignore synthetic mouseup events from Android touch interactions.
       if (this.#isSyntheticMouseEvent(event)) {
@@ -440,7 +450,8 @@ class TableView {
         this.hot.unlisten();
       }
 
-      if (activeHTMLElement !== null && isFocusLostToOutside && selection.isSelected()) {
+      if (!wasOutsideClickHandled && activeHTMLElement !== null &&
+          isFocusLostToOutside && selection.isSelected()) {
         const clickTarget = eventPath.length > 0 ? eventPath[0] : event.target;
         const clickTargetElement = isHTMLElement(clickTarget) ? clickTarget : activeHTMLElement;
         const outsideClickDeselects = typeof this.settings.outsideClickDeselects === 'function' ?
@@ -491,6 +502,8 @@ class TableView {
       const eventX = (event as MouseEvent).clientX;
       const eventY = (event as MouseEvent).clientY;
 
+      this.#outsideClickHandled = false;
+
       if (this.#mouseDown || !rootElement || !this.hot.view) {
         return; // it must have been started in a cell
       }
@@ -518,6 +531,8 @@ class TableView {
       }
 
       // function did not return until here, we have an outside click!
+      this.#outsideClickHandled = true;
+
       const outsideClickDeselects = typeof this.settings.outsideClickDeselects === 'function' ?
         this.settings.outsideClickDeselects(originalTarget as HTMLElement) :
         this.settings.outsideClickDeselects;

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -441,8 +441,10 @@ class TableView {
       }
 
       if (activeHTMLElement !== null && isFocusLostToOutside && selection.isSelected()) {
+        const clickTarget = eventPath.length > 0 ? eventPath[0] : event.target;
+        const clickTargetElement = isHTMLElement(clickTarget) ? clickTarget : activeHTMLElement;
         const outsideClickDeselects = typeof this.settings.outsideClickDeselects === 'function' ?
-          this.settings.outsideClickDeselects(activeHTMLElement) :
+          this.settings.outsideClickDeselects(clickTargetElement) :
           this.settings.outsideClickDeselects;
 
         if (outsideClickDeselects) {

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -15,8 +15,12 @@ import {
   getScrollbarWidth,
   hasClass,
   isChildOf,
+  getDeepActiveElement,
+  getShadowHostChain,
+  isHTMLElement,
   isInput,
   isOutsideInput,
+  isShadowRoot,
   isVisible,
   setAttribute,
   getParentWindow,
@@ -407,6 +411,8 @@ class TableView {
         selection.finish();
       }
 
+      const wasInsideGridClick = this.#mouseDown;
+
       this.#mouseDown = false;
 
       // Ignore synthetic mouseup events from Android touch interactions.
@@ -414,15 +420,34 @@ class TableView {
         return;
       }
 
-      const isOutsideInputElement = isOutsideInput(rootDocument.activeElement as HTMLElement);
+      const activeElement = getDeepActiveElement(rootDocument);
+      const activeHTMLElement = isHTMLElement(activeElement) ? activeElement : null;
+      const isOutsideInputElement = activeHTMLElement !== null && isOutsideInput(activeHTMLElement);
 
-      if (isInput(rootDocument.activeElement as HTMLElement) && !isOutsideInputElement) {
+      if (activeHTMLElement !== null && isInput(activeHTMLElement) && !isOutsideInputElement) {
         return;
       }
 
-      if (isOutsideInputElement || (!selection.isSelected() && !selection.isSelectedByAnyHeader() &&
-          !(rootWrapperElement ?? rootElement).contains(event.target as Node) && !isRightClick(event))) {
+      const eventPath = event.composedPath();
+      const isPathThroughGridUi = eventPath.includes(rootWrapperElement ?? rootElement) ||
+        (this.hot.rootPortalElement && eventPath.includes(this.hot.rootPortalElement));
+      const isFocusLostToOutside = this.hot.getFocusManager().isForeignFocusTarget(activeHTMLElement) ||
+        (!wasInsideGridClick && !this.hot.getFocusManager().hasBrowserFocus() && !isPathThroughGridUi);
+
+      if (isOutsideInputElement || isFocusLostToOutside ||
+          (!selection.isSelected() && !selection.isSelectedByAnyHeader() &&
+          !this.#isPathWithinGrid(event.composedPath()) && !isRightClick(event))) {
         this.hot.unlisten();
+      }
+
+      if (activeHTMLElement !== null && isFocusLostToOutside && selection.isSelected()) {
+        const outsideClickDeselects = typeof this.settings.outsideClickDeselects === 'function' ?
+          this.settings.outsideClickDeselects(activeHTMLElement) :
+          this.settings.outsideClickDeselects;
+
+        if (outsideClickDeselects) {
+          this.hot.deselectCell();
+        }
       }
     });
 
@@ -459,10 +484,10 @@ class TableView {
     });
 
     this.eventManager.addEventListener(documentElement, 'mousedown', (event) => {
-      const originalTarget = event.target;
+      const eventPath = event.composedPath();
+      const originalTarget = eventPath.length > 0 ? eventPath[0] : event.target;
       const eventX = (event as MouseEvent).clientX;
       const eventY = (event as MouseEvent).clientY;
-      let next = event.target;
 
       if (this.#mouseDown || !rootElement || !this.hot.view) {
         return; // it must have been started in a cell
@@ -476,31 +501,18 @@ class TableView {
       // immediate click on "holder" means click on the right side of vertical scrollbar
       const { holder } = this._wt.wtTable;
 
-      if (next === holder) {
+      if (originalTarget === holder) {
         const scrollbarWidth = getScrollbarWidth(rootDocument);
+        const rootNode = rootElement.getRootNode();
+        const pointReader = isShadowRoot(rootNode) ? rootNode : rootDocument;
 
-        if (rootDocument.elementFromPoint(eventX + scrollbarWidth, eventY) !== holder ||
-          rootDocument.elementFromPoint(eventX, eventY + scrollbarWidth) !== holder) {
+        if (pointReader.elementFromPoint(eventX + scrollbarWidth, eventY) !== holder ||
+          pointReader.elementFromPoint(eventX, eventY + scrollbarWidth) !== holder) {
           return;
         }
-      } else {
-        const { rootPortalElement } = this.hot;
-
-        while (next !== documentElement) {
-          if (next === null) {
-            if ((event as MouseEvent & { isTargetWebComponent?: boolean }).isTargetWebComponent) {
-              break;
-            }
-
-            // click on something that was a row but now is detached (possibly because your click triggered a rerender)
-            return;
-          }
-          if (next === rootElement || next === rootPortalElement) {
-            // click inside container or portal
-            return;
-          }
-          next = (next as Node).parentNode;
-        }
+      } else if (this.#isPathWithinGrid(eventPath)) {
+        // click inside container, portal, or a shadow host the grid is rendered within
+        return;
       }
 
       // function did not return until here, we have an outside click!
@@ -1518,6 +1530,25 @@ class TableView {
     }
 
     return this.#recentTouchEnd;
+  }
+
+  /**
+   * Checks whether the event path points into the grid. The path counts as internal when it
+   * contains the grid's root element, its portal element, or any shadow host the grid is
+   * rendered within. The host chain check matters for sandboxed hosts (e.g. Salesforce
+   * Lightning Web Security) that retarget events observed at the document level to the
+   * nearest visible shadow host, hiding the grid internals from the path.
+   *
+   * @param {EventTarget[]} eventPath The event propagation path (`event.composedPath()`).
+   * @private
+   * @returns {boolean}
+   */
+  #isPathWithinGrid(eventPath: EventTarget[]): boolean {
+    const { rootElement, rootPortalElement } = this.hot;
+
+    return eventPath.includes(rootElement) ||
+      (!!rootPortalElement && eventPath.includes(rootPortalElement)) ||
+      getShadowHostChain(rootElement).some(host => eventPath.includes(host));
   }
 
   /**

--- a/tests/e2e/shadow-dom.spec.ts
+++ b/tests/e2e/shadow-dom.spec.ts
@@ -90,6 +90,18 @@ test.describe('grid inside a native shadow root', () => {
     await expect.poll(() => grid.selected()).toBeNull();
   });
 
+  test('passes the clicked element to the outsideClickDeselects callback when focus moves elsewhere', async () => {
+    await grid.armOutsideClickRecorder();
+    await grid.cell(0, 0).click();
+    await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);
+
+    await grid.focusMover.click();
+
+    await expect(grid.outsideInput).toBeFocused();
+    await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);
+    expect(await grid.outsideClickTargets()).toEqual(['focus-mover', 'focus-mover']);
+  });
+
   test('deselects when a light-DOM element outside the shadow host is clicked', async () => {
     await grid.cell(0, 0).click();
     await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);

--- a/tests/e2e/shadow-dom.spec.ts
+++ b/tests/e2e/shadow-dom.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '../fixtures/test';
+import { ShadowGridPage } from '../fixtures/pages/ShadowGridPage';
+
+/**
+ * Shadow DOM embedding (DEV-1619). When the grid lives inside a native shadow
+ * root, document-level listeners see events retargeted to the shadow host and
+ * `document.activeElement` reports the host instead of the focused element.
+ * Before the fix, every in-grid click was misclassified as an outside click:
+ * the open editor closed, the selection dropped, and the grid stopped
+ * listening. These tests drive the real interactions across the boundary.
+ */
+test.describe('grid inside a native shadow root', () => {
+  let grid: ShadowGridPage;
+
+  test.beforeEach(async ({ page, theme, bundle }) => {
+    grid = new ShadowGridPage(page, theme, bundle);
+    await grid.goto();
+  });
+
+  test('keeps the editor open when its textarea is clicked', async () => {
+    await grid.openEditor(1, 0);
+
+    await grid.editor().click();
+
+    await expect(grid.editor()).toBeVisible();
+    expect(await grid.isListening()).toBe(true);
+
+    await grid.editor().fill('edited in shadow');
+    await grid.editor().press('Enter');
+    await grid.expectCell(1, 0, 'edited in shadow');
+  });
+
+  test('moves the selection between cells without dropping the keyboard listener', async () => {
+    await grid.cell(0, 0).click();
+    await grid.cell(2, 1).click();
+
+    await expect.poll(() => grid.selected()).toEqual([[2, 1, 2, 1]]);
+    expect(await grid.isListening()).toBe(true);
+
+    await grid.page.keyboard.type('typed');
+    await grid.page.keyboard.press('Enter');
+    await grid.expectCell(2, 1, 'typed');
+  });
+
+  test('copies and pastes between cells with keyboard shortcuts', async () => {
+    await grid.cell(0, 0).click();
+    await grid.page.keyboard.press('ControlOrMeta+c');
+
+    await grid.cell(4, 2).click();
+    await grid.page.keyboard.press('ControlOrMeta+v');
+
+    await grid.expectCell(4, 2, 'A1');
+  });
+
+  test('does not steal focus back when typing into an input outside the shadow host', async () => {
+    await grid.cell(0, 0).click();
+    await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);
+
+    await grid.outsideInput.click();
+    await grid.page.keyboard.type('typed outside');
+
+    await expect(grid.outsideInput).toHaveValue('typed outside');
+    await expect(grid.outsideInput).toBeFocused();
+    await grid.expectCell(0, 0, 'A1');
+  });
+
+  test('executes a context menu action on the selection that opened it', async () => {
+    await grid.cell(1, 0).click({ button: 'right' });
+
+    const menuItem = grid.page.locator('.htContextMenu').getByText('Insert row below', { exact: true });
+
+    await menuItem.click();
+
+    await expect(grid.page.locator('.ht_master .htCore tbody tr')).toHaveCount(6);
+  });
+
+  test('deselects when a light-DOM element outside the shadow host is clicked', async () => {
+    await grid.cell(0, 0).click();
+    await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);
+
+    await grid.outsideTextarea.click();
+
+    await expect.poll(() => grid.selected()).toBeNull();
+  });
+});

--- a/tests/e2e/shadow-dom.spec.ts
+++ b/tests/e2e/shadow-dom.spec.ts
@@ -17,6 +17,13 @@ test.describe('grid inside a native shadow root', () => {
     await grid.goto();
   });
 
+  test('isolates the internal z-index stack from the host page', async () => {
+    const wrapper = grid.page.locator('.ht-root-wrapper');
+
+    await expect(wrapper).toHaveClass(/ht-shadow-dom/);
+    await expect(wrapper).toHaveCSS('isolation', 'isolate');
+  });
+
   test('keeps the editor open when its textarea is clicked', async () => {
     await grid.openEditor(1, 0);
 

--- a/tests/e2e/shadow-dom.spec.ts
+++ b/tests/e2e/shadow-dom.spec.ts
@@ -81,6 +81,15 @@ test.describe('grid inside a native shadow root', () => {
     await expect(grid.page.locator('.ht_master .htCore tbody tr')).toHaveCount(6);
   });
 
+  test('deselects when a non-focusable sibling in the same shadow root is clicked', async () => {
+    await grid.cell(0, 0).click();
+    await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);
+
+    await grid.shadowSibling.click();
+
+    await expect.poll(() => grid.selected()).toBeNull();
+  });
+
   test('deselects when a light-DOM element outside the shadow host is clicked', async () => {
     await grid.cell(0, 0).click();
     await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);

--- a/tests/e2e/shadow-dom.spec.ts
+++ b/tests/e2e/shadow-dom.spec.ts
@@ -99,7 +99,7 @@ test.describe('grid inside a native shadow root', () => {
 
     await expect(grid.outsideInput).toBeFocused();
     await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);
-    expect(await grid.outsideClickTargets()).toEqual(['focus-mover', 'focus-mover']);
+    expect(await grid.outsideClickTargets()).toEqual(['focus-mover']);
   });
 
   test('deselects when a light-DOM element outside the shadow host is clicked', async () => {

--- a/tests/e2e/widget-cell.spec.ts
+++ b/tests/e2e/widget-cell.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '../fixtures/test';
+import { WidgetCellGridPage } from '../fixtures/pages/WidgetCellGridPage';
+
+/**
+ * In-cell widgets (DEV-1619 follow-up). Custom renderers embed self-managed
+ * widgets — buttons that keep the browser focus where it is, web components
+ * that render selectable text behind their own shadow boundary. Interacting
+ * with such a widget is an in-grid interaction: it must not be misread as an
+ * outside click that drops the selection, and copying text selected inside
+ * the widget's shadow root must reach the browser instead of being replaced
+ * by the grid's cell-range copy.
+ */
+test.describe('grid with self-managed widgets inside cells', () => {
+  let grid: WidgetCellGridPage;
+
+  test.beforeEach(async ({ page, theme, bundle }) => {
+    grid = new WidgetCellGridPage(page, theme, bundle);
+    await grid.goto();
+  });
+
+  test('keeps the selection when a focus-preserving widget inside a cell is clicked', async () => {
+    await grid.selectAndParkFocusOutside();
+    await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);
+    await expect(grid.outsideInput).toBeFocused();
+
+    await grid.keepFocusWidget.click();
+
+    await expect(grid.outsideInput).toBeFocused();
+    await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);
+  });
+
+  test('lets the browser copy text selected inside a widget shadow root', async () => {
+    await grid.cell(0, 0).click();
+    await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);
+
+    await grid.armCopyProbe();
+    await grid.textWidget.dblclick();
+    await grid.page.keyboard.press('ControlOrMeta+c');
+
+    await expect.poll(() => grid.lastCopyDefaultPrevented()).toBe(false);
+  });
+});

--- a/tests/fixtures/demo/shadow-dom.html
+++ b/tests/fixtures/demo/shadow-dom.html
@@ -63,6 +63,13 @@
     container.setAttribute('data-testid', 'grid');
     shadowRoot.appendChild(container);
 
+    const shadowSibling = document.createElement('div');
+    shadowSibling.setAttribute('data-testid', 'shadow-sibling');
+    shadowSibling.style.cssText = 'padding: 16px; margin-top: 8px; background: #eee;';
+    shadowSibling.textContent = 'Non-focusable sibling inside the same shadow root';
+    shadowSibling.addEventListener('mousedown', (event) => event.preventDefault());
+    shadowRoot.appendChild(shadowSibling);
+
     const testIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
       Handsontable.renderers.TextRenderer.apply(this, arguments);
       td.setAttribute('data-testid', `cell-${row}-${col}`);

--- a/tests/fixtures/demo/shadow-dom.html
+++ b/tests/fixtures/demo/shadow-dom.html
@@ -38,6 +38,7 @@
   <div id="outside-area">
     <textarea data-testid="outside-textarea" rows="3" cols="40"></textarea>
     <input data-testid="outside-input" type="text">
+    <button data-testid="focus-mover" type="button">Move focus to the input</button>
   </div>
 
   <script>
@@ -90,10 +91,29 @@
       licenseKey: 'non-commercial-and-evaluation',
     });
 
+    document.querySelector('[data-testid="focus-mover"]').addEventListener('mousedown', (event) => {
+      event.preventDefault();
+      document.querySelector('[data-testid="outside-input"]').focus();
+    });
+
     window.__hotProbe = {
       isListening: () => hot.isListening(),
       selected: () => hot.getSelected() ?? null,
       valueAt: (row, col) => hot.getDataAtCell(row, col),
+      armOutsideClickRecorder: () => {
+        const targets = [];
+
+        hot.updateSettings({
+          outsideClickDeselects: (target) => {
+            targets.push(target.getAttribute('data-testid') || target.tagName.toLowerCase());
+
+            return target.getAttribute('data-testid') !== 'focus-mover';
+          },
+        });
+
+        window.__outsideClickTargets = targets;
+      },
+      outsideClickTargets: () => window.__outsideClickTargets,
     };
   </script>
 </body>

--- a/tests/fixtures/demo/shadow-dom.html
+++ b/tests/fixtures/demo/shadow-dom.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable shadow DOM e2e fixture</title>
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back — a
+    // typo in the project config must be one red leg, never a silently
+    // mislabeled green one (nothing else asserts which file actually loaded).
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } #outside-area { margin-top: .8rem; } </style>
+</head>
+<body>
+  <!--
+    Shadow DOM fixture (DEV-1619). The grid is mounted inside a native open
+    shadow root, the way web-component hosts (Salesforce LWC, Lit, Stencil)
+    embed Handsontable. The stylesheets are linked INSIDE the shadow root —
+    document-level styles do not cross the boundary. The textarea below stays
+    in the light DOM so outside-click behavior can be asserted across the
+    shadow boundary. Cells are stamped with data-testid via a renderer;
+    Playwright locators pierce open shadow roots transparently.
+  -->
+  <div id="shadow-host" data-testid="shadow-host"></div>
+  <div id="outside-area">
+    <textarea data-testid="outside-textarea" rows="3" cols="40"></textarea>
+    <input data-testid="outside-input" type="text">
+  </div>
+
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The
+    // closing tag is split so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const shadowRoot = document.querySelector('[data-testid="shadow-host"]').attachShadow({ mode: 'open' });
+
+    const baseCss = document.createElement('link');
+    baseCss.rel = 'stylesheet';
+    baseCss.href = '/handsontable/styles/handsontable.min.css';
+    shadowRoot.appendChild(baseCss);
+
+    const themeCss = document.createElement('link');
+    themeCss.rel = 'stylesheet';
+    themeCss.href = `/handsontable/styles/ht-theme-${window.htTheme}.min.css`;
+    shadowRoot.appendChild(themeCss);
+
+    const container = document.createElement('div');
+    container.className = `ht-theme-${window.htTheme}`;
+    container.setAttribute('data-testid', 'grid');
+    shadowRoot.appendChild(container);
+
+    const testIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    };
+
+    const hot = new Handsontable(container, {
+      data: [
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+        ['A4', 'B4', 'C4'],
+        ['A5', 'B5', 'C5'],
+      ],
+      colHeaders: true,
+      rowHeaders: true,
+      contextMenu: true,
+      renderer: testIdRenderer,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    window.__hotProbe = {
+      isListening: () => hot.isListening(),
+      selected: () => hot.getSelected() ?? null,
+      valueAt: (row, col) => hot.getDataAtCell(row, col),
+    };
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/widget-cell.html
+++ b/tests/fixtures/demo/widget-cell.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable in-cell widget e2e fixture</title>
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back — a
+    // typo in the project config must be one red leg, never a silently
+    // mislabeled green one (nothing else asserts which file actually loaded).
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+
+    document.write('<link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">');
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } #outside-area { margin-top: .8rem; } </style>
+</head>
+<body>
+  <!--
+    In-cell widget fixture (DEV-1619 follow-up). The grid lives in the light
+    DOM the classic way, but two cells host self-managed widgets, the way
+    custom renderers embed web components:
+
+    - widget-keep-focus stops mousedown propagation AND prevents its default,
+      so a click on it never moves the browser focus — an app can keep the
+      focus parked in the outside input while interacting with the widget.
+    - widget-text stops mousedown propagation only and renders its content
+      inside an open shadow root, so the user can select and copy text that
+      lives behind a shadow boundary inside the grid.
+  -->
+  <div id="grid-container" data-testid="grid"></div>
+  <div id="outside-area">
+    <input data-testid="outside-input" type="text">
+  </div>
+
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The
+    // closing tag is split so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const widgetRenderer = function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.BaseRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+      Handsontable.dom.empty(td);
+
+      if (row === 1 && col === 1) {
+        const widget = document.createElement('button');
+
+        widget.type = 'button';
+        widget.setAttribute('data-testid', 'widget-keep-focus');
+        widget.textContent = 'widget button';
+        widget.addEventListener('mousedown', (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        });
+        td.appendChild(widget);
+
+        return;
+      }
+
+      if (row === 2 && col === 1) {
+        const widget = document.createElement('span');
+        const shadow = widget.attachShadow({ mode: 'open' });
+        const inner = document.createElement('span');
+
+        widget.setAttribute('data-testid', 'widget-text');
+        inner.textContent = 'shadowtext';
+        shadow.appendChild(inner);
+        widget.addEventListener('mousedown', (event) => {
+          event.stopPropagation();
+        });
+        td.appendChild(widget);
+
+        return;
+      }
+
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    };
+
+    const hot = new Handsontable(container, {
+      data: [
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+        ['A4', 'B4', 'C4'],
+        ['A5', 'B5', 'C5'],
+      ],
+      colHeaders: true,
+      rowHeaders: true,
+      renderer: widgetRenderer,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    window.__hotProbe = {
+      isListening: () => hot.isListening(),
+      selected: () => hot.getSelected() ?? null,
+      selectAndParkFocusOutside: () => {
+        hot.selectCells([[0, 0, 0, 0]], true, false);
+        document.querySelector('[data-testid="outside-input"]').focus();
+      },
+      armCopyProbe: () => {
+        window.__lastCopyDefaultPrevented = null;
+        window.addEventListener('copy', (event) => {
+          window.__lastCopyDefaultPrevented = event.defaultPrevented;
+        });
+      },
+      lastCopyDefaultPrevented: () => window.__lastCopyDefaultPrevented,
+    };
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/ShadowGridPage.ts
+++ b/tests/fixtures/pages/ShadowGridPage.ts
@@ -1,0 +1,68 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the shadow DOM fixture (DEV-1619).
+ *
+ * The grid is mounted inside a native open shadow root; Playwright locators
+ * pierce open shadow roots, so the same `data-testid` hooks work unchanged.
+ * The fixture also exposes a light-DOM textarea used to assert focus and
+ * deselection behavior across the shadow boundary.
+ */
+export class ShadowGridPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly grid: Locator;
+  readonly outsideTextarea: Locator;
+  readonly outsideInput: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.grid = page.getByTestId('grid');
+    this.outsideTextarea = page.getByTestId('outside-textarea');
+    this.outsideInput = page.getByTestId('outside-input');
+  }
+
+  /**
+   * Navigate to the fixture and wait for the grid to render inside the shadow
+   * root. Waits on a real DOM condition (first cell visible) — web-first, no
+   * readiness flags.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(`/tests/fixtures/demo/shadow-dom.html?theme=${this.theme}&bundle=${this.bundle}`);
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /** A single data cell, by visual row/column, via its stable test id. */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /** The cell editor textarea rendered inside the shadow root. */
+  editor(): Locator {
+    return this.page.locator('textarea.handsontableInput');
+  }
+
+  /** Assert a cell shows the expected text (web-first, auto-retrying). */
+  async expectCell(row: number, col: number, text: string): Promise<void> {
+    await expect(this.cell(row, col)).toHaveText(text);
+  }
+
+  /** Open the editor on a cell with a double click. */
+  async openEditor(row: number, col: number): Promise<void> {
+    await this.cell(row, col).dblclick();
+    await expect(this.editor()).toBeVisible();
+  }
+
+  /** Whether the grid currently listens for keyboard input (fixture probe). */
+  async isListening(): Promise<boolean> {
+    return this.page.evaluate(() => (window as any).__hotProbe.isListening());
+  }
+
+  /** The grid's current selection as `[startRow, startCol, endRow, endCol]` (fixture probe). */
+  async selected(): Promise<number[][] | null> {
+    return this.page.evaluate(() => (window as any).__hotProbe.selected());
+  }
+}

--- a/tests/fixtures/pages/ShadowGridPage.ts
+++ b/tests/fixtures/pages/ShadowGridPage.ts
@@ -15,6 +15,7 @@ export class ShadowGridPage {
   readonly grid: Locator;
   readonly outsideTextarea: Locator;
   readonly outsideInput: Locator;
+  readonly shadowSibling: Locator;
 
   constructor(page: Page, theme = 'main', bundle = 'umd') {
     this.page = page;
@@ -23,6 +24,7 @@ export class ShadowGridPage {
     this.grid = page.getByTestId('grid');
     this.outsideTextarea = page.getByTestId('outside-textarea');
     this.outsideInput = page.getByTestId('outside-input');
+    this.shadowSibling = page.getByTestId('shadow-sibling');
   }
 
   /**

--- a/tests/fixtures/pages/ShadowGridPage.ts
+++ b/tests/fixtures/pages/ShadowGridPage.ts
@@ -16,6 +16,7 @@ export class ShadowGridPage {
   readonly outsideTextarea: Locator;
   readonly outsideInput: Locator;
   readonly shadowSibling: Locator;
+  readonly focusMover: Locator;
 
   constructor(page: Page, theme = 'main', bundle = 'umd') {
     this.page = page;
@@ -25,6 +26,7 @@ export class ShadowGridPage {
     this.outsideTextarea = page.getByTestId('outside-textarea');
     this.outsideInput = page.getByTestId('outside-input');
     this.shadowSibling = page.getByTestId('shadow-sibling');
+    this.focusMover = page.getByTestId('focus-mover');
   }
 
   /**
@@ -66,5 +68,19 @@ export class ShadowGridPage {
   /** The grid's current selection as `[startRow, startCol, endRow, endCol]` (fixture probe). */
   async selected(): Promise<number[][] | null> {
     return this.page.evaluate(() => (window as any).__hotProbe.selected());
+  }
+
+  /**
+   * Swap `outsideClickDeselects` for a recording callback (fixture probe). The callback keeps
+   * the selection when the clicked element is the focus-mover button and records the test id
+   * of every element it receives.
+   */
+  async armOutsideClickRecorder(): Promise<void> {
+    await this.page.evaluate(() => (window as any).__hotProbe.armOutsideClickRecorder());
+  }
+
+  /** Test ids of the elements passed to the recording `outsideClickDeselects` callback. */
+  async outsideClickTargets(): Promise<string[]> {
+    return this.page.evaluate(() => (window as any).__hotProbe.outsideClickTargets());
   }
 }

--- a/tests/fixtures/pages/WidgetCellGridPage.ts
+++ b/tests/fixtures/pages/WidgetCellGridPage.ts
@@ -1,0 +1,70 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the in-cell widget fixture (DEV-1619 follow-up).
+ *
+ * The grid lives in the light DOM; two cells host self-managed widgets the way
+ * custom renderers embed web components. The `widget-keep-focus` button keeps
+ * the browser focus where it is (mousedown default prevented), the
+ * `widget-text` element renders selectable text inside its own open shadow
+ * root. The fixture also exposes a light-DOM input used to park the focus
+ * outside the grid.
+ */
+export class WidgetCellGridPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly grid: Locator;
+  readonly outsideInput: Locator;
+  readonly keepFocusWidget: Locator;
+  readonly textWidget: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.grid = page.getByTestId('grid');
+    this.outsideInput = page.getByTestId('outside-input');
+    this.keepFocusWidget = page.getByTestId('widget-keep-focus');
+    this.textWidget = page.getByTestId('widget-text');
+  }
+
+  /**
+   * Navigate to the fixture and wait for the grid to render. Waits on a real
+   * DOM condition (first cell visible) — web-first, no readiness flags.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(`/tests/fixtures/demo/widget-cell.html?theme=${this.theme}&bundle=${this.bundle}`);
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /** A single data cell, by visual row/column, via its stable test id. */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /** The grid's current selection as `[startRow, startCol, endRow, endCol]` (fixture probe). */
+  async selected(): Promise<number[][] | null> {
+    return this.page.evaluate(() => (window as any).__hotProbe.selected());
+  }
+
+  /**
+   * Select cell A1 programmatically without switching the keyboard listener,
+   * then park the browser focus in the outside input (fixture probe) — the
+   * pattern of an app that drives the selection while an external form field
+   * keeps the focus.
+   */
+  async selectAndParkFocusOutside(): Promise<void> {
+    await this.page.evaluate(() => (window as any).__hotProbe.selectAndParkFocusOutside());
+  }
+
+  /** Start recording whether the next `copy` event reaches the window with its default prevented (fixture probe). */
+  async armCopyProbe(): Promise<void> {
+    await this.page.evaluate(() => (window as any).__hotProbe.armCopyProbe());
+  }
+
+  /** Whether the recorded `copy` event had its default prevented; `null` until one fires (fixture probe). */
+  async lastCopyDefaultPrevented(): Promise<boolean | null> {
+    return this.page.evaluate(() => (window as any).__hotProbe.lastCopyDefaultPrevented());
+  }
+}


### PR DESCRIPTION
### Context

The PR makes Handsontable work inside Shadow DOM trees and sandboxed web-component platforms — most importantly Salesforce Lightning Web Components — without wrapper-side glue code.

When the grid renders inside a shadow root, document-level listeners see events retargeted to the shadow host and `document.activeElement` reports the host instead of the focused element. Every in-grid click classified as an outside click: the open editor closed on the first click into it, the selection dropped, and the grid stopped listening. Salesforce Lightning Web Security (LWS) additionally filters `composedPath()` down to the shadow host chain for sandboxed code and hides foreign shadow internals from `activeElement` resolution, which also broke copy/paste, let the grid steal focus back from external inputs, and made genuine outside clicks undetectable.

The changes:

- New DOM helpers: `getDeepActiveElement()` descends `shadowRoot.activeElement` chains; `getShadowHostChain()` returns the shadow hosts an element is rendered within. Used in `tableView`, the focus manager, editors, comments, `selectElementIfAllowed()`, and Walkontable's mousedown guard.
- Outside-click classification uses `composedPath()` plus the grid's shadow host chain instead of a `parentNode` walk (removes the dead `isTargetWebComponent` branch).
- `CopyPaste` binds its clipboard listeners to the grid's shadow root next to the document ones (with per-event dedupe) and resolves the event source from `event.target` when it points inside the grid — the only reliable reference under LWS.
- `FocusGridManager` owns the focus semantics: it tracks browser focus with `focusin`/`focusout` listeners bound inside the grid's root wrapper and portal (where sandboxed hosts still report true event targets) and classifies foreign focus targets. Both are public API: `getFocusManager().hasBrowserFocus()` and `.isForeignFocusTarget(element)`. `TableView` only orchestrates: a mouseup that neither started in the grid nor left the focus inside it releases the keyboard listener and applies `outsideClickDeselects`.
- The core stamps the `ht-shadow-dom` class on the root wrapper when the grid renders inside a shadow root; the base stylesheet turns it into an isolated stacking context (`isolation: isolate`), so internal z-index values stop competing with the host page UI (e.g. frozen headers painting above Salesforce navigation). Light DOM embeddings keep the current stacking behavior untouched.
- `EventManager`'s element type accepts `ShadowRoot`.
- New guide: *Shadow DOM* (`docs/content/guides/tools-and-building/shadow-dom/`).

**Upgrade-visible behavior change (Shadow DOM embeddings only):** grids inside a shadow root now render in an isolated stacking context. A host page that relied on grid internals painting above its own UI will see the new, contained stacking.

Known limitations (documented in the guide): the `ht-shadow-dom` class is stamped at init only; an editor overflowing the wrapper can paint under host content that creates its own stacking context; the synthetic Shadow DOM polyfill (older Salesforce experiences) is untested.

### How has this been tested?

- New Playwright E2E suite `tests/e2e/shadow-dom.spec.ts` (7 tests) with a native-shadow-root fixture: editor survives a click into its textarea, selection moves without dropping the keyboard listener, copy/paste via keyboard shortcuts, context menu action on the selection that opened it, no focus stealing from an outside input, outside-click deselect, z-index isolation. The editor-survival test was verified red against the pre-fix build. Green on the full theme × bundle matrix (42/42 across all six legs).
  - `cd tests && npx playwright test e2e/shadow-dom.spec.ts`
- Unit tests for `getDeepActiveElement()` (incl. nested shadow roots) and `getShadowHostChain()` (`npm run test:unit --prefix handsontable -- --testPathPattern=helpers/dom`).
- Full regression: legacy E2E 9606/9606, unit 3271/3271, Walkontable suite, React and Vue wrapper suites, eslint/stylelint/tsc. The mouseup logic was regression-tested against the context menu, dropdown menu, and MultiSelect editor suites specifically — early iterations broke all three, and the final shape is pinned by them.
- Verified live in a Salesforce Developer Edition org (Lightning's default synthetic shadow DOM + LWS, live Account data via Lightning Data Service; the native opt-in `shadowSupportMode = 'native'` is verified on a dedicated page and requires the stylesheets injected into the component's shadow tree, since Salesforce's `loadStyle` targets the document head, which a native shadow root ignores): all five reported symptoms fixed — editor close on click-in, broken copy/paste, focus stolen from the Lightning global search while typing, missing outside-click deselect (including targets whose focus LWS hides behind the host chain), and grid headers painting above the Salesforce navigation. Also verified: two grid instances on one Lightning page with cross-grid focus handoff, and listener cleanup on `destroy()` (add/remove balanced).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1619

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1619

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global mouseup/mousedown, focus, and clipboard paths used on every interaction; behavior is intentionally different only in shadow/sandbox cases but regression risk is moderate given scope (context menus, dropdowns, MultiSelect were previously fragile).
> 
> **Overview**
> Fixes **Handsontable inside Shadow DOM** (web components, Salesforce LWC/LWS) where document-level APIs retarget events and collapse focus, so in-grid clicks were treated as outside clicks and editors, selection, copy/paste, and focus handoff broke.
> 
> **DOM helpers** `getDeepActiveElement()` and `getShadowHostChain()` replace raw `document.activeElement` and parent walks across editors, Walkontable, focus scope, copy/paste, and `tableView`.
> 
> **Outside-click and listen state** in `tableView` use `composedPath()`, shadow host chains, and `FocusGridManager.hasBrowserFocus()` / `isForeignFocusTarget()` (new `focusin`/`focusout` tracking inside the grid tree) so deselect and `unlisten` behave under filtered `composedPath()` and sandboxed `activeElement`.
> 
> **Copy/paste** adds shadow-root clipboard listeners with deduplication and smarter event-target resolution for LWS-filtered paths.
> 
> **Presentation:** shadow-hosted grids get `ht-shadow-dom` on the root wrapper with `isolation: isolate` so internal z-indexes do not paint over host UI.
> 
> Adds a **Shadow DOM** guide, **AGENTS.md** rules, changelog **#13194**, and Playwright E2E for shadow-embedded and in-cell widget scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cebb7d6e94f44238a486979109230b4ceb9798d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


