### PR TITLE
DEV-2551: Keep fixed rows and columns pinned after undoing an insertion

### DIFF
--- a/.changelogs/13200.json
+++ b/.changelogs/13200.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the `fixedRowsBottom` option losing its value after undoing a row insertion, which un-pinned the bottom row.",
+  "type": "fixed",
+  "issueOrPR": 13200,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13200.json
+++ b/.changelogs/13200.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed the `fixedRowsBottom` option losing its value after undoing a row insertion, which un-pinned the bottom row.",
+  "title": "Fixed the `fixedRowsTop`, `fixedRowsBottom`, and `fixedColumnsStart` options losing their value after undoing a row or column insertion, which un-pinned a frozen row or column.",
   "type": "fixed",
   "issueOrPR": 13200,
   "breaking": false,

--- a/handsontable/src/__tests__/core/removeRow.spec.js
+++ b/handsontable/src/__tests__/core/removeRow.spec.js
@@ -544,6 +544,85 @@ describe('Core.alter', () => {
       expect(getSettings().fixedRowsTop).toEqual(1);
     });
 
+    it('should decrement the number of bottom fixed rows, if a bottom fixed row is removed', async() => {
+      handsontable({
+        startCols: 1,
+        startRows: 5,
+        fixedRowsBottom: 2,
+      });
+
+      await alter('remove_row', 4, 1);
+
+      expect(getSettings().fixedRowsBottom).toEqual(1);
+
+      await alter('remove_row', 3, 1);
+
+      expect(getSettings().fixedRowsBottom).toEqual(0);
+    });
+
+    it('should not decrement the number of bottom fixed rows, if the removed row is above them', async() => {
+      handsontable({
+        startCols: 1,
+        startRows: 5,
+        fixedRowsBottom: 1,
+      });
+
+      await alter('remove_row', 3, 1);
+
+      expect(getSettings().fixedRowsBottom).toEqual(1);
+    });
+
+    it('should not decrement the number of bottom fixed rows, if a range of rows above them is removed', async() => {
+      handsontable({
+        startCols: 1,
+        startRows: 8,
+        fixedRowsBottom: 2,
+      });
+
+      await alter('remove_row', 1, 3);
+
+      expect(getSettings().fixedRowsBottom).toEqual(2);
+    });
+
+    it('should decrement the number of bottom fixed rows only by the number of removed fixed rows', async() => {
+      handsontable({
+        startCols: 1,
+        startRows: 6,
+        fixedRowsBottom: 2,
+      });
+
+      // Removes rows 3, 4 and 5 - only rows 4 and 5 belong to the bottom fixed rows.
+      await alter('remove_row', 3, 3);
+
+      expect(getSettings().fixedRowsBottom).toEqual(0);
+    });
+
+    it('should decrement the number of bottom fixed rows only by the fixed rows within a straddling range', async() => {
+      handsontable({
+        startCols: 1,
+        startRows: 6,
+        fixedRowsBottom: 3,
+      });
+
+      // Removes rows 2 and 3 - only row 3 belongs to the bottom fixed rows (rows 3, 4 and 5).
+      await alter('remove_row', 2, 2);
+
+      expect(getSettings().fixedRowsBottom).toEqual(2);
+    });
+
+    it('should decrement the number of bottom fixed rows by one when only the topmost fixed row is removed', async() => {
+      handsontable({
+        startCols: 1,
+        startRows: 6,
+        fixedRowsBottom: 3,
+      });
+
+      // Row 3 is the first of the three bottom fixed rows (rows 3, 4 and 5).
+      await alter('remove_row', 3, 1);
+
+      expect(getSettings().fixedRowsBottom).toEqual(2);
+    });
+
     it('should shift the cell meta according to the new row layout', async() => {
       handsontable({
         startCols: 3,

--- a/handsontable/src/__tests__/core/removeRow.spec.js
+++ b/handsontable/src/__tests__/core/removeRow.spec.js
@@ -597,6 +597,34 @@ describe('Core.alter', () => {
       expect(getSettings().fixedRowsBottom).toEqual(0);
     });
 
+    it('should decrement the number of bottom fixed rows when the rows are removed from the end', async() => {
+      handsontable({
+        startCols: 1,
+        startRows: 6,
+        fixedRowsBottom: 2,
+      });
+
+      // With no index passed the last two rows (4 and 5) are removed - both are bottom fixed rows.
+      await alter('remove_row', undefined, 2);
+
+      expect(countRows()).toEqual(4);
+      expect(getSettings().fixedRowsBottom).toEqual(0);
+    });
+
+    it('should decrement the number of bottom fixed rows only by the fixed rows removed from the end', async() => {
+      handsontable({
+        startCols: 1,
+        startRows: 6,
+        fixedRowsBottom: 1,
+      });
+
+      // With no index passed the last three rows (3, 4 and 5) are removed - only row 5 is a bottom fixed row.
+      await alter('remove_row', undefined, 3);
+
+      expect(countRows()).toEqual(3);
+      expect(getSettings().fixedRowsBottom).toEqual(0);
+    });
+
     it('should decrement the number of bottom fixed rows only by the fixed rows within a straddling range', async() => {
       handsontable({
         startCols: 1,

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -1022,9 +1022,17 @@ export default function Core(
                 // to be compared with the row count from *before* the removal. Rows removed above that
                 // range keep the setting untouched (DEV-2551).
                 const removedRowsCount = totalRowsBefore - totalRows;
+                // With no index passed, `datamap.removeRow` takes the rows from the end, so the removal
+                // starts that many rows before the last one. `calcIndex` points at the last row then, not
+                // at the first removed one.
+                const firstRemovedRowIndex = Number.isInteger(groupIndex)
+                  ? calcIndex
+                  : Math.max(totalRowsBefore - removedRowsCount, 0);
                 const firstFixedRowIndex = totalRowsBefore - fixedRowsBottom;
-                const lastRemovedRowIndex = Math.min(calcIndex + removedRowsCount - 1, totalRowsBefore - 1);
-                const removedFixedRowsCount = lastRemovedRowIndex - Math.max(calcIndex, firstFixedRowIndex) + 1;
+                const lastRemovedRowIndex =
+                  Math.min(firstRemovedRowIndex + removedRowsCount - 1, totalRowsBefore - 1);
+                const removedFixedRowsCount =
+                  lastRemovedRowIndex - Math.max(firstRemovedRowIndex, firstFixedRowIndex) + 1;
 
                 if (removedFixedRowsCount > 0) {
                   tableMeta.fixedRowsBottom -= Math.min(removedFixedRowsCount, fixedRowsBottom);

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -989,6 +989,8 @@ export default function Core(
                 groupIndex = Math.max(groupIndex - offset, 0);
               }
 
+              const totalRowsBefore = instance.countRows();
+
               // TODO: for datamap.removeRow index should be passed as it is (with undefined and null values). If not, the logic
               // inside the datamap.removeRow breaks the removing functionality.
               const wasRemoved = datamap.removeRow(groupIndex, groupAmount, source);
@@ -1014,8 +1016,19 @@ export default function Core(
 
               const fixedRowsBottom = tableMeta.fixedRowsBottom;
 
-              if (fixedRowsBottom && calcIndex >= totalRows - fixedRowsBottom) {
-                tableMeta.fixedRowsBottom -= Math.min(groupAmount, fixedRowsBottom);
+              if (fixedRowsBottom) {
+                // Count how many of the removed rows belonged to the bottom fixed rows. Those rows occupied
+                // the `[totalRowsBefore - fixedRowsBottom, totalRowsBefore - 1]` range, so the boundary has
+                // to be compared with the row count from *before* the removal. Rows removed above that
+                // range keep the setting untouched (DEV-2551).
+                const removedRowsCount = totalRowsBefore - totalRows;
+                const firstFixedRowIndex = totalRowsBefore - fixedRowsBottom;
+                const lastRemovedRowIndex = Math.min(calcIndex + removedRowsCount - 1, totalRowsBefore - 1);
+                const removedFixedRowsCount = lastRemovedRowIndex - Math.max(calcIndex, firstFixedRowIndex) + 1;
+
+                if (removedFixedRowsCount > 0) {
+                  tableMeta.fixedRowsBottom -= Math.min(removedFixedRowsCount, fixedRowsBottom);
+                }
               }
 
               if (totalRows === 0) {

--- a/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -1862,6 +1862,67 @@ describe('UndoRedo', () => {
         expect(getBottomClone().find('tbody tr').length).toBe(3);
       });
 
+      it('should render the bottom fixed rows only once while undoing an insertion within them', async() => {
+        handsontable({
+          data: createSpreadsheetData(5, 2),
+          colHeaders: true,
+          rowHeaders: true,
+          fixedRowsBottom: 2,
+        });
+
+        await alter('insert_row_below', 4, 1);
+
+        const fixedRowsBottomPerRender = [];
+
+        addHook('afterRender', () => {
+          fixedRowsBottomPerRender.push(getSettings().fixedRowsBottom);
+        });
+
+        getPlugin('undoRedo').undo();
+
+        expect(fixedRowsBottomPerRender).toEqual([2]);
+      });
+
+      it('should keep the number of start fixed columns after undoing an insertion within them', async() => {
+        handsontable({
+          data: createSpreadsheetData(2, 5),
+          colHeaders: true,
+          rowHeaders: true,
+          fixedColumnsStart: 2,
+        });
+
+        await alter('insert_col_start', 0, 1);
+
+        expect(countCols()).toBe(6);
+
+        getPlugin('undoRedo').undo();
+
+        expect(countCols()).toBe(5);
+        expect(getSettings().fixedColumnsStart).toBe(2);
+        expect(getInlineStartClone().find('tbody tr:eq(0) td').length).toBe(2);
+      });
+
+      it('should restore the number of start fixed columns changed after the insertion', async() => {
+        handsontable({
+          data: createSpreadsheetData(2, 5),
+          colHeaders: true,
+          rowHeaders: true,
+          fixedColumnsStart: 1,
+        });
+
+        await alter('insert_col_start', 0, 1);
+
+        await updateSettings({
+          fixedColumnsStart: 3,
+        });
+
+        getPlugin('undoRedo').undo();
+
+        expect(countCols()).toBe(5);
+        expect(getSettings().fixedColumnsStart).toBe(3);
+        expect(getInlineStartClone().find('tbody tr:eq(0) td').length).toBe(3);
+      });
+
       it('should keep the number of top fixed rows after undoing an insertion within them', async() => {
         handsontable({
           data: createSpreadsheetData(5, 2),

--- a/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -1838,6 +1838,28 @@ describe('UndoRedo', () => {
 
         expect(countRows()).toBe(5);
         expect(getSettings().fixedRowsBottom).toBe(2);
+        expect(getBottomClone().find('tbody tr').length).toBe(2);
+      });
+
+      it('should restore the number of bottom fixed rows changed after the insertion', async() => {
+        handsontable({
+          data: createSpreadsheetData(5, 2),
+          colHeaders: true,
+          rowHeaders: true,
+          fixedRowsBottom: 1,
+        });
+
+        await alter('insert_row_below', 4, 1);
+
+        await updateSettings({
+          fixedRowsBottom: 3,
+        });
+
+        getPlugin('undoRedo').undo();
+
+        expect(countRows()).toBe(5);
+        expect(getSettings().fixedRowsBottom).toBe(3);
+        expect(getBottomClone().find('tbody tr').length).toBe(3);
       });
 
       it('should keep the number of top fixed rows after undoing an insertion within them', async() => {

--- a/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -1803,6 +1803,61 @@ describe('UndoRedo', () => {
         expect(getSettings().fixedRowsTop).toBe(1);
       });
 
+      it('should keep the number of bottom fixed rows after undoing an insertion above them', async() => {
+        handsontable({
+          data: createSpreadsheetData(5, 2),
+          colHeaders: true,
+          rowHeaders: true,
+          fixedRowsBottom: 1,
+        });
+
+        await alter('insert_row_below', 3, 1);
+
+        expect(countRows()).toBe(6);
+        expect(getSettings().fixedRowsBottom).toBe(1);
+
+        getPlugin('undoRedo').undo();
+
+        expect(countRows()).toBe(5);
+        expect(getSettings().fixedRowsBottom).toBe(1);
+      });
+
+      it('should keep the number of bottom fixed rows after undoing an insertion within them', async() => {
+        handsontable({
+          data: createSpreadsheetData(5, 2),
+          colHeaders: true,
+          rowHeaders: true,
+          fixedRowsBottom: 2,
+        });
+
+        await alter('insert_row_below', 4, 1);
+
+        expect(countRows()).toBe(6);
+
+        getPlugin('undoRedo').undo();
+
+        expect(countRows()).toBe(5);
+        expect(getSettings().fixedRowsBottom).toBe(2);
+      });
+
+      it('should keep the number of top fixed rows after undoing an insertion within them', async() => {
+        handsontable({
+          data: createSpreadsheetData(5, 2),
+          colHeaders: true,
+          rowHeaders: true,
+          fixedRowsTop: 2,
+        });
+
+        await alter('insert_row_above', 0, 1);
+
+        expect(countRows()).toBe(6);
+
+        getPlugin('undoRedo').undo();
+
+        expect(countRows()).toBe(5);
+        expect(getSettings().fixedRowsTop).toBe(2);
+      });
+
       it('should undo multiple changes', async() => {
         handsontable({
           data: createObjectData().slice(0, 2)

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/createRow.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/createRow.spec.js
@@ -29,6 +29,8 @@ describe('UndoRedo -> CreateRow action', () => {
       actionType: 'insert_row',
       index: 1,
       amount: 2,
+      fixedRowsBottom: 0,
+      fixedRowsTop: 0,
     });
 
     afterUndo.calls.reset();
@@ -39,6 +41,8 @@ describe('UndoRedo -> CreateRow action', () => {
       actionType: 'insert_row',
       index: 3,
       amount: 3,
+      fixedRowsBottom: 0,
+      fixedRowsTop: 0,
     });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/createRow.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/createRow.spec.js
@@ -29,8 +29,6 @@ describe('UndoRedo -> CreateRow action', () => {
       actionType: 'insert_row',
       index: 1,
       amount: 2,
-      fixedRowsBottom: 0,
-      fixedRowsTop: 0,
     });
 
     afterUndo.calls.reset();
@@ -41,8 +39,6 @@ describe('UndoRedo -> CreateRow action', () => {
       actionType: 'insert_row',
       index: 3,
       amount: 3,
-      fixedRowsBottom: 0,
-      fixedRowsTop: 0,
     });
   });
 });

--- a/handsontable/src/plugins/undoRedo/actions/createColumn.ts
+++ b/handsontable/src/plugins/undoRedo/actions/createColumn.ts
@@ -1,6 +1,7 @@
 import type { HookCallback } from '../../../core/hooks/bucket';
 import type { HotInstance } from '../../../core/types';
 import { BaseAction } from './_base';
+import { FIXED_COLUMN_COUNTS, removeAndKeepFixedCounts } from './fixedCounts';
 
 /**
  * Action that tracks column creation.
@@ -44,7 +45,10 @@ export class CreateColumnAction extends BaseAction {
    */
   undo(hot: HotInstance, undoneCallback: HookCallback) {
     hot.addHookOnce('afterRemoveCol', undoneCallback);
-    hot.alter('remove_col', this.index, this.amount, 'UndoRedo.undo');
+
+    removeAndKeepFixedCounts(hot, FIXED_COLUMN_COUNTS, () => {
+      hot.alter('remove_col', this.index, this.amount, 'UndoRedo.undo');
+    });
   }
 
   /**

--- a/handsontable/src/plugins/undoRedo/actions/createRow.ts
+++ b/handsontable/src/plugins/undoRedo/actions/createRow.ts
@@ -17,14 +17,29 @@ export class CreateRowAction extends BaseAction {
    * @param {number} amount The number of created rows.
    */
   amount;
+  /**
+   * @param {number} fixedRowsBottom Number of fixed rows on the bottom, taken from before the insertion.
+   *   Undoing the insertion removes rows, and removing a bottom fixed row decreases that setting.
+   */
+  fixedRowsBottom;
+  /**
+   * @param {number} fixedRowsTop Number of fixed rows on the top, taken from before the insertion.
+   *   Undoing the insertion removes rows, and removing a top fixed row decreases that setting.
+   */
+  fixedRowsTop;
 
   /**
-   * Initializes the create row action with the visual insertion index and the number of rows created.
+   * Initializes the create row action with the visual insertion index, the number of rows created, and the
+   * fixed-row counts to restore on undo.
    */
-  constructor({ index, amount }: { index: number, amount: number }) {
+  constructor({ index, amount, fixedRowsBottom, fixedRowsTop }: {
+    index: number, amount: number, fixedRowsBottom: number, fixedRowsTop: number
+  }) {
     super('insert_row');
     this.index = index;
     this.amount = amount;
+    this.fixedRowsBottom = fixedRowsBottom;
+    this.fixedRowsTop = fixedRowsTop;
   }
 
   /**
@@ -33,7 +48,13 @@ export class CreateRowAction extends BaseAction {
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('afterCreateRow', (index: number, amount: number, source: string) => {
       (undoRedoPlugin as { done: (...args: unknown[]) => void }).done(
-        () => new CreateRowAction({ index, amount }), source
+        () => new CreateRowAction({
+          index,
+          amount,
+          // Inserting rows never changes these, so the values read here are the ones from before the insertion.
+          fixedRowsBottom: hot.getSettings().fixedRowsBottom ?? 0,
+          fixedRowsTop: hot.getSettings().fixedRowsTop ?? 0,
+        }), source
       );
     });
   }
@@ -52,6 +73,19 @@ export class CreateRowAction extends BaseAction {
 
     hot.addHookOnce('afterRemoveRow', undoneCallback);
     hot.alter('remove_row', this.index, this.amount, 'UndoRedo.undo');
+
+    const settings = hot.getSettings();
+
+    // Rows inserted into the fixed area belong to that area when the undo removes them, so `alter`
+    // legitimately decreases the counters. Restore the values captured before the insertion so the undo
+    // brings back the whole previous state, including the pinned rows.
+    if (settings.fixedRowsBottom !== this.fixedRowsBottom || settings.fixedRowsTop !== this.fixedRowsTop) {
+      // Changing by the reference as `updateSettings` doesn't work the best.
+      settings.fixedRowsBottom = this.fixedRowsBottom;
+      settings.fixedRowsTop = this.fixedRowsTop;
+
+      hot.render();
+    }
   }
 
   /**

--- a/handsontable/src/plugins/undoRedo/actions/createRow.ts
+++ b/handsontable/src/plugins/undoRedo/actions/createRow.ts
@@ -17,29 +17,14 @@ export class CreateRowAction extends BaseAction {
    * @param {number} amount The number of created rows.
    */
   amount;
-  /**
-   * @param {number} fixedRowsBottom Number of fixed rows on the bottom, taken from before the insertion.
-   *   Undoing the insertion removes rows, and removing a bottom fixed row decreases that setting.
-   */
-  fixedRowsBottom;
-  /**
-   * @param {number} fixedRowsTop Number of fixed rows on the top, taken from before the insertion.
-   *   Undoing the insertion removes rows, and removing a top fixed row decreases that setting.
-   */
-  fixedRowsTop;
 
   /**
-   * Initializes the create row action with the visual insertion index, the number of rows created, and the
-   * fixed-row counts to restore on undo.
+   * Initializes the create row action with the visual insertion index and the number of rows created.
    */
-  constructor({ index, amount, fixedRowsBottom, fixedRowsTop }: {
-    index: number, amount: number, fixedRowsBottom: number, fixedRowsTop: number
-  }) {
+  constructor({ index, amount }: { index: number, amount: number }) {
     super('insert_row');
     this.index = index;
     this.amount = amount;
-    this.fixedRowsBottom = fixedRowsBottom;
-    this.fixedRowsTop = fixedRowsTop;
   }
 
   /**
@@ -48,13 +33,7 @@ export class CreateRowAction extends BaseAction {
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('afterCreateRow', (index: number, amount: number, source: string) => {
       (undoRedoPlugin as { done: (...args: unknown[]) => void }).done(
-        () => new CreateRowAction({
-          index,
-          amount,
-          // Inserting rows never changes these, so the values read here are the ones from before the insertion.
-          fixedRowsBottom: hot.getSettings().fixedRowsBottom ?? 0,
-          fixedRowsTop: hot.getSettings().fixedRowsTop ?? 0,
-        }), source
+        () => new CreateRowAction({ index, amount }), source
       );
     });
   }
@@ -65,24 +44,28 @@ export class CreateRowAction extends BaseAction {
    */
   undo(hot: HotInstance, undoneCallback: HookCallback) {
     const rowCount = hot.countRows();
-    const minSpareRows = hot.getSettings().minSpareRows;
+    const settings = hot.getSettings();
+    const minSpareRows = settings.minSpareRows;
 
     if (this.index >= rowCount && this.index - (minSpareRows ?? 0) < rowCount) {
       this.index -= (minSpareRows ?? 0); // work around the situation where the needed row was removed due to an 'undo' of a made change
     }
 
+    // Read before the removal - `alter` decreases these when it removes a fixed row.
+    const fixedRowsBottom = settings.fixedRowsBottom ?? 0;
+    const fixedRowsTop = settings.fixedRowsTop ?? 0;
+
     hot.addHookOnce('afterRemoveRow', undoneCallback);
     hot.alter('remove_row', this.index, this.amount, 'UndoRedo.undo');
 
-    const settings = hot.getSettings();
-
     // Rows inserted into the fixed area belong to that area when the undo removes them, so `alter`
-    // legitimately decreases the counters. Restore the values captured before the insertion so the undo
-    // brings back the whole previous state, including the pinned rows.
-    if (settings.fixedRowsBottom !== this.fixedRowsBottom || settings.fixedRowsTop !== this.fixedRowsTop) {
+    // decreases the counters. The rows are back to the state from before the insertion, so the counters
+    // have to go back as well (DEV-2551). Only a decrease is reverted - a value raised in the meantime
+    // by `updateSettings` stays as the user set it.
+    if ((settings.fixedRowsBottom ?? 0) < fixedRowsBottom || (settings.fixedRowsTop ?? 0) < fixedRowsTop) {
       // Changing by the reference as `updateSettings` doesn't work the best.
-      settings.fixedRowsBottom = this.fixedRowsBottom;
-      settings.fixedRowsTop = this.fixedRowsTop;
+      settings.fixedRowsBottom = fixedRowsBottom;
+      settings.fixedRowsTop = fixedRowsTop;
 
       hot.render();
     }

--- a/handsontable/src/plugins/undoRedo/actions/createRow.ts
+++ b/handsontable/src/plugins/undoRedo/actions/createRow.ts
@@ -1,6 +1,7 @@
 import type { HookCallback } from '../../../core/hooks/bucket';
 import type { HotInstance } from '../../../core/types';
 import { BaseAction } from './_base';
+import { FIXED_ROW_COUNTS, removeAndKeepFixedCounts } from './fixedCounts';
 
 /**
  * Action that tracks row creation.
@@ -44,31 +45,17 @@ export class CreateRowAction extends BaseAction {
    */
   undo(hot: HotInstance, undoneCallback: HookCallback) {
     const rowCount = hot.countRows();
-    const settings = hot.getSettings();
-    const minSpareRows = settings.minSpareRows;
+    const minSpareRows = hot.getSettings().minSpareRows;
 
     if (this.index >= rowCount && this.index - (minSpareRows ?? 0) < rowCount) {
       this.index -= (minSpareRows ?? 0); // work around the situation where the needed row was removed due to an 'undo' of a made change
     }
 
-    // Read before the removal - `alter` decreases these when it removes a fixed row.
-    const fixedRowsBottom = settings.fixedRowsBottom ?? 0;
-    const fixedRowsTop = settings.fixedRowsTop ?? 0;
-
     hot.addHookOnce('afterRemoveRow', undoneCallback);
-    hot.alter('remove_row', this.index, this.amount, 'UndoRedo.undo');
 
-    // Rows inserted into the fixed area belong to that area when the undo removes them, so `alter`
-    // decreases the counters. The rows are back to the state from before the insertion, so the counters
-    // have to go back as well (DEV-2551). Only a decrease is reverted - a value raised in the meantime
-    // by `updateSettings` stays as the user set it.
-    if ((settings.fixedRowsBottom ?? 0) < fixedRowsBottom || (settings.fixedRowsTop ?? 0) < fixedRowsTop) {
-      // Changing by the reference as `updateSettings` doesn't work the best.
-      settings.fixedRowsBottom = fixedRowsBottom;
-      settings.fixedRowsTop = fixedRowsTop;
-
-      hot.render();
-    }
+    removeAndKeepFixedCounts(hot, FIXED_ROW_COUNTS, () => {
+      hot.alter('remove_row', this.index, this.amount, 'UndoRedo.undo');
+    });
   }
 
   /**

--- a/handsontable/src/plugins/undoRedo/actions/fixedCounts.ts
+++ b/handsontable/src/plugins/undoRedo/actions/fixedCounts.ts
@@ -1,0 +1,77 @@
+import type { HotInstance } from '../../../core/types';
+
+/**
+ * A fixed-area counter, described by the setting its value is read from and the setting its value is
+ * written to. The two keys differ for the fixed columns - see `FIXED_COLUMN_COUNTS`.
+ */
+interface FixedCount {
+  readKey: string;
+  writeKey: string;
+}
+
+/**
+ * The counters that `alter` lowers when it removes rows from a fixed area.
+ */
+export const FIXED_ROW_COUNTS: FixedCount[] = [
+  { readKey: 'fixedRowsTop', writeKey: 'fixedRowsTop' },
+  { readKey: 'fixedRowsBottom', writeKey: 'fixedRowsBottom' },
+];
+
+/**
+ * The counters that `alter` lowers when it removes columns from a fixed area.
+ *
+ * Since 12.0.0, the "fixedColumnsLeft" option is replaced with the "fixedColumnsStart" option. The old
+ * name still works, and using both names together throws an error. To prevent that, the engine needs to
+ * modify the original option key to bypass the validation.
+ */
+export const FIXED_COLUMN_COUNTS: FixedCount[] = [
+  { readKey: 'fixedColumnsStart', writeKey: '_fixedColumnsStart' },
+];
+
+/**
+ * Removes rows or columns and brings back the fixed-area counters that the removal lowered.
+ *
+ * Undoing an insertion removes the created rows or columns. When they belong to a fixed area, `alter`
+ * lowers the matching counter, which un-pins a row or column that was pinned before the insertion
+ * (DEV-2551). The values from before the removal are put back from the `beforeRender` hook, so `alter`
+ * still draws the grid once, with the counters already correct. Only a decrease is reverted - a value
+ * raised in the meantime by `updateSettings` stays as the user set it.
+ *
+ * @param {Core} hot The Handsontable instance.
+ * @param {Array} counts The counters to keep.
+ * @param {function(): void} removeCallback The callback that removes the rows or columns.
+ */
+export function removeAndKeepFixedCounts(
+  hot: HotInstance,
+  counts: FixedCount[],
+  removeCallback: () => void
+) {
+  // Changing by the reference as `updateSettings` doesn't work the best.
+  const settings = hot.getSettings() as unknown as Record<string, number | undefined>;
+  const countsBefore = counts.map(({ readKey }) => settings[readKey] ?? 0);
+  const restore = () => {
+    let wasRestored = false;
+
+    counts.forEach(({ readKey, writeKey }, index) => {
+      if ((settings[readKey] ?? 0) < countsBefore[index]) {
+        settings[writeKey] = countsBefore[index];
+        wasRestored = true;
+      }
+    });
+
+    return wasRestored;
+  };
+  const onBeforeRender = () => {
+    restore();
+  };
+
+  // `alter` lowers the counters after the rows or columns are gone, but before it renders the grid.
+  hot.addHookOnce('beforeRender', onBeforeRender);
+  removeCallback();
+  hot.removeHook('beforeRender', onBeforeRender);
+
+  // The hook doesn't run while the rendering is suspended, so the counters are restored here instead.
+  if (restore()) {
+    hot.render();
+  }
+}


### PR DESCRIPTION
### Context

The PR fixes `fixedRowsBottom` silently dropping to `0` after a row insertion is undone, which un-pins a footer row such as "Overall Totals".

Reported by a pre-sales contact on 18.0.0, and reproducible in every version back to 12.4.0 — not a regression.

**Reproduction (before this PR):**

| | `countSourceRows()` | `fixedRowsBottom` |
| --- | --- | --- |
| initial | 5 | 1 |
| after `alter('insert_row_below', 3, 1)` | 6 | 1 |
| after `getPlugin('undoRedo').undo()` | 5 | **0** ← bug |

**Root cause.** The bug is in the `remove_row` branch of `Core#alter`, not in the undo plugin. The code read `instance.countRows()` *after* `datamap.removeRow()` had already run, then compared the removed index against `totalRows - fixedRowsBottom`. Because `totalRows` was the post-removal count, the boundary of the pinned area sat too high by the number of removed rows, so a row removed *above* the pinned area was treated as one of the pinned rows. The decrement also used `Math.min(groupAmount, fixedRowsBottom)`, which assumed every removed row belonged to the pinned area.

The undo path is only one caller. The same defect is reachable with no undo at all — on a 5-row grid with `fixedRowsBottom: 1`, a plain `hot.alter('remove_row', 3)` un-pins the footer.

**The fix, in two parts:**

1. `handsontable/src/core.ts` — the boundary is now compared against the row count captured *before* the removal, and `fixedRowsBottom` is decreased only by how many removed rows actually overlapped the pinned range.
2. `handsontable/src/plugins/undoRedo/actions/fixedCounts.ts` (new) — a shared helper used by `CreateRowAction.undo` and `CreateColumnAction.undo`. It reads the fixed-area counters before the removal and puts them back when `alter` lowered them. This covers the remaining case where the inserted row or column really was inside the pinned area, so the removal legitimately decreases the counter but undo must still restore the previous state. `RemoveRowAction` and `RemoveColumnAction` already do the same on their side.

The helper covers `fixedRowsTop`, `fixedRowsBottom`, and `fixedColumnsStart`. The column case had the same asymmetry: with `fixedColumnsStart: 2`, inserting a column at index `0` and undoing it left `fixedColumnsStart` at `1`.

Two details worth calling out:

- **Only a decrease is reverted.** `updateSettings({ fixedRowsBottom })` does not clear the undo stack, so a user can raise the value after the insertion. The helper compares the value after `alter` with the value before it and restores only when `alter` lowered it, so a value the user raised in the meantime stays as they set it.
- **The grid is still drawn once.** The counters are restored from the `beforeRender` hook, which runs after `alter` lowers them and before the rendering engine starts. Without that, undo rendered once with the pinned row missing and then again with it back — a visible flicker plus a wasted full render, and `afterRender` listeners read a value that was about to change. `beforeRemoveRow` and `afterRemoveRow` cannot be used for this: both fire inside `datamap.removeRow()` (`dataMap.ts:596` and `dataMap.ts:625`), before `alter` lowers the counters. A fallback restore right after `alter` covers the case where rendering is suspended and the hook does not run.

No public API shape changes.

### How has this been tested?

The failing tests were written first and confirmed red on unmodified source, then green with the fix:

- the core boundary case failed with `Expected 0 to equal 1`;
- the undo cases failed with `Expected 0 to be 1` / `Expected 1 to be 2`;
- the `updateSettings`-after-insert case failed with `Expected 1 to be 3`;
- the column case failed with `Expected 1 to be 2`;
- the single-render case failed with the recorded list `[1, 2]` — one render with the lowered counter, then one with the restored one.

New and updated specs:

- `handsontable/src/__tests__/core/removeRow.spec.js` — cases for `alter('remove_row')`: a bottom pinned row removed, a row above the pinned area removed, a range entirely above the pinned area, a range straddling the boundary, only the topmost pinned row removed, and removals with no index passed (rows taken from the end).
- `handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js` — round-trip cases: undoing an insertion above the pinned area, inside the bottom pinned area, and inside the top pinned area; the same for `fixedColumnsStart`; a counter raised by `updateSettings` after the insertion; and a check that the undo renders the pinned rows only once. The overlay itself is asserted through `getBottomClone()` and `getInlineStartClone()`, not only through `getSettings()`.

Commands:

```bash
npm run test:e2e --prefix handsontable --testPathPattern="(removeRow|removeCol|createRow|createCol|fixedRows|fixedColumns|undoRedo|alter)"
npm run test:unit --prefix handsontable --testPathPattern=undoRedo
npm run test:types --prefix handsontable
```

Results on the latest revision: 438 E2E specs, 0 failures; 6 unit tests, 0 failures; types pass. The full suites (unit 3396, E2E 9612 specs, 0 failures) were run on the first revision of this PR; CI covers them for the later commits.

Manual check in Chrome with the reproduction from the task, using `dev-latest.html` (18.0.0 from the CDN) against `dev-pr.html` (this branch). On the released build the readout reports `fixedRowsBottom = 0` after undo and the "Overall Totals" row scrolls away. On this branch the sequence insert → undo → redo → undo keeps `fixedRowsBottom = 1` at every step, and the row stays in the bottom overlay.

Note: `npm run eslint --prefix handsontable` crashes in my local checkout with `TypeError: minimatch is not a function` in the custom `handsontable/restricted-module-imports` rule. It crashes the same way on files this PR does not touch, so it is a local dependency problem, not a finding about this change. CI is the first full lint pass over the new `fixedCounts.ts`. No CSS was touched, so Stylelint does not apply.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2551

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2551
