### PR TITLE
DEV-2124: Fix autofill column resolution near horizontally merged cells

### DIFF
--- a/.changelogs/13201.json
+++ b/.changelogs/13201.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed autofill dragging near horizontally merged cells — the fill handle can now target columns inside a merged band in a row below the merge instead of snapping back to the merge anchor.",
+  "type": "fixed",
+  "issueOrPR": 13201,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/helpers/dom/__tests__/cellCoords.unit.js
+++ b/handsontable/src/helpers/dom/__tests__/cellCoords.unit.js
@@ -5,8 +5,10 @@ import { getCellCoordsFromMousePosition } from 'handsontable/helpers/dom/cellCoo
  *
  * Merges are described declaratively through `mergedCells`: only the anchor cell reports a
  * `rowspan`/`colspan` in its meta (matching real Handsontable), and every rendered slave of a
- * vertical merge resolves to the SAME cached `<td>` element — so a lookup can detect the merge by
- * element identity even when the anchor sits outside the scanned range.
+ * merge resolves to the SAME cached `<td>` element, positioned at the merge's top-left corner —
+ * so a lookup can detect the merge by element identity even when the anchor sits outside the
+ * scanned range. This holds on both axes: a vertical merge's slave rows and a horizontal merge's
+ * slave columns all share the anchor's element.
  *
  * @param {object} opts
  * @param {boolean} opts.isWindowScrollV  Whether the table scrolls vertically via window.
@@ -26,8 +28,10 @@ import { getCellCoordsFromMousePosition } from 'handsontable/helpers/dom/cellCoo
  * @param {number}   opts.totalCols        Total number of columns (defaults to lastCol + 1).
  * @param {number}   opts.fixedRowsTop     Count of frozen top rows.
  * @param {number}   opts.fixedRowsBottom  Count of frozen bottom rows.
+ * @param {number}   opts.fixedColumnsStart Count of frozen start columns.
  * @param {Array}    opts.mergedCells      Merge anchors as `{ row, col, rowspan?, colspan? }`.
  * @param {number[]} opts.hiddenColumns    Columns that render no cell (`getCell` returns null).
+ * @param {number[]} opts.hiddenRows       Rows that render no cell (`getCell` returns null).
  * @param {number[]} opts.hiddenMetaColumns Columns that render but report `hidden: true` meta
  *                                          (e.g. a horizontal-merge slave).
  * @param {boolean}  opts.isRtl            Whether the table is in RTL layout.
@@ -54,8 +58,10 @@ function buildHot({
   totalCols,
   fixedRowsTop = 0,
   fixedRowsBottom = 0,
+  fixedColumnsStart = 0,
   mergedCells = [],
   hiddenColumns = [],
+  hiddenRows = [],
   hiddenMetaColumns = [],
   rowHeight = 23,
   colWidth = 80,
@@ -79,7 +85,15 @@ function buildHot({
       return tableRect.top + colHeaderHeight + viewportHeight - ((rowCount - row) * rowHeight);
     }
 
-    return tableRect.top + colHeaderHeight + ((row - firstRow) * rowHeight);
+    let hiddenBefore = 0;
+
+    for (let r = firstRow; r < row; r++) {
+      if (hiddenRows.includes(r)) {
+        hiddenBefore += 1;
+      }
+    }
+
+    return tableRect.top + colHeaderHeight + ((row - firstRow - hiddenBefore) * rowHeight);
   };
   // Rendered left for a column, skipping the width of any hidden columns before it.
   const cellLeft = (col) => {
@@ -99,12 +113,13 @@ function buildHot({
   const makeCell = (row, col, merge) => {
     const el = document.createElement('td');
     const anchorRow = merge ? merge.row : row;
+    const anchorCol = merge ? merge.col : col;
     const height = rowHeight * (merge ? merge.rowspan : 1);
     const width = colWidth * (merge ? merge.colspan : 1);
     const top = cellTop(anchorRow);
     const rect = isRtl
-      ? { top, right: cellRight(col), bottom: top + height, left: cellRight(col) - width }
-      : { top, left: cellLeft(col), bottom: top + height, right: cellLeft(col) + width };
+      ? { top, right: cellRight(anchorCol), bottom: top + height, left: cellRight(anchorCol) - width }
+      : { top, left: cellLeft(anchorCol), bottom: top + height, right: cellLeft(anchorCol) + width };
 
     Object.defineProperty(el, 'offsetHeight', { get: () => height });
     Object.defineProperty(el, 'offsetWidth', { get: () => width });
@@ -113,17 +128,17 @@ function buildHot({
     return el;
   };
 
-  // Cache one element per vertical-merge band so its slaves share element identity.
+  // Cache one element per merge band so its slaves share element identity, on either axis.
   const bandCache = new Map();
 
   const getCell = (row, col) => {
-    if (hiddenColumns.includes(col)) {
+    if (hiddenColumns.includes(col) || hiddenRows.includes(row)) {
       return null;
     }
 
     const merge = findMerge(row, col);
 
-    if (merge && merge.rowspan > 1) {
+    if (merge && (merge.rowspan > 1 || merge.colspan > 1)) {
       const key = `${merge.row}:${merge.col}`;
 
       if (!bandCache.has(key)) {
@@ -183,7 +198,7 @@ function buildHot({
       getViewportHeight: () => viewportHeight,
       getColumnHeaderHeight: () => colHeaderHeight,
       getRowHeaderWidth: () => rowHeaderWidth,
-      countNotHiddenFixedColumnsStart: () => 0,
+      countNotHiddenFixedColumnsStart: () => fixedColumnsStart,
       countNotHiddenFixedRowsTop: () => fixedRowsTop,
       countNotHiddenFixedRowsBottom: () => fixedRowsBottom,
     },
@@ -583,6 +598,156 @@ describe('getCellCoordsFromMousePosition', () => {
       expect(coords.row).toBe(12);
       // Guard: without the identity check the merged column 0 would be used and collapse to row 10.
       expect(coords.row).not.toBe(10);
+    });
+  });
+
+  describe('horizontal merge in the reference row (DEV-2124)', () => {
+    // Reproduces DEV-2124, the X-axis analog of DEV-2115: the first visible row (row 0) holds a
+    // horizontal merge spanning columns 0-2 (colspan 3). The column lookup used to always measure
+    // against that first row, so any mouse X inside the merged band collapsed onto the merge
+    // anchor (column 0). When the mouse is over a row OUTSIDE the merge, the column must be the
+    // real column under the pointer.
+    const mergedFirstRowGeometry = {
+      tableRect: { left: 0, top: 0, right: 400, bottom: 300 },
+      viewportWidth: 400,
+      viewportHeight: 300,
+      firstRow: 0,
+      lastRow: 9,
+      firstCol: 0,
+      lastCol: 4,
+      totalRows: 10,
+      totalCols: 5,
+      rowHeight: 30,
+      colWidth: 80,
+      mergedCells: [{ row: 0, col: 0, colspan: 3 }], // A1:C1 - horizontal merge in row 0 only
+    };
+
+    it('resolves the column under the mouse in a non-merged row, ignoring the merge in row 0', () => {
+      const hot = buildHot(mergedFirstRowGeometry);
+      // X at the centre of column 2 (160..240 -> 200), inside row 0's merged band.
+      // Y at the centre of row 2 (60..90 -> 75), well below the merge.
+      const coords = getCellCoordsFromMousePosition(hot, 200, 75);
+
+      expect(coords.col).toBe(2);
+      expect(coords.row).toBe(2);
+      // Guard: measuring against the merged row 0 collapses every X in the band onto the anchor.
+      expect(coords.col).not.toBe(0);
+    });
+
+    it('resolves the middle column of the merged band', () => {
+      const hot = buildHot(mergedFirstRowGeometry);
+      // X at the centre of column 1 (80..160 -> 120), still inside row 0's merged band.
+      const coords = getCellCoordsFromMousePosition(hot, 120, 75);
+
+      expect(coords.col).toBe(1);
+      expect(coords.row).toBe(2);
+    });
+
+    it('resolves a column outside the merged band', () => {
+      const hot = buildHot(mergedFirstRowGeometry);
+      // X at the centre of column 3 (240..320 -> 280), past the end of row 0's merged band.
+      const coords = getCellCoordsFromMousePosition(hot, 280, 75);
+
+      expect(coords.col).toBe(3);
+    });
+  });
+
+  describe('horizontal merge whose anchor sits left of the scanned range (DEV-2124)', () => {
+    // Regression guard for the width over-count: the scrollable range starts at column 1, inside
+    // a horizontal merge anchored at column 0 (colspan 3, columns 0-2). None of the scanned slave
+    // columns (1-2) reports a colspan - only the anchor does, and it is out of range - so
+    // `findColumnAtX` cannot skip the band. Every slave resolves to the same wide element, whose
+    // full band width is then counted once per slave column, pushing every later column left.
+    const anchorLeftOfRangeGeometry = {
+      tableRect: { left: 0, top: 0, right: 320, bottom: 300 },
+      viewportWidth: 320,
+      viewportHeight: 300,
+      firstRow: 0,
+      lastRow: 9,
+      firstCol: 1,
+      lastCol: 4,
+      totalRows: 10,
+      totalCols: 5,
+      rowHeight: 30,
+      colWidth: 80,
+      // columns 0-2; the anchor (column 0) sits left of the scanned range
+      mergedCells: [{ row: 0, col: 0, colspan: 3 }],
+    };
+
+    it('detects the merge by element identity and resolves the true column under the pointer', () => {
+      const hot = buildHot(anchorLeftOfRangeGeometry);
+      // Column 3 is rendered at 160..240 (columns 1 and 2 come first), so X 200 is its centre.
+      // Y at the centre of row 2 (60..90 -> 75), below the merge.
+      const coords = getCellCoordsFromMousePosition(hot, 200, 75);
+
+      expect(coords.col).toBe(3);
+      expect(coords.row).toBe(2);
+      // Guard: re-counting the band width per slave column shifts the result two columns left.
+      expect(coords.col).not.toBe(2);
+    });
+  });
+
+  describe('hidden row between the merged row and a usable one (DEV-2124)', () => {
+    // Regression guard: row 0 is horizontally merged (columns 0-2) and row 1 is hidden, so it
+    // renders no cell. A reference row is only usable if it actually renders cells - accepting
+    // the hidden row 1 leaves `getCell` returning null and drops the lookup back onto the first
+    // visible column.
+    const hiddenRowGeometry = {
+      tableRect: { left: 0, top: 0, right: 400, bottom: 300 },
+      viewportWidth: 400,
+      viewportHeight: 300,
+      firstRow: 0,
+      lastRow: 9,
+      firstCol: 0,
+      lastCol: 4,
+      totalRows: 10,
+      totalCols: 5,
+      rowHeight: 30,
+      colWidth: 80,
+      hiddenRows: [1],
+      mergedCells: [{ row: 0, col: 0, colspan: 3 }], // A1:C1 - horizontal merge in row 0
+    };
+
+    it('skips the hidden row and resolves the column against row 2', () => {
+      const hot = buildHot(hiddenRowGeometry);
+      // Row 1 is hidden, so row 2 renders at 30..60 - X at the centre of column 2 (200),
+      // Y at the centre of the rendered row 2 (45).
+      const coords = getCellCoordsFromMousePosition(hot, 200, 45);
+
+      expect(coords.col).toBe(2);
+      expect(coords.row).toBe(2);
+    });
+  });
+
+  describe('horizontal merge inside the fixed (frozen) start columns (DEV-2124)', () => {
+    // Regression guard: the frozen start columns are resolved in their own branch, which must
+    // pick its reference row over its own column range. A horizontal merge in the first visible
+    // row of the frozen band would otherwise collapse the resolved column onto the merge anchor.
+    const frozenMergeGeometry = {
+      tableRect: { left: 0, top: 0, right: 560, bottom: 300 },
+      viewportWidth: 560,
+      viewportHeight: 300,
+      firstRow: 0,
+      lastRow: 9,
+      firstCol: 0,
+      lastCol: 6,
+      totalRows: 10,
+      totalCols: 7,
+      fixedColumnsStart: 3,
+      rowHeight: 30,
+      colWidth: 80,
+      mergedCells: [{ row: 0, col: 0, colspan: 3 }], // A1:C1 - spans the whole frozen band
+    };
+
+    it('resolves a frozen column inside the merged band using a merge-free reference row', () => {
+      const hot = buildHot(frozenMergeGeometry);
+      // X at the centre of frozen column 1 (80..160 -> 120), inside row 0's merged band.
+      // Y at the centre of row 2 (60..90 -> 75). Must resolve to column 1, not the anchor.
+      const coords = getCellCoordsFromMousePosition(hot, 120, 75);
+
+      expect(coords.col).toBe(1);
+      expect(coords.row).toBe(2);
+      expect(coords.col).not.toBe(0);
     });
   });
 });

--- a/handsontable/src/helpers/dom/cellCoords.ts
+++ b/handsontable/src/helpers/dom/cellCoords.ts
@@ -159,6 +159,71 @@ function findRowReferenceColumn(
 }
 
 /**
+ * Finds a row suitable for mapping an X coordinate to a column: the first row in the range
+ * whose cells across the scanned columns each occupy their own single column. `findColumnAtX`
+ * walks one row's cell widths and skips a merged cell's spanned columns, so it is distorted by a
+ * cell that spans multiple columns - a horizontal-merge anchor or any of its slaves. Such a row
+ * is detected two ways: `colspan > 1` on the anchor's meta, and element identity, since every
+ * column inside a horizontal merge resolves to the same rendered cell. A purely vertical merge
+ * resolves to a distinct, single-column master cell per column, so its rows stay valid. A merge
+ * in one row must not distort the column lookup used for other rows (DEV-2124).
+ *
+ * The scanned column range must match the range the returned row will be walked over (the frozen
+ * overlays and the scrollable body are resolved separately), so a merge confined to frozen
+ * columns cannot leak into the body lookup or vice versa.
+ *
+ * @param {Handsontable} hotInstance The Handsontable instance.
+ * @param {number} startRow First row to consider.
+ * @param {number} endRow Last row to consider (inclusive).
+ * @param {number} startColumn First column of the scanned range.
+ * @param {number} endColumn Last column of the scanned range (inclusive).
+ * @returns {number} A row index free of horizontal-merge distortion, or `startRow` if none qualifies.
+ */
+function findColumnReferenceRow(
+  hotInstance: HotInstance,
+  startRow: number,
+  endRow: number,
+  startColumn: number,
+  endColumn: number,
+): number {
+  for (let row = startRow; row <= endRow; row++) {
+    let spansMultipleColumns = false;
+    let hasRenderableCell = false;
+    let previousCell: HTMLElement | null = null;
+
+    for (let column = startColumn; column <= endColumn; column++) {
+      const cell = hotInstance.getCell(row, column, true);
+      const { colspan } = hotInstance.getCellMetaTransient<{ colspan?: number }>(row, column);
+
+      // A horizontally merged cell reports `colspan > 1` on its anchor and resolves to the same
+      // rendered element for every column it covers; either signal marks the row as distorting.
+      if ((colspan !== undefined && colspan > 1) || (cell !== null && cell === previousCell)) {
+        spansMultipleColumns = true;
+        break;
+      }
+
+      if (cell !== null) {
+        previousCell = cell;
+        hasRenderableCell = true;
+      }
+    }
+
+    // A hidden row (e.g. `hiddenRows`) renders no cells, so `findColumnAtX` cannot measure
+    // against it. Require at least one renderable cell so a hidden row between the merged
+    // row and a usable one is skipped rather than picked as the reference.
+    if (!spansMultipleColumns && hasRenderableCell) {
+      return row;
+    }
+  }
+
+  // Best-effort fallback: every row in the scanned range is horizontally merged (e.g. a banded
+  // report grid whose visible rows all merge across the same columns). No row is free of the
+  // distortion, so `findColumnAtX` will still collapse the band onto its anchor - `startRow` is
+  // simply the least-surprising choice. This is a known narrow case of DEV-2124, not a bug here.
+  return startRow;
+}
+
+/**
  * Get the cell coordinates from the mouse position. When the mouse is outside of the table,
  * the nearest cell is returned.
  *
@@ -222,6 +287,21 @@ export function getCellCoordsFromMousePosition(
   const clampedX = clamp(mouseX, tableViewportLeft, tableViewportRight);
   const clampedY = clamp(mouseY, tableViewportTop, tableViewportBottom);
 
+  // Resolve the column against a row that has no horizontal merge across the columns being
+  // walked. `findColumnAtX` skips a merged cell's spanned columns, so measuring against a
+  // horizontally merged row collapses every X inside the band onto the merge anchor - and when
+  // the anchor is scrolled out of view the band's full width is counted once per slave column.
+  // Neither a fixed row nor the pointer's row is universally safe (a merge can live in either),
+  // so each column-scan branch picks the first row free of horizontal merges within its own
+  // column range (DEV-2124).
+  const columnReferenceRowStart = firstPartiallyVisibleRow ?? 0;
+  // When the viewport query returns null nothing is rendered, so there is no cell to measure
+  // against. Keep the search inside the (empty) rendered range instead of opening it to every
+  // row in the grid - otherwise `findColumnReferenceRow` walks the full row x column product,
+  // calling `getCellMetaTransient` on each step, and a single held autofill/`dragToScroll` drag
+  // on a large off-screen grid locks the tab.
+  const columnReferenceRowEnd = lastPartiallyVisibleRow ?? columnReferenceRowStart;
+
   let foundColumn: number | null = null;
 
   // Check fixed columns first
@@ -233,7 +313,9 @@ export function getCellCoordsFromMousePosition(
       : null;
 
     if (firstNonHiddenColumn !== null && lastFixedColumn !== null) {
-      const fixedCell = hotInstance.getCell(firstPartiallyVisibleRow, firstNonHiddenColumn, true);
+      const columnReferenceRow = findColumnReferenceRow(
+        hotInstance, columnReferenceRowStart, columnReferenceRowEnd, firstNonHiddenColumn, lastFixedColumn);
+      const fixedCell = hotInstance.getCell(columnReferenceRow, firstNonHiddenColumn, true);
 
       if (fixedCell instanceof HTMLElement) {
         const fixedCellRect = fixedCell.getBoundingClientRect();
@@ -241,7 +323,7 @@ export function getCellCoordsFromMousePosition(
 
         foundColumn = findColumnAtX(
           hotInstance,
-          firstPartiallyVisibleRow,
+          columnReferenceRow,
           firstNonHiddenColumn,
           lastFixedColumn,
           fixedRelativeX,
@@ -252,7 +334,14 @@ export function getCellCoordsFromMousePosition(
 
   // If not in fixed columns, check scrollable columns (main table)
   if (foundColumn === null) {
-    const scrollCell = hotInstance.getCell(firstPartiallyVisibleRow, firstPartiallyVisibleColumn, true);
+    const columnReferenceRow = findColumnReferenceRow(
+      hotInstance,
+      columnReferenceRowStart,
+      columnReferenceRowEnd,
+      firstPartiallyVisibleColumn,
+      lastPartiallyVisibleColumn,
+    );
+    const scrollCell = hotInstance.getCell(columnReferenceRow, firstPartiallyVisibleColumn, true);
 
     if (scrollCell instanceof HTMLElement) {
       const scrollCellRect = scrollCell.getBoundingClientRect();
@@ -260,7 +349,7 @@ export function getCellCoordsFromMousePosition(
 
       foundColumn = findColumnAtX(
         hotInstance,
-        firstPartiallyVisibleRow,
+        columnReferenceRow,
         firstPartiallyVisibleColumn,
         lastPartiallyVisibleColumn,
         scrollRelativeX,

--- a/handsontable/src/plugins/mergeCells/__tests__/autofill.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/autofill.spec.js
@@ -88,6 +88,63 @@ describe('MergeCells cooperation with autofill', () => {
     expect(getDataAtCell(4, 2)).toBe('C5'); // untouched - drag stopped one row down
   });
 
+  it('should fill a column that sits within a horizontal merge belonging to a different row (DEV-2124)', async() => {
+    handsontable({
+      data: createSpreadsheetData(10, 10),
+      mergeCells: [
+        { row: 0, col: 0, rowspan: 1, colspan: 3 }, // A1:C1 - horizontal merge in row 0 only
+      ],
+    });
+
+    await selectCell(2, 0); // A3 - normal cell below the merged row
+
+    // Drag the fill handle right by a single column, to B3 - a column that lies inside row 0's
+    // merged band (columns 0-2). Regression: the mouse-to-column lookup measured against the
+    // merged row, so every X inside the band collapsed onto the merge anchor (A3) and the drag
+    // resolved back to the source cell, filling nothing.
+    simulateFillHandleDrag(getCell(2, 1));
+
+    expect(getDataAtCell(2, 1)).toBe('A3'); // filled from the source
+    expect(getDataAtCell(2, 2)).toBe('C3'); // untouched - drag stopped at B3
+  });
+
+  it('should fill several columns within a horizontal merge belonging to a different row (DEV-2124)', async() => {
+    handsontable({
+      data: createSpreadsheetData(10, 10),
+      mergeCells: [
+        { row: 0, col: 0, rowspan: 1, colspan: 3 }, // A1:C1 - horizontal merge in row 0 only
+      ],
+    });
+
+    await selectCell(2, 0); // A3
+
+    // Drag right to C3 - the last column inside row 0's merged band.
+    simulateFillHandleDrag(getCell(2, 2));
+
+    expect(getDataAtCell(2, 1)).toBe('A3');
+    expect(getDataAtCell(2, 2)).toBe('A3');
+    expect(getDataAtCell(2, 3)).toBe('D3'); // untouched - right of the drag range
+  });
+
+  it('should fill into a merged band when a hidden row sits between it and the dragged row (DEV-2124)', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 10),
+      hiddenRows: { rows: [1] }, // hide row 1, between the merged row 0 and row 2
+      mergeCells: [
+        { row: 0, col: 0, rowspan: 1, colspan: 3 }, // A1:C1 horizontal merge in row 0
+      ],
+    });
+
+    await selectCell(2, 0); // the first cell of row 2 within the merged band (row 1 hidden)
+
+    // Drag right one column. The reference-row search must skip the hidden row 1 (no rendered
+    // cell) instead of picking it, which would collapse the column lookup onto the merge anchor.
+    simulateFillHandleDrag(getCell(2, 1));
+
+    expect(getDataAtCell(2, 1)).toBe('A3'); // filled from the source
+    expect(getDataAtCell(2, 2)).toBe('C3'); // untouched - drag stopped one column right
+  });
+
   it('should populate merged cells data up', async() => {
     handsontable({
       data: createSpreadsheetData(10, 10),


### PR DESCRIPTION
### Context

The PR fixes autofill column resolution when a horizontal merge sits in the first visible row. This is the X-axis mirror of the Y-axis problem fixed in DEV-2115 (#13105); that fix left the column axis untouched.

`getCellCoordsFromMousePosition` maps a pointer X to a column by walking one reference row with `findColumnAtX`, and it always used the raw `firstPartiallyVisibleRow`. When that row holds a horizontal merge, two things go wrong:

1. **The band collapses onto its anchor.** The anchor cell's `offsetWidth` covers the whole merged band, so every X inside the band resolves to the anchor column. Dragging a fill handle sideways in a row below the merge resolves back to the source cell and fills nothing.
2. **The band width is over-counted.** Once the merge anchor scrolls out of view, none of the scanned slave columns reports a `colspan`, so `findColumnAtX` cannot skip the band. Every slave resolves to the same wide element, whose full width is counted once per slave column — pushing every later column to the left.

The existing merge autofill spec missed this because all of its merges start at row 1.

### The fix

A `findColumnReferenceRow` analog of `findRowReferenceColumn`, in `handsontable/src/helpers/dom/cellCoords.ts`. Each column-scan branch (frozen start columns, and the scrollable body) picks the first row within its own column range whose cells each occupy a single column — detected both by `colspan > 1` on the anchor's meta and by element identity, so a merge whose anchor sits outside the scanned range is still caught. A candidate row must render at least one cell, so a hidden row is skipped rather than picked.

`findColumnAtX` itself is unchanged, matching how DEV-2115 left `findRowAtY` alone and relied on a clean reference axis.

### How has this been tested?

Every new test was confirmed to **fail before** the fix and pass after.

Unit — 5 new cases in `cellCoords.unit.js`, all red on the unfixed helper:

| Case | Expected column | Before the fix |
|---|---|---|
| Pointer over column 2, merge A1:C1 | 2 | 0 (collapsed to anchor) |
| Pointer over column 1, same merge | 1 | 0 |
| Merge anchor scrolled left of view, pointer over column 3 | 3 | 2 (width over-count) |
| Hidden row 1 below the merged row 0 | 2 | 0 |
| Merge inside the frozen start columns | 1 | 0 |

E2E — 3 new cases in the existing `mergeCells/__tests__/autofill.spec.js`. Without the fix all three fail with `Expected 'B3' to be 'A3'` — the horizontal fill drag does nothing.

```bash
npm run test:unit --prefix handsontable -- --testPathPattern=cellCoords
npm run test:e2e --prefix handsontable -- --testPathPattern="mergeCells/__tests__/autofill"
```

Full runs on this branch:

- `npm run test:unit --prefix handsontable` — 3402 passed, 293 suites, 0 failures
- `npm run test:e2e --prefix handsontable -- --testPathPattern="(mergeCells|autofill|dragToScroll|hiddenRows|hiddenColumns|fixedColumns|fixedRows)"` — 1302 specs, 0 failures
- `npm run eslint --prefix handsontable` — 0 errors

Manual — a side-by-side demo page was driven in Chrome. Selecting A3 and dragging the fill handle right to C3, with `mergeCells: [{ row: 0, col: 0, rowspan: 1, colspan: 3 }]`:

- Released v18.0.0: `B3='B3'`, `C3='C3'` — nothing filled.
- This branch: `B3='A3'`, `C3='A3'`, `D3='D3'` — filled correctly, and the drag stops where it should.

The test stub in `cellCoords.unit.js` was extended so a horizontal merge's slave columns share the anchor's rendered element, matching how the real grid resolves them; hidden-row and frozen-start-column support was added alongside. No existing test changed behavior.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2124
2. Follow-up from #13105 (DEV-2115)

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2124

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared mouse-to-cell coordinate logic used by autofill and drag-to-scroll; scope is narrow and mirrors the prior vertical-merge fix, but incorrect column resolution could still affect fill range and selection at the grid edge.
> 
> **Overview**
> Fixes **autofill and pointer-to-column mapping** when a **horizontal merge** sits in the first visible row (DEV-2124), the X-axis counterpart to DEV-2115.
> 
> `getCellCoordsFromMousePosition` used **`firstPartiallyVisibleRow`** as the sole reference for `findColumnAtX`, so a merged band in that row collapsed every X onto the anchor column or **double-counted band width** when the anchor was scrolled out of view. The change adds **`findColumnReferenceRow`** (parallel to `findRowReferenceColumn`) and uses the first row in each scan range whose cells are single-column-wide—via `colspan > 1` and shared DOM identity—for frozen and scrollable column branches.
> 
> Reference-row search stays bounded to the partially visible row range to avoid performance regressions on large off-screen grids during long drags. Unit and mergeCells autofill specs cover hidden rows, frozen columns, and anchor-out-of-range cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0651f7b8084bf326849eef59a924acaa7712f3d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->