### PR TITLE
SU-688: Define severity levels and regression urgency in the LTS backport policy

### DIFF
--- a/docs/content/guides/upgrade-and-migration/long-term-support/long-term-support.md
+++ b/docs/content/guides/upgrade-and-migration/long-term-support/long-term-support.md
@@ -85,7 +85,16 @@ The LTS model is designed to minimize disruption while ensuring applications sta
 
 Backporting involves taking specific fixes from newer versions and retrofitting (cherry-picking) them to LTS releases, ensuring production systems receive critical updates without the disruption of major upgrades. Our backport policy prioritizes stability while addressing essential security and reliability concerns.
 
-The backport process is selective and risk-aware. Not all fixes from newer versions are suitable for backporting—only those that meet strict criteria for importance and stability. This approach ensures LTS releases remain stable and predictable while still receiving necessary updates.
+The backport process is selective and risk-aware. Not all fixes from newer versions are suitable for backporting -- only those that meet strict criteria for importance and stability. This approach ensures LTS releases remain stable and predictable while still receiving necessary updates.
+
+Two things are assessed for every fix: its **severity**, which decides whether it is backported, and its **regression status**, which decides how urgently.
+
+### Severity levels
+
+*   **Critical** -- the grid is unusable or data integrity is at risk: it fails to render, throws on a documented configuration, corrupts or loses data, or a core interaction (scrolling, editing, selection) is permanently broken.
+*   **Major** -- a documented feature does not work as specified, but a workaround exists or the impact is limited to a specific configuration.
+*   **Minor** -- cosmetic or transient issues that do not prevent completing a task, including visual artifacts that resolve on their own.
+*   **Performance** -- the grid works correctly, but slower than a previous release.
 
 ### Backport Decision Matrix
 
@@ -101,8 +110,22 @@ The following matrix defines which types of fixes are backported to each support
 
 *   **Security vulnerabilities** receive immediate attention across all supported versions, including those in Maintenance LTS. These fixes are prioritized and released as quickly as possible to protect production deployments.
 *   **Critical bugs** that significantly impact functionality are backported to Active LTS releases in the next patch version. These fixes undergo thorough testing to ensure they don't introduce new issues.
-*   **Bugs and performance improvements** are backported to Active LTS only when they present low risk and critical importance. The evaluation considers the fix complexity, potential for regression, and number of affected users
-*   **New features** are never backported to LTS releases. This policy maintains the stability promise of LTS versions—users can confidently apply updates knowing they contain only fixes, not functionality changes that might require application modifications.
+*   **Bugs and performance improvements** are backported to Active LTS only when they present low risk and critical importance. The evaluation considers the fix complexity, potential for regression, and number of affected users.
+*   **New features** are never backported to LTS releases. This policy maintains the stability promise of LTS versions -- users can confidently apply updates knowing they contain only fixes, not functionality changes that might require application modifications.
+
+### Regressions
+
+A regression is a defect in behavior that worked before. Regression status does not change which column of the matrix a fix lands in, but it does change how quickly the fix is scheduled. A long-standing defect is not disqualified from a backport by its age -- it is assessed on severity alone.
+
+| Type | Definition | Effect on urgency |
+| ---| ---| --- |
+| Version regression | Worked in an earlier release of the same LTS line, broke in a later one | Normal -- scheduled into the next patch |
+| Environment regression | Worked with a previous browser or dependency version, broke with a new one | Elevated -- you changed nothing, so we treat it as a compatibility guarantee |
+| Long-standing defect | Never worked in this LTS line; fixed only in a later major | None -- assessed on severity alone |
+
+Keeping the Active LTS line working on current browser versions is part of the LTS commitment, so environment regressions are triaged ahead of other work at the same severity.
+
+A browser update that *exposes* a defect already present in the LTS line is not an environment regression. To qualify, the same Handsontable version must be verifiably working on the previous browser version, so a reproduction on both the previous and the new browser version is required before a report is treated as one.
 
 ## Support Commitment
 


### PR DESCRIPTION
### Context

The PR adds the missing detail to the LTS **Backport Decision Matrix**: what the severity words in the matrix actually mean, and how a regression changes the urgency of a fix.

The matrix already routed fixes by issue type (`Critical bug`, `Major/Minor bug`, `Performance`), but the page never defined those terms, and it said nothing about regressions. That left the two cases raised in the discussion behind SU-688 unanswered:

1. Something that worked in 16.0/16.1 and broke in 16.2 -- fixed in Active LTS with normal urgency.
2. Something that worked in 16.2 on Chrome 150 and broke on Chrome 151 -- fixed in Active LTS with elevated urgency, because it is a compatibility guarantee.

Changes to `docs/content/guides/upgrade-and-migration/long-term-support/long-term-support.md`:

- New **Severity levels** section defining `Critical`, `Major`, `Minor`, and `Performance`, placed before the matrix that uses those terms.
- New **Regressions** section with a three-row table (version regression, environment regression, long-standing defect) and its effect on urgency.
- A stated split of concerns: severity decides **whether** a fix is backported, regression status decides **how urgently**. A long-standing defect is not disqualified by its age.
- A "cause vs. occasion" rule: a browser update that only *exposes* a pre-existing defect is not an environment regression, and a reproduction on both the previous and the new browser version is required before a report is treated as one.
- Style fixes in the section being edited: em dashes replaced with the docs-site `--` separator, and a missing sentence-ending period restored.

No policy change to the matrix itself -- which fixes land in which phase is unchanged.

[skip changelog]

### How has this been tested?

Documentation-only change. Reviewed the rendered Markdown structure and verified the page contains no em or en dashes, per the docs-site style rule:

```bash
grep -n "[—–]" docs/content/guides/upgrade-and-migration/long-term-support/long-term-support.md
```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. SU-688

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/SU-688

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to LTS policy wording; no runtime, API, or matrix behavior changes.
> 
> **Overview**
> Documentation-only update to the LTS **Backport Policy** in `long-term-support.md`. The decision matrix already used terms like Critical/Major/Minor and Performance, but the page did not define them or explain regressions.
> 
> **Severity levels** are added before the matrix: Critical, Major, Minor, and Performance, each with concrete grid-focused criteria. A short framing states that **severity** decides whether a fix is backported and **regression status** decides how urgently it is scheduled.
> 
> A new **Regressions** subsection adds a table for version regression (normal urgency), environment regression (elevated urgency as a compatibility guarantee), and long-standing defect (urgency from severity only, not disqualified by age). It notes that environment regressions are triaged ahead of same-severity work, and that a browser update that only *exposes* an existing defect is not an environment regression—reproduction on both old and new browser versions is required.
> 
> Minor style edits in the same section: em dashes replaced with `--` and a missing period restored. The matrix columns and which fix types apply to each support phase are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4222f47cccdd95028734cea5c7857d6d62396aa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->