### PR TITLE
Fix the dropdown editor list rendering narrower than the column when trimDropdown is false (#13180)

### DIFF
--- a/.changelogs/13180.json
+++ b/.changelogs/13180.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the dropdown and autocomplete editor list rendering narrower than the edited column when `trimDropdown` is set to `false`.",
+  "type": "fixed",
+  "issueOrPR": 13180,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13197.json
+++ b/.changelogs/13197.json
@@ -1,8 +1,8 @@
 {
-  "issuesOrigin": "public",
+  "issuesOrigin": "private",
   "title": "Fixed the dropdown and autocomplete editor list rendering narrower than the edited column when `trimDropdown` is set to `false`.",
   "type": "fixed",
-  "issueOrPR": 13180,
+  "issueOrPR": 13197,
   "breaking": false,
   "framework": "none"
 }

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -44,7 +44,7 @@ This example uses the `autocomplete` feature in the default flexible mode. In th
 
 The [`visibleRows`](@/api/options.md#visiblerows) option sets how many suggestions the dropdown shows without scrolling. The default is 10 rows. The **Chassis color** column sets `visibleRows: 4`, so the dropdown shows only four suggestions at a time and scrolls to reveal the rest.
 
-The [`trimDropdown`](@/api/options.md#trimdropdown) option controls the dropdown's width. By default (`trimDropdown: true`), the dropdown matches the width of the edited cell, which can truncate long suggestions. The **Bumper color** column sets `trimDropdown: false`, so the dropdown expands to fit its widest suggestion, even if that makes it wider than the cell.
+The [`trimDropdown`](@/api/options.md#trimdropdown) option controls the dropdown's width. By default (`trimDropdown: true`), the dropdown matches the width of the edited cell, which can truncate long suggestions. The **Bumper color** column sets `trimDropdown: false`, so the dropdown expands to fit its widest suggestion. It can grow wider than the cell, but never narrower.
 
 ::: only-for javascript
 

--- a/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
+++ b/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
@@ -237,10 +237,10 @@ When working with object-based dropdown data, you can use methods like [`getSour
 
 By default, the dropdown list matches the width of the edited cell, so long options can be truncated. To let the list expand to fit its longest option, set [`trimDropdown`](@/api/options.md#trimdropdown) to `false`.
 
-| Setting          | Description                                               |
-| ---------------- | --------------------------------------------------------- |
-| `true` (default) | Match the dropdown list's width to the edited cell.       |
-| `false`          | Scale the dropdown list's width to its longest option.    |
+| Setting          | Description                                                                      |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `true` (default) | Match the dropdown list's width to the edited cell.                              |
+| `false`          | Expand the list to its content, but keep it at least as wide as the edited cell. |
 
 In the example below, the **Department (default)** column trims the list to the cell, while the **Department (full width)** column expands it. Open a cell in each column to compare.
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -6222,14 +6222,14 @@ export default (): Record<string, unknown> => {
      *
      * When set to `true` (default), the list is trimmed to match the width of the edited cell,
      * which can truncate long option labels. When set to `false`, the list expands to fit its
-     * longest option, which may make the list wider than the cell.
+     * longest option – it can grow wider than the cell, but never narrower.
      *
      * You can set the `trimDropdown` option to one of the following:
      *
      * | Setting          | Description                                                                     |
      * | ---------------- | ------------------------------------------------------------------------------- |
      * | `true` (default) | Make the dropdown/autocomplete list's width the same as the edited cell's width |
-     * | `false`          | Scale the dropdown/autocomplete list's width to the list's content              |
+     * | `false`          | Expand the list to its content, but keep it at least as wide as the edited cell |
      *
      * This option can be set at any level of the [cascading configuration](@/guides/getting-started/configuration-options/configuration-options.md#cascading-configuration):
      * the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options), the [`columns`](#columns) level, the [`cells`](#cells) level, and the [`cell`](#cell) level.

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -168,6 +168,14 @@ export class AutocompleteEditor extends HandsontableEditor {
     this.htEditor.updateSettings({
       colWidths: trimDropdown ? [outerWidth(this.TEXTAREA) - 2] : undefined,
       autoColumnSize: true,
+      // With `trimDropdown: false` the list column is sized from its content by
+      // AutoColumnSize, so short options produced a list narrower than the edited
+      // cell (#13180). Floor the column at the cell width: the option rows stay
+      // full-width click targets, and `getTargetEditorWidth()` (which reads
+      // `getColWidth(0)`) widens the outer container to match automatically.
+      modifyColWidth: trimDropdown ? undefined : (width?: number): number => {
+        return Math.max(width ?? 0, outerWidth(this.TEXTAREA) - 2);
+      },
       renderer: (
         hotInstance: HotInstance, TD: HTMLTableCellElement, row: number, col: number,
         prop: string | number, value: unknown, cellProperties: CellProperties) => {

--- a/tests/e2e/dropdown-width.spec.ts
+++ b/tests/e2e/dropdown-width.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '../fixtures/test';
+import { DropdownWidthPage } from '../fixtures/pages/DropdownWidthPage';
+
+/**
+ * #13180: with trimDropdown:false the dropdown list rendered narrower than the
+ * edited column when the option labels were short (list column width came from
+ * autoColumnSize content measurement only, floored at defaultColumnWidth).
+ * The list — including its rows, not just the outer container — must be at
+ * least as wide as the edited cell, while long options must still widen it.
+ */
+test.describe('dropdown list width', () => {
+  let grid: DropdownWidthPage;
+
+  test.beforeEach(async ({ page, theme, bundle }) => {
+    grid = new DropdownWidthPage(page, theme, bundle);
+    await grid.goto();
+  });
+
+  test('trimDropdown:false — short options: list rows are at least as wide as the edited cell', async () => {
+    await grid.openDropdownAt(0, 1);
+
+    const cellBox = await grid.cell(0, 1).boundingBox();
+    const listBox = await grid.dropdownList().boundingBox();
+    const rowBox = await grid.firstListRowCell().boundingBox();
+
+    if (!cellBox || !listBox || !rowBox) {
+      throw new Error('cell, list, or list row is not rendered');
+    }
+
+    // The list table and the actual option rows (click/highlight targets)
+    // must both span at least the cell width; small tolerance for the 2px
+    // border compensation that differs between the classic and CSS-var themes.
+    expect(listBox.width).toBeGreaterThanOrEqual(cellBox.width - 3);
+    expect(rowBox.width).toBeGreaterThanOrEqual(cellBox.width - 5);
+  });
+
+  test('trimDropdown:false — long options: list still grows wider than the edited cell', async () => {
+    await grid.openDropdownAt(0, 2);
+
+    const cellBox = await grid.cell(0, 2).boundingBox();
+    const listBox = await grid.dropdownList().boundingBox();
+
+    if (!cellBox || !listBox) {
+      throw new Error('cell or list is not rendered');
+    }
+
+    expect(listBox.width).toBeGreaterThan(cellBox.width + 20);
+  });
+
+  test('trimDropdown default — list keeps matching the edited cell width', async () => {
+    await grid.openDropdownAt(0, 3);
+
+    const cellBox = await grid.cell(0, 3).boundingBox();
+    const listBox = await grid.dropdownList().boundingBox();
+
+    if (!cellBox || !listBox) {
+      throw new Error('cell or list is not rendered');
+    }
+
+    expect(Math.abs(listBox.width - cellBox.width)).toBeLessThanOrEqual(3);
+  });
+});

--- a/tests/fixtures/demo/dropdown-width.html
+++ b/tests/fixtures/demo/dropdown-width.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable e2e fixture — dropdown width</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back — a
+    // typo in the project config must be one red leg, never a silently
+    // mislabeled green one (nothing else asserts which file actually loaded).
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } </style>
+</head>
+<body>
+  <!--
+    E2E fixture for #13180: dropdown/autocomplete list width vs column width.
+    Column 1: short items + trimDropdown:false (the bug — list must not be
+    narrower than the 260px column). Column 2: long items + trimDropdown:false
+    (list must still grow past the 200px column). Column 3: short items with
+    default trimDropdown (regression guard — list matches the cell exactly).
+    TDs are stamped with data-testid in afterRender because the dropdown cell
+    type owns its renderer (the arrow), so a custom renderer would break it.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    window.hot = new Handsontable(container, {
+      data: [
+        ['A1', 'yes', 'Lorem ipsum dolor sit amet', 'no'],
+        ['A2', 'no', 'Consectetur adipiscing elit', 'yes'],
+        ['A3', 'n/a', 'Sed do eiusmod tempor', 'n/a'],
+      ],
+      colHeaders: ['Item', 'Short choices', 'Long choices', 'Trimmed'],
+      rowHeaders: true,
+      colWidths: [100, 260, 200, 150],
+      columns: [
+        {},
+        { type: 'dropdown', source: ['yes', 'no', 'n/a'], trimDropdown: false },
+        {
+          type: 'dropdown',
+          source: [
+            'Lorem ipsum dolor sit amet',
+            'Consectetur adipiscing elit, sed do eiusmod tempor incididunt',
+            'Sed do eiusmod tempor',
+          ],
+          trimDropdown: false,
+        },
+        { type: 'dropdown', source: ['yes', 'no', 'n/a'] },
+      ],
+      afterRender() {
+        this.getData().forEach((rowData, row) => {
+          rowData.forEach((cellValue, col) => {
+            const td = this.getCell(row, col);
+
+            if (td) {
+              td.setAttribute('data-testid', `cell-${row}-${col}`);
+            }
+          });
+        });
+      },
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/DropdownWidthPage.ts
+++ b/tests/fixtures/pages/DropdownWidthPage.ts
@@ -1,0 +1,57 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the dropdown-width fixture (#13180): three dropdown columns
+ * exercising trimDropdown:false with short items (the bug), trimDropdown:false
+ * with long items (must keep growing), and default trimDropdown (must keep
+ * matching the cell). Encapsulates opening the editor list and locating the
+ * inner listbox table for width measurements.
+ */
+export class DropdownWidthPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly grid: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.grid = page.getByTestId('grid');
+  }
+
+  /**
+   * Navigate and wait for the grid to render (a real DOM condition, no sleep).
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(`/tests/fixtures/demo/dropdown-width.html?theme=${this.theme}&bundle=${this.bundle}`);
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /** A data cell in the master table, addressed by the stamped test id. */
+  cell(row: number, col: number): Locator {
+    return this.page.locator('.ht_master').getByTestId(`cell-${row}-${col}`);
+  }
+
+  /** Open the dropdown editor on a cell and wait for the list to show. */
+  async openDropdownAt(row: number, col: number): Promise<void> {
+    await this.cell(row, col).dblclick();
+    await expect(this.dropdownList()).toBeVisible();
+  }
+
+  /** Close the editor between measurements so lists never overlap. */
+  async closeDropdown(): Promise<void> {
+    await this.page.keyboard.press('Escape');
+    await expect(this.dropdownList()).toBeHidden();
+  }
+
+  /** The inner listbox table of the open dropdown editor. */
+  dropdownList(): Locator {
+    return this.page.locator('.handsontableInputHolder .autocompleteEditor .ht_master .htCore');
+  }
+
+  /** The first option row's cell — the user-visible click/highlight target. */
+  firstListRowCell(): Locator {
+    return this.dropdownList().locator('tbody tr').first().locator('td');
+  }
+}


### PR DESCRIPTION
### Context

The PR fixes the autocomplete/dropdown editor list rendering narrower than the edited column when `trimDropdown: false` is set and the option labels are short (#13180).

With `trimDropdown: false`, the editor's internal listbox column is sized from its content by AutoColumnSize, floored only at the 50px default column width. Short options therefore produced a ~50px list under a much wider column. The behavior is long-standing (reproduced on v11, v12, v14, and v18), not a v18 regression.

The fix registers a `modifyColWidth` hook on the internal listbox instance (in `AutocompleteEditor.open()`) that floors the list column width at the edited cell width (`outerWidth(TEXTAREA) - 2` — the same expression the `trimDropdown: true` branch uses, so merged and stretched cells behave consistently). Because `getTargetEditorWidth()` reads `getColWidth(0)`, the outer dropdown container, scrollbar compensation, and flip positioning all pick up the floor automatically. Long options keep widening the list past the column, and the option rows themselves stay full-width click/highlight targets.

This supersedes the approach in #13193 (thanks @waterWang for the report analysis and the initial patch): flooring only `getTargetEditorWidth()` widens the outer container but leaves the inner rows, hover highlight, and click targets at 50px.

Note for existing `trimDropdown: false` users: the list can now only render wider than before (never narrower than the cell). No defaults changed.

### How has this been tested?

- New Playwright E2E spec `tests/e2e/dropdown-width.spec.ts` (fixture `tests/fixtures/demo/dropdown-width.html`, page object `DropdownWidthPage`): short options floor to the cell width (list and row cells), long options still grow past the column, and default `trimDropdown` keeps matching the cell — `cd tests && npx playwright test e2e/dropdown-width.spec.ts --project=e2e-main` (3/3, written red-first against the bug).
- Legacy regression sweep: `npm run test:e2e --prefix handsontable -- --testPathPattern="autocompleteEditor|dropdownEditor|handsontableEditor"` — 236 specs, 0 failures.
- `npm run test:unit --prefix handsontable -- --testPathPattern=editors` — 13/13.
- Full Playwright main leg: `cd tests && npm run test:e2e` — 65 passed, 1 pre-existing skip.
- `npm run test:types --prefix handsontable` and `npm run eslint --prefix handsontable` — clean.
- Manual browser verification (main theme): short items — container 261px/rows 259px under a 260px column; long items — 421px over a 200px column; clicks on the right half of an option row select the value; RTL — list stays flush with the cell's inline-start edge.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Fixes #13180
2. Supersedes #13193

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

Documentation is updated in this PR: the `trimDropdown` API reference (`metaSchema.ts` JSDoc) and the dropdown/autocomplete cell-type guides now state the list expands to its content but never renders narrower than the edited cell.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized editor layout fix with documentation alignment and new E2E coverage; no API or default option changes beyond correcting trimDropdown:false behavior.
> 
> **Overview**
> Fixes **#13180**: with `trimDropdown: false`, short option labels made the autocomplete/dropdown suggestion list narrower than the edited column (inner list sized only from AutoColumnSize, floored at the default column width).
> 
> **`AutocompleteEditor`** now sets a `modifyColWidth` hook on the internal listbox when `trimDropdown` is false, flooring list column width at `outerWidth(TEXTAREA) - 2` (same as the `trimDropdown: true` branch). Long options can still widen the list; option rows stay full-width click targets, and outer container sizing via `getTargetEditorWidth()` follows automatically.
> 
> Docs and **`trimDropdown`** API text (meta schema, autocomplete and dropdown guides) now state that `false` expands to content but **never narrower than the edited cell**. Adds changelog **13197**, Playwright E2E (`dropdown-width.spec.ts` + fixture/page object) covering short options, long options, and default `trimDropdown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b75792b9b5580814713fea02de7d7d185461fe8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->