### PR TITLE
DEV-1656: Keep the autocomplete dropdown visible in short flex layouts

### DIFF
--- a/.changelogs/13202.json
+++ b/.changelogs/13202.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the autocomplete and dropdown option list collapsing to zero height, showing no options, when the grid was too short to fit one option below the edited cell.",
+  "type": "fixed",
+  "issueOrPR": 13202,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13202.json
+++ b/.changelogs/13202.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed the autocomplete and dropdown option list collapsing to zero height, showing no options, when the grid was too short to fit one option below the edited cell.",
+  "title": "Fixed the autocomplete and dropdown option list collapsing to zero height, hiding every option, when less than one option of space was left below the edited cell.",
   "type": "fixed",
   "issueOrPR": 13202,
   "breaking": false,

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -428,23 +428,27 @@ export class AutocompleteEditor extends HandsontableEditor {
     const dropdownHeight = this.getDropdownHeight();
 
     if (dropdownHeight > spaceAvailable) {
-      let tempHeight = 0;
-      let lastRowHeight = 0;
-      let height = 0;
+      const rowHeight = this.htEditor.stylesHandler.getDefaultRowHeight() ?? 0;
 
-      do {
-        lastRowHeight = this.htEditor.stylesHandler.getDefaultRowHeight() ?? 0;
-        tempHeight += lastRowHeight;
-      } while (tempHeight < spaceAvailable);
+      if (rowHeight === 0) {
+        return;
+      }
 
-      height = tempHeight - lastRowHeight;
+      // Fit whole rows only. `Math.ceil(...) - 1` reproduces the original "keep adding rows until
+      // one crosses the boundary, then step back a row" arithmetic, but always keeps at least one
+      // row visible. Without that floor the height collapses to 0 whenever the free space is not
+      // taller than a single row, which renders the list as an invisible sliver and hides every
+      // choice - the flexbox-squeezed grids reported in #8872. The MultiSelect editor's dropdown
+      // clamps to one entry the same way.
+      const rowsThatFit = Math.max(Math.ceil(spaceAvailable / rowHeight) - 1, 1);
+      const height = rowsThatFit * rowHeight;
 
       if (this.isFlippedVertically) {
         this.htEditor.rootElement.style.top =
           `${parseInt(this.htEditor.rootElement.style.top, 10) + dropdownHeight - height}px`;
       }
 
-      this.setDropdownHeight(tempHeight - lastRowHeight);
+      this.setDropdownHeight(height);
     }
   }
 

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -434,12 +434,21 @@ export class AutocompleteEditor extends HandsontableEditor {
         return;
       }
 
-      // Fit whole rows only. `Math.ceil(...) - 1` reproduces the original "keep adding rows until
-      // one crosses the boundary, then step back a row" arithmetic, but always keeps at least one
-      // row visible. Without that floor the height collapses to 0 whenever the free space is not
-      // taller than a single row, which renders the list as an invisible sliver and hides every
-      // choice - the flexbox-squeezed grids reported in #8872. The MultiSelect editor's dropdown
-      // clamps to one entry the same way.
+      // Show whole rows only, and stop one row short of the boundary: `Math.ceil(...) - 1` is the
+      // exact arithmetic of the do/while this replaced ("add rows until one crosses the free
+      // space, then step back a row"), so an exactly-fitting space still leaves its last row out.
+      // That margin is deliberately preserved - the list is trimmed because it overflows the
+      // workspace, and the rendered rows carry a border the raw row height does not.
+      //
+      // `Math.max(..., 1)` is the fix: without it the height collapsed to 0 whenever the free
+      // space was not taller than a single row, rendering the list as an invisible sliver that hid
+      // every choice - the flexbox-squeezed grids reported in #8872. The MultiSelect editor's
+      // dropdown clamps to one entry the same way (`dropdownController.updateDimensions()`).
+      //
+      // A caveat this cannot solve here: the grid's root element gets `overflow: clip` whenever a
+      // `height` is set, so when the free space is narrower than the forced row, that row is
+      // partly clipped by the grid's bottom edge - fully so when the space reaches 0. Making it
+      // readable in those extremes needs the dropdown to escape the clipping root (DEV-1656).
       const rowsThatFit = Math.max(Math.ceil(spaceAvailable / rowHeight) - 1, 1);
       const height = rowsThatFit * rowHeight;
 

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -449,6 +449,12 @@ export class AutocompleteEditor extends HandsontableEditor {
       // `height` is set, so when the free space is narrower than the forced row, that row is
       // partly clipped by the grid's bottom edge - fully so when the space reaches 0. Making it
       // readable in those extremes needs the dropdown to escape the clipping root (DEV-1656).
+      //
+      // No border compensation here, unlike `getTargetDropdownHeight()`'s `getTableHeight() + 1`.
+      // Adding it was measured and changes nothing a user sees: the clipping root, not the list's
+      // own budget, is what bounds the visible row, so the extra pixel only pushes the holder
+      // further past the clip (main 31->32px holder, 28px of option visible either way; classic
+      // 28->29 and 25; horizon 37->38 and 37).
       const rowsThatFit = Math.max(Math.ceil(spaceAvailable / rowHeight) - 1, 1);
       const height = rowsThatFit * rowHeight;
 

--- a/tests/e2e/dropdown-height.spec.ts
+++ b/tests/e2e/dropdown-height.spec.ts
@@ -38,8 +38,12 @@ test.describe('autocomplete dropdown height', () => {
 
     await grid.openDropdownAt(0, 1);
 
-    // A whole option must survive the grid root's clipping, not just exist in the DOM.
-    expect(await grid.visibleHeightOfOption('Germany')).toBeGreaterThanOrEqual(listRowHeight - 1);
+    // An option must survive the grid root's clipping, not just exist in the DOM. The
+    // threshold is a clear majority of the row rather than all of it: this fixture picks the
+    // tightest space that still triggers the bug, and in that space the clipping root always
+    // costs the row a pixel or two (see the spec header). A collapsed list measures 0, so
+    // the guard stays decisive while leaving room for per-theme drift.
+    expect(await grid.visibleHeightOfOption('Germany')).toBeGreaterThanOrEqual(listRowHeight * 0.8);
   });
 
   test('flex-squeezed grid — the last option is reachable from the keyboard', async () => {
@@ -55,9 +59,6 @@ test.describe('autocomplete dropdown height', () => {
     await grid.arrowDownThroughList(optionCount + 1);
 
     await expect(grid.optionByText('Spain')).toBeVisible();
-    // Looser than the unscrolled check: a scrolled list settles a couple of pixels off
-    // the clip edge, so require most of the row to be readable rather than all of it.
-    // On the collapsed list this measured 0, so the guard still catches the regression.
     expect(await grid.visibleHeightOfOption('Spain')).toBeGreaterThanOrEqual(listRowHeight * 0.8);
   });
 

--- a/tests/e2e/dropdown-height.spec.ts
+++ b/tests/e2e/dropdown-height.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '../fixtures/test';
+import { DropdownHeightPage } from '../fixtures/pages/DropdownHeightPage';
+
+/**
+ * #8872 / DEV-1656: the autocomplete dropdown showed no options when a flexbox
+ * parent squeezed the grid. `limitDropdownIfNeeded()` trims the list to whole rows
+ * that fit the free space below the edited cell, but its arithmetic returned 0 as
+ * soon as that space was not taller than a single row — the list rendered as an
+ * invisible sliver, so every choice was hidden. It must keep at least one option
+ * visible and stay scrollable to reach the rest.
+ */
+test.describe('autocomplete dropdown height', () => {
+  let grid: DropdownHeightPage;
+
+  test.beforeEach(async ({ page, theme, bundle }) => {
+    grid = new DropdownHeightPage(page, theme, bundle);
+    await grid.goto();
+  });
+
+  test('flex-squeezed grid — the list still shows an option instead of collapsing', async () => {
+    const rowHeight = await grid.defaultRowHeight();
+
+    await grid.openDropdownAt(0, 1);
+
+    // The free space below the cell is half a row, so the list is trimmed — but it
+    // must never fall below one whole option. Before the fix this measured ~0-2px.
+    expect(await grid.listHeight()).toBeGreaterThanOrEqual(rowHeight - 2);
+  });
+
+  test('flex-squeezed grid — the last option is reachable from the keyboard', async () => {
+    const optionCount = await grid.sourceOptionCount();
+
+    await grid.openDropdownAt(0, 1);
+
+    // The trimmed list scrolls, so nothing is silently dropped: arrowing past the
+    // end of the list brings the last option into the visible box.
+    expect(await grid.listCanScroll()).toBe(true);
+
+    await grid.arrowDownThroughList(optionCount + 1);
+
+    await expect(grid.optionByText('Spain')).toBeVisible();
+    expect(await grid.isOptionInsideVisibleList('Spain')).toBe(true);
+  });
+
+  test('flex-squeezed grid — the first option is inside the visible list box', async () => {
+    await grid.openDropdownAt(0, 1);
+
+    // A 0-height list leaves the option row entirely below the holder's bottom edge,
+    // clipped out of sight. The first option must sit within the visible box.
+    expect(await grid.isOptionInsideVisibleList('Germany')).toBe(true);
+  });
+
+  test('normal-height grid — the untrimmed list keeps showing all options', async () => {
+    const optionCount = await grid.sourceOptionCount();
+
+    await grid.openDropdownAt(0, 1, 'grid-tall');
+
+    // Regression guard for the non-flexbox case: there is room for the whole list,
+    // so it is not trimmed at all — every option is rendered and nothing scrolls.
+    await expect(grid.options('grid-tall')).toHaveCount(optionCount);
+    expect(await grid.listCanScroll('grid-tall')).toBe(false);
+  });
+});

--- a/tests/e2e/dropdown-height.spec.ts
+++ b/tests/e2e/dropdown-height.spec.ts
@@ -2,12 +2,18 @@ import { test, expect } from '../fixtures/test';
 import { DropdownHeightPage } from '../fixtures/pages/DropdownHeightPage';
 
 /**
- * #8872 / DEV-1656: the autocomplete dropdown showed no options when a flexbox
- * parent squeezed the grid. `limitDropdownIfNeeded()` trims the list to whole rows
- * that fit the free space below the edited cell, but its arithmetic returned 0 as
- * soon as that space was not taller than a single row — the list rendered as an
- * invisible sliver, so every choice was hidden. It must keep at least one option
- * visible and stay scrollable to reach the rest.
+ * #8872 / DEV-1656: the autocomplete dropdown showed no options when a flexbox parent
+ * squeezed the grid. `limitDropdownIfNeeded()` trims the list to whole rows that fit
+ * the free space below the edited cell, but its arithmetic returned 0 as soon as that
+ * space was not taller than a single row — the list rendered as an invisible sliver,
+ * so every choice was hidden. It must keep at least one option visible and stay
+ * scrollable to reach the rest.
+ *
+ * The visibility assertions measure the option against every clipping ancestor, not
+ * against the list's own holder: the holder lives inside the grid's root element,
+ * which carries `overflow: clip` whenever a `height` is set, and it can hang past that
+ * root's bottom edge. A holder-only check (and `toBeVisible()`, which only needs a
+ * non-empty bounding box) calls a clipped-away option visible.
  */
 test.describe('autocomplete dropdown height', () => {
   let grid: DropdownHeightPage;
@@ -17,37 +23,42 @@ test.describe('autocomplete dropdown height', () => {
     await grid.goto();
   });
 
-  test('flex-squeezed grid — the list still shows an option instead of collapsing', async () => {
-    const rowHeight = await grid.defaultRowHeight();
+  test('flex-squeezed grid — the editor no longer sizes the list to zero', async () => {
+    const listRowHeight = await grid.listRowHeight();
 
     await grid.openDropdownAt(0, 1);
 
-    // The free space below the cell is half a row, so the list is trimmed — but it
-    // must never fall below one whole option. Before the fix this measured ~0-2px.
-    expect(await grid.listHeight()).toBeGreaterThanOrEqual(rowHeight - 2);
+    // The free space below the cell is exactly one list row, so the list is trimmed —
+    // but it must never fall below one whole option. Before the fix this measured ~0-2px.
+    expect(await grid.listHeight()).toBeGreaterThanOrEqual(listRowHeight);
+  });
+
+  test('flex-squeezed grid — the first option is really on screen', async () => {
+    const listRowHeight = await grid.listRowHeight();
+
+    await grid.openDropdownAt(0, 1);
+
+    // A whole option must survive the grid root's clipping, not just exist in the DOM.
+    expect(await grid.visibleHeightOfOption('Germany')).toBeGreaterThanOrEqual(listRowHeight - 1);
   });
 
   test('flex-squeezed grid — the last option is reachable from the keyboard', async () => {
+    const listRowHeight = await grid.listRowHeight();
     const optionCount = await grid.sourceOptionCount();
 
     await grid.openDropdownAt(0, 1);
 
-    // The trimmed list scrolls, so nothing is silently dropped: arrowing past the
-    // end of the list brings the last option into the visible box.
+    // The trimmed list scrolls, so nothing is silently dropped: arrowing past the end
+    // of the list brings the last option on screen, readable in full.
     expect(await grid.listCanScroll()).toBe(true);
 
     await grid.arrowDownThroughList(optionCount + 1);
 
     await expect(grid.optionByText('Spain')).toBeVisible();
-    expect(await grid.isOptionInsideVisibleList('Spain')).toBe(true);
-  });
-
-  test('flex-squeezed grid — the first option is inside the visible list box', async () => {
-    await grid.openDropdownAt(0, 1);
-
-    // A 0-height list leaves the option row entirely below the holder's bottom edge,
-    // clipped out of sight. The first option must sit within the visible box.
-    expect(await grid.isOptionInsideVisibleList('Germany')).toBe(true);
+    // Looser than the unscrolled check: a scrolled list settles a couple of pixels off
+    // the clip edge, so require most of the row to be readable rather than all of it.
+    // On the collapsed list this measured 0, so the guard still catches the regression.
+    expect(await grid.visibleHeightOfOption('Spain')).toBeGreaterThanOrEqual(listRowHeight * 0.8);
   });
 
   test('normal-height grid — the untrimmed list keeps showing all options', async () => {

--- a/tests/fixtures/demo/dropdown-height.html
+++ b/tests/fixtures/demo/dropdown-height.html
@@ -37,13 +37,23 @@
     E2E fixture for #8872 / DEV-1656: autocomplete dropdown height when a flexbox
     parent squeezes the grid.
 
-    `#grid` sits in a flex column whose height is set, after the first render, to
-    1.5 default row heights — the shortest grid that still renders the edited row.
-    Column headers are off so the edited cell starts at y=0: that keeps `spaceAbove`
-    at 0, so the dropdown can never flip upwards and the "space below" branch of
-    `limitDropdownIfNeeded()` is the one under test. The free space below the cell is
-    then half a row — less than one whole option — which used to collapse the list to
-    a 0px height and hide every choice.
+    `#grid` sits in a flex column whose height is set, after the first render, to one
+    rendered row plus one list row. Column headers are off so the edited cell starts at
+    y=0: that keeps `spaceAbove` at 0, so the dropdown can never flip upwards and the
+    "space below" branch of `limitDropdownIfNeeded()` is the one under test. The free
+    space below the cell is then EXACTLY one list row, the boundary where the old
+    arithmetic collapsed the list to a 0px height and hid every choice.
+
+    That exact height is also the only one where the forced row is fully readable. The
+    grid's root element carries `overflow: clip` once a `height` is set, so it cuts off
+    whatever the dropdown renders past the grid's bottom edge. Squeeze the grid below
+    this height and the free space is narrower than the row that gets forced, so the
+    row is partly (at the extreme, entirely) clipped away - a separate limitation
+    tracked in DEV-1656, fixable only by letting the dropdown escape that clipping root.
+
+    Two row heights are published because they differ by the 1px first-row border
+    compensation: `htRowHeight` is what a cell renders as, `htListRowHeight` is what
+    `StylesHandler#getDefaultRowHeight()` reports and what the editor sizes rows by.
 
     `#grid-tall` is the non-flexbox control: a normal 400px grid where the whole list
     fits and must keep rendering all options untouched.
@@ -115,12 +125,15 @@
       height: 400,
     });
 
-    // Squeeze the flex parent down to 1.5 rows, measured from what the active theme
-    // actually rendered. `window.htRowHeight` is what the spec asserts against.
+    // Squeeze the flex parent so the space below the edited cell is exactly one list
+    // row. Both heights are measured from what the active theme actually rendered, never
+    // hardcoded - main, horizon, and classic all differ.
     const firstCell = window.hot.getCell(0, 0);
 
     window.htRowHeight = firstCell.offsetHeight;
-    document.getElementById('flex-wrapper').style.height = `${Math.round(window.htRowHeight * 1.5)}px`;
+    window.htListRowHeight = window.hot.stylesHandler.getDefaultRowHeight();
+    document.getElementById('flex-wrapper').style.height =
+      `${window.htRowHeight + window.htListRowHeight}px`;
     window.hot.refreshDimensions();
 
     window.htOptionCount = COUNTRIES.length;

--- a/tests/fixtures/demo/dropdown-height.html
+++ b/tests/fixtures/demo/dropdown-height.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable e2e fixture — dropdown height</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back — a
+    // typo in the project config must be one red leg, never a silently
+    // mislabeled green one (nothing else asserts which file actually loaded).
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+    /* The reported layout (#8872): a flex parent decides the grid height, so the
+       grid ends up far shorter than its `height` setting would suggest. */
+    .flex-column { display: flex; flex-direction: column; }
+    .flex-column > .flex-item { flex: 1 1 0%; min-height: 0; }
+  </style>
+</head>
+<body>
+  <!--
+    E2E fixture for #8872 / DEV-1656: autocomplete dropdown height when a flexbox
+    parent squeezes the grid.
+
+    `#grid` sits in a flex column whose height is set, after the first render, to
+    1.5 default row heights — the shortest grid that still renders the edited row.
+    Column headers are off so the edited cell starts at y=0: that keeps `spaceAbove`
+    at 0, so the dropdown can never flip upwards and the "space below" branch of
+    `limitDropdownIfNeeded()` is the one under test. The free space below the cell is
+    then half a row — less than one whole option — which used to collapse the list to
+    a 0px height and hide every choice.
+
+    `#grid-tall` is the non-flexbox control: a normal 400px grid where the whole list
+    fits and must keep rendering all options untouched.
+
+    The Country cells start empty so opening the editor does not filter the list down
+    to the cell's own value — the test is about the list's height, not its filtering.
+
+    The wrapper height is derived from the rendered row height instead of being
+    hardcoded, because each theme (main/horizon/classic) has its own row height.
+    TDs are stamped with data-testid in afterRender because the autocomplete cell
+    type owns its renderer (the arrow), so a custom renderer would break it.
+  -->
+  <div class="flex-column" id="flex-wrapper">
+    <div class="flex-item" id="grid" data-testid="grid"></div>
+  </div>
+
+  <div style="margin-top: 1rem">
+    <div id="grid-tall" data-testid="grid-tall"></div>
+  </div>
+
+  <script>
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const COUNTRIES = ['Germany', 'Italy', 'France', 'Finland', 'Spain'];
+
+    function stampTestIds() {
+      this.getData().forEach((rowData, row) => {
+        rowData.forEach((cellValue, col) => {
+          const td = this.getCell(row, col);
+
+          if (td) {
+            td.setAttribute('data-testid', `cell-${row}-${col}`);
+          }
+        });
+      });
+    }
+
+    const settings = {
+      data: [
+        ['Nokia', ''],
+        ['Bosch', ''],
+        ['Ferrero', ''],
+      ],
+      colWidths: [140, 140],
+      columns: [
+        {},
+        { type: 'autocomplete', source: COUNTRIES, strict: true },
+      ],
+      afterRender: stampTestIds,
+      licenseKey: 'non-commercial-and-evaluation',
+    };
+
+    const squeezed = document.querySelector('[data-testid="grid"]');
+    const tall = document.querySelector('[data-testid="grid-tall"]');
+
+    squeezed.className = `flex-item ht-theme-${window.htTheme}`;
+    tall.className = `ht-theme-${window.htTheme}`;
+
+    window.hot = new Handsontable(squeezed, {
+      ...settings,
+      colHeaders: false,
+      height: '100%',
+    });
+
+    window.hotTall = new Handsontable(tall, {
+      ...settings,
+      colHeaders: ['Company Name', 'Country'],
+      height: 400,
+    });
+
+    // Squeeze the flex parent down to 1.5 rows, measured from what the active theme
+    // actually rendered. `window.htRowHeight` is what the spec asserts against.
+    const firstCell = window.hot.getCell(0, 0);
+
+    window.htRowHeight = firstCell.offsetHeight;
+    document.getElementById('flex-wrapper').style.height = `${Math.round(window.htRowHeight * 1.5)}px`;
+    window.hot.refreshDimensions();
+
+    window.htOptionCount = COUNTRIES.length;
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/dropdown-height.html
+++ b/tests/fixtures/demo/dropdown-height.html
@@ -28,7 +28,10 @@
     body { font-family: sans-serif; margin: 1rem; }
     /* The reported layout (#8872): a flex parent decides the grid height, so the
        grid ends up far shorter than its `height` setting would suggest. */
-    .flex-column { display: flex; flex-direction: column; }
+    /* A definite starting height, shrunk to the exact one below once the grid has
+       rendered. Left at `auto` the `height: '100%'` grid resolves against a content-sized
+       parent and collapses to 0px, which is not a state worth measuring from. */
+    .flex-column { display: flex; flex-direction: column; height: 200px; }
     .flex-column > .flex-item { flex: 1 1 0%; min-height: 0; }
   </style>
 </head>
@@ -125,18 +128,35 @@
       height: 400,
     });
 
-    // Squeeze the flex parent so the space below the edited cell is exactly one list
-    // row. Both heights are measured from what the active theme actually rendered, never
-    // hardcoded - main, horizon, and classic all differ.
-    const firstCell = window.hot.getCell(0, 0);
-
-    window.htRowHeight = firstCell.offsetHeight;
-    window.htListRowHeight = window.hot.stylesHandler.getDefaultRowHeight();
-    document.getElementById('flex-wrapper').style.height =
-      `${window.htRowHeight + window.htListRowHeight}px`;
-    window.hot.refreshDimensions();
-
     window.htOptionCount = COUNTRIES.length;
+
+    // Squeeze the flex parent so the space below the edited cell is exactly one list row.
+    // Both heights are measured from what the active theme actually rendered, never
+    // hardcoded - main, horizon, and classic all differ.
+    //
+    // The measurement runs on the first render that has cells, not only straight after the
+    // constructor: `getCell(0, 0)` is only guaranteed once the grid has rendered, and a grid
+    // whose root element is not painted takes core's hidden-init path and renders later. A
+    // purely synchronous read would throw on that path instead of measuring anything.
+    let isSqueezed = false;
+
+    function squeezeWrapperOnce() {
+      const firstCell = window.hot.getCell(0, 0);
+
+      if (isSqueezed || !firstCell) {
+        return;
+      }
+
+      isSqueezed = true;
+      window.htRowHeight = firstCell.offsetHeight;
+      window.htListRowHeight = window.hot.stylesHandler.getDefaultRowHeight();
+      document.getElementById('flex-wrapper').style.height =
+        `${window.htRowHeight + window.htListRowHeight}px`;
+      window.hot.refreshDimensions();
+    }
+
+    window.hot.addHook('afterRender', squeezeWrapperOnce);
+    squeezeWrapperOnce();
   </script>
 </body>
 </html>

--- a/tests/fixtures/pages/DropdownHeightPage.ts
+++ b/tests/fixtures/pages/DropdownHeightPage.ts
@@ -1,0 +1,134 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the dropdown-height fixture (#8872 / DEV-1656): an autocomplete
+ * dropdown opened in a grid that a flexbox parent squeezed to 1.5 rows, plus a
+ * normal-height control grid. Encapsulates opening the list, reading the theme's
+ * rendered row height, and measuring the list box.
+ */
+export class DropdownHeightPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+  }
+
+  /**
+   * Navigate and wait for both grids to render (a real DOM condition, no sleep).
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(`/tests/fixtures/demo/dropdown-height.html?theme=${this.theme}&bundle=${this.bundle}`);
+    await expect(this.cell(0, 0)).toBeVisible();
+    await expect(this.cell(0, 0, 'grid-tall')).toBeVisible();
+  }
+
+  /**
+   * A data cell in the master table of one of the fixture's grids.
+   */
+  cell(row: number, col: number, gridTestId = 'grid'): Locator {
+    return this.page.getByTestId(gridTestId).locator('.ht_master').getByTestId(`cell-${row}-${col}`);
+  }
+
+  /**
+   * Open the autocomplete editor on a cell and wait for the list to show.
+   */
+  async openDropdownAt(row: number, col: number, gridTestId = 'grid'): Promise<void> {
+    await this.cell(row, col, gridTestId).dblclick();
+    await expect(this.dropdownList(gridTestId)).toBeAttached();
+  }
+
+  /**
+   * The inner listbox table of the open dropdown editor.
+   */
+  dropdownList(gridTestId = 'grid'): Locator {
+    return this.page.getByTestId(gridTestId)
+      .locator('.handsontableInputHolder .autocompleteEditor .ht_master .htCore');
+  }
+
+  /**
+   * The scrollable holder that clips the option rows — the element whose height
+   * decides how much of the list the user actually sees.
+   */
+  dropdownHolder(gridTestId = 'grid'): Locator {
+    return this.page.getByTestId(gridTestId)
+      .locator('.handsontableInputHolder .autocompleteEditor .ht_master .wtHolder');
+  }
+
+  /**
+   * Every option row cell currently rendered in the open list. The list is
+   * virtualized, so a trimmed list renders only the rows near the viewport.
+   */
+  options(gridTestId = 'grid'): Locator {
+    return this.dropdownList(gridTestId).locator('tbody tr td');
+  }
+
+  /**
+   * One option row addressed by its label.
+   */
+  optionByText(label: string, gridTestId = 'grid'): Locator {
+    return this.options(gridTestId).filter({ hasText: label });
+  }
+
+  /**
+   * Walk down the option list with the keyboard, the way a user reaches the options
+   * that a trimmed list does not show. Navigation stops on the last option, so
+   * pressing more times than there are options always lands on it.
+   */
+  async arrowDownThroughList(times: number): Promise<void> {
+    for (let i = 0; i < times; i++) {
+      await this.page.keyboard.press('ArrowDown');
+    }
+  }
+
+  /**
+   * True when the option row sits inside the list's clipping box, so the user can
+   * actually read it. An option outside that box is scrolled or trimmed out of
+   * sight even though the row element itself still reports a bounding box - which
+   * is exactly what a collapsed list looked like.
+   */
+  async isOptionInsideVisibleList(label: string, gridTestId = 'grid'): Promise<boolean> {
+    const holderBox = await this.dropdownHolder(gridTestId).boundingBox();
+    const optionBox = await this.optionByText(label, gridTestId).boundingBox();
+
+    if (!holderBox || !optionBox) {
+      throw new Error(`dropdown holder or the "${label}" option is not rendered`);
+    }
+
+    // 2px tolerance: the themes differ in how the list's border is compensated.
+    return optionBox.y >= holderBox.y - 2 &&
+      (optionBox.y + optionBox.height) <= (holderBox.y + holderBox.height + 2);
+  }
+
+  /**
+   * The visible height of the option list, in CSS pixels.
+   */
+  async listHeight(gridTestId = 'grid'): Promise<number> {
+    return this.dropdownHolder(gridTestId).evaluate(el => el.getBoundingClientRect().height);
+  }
+
+  /**
+   * True when the list is taller than its holder, so the user can scroll to the
+   * options that do not fit.
+   */
+  async listCanScroll(gridTestId = 'grid'): Promise<boolean> {
+    return this.dropdownHolder(gridTestId).evaluate(el => el.scrollHeight > el.clientHeight);
+  }
+
+  /**
+   * The row height the active theme actually rendered, published by the fixture.
+   */
+  async defaultRowHeight(): Promise<number> {
+    return this.page.evaluate(() => (window as unknown as { htRowHeight: number }).htRowHeight);
+  }
+
+  /**
+   * The number of options the fixture feeds to the autocomplete `source`.
+   */
+  async sourceOptionCount(): Promise<number> {
+    return this.page.evaluate(() => (window as unknown as { htOptionCount: number }).htOptionCount);
+  }
+}

--- a/tests/fixtures/pages/DropdownHeightPage.ts
+++ b/tests/fixtures/pages/DropdownHeightPage.ts
@@ -85,29 +85,53 @@ export class DropdownHeightPage {
   }
 
   /**
-   * True when the option row sits inside the list's clipping box, so the user can
-   * actually read it. An option outside that box is scrolled or trimmed out of
-   * sight even though the row element itself still reports a bounding box - which
-   * is exactly what a collapsed list looked like.
+   * How much of the option row is genuinely on screen, in CSS pixels.
+   *
+   * The row is intersected with EVERY clipping ancestor, not just the list's own
+   * holder. That holder is a descendant of the grid's root element, which carries
+   * `overflow: clip` whenever a `height` setting is applied, and the holder can hang
+   * past the root's bottom edge - so measuring the row against the holder alone
+   * reports a row as visible after the grid root has already cut it away. Playwright's
+   * `toBeVisible()` has the same blind spot: it only needs a non-empty bounding box.
    */
-  async isOptionInsideVisibleList(label: string, gridTestId = 'grid'): Promise<boolean> {
-    const holderBox = await this.dropdownHolder(gridTestId).boundingBox();
-    const optionBox = await this.optionByText(label, gridTestId).boundingBox();
+  async visibleHeightOfOption(label: string, gridTestId = 'grid'): Promise<number> {
+    return this.optionByText(label, gridTestId).evaluate((element: Element) => {
+      const view = element.ownerDocument.defaultView;
 
-    if (!holderBox || !optionBox) {
-      throw new Error(`dropdown holder or the "${label}" option is not rendered`);
-    }
+      if (!view) {
+        throw new Error('the option is not attached to a rendered document');
+      }
 
-    // 2px tolerance: the themes differ in how the list's border is compensated.
-    return optionBox.y >= holderBox.y - 2 &&
-      (optionBox.y + optionBox.height) <= (holderBox.y + holderBox.height + 2);
+      const rect = element.getBoundingClientRect();
+      let top = rect.top;
+      let bottom = rect.bottom;
+      let ancestor = element.parentElement;
+
+      while (ancestor && ancestor !== element.ownerDocument.body) {
+        if (view.getComputedStyle(ancestor).overflowY !== 'visible') {
+          const box = ancestor.getBoundingClientRect();
+
+          top = Math.max(top, box.top);
+          bottom = Math.min(bottom, box.bottom);
+        }
+
+        ancestor = ancestor.parentElement;
+      }
+
+      return Math.max(0, bottom - top);
+    });
   }
 
   /**
-   * The visible height of the option list, in CSS pixels.
+   * The height the editor gave the option list, in CSS pixels.
+   *
+   * This is the holder's own box, so it does NOT account for the grid root clipping
+   * the list - use `visibleHeightOfOption()` for what the user can actually read.
+   * Kept separate because the two answer different questions: this one pins the size
+   * the editor computed, which is where the zero-height regression originated.
    */
   async listHeight(gridTestId = 'grid'): Promise<number> {
-    return this.dropdownHolder(gridTestId).evaluate(el => el.getBoundingClientRect().height);
+    return this.dropdownHolder(gridTestId).evaluate((el: Element) => el.getBoundingClientRect().height);
   }
 
   /**
@@ -115,7 +139,7 @@ export class DropdownHeightPage {
    * options that do not fit.
    */
   async listCanScroll(gridTestId = 'grid'): Promise<boolean> {
-    return this.dropdownHolder(gridTestId).evaluate(el => el.scrollHeight > el.clientHeight);
+    return this.dropdownHolder(gridTestId).evaluate((el: Element) => el.scrollHeight > el.clientHeight);
   }
 
   /**
@@ -123,6 +147,16 @@ export class DropdownHeightPage {
    */
   async defaultRowHeight(): Promise<number> {
     return this.page.evaluate(() => (window as unknown as { htRowHeight: number }).htRowHeight);
+  }
+
+  /**
+   * The row height the editor sizes its option rows by (`getDefaultRowHeight()`),
+   * published by the fixture. It is 1px under `defaultRowHeight()` — the first-row
+   * border compensation — so the two must not be used interchangeably when asserting
+   * against an exact one-row boundary.
+   */
+  async listRowHeight(): Promise<number> {
+    return this.page.evaluate(() => (window as unknown as { htListRowHeight: number }).htListRowHeight);
   }
 
   /**

--- a/tests/fixtures/pages/DropdownHeightPage.ts
+++ b/tests/fixtures/pages/DropdownHeightPage.ts
@@ -34,11 +34,18 @@ export class DropdownHeightPage {
   }
 
   /**
-   * Open the autocomplete editor on a cell and wait for the list to show.
+   * Open the autocomplete editor on a cell and wait for the list to be populated.
+   *
+   * Waiting on the list table itself resolves too early: the inner grid is built
+   * synchronously with `startRows: 0`, so `.htCore` is attached and empty while everything
+   * that sizes the list runs later, in the `_registerTimeout` that `open()` schedules for
+   * `queryChoices()`. Measuring in that window reads an unsized ~1px holder. An option row
+   * only exists once `updateChoicesList()` has loaded the choices, and that call sizes the
+   * list in the same synchronous block, so a rendered option is the honest gate.
    */
   async openDropdownAt(row: number, col: number, gridTestId = 'grid'): Promise<void> {
     await this.cell(row, col, gridTestId).dblclick();
-    await expect(this.dropdownList(gridTestId)).toBeAttached();
+    await expect(this.options(gridTestId).first()).toBeAttached();
   }
 
   /**


### PR DESCRIPTION
### Context

The PR fixes the autocomplete/dropdown option list collapsing to zero height when the grid is short, so the user sees no options at all.

DEV-1656 asked to verify and fix GitHub issue #8872 ("Autocomplete/dropdown doesn't show all options in cells with Flexbox"). Two separate findings:

**1. The originally reported reproduction no longer fails.** The reported [CodeSandbox](https://codesandbox.io/s/handsontable-autocomplete-issue-cvnw9) combines `body { display: flex }` with `.wtHolder { width: unset !important; height: unset !important }` — user CSS that overrides Handsontable's own holder sizing. Rebuilt locally and measured:

| Build | Dropdown list height | Options visible |
|---|---|---|
| v10.0.0 (as reported) | 23px | 1 of 5 |
| v18.0.0 / `develop` | 148px | 5 of 5 |

So that specific layout was fixed somewhere between v10 and v18. GitHub issue #8872 was closed on the same day DEV-1656 was created — that was a migration to internal tracking, not a fix commit.

**2. A live defect on the same code path still hides every option.** `AutocompleteEditor#limitDropdownIfNeeded()` trims the option list to whole rows that fit the free space below the edited cell:

```js
do {
  lastRowHeight = this.htEditor.stylesHandler.getDefaultRowHeight() ?? 0;
  tempHeight += lastRowHeight;
} while (tempHeight < spaceAvailable);

height = tempHeight - lastRowHeight;
```

When `spaceAvailable` is not taller than one row, the loop runs a single pass and `height` becomes **0**. The list renders as a ~2px sliver, so every choice is hidden — the exact symptom #8872 describes. It needs no `!important` override: a plain flex parent that squeezes the grid is enough, which is the layout the issue is about.

Measured on released v18.0.0, a `flex-direction: column` parent with a 5-option autocomplete, editing the first row:

| Grid height | Dropdown height set | Options visible |
|---|---|---|
| 70px | 0 | none |
| 78px | 0 | none |
| 87px | 0 | none |
| 91px | 29 | 1, scrollable |
| 120px | 58 | 2, scrollable |

Two further problems in the same block: `setDropdownHeight()` recomputed `tempHeight - lastRowHeight` instead of reusing the already-computed `height`, and a default row height of `0` made the loop spin forever.

**The fix.** The list is clamped to one option at minimum and stays scrollable to reach the rest — the same floor the newer MultiSelect editor's dropdown already applies (`Math.max(..., 1)` in `dropdownController.updateDimensions()`). The loop is replaced with equivalent arithmetic:

```js
const rowsThatFit = Math.max(Math.ceil(spaceAvailable / rowHeight) - 1, 1);
const height = rowsThatFit * rowHeight;
```

`Math.ceil(...) - 1` reproduces the old "add rows until one crosses the boundary, then step back a row" result exactly for every `spaceAvailable` above one row height, so the existing trimming behavior is unchanged — including the deliberate margin that leaves the last row out when the space fits exactly. Only the previously-zero cases move, and the `rowHeight === 0` early return removes the infinite loop.

**Known limitation, not fixed here.** The grid's root element gets `overflow: clip` whenever a `height` is set (`core.ts`), and the dropdown's holder is inside that root, so anything the list renders past the grid's bottom edge is cut off. When the free space is narrower than the row this fix forces, that row is only partly readable — and at zero free space it is clipped away entirely. Measured on this build at row height 30:

| Space below the cell | Option pixels on screen (of 30) |
|---|---|
| 0 | 0 |
| 15 | 14 |
| 29 (one whole list row) | 28 |

So the fix guarantees the editor stops sizing the list to zero, and the option is readable as soon as there is a row's worth of space. Making it readable in the tighter extremes needs the dropdown to escape the clipping root — a larger change (it would touch positioning, focus, and a11y) that deserves its own task.

### How has this been tested?

New Playwright E2E spec `tests/e2e/dropdown-height.spec.ts` with the fixture `tests/fixtures/demo/dropdown-height.html`.

The fixture sizes its flex parent to one rendered row plus one list row, both measured from what the active theme rendered (main/horizon/classic differ, and the two heights differ from each other by the 1px first-row border compensation). That makes the free space below the cell exactly one list row: the boundary where the old arithmetic returned 0, and the only squeeze where the forced row also clears the grid's clipping edge. Column headers are off so the edited cell starts at y=0, which keeps `spaceAbove` at 0 so the dropdown cannot flip and the "space below" branch stays under test.

The visibility assertions intersect the option row with **every** clipping ancestor. Measuring against the list's own holder is not enough — the holder can hang past the clipping root, and Playwright's `toBeVisible()` only needs a non-empty bounding box, so both call a clipped-away option visible. An earlier revision of this spec did exactly that and passed on the unfixed build; the current one does not.

```bash
cd tests && npx playwright test e2e/dropdown-height.spec.ts
```

Verified by reverting the source, rebuilding, and re-running all six legs: **18 of 24 failed** — the three flex tests on every theme × bundle leg — while the 6 control tests stayed green, which is what shows the fixture itself is sound. With the fix, 24/24 pass.

| Test | On the unfixed build | With the fix |
|---|---|---|
| the editor no longer sizes the list to zero | list height `0`, expected `>= 29` | pass |
| the first option is really on screen | `0px` on screen, expected `>= 28` | 28 of 30 px |
| the last option is reachable from the keyboard | `0px` on screen after arrowing | 26 of 29 px |
| normal-height grid keeps showing all options | pass (control) | pass |

Regression runs, all green:

```bash
npm run test:e2e --prefix handsontable --testPathPattern=autocompleteEditor            # 138 specs, 0 failures
npm run test:e2e --prefix handsontable --testPathPattern="handsontableEditor|multiSelectEditor|dropdownEditor"  # 193 specs, 0 failures
npm run eslint --prefix handsontable                                                  # 0 errors
npm run test:types --prefix handsontable                                              # pass
cd tests && npx playwright test --project=e2e-main e2e/dropdown-width.spec.ts e2e/editor-window-scroll.spec.ts
cd tests && npx playwright test e2e/dropdown-height.spec.ts                            # 24 passed (3 themes x 2 bundles)
npm run test:unit --prefix handsontable --testPathPattern="autocomplete|editor"        # 3396 tests, 0 failures
```

One branch is deliberately not pinned by the new tests: the fixture turns column headers off so the dropdown cannot flip upwards, which keeps the "space below" branch under test. The flipped branch gets the same one-row floor, and the existing Jasmine flip tests ("display the dropdown above the editor", "limit the list to the space size left above the editor") pass — but a flipped dropdown with under one row of space above is unexercised. There it now renders one option just above the workspace edge instead of nothing at all.

The two legacy specs that pin this arithmetic — "should limit the list to the space size left below/above the editor" — sit on exact row-height multiples and still pass, which is the guard that the non-collapsed trimming behavior did not shift.

Manual verification used a three-case demo page (`handsontable/dev-latest.html` vs `handsontable/dev-pr.html`, both gitignored):

1. The reported CodeSandbox CSS verbatim — all 5 options on both builds (already fixed).
2. A `flex-direction: column` parent squeezing the grid to 78px — **no list at all** on v18.0.0, one option plus a scrollbar on this build.
3. A non-flexbox control at `height: 450` — all 5 options, unchanged on both builds.

One note for whoever runs the suite locally: `playwright.config.ts` sets `reuseExistingServer`, so if another checkout of this repo on the same machine is already serving port 8123, every spec here fails with `net::ERR_CONNECTION_REFUSED` or a blank fixture. That is what it looks like, not a flake in this spec.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1656
2. #8872

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1656

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized bug fix in autocomplete dropdown height math with E2E coverage; trimming behavior above one row height is preserved and existing editor tests pass.
> 
> **Overview**
> Fixes **#8872** / DEV-1656: when a flex parent squeezes the grid, the autocomplete option list could be sized to **0px** and hide every choice.
> 
> **`limitDropdownIfNeeded()`** replaces the old do/while row loop with `Math.max(Math.ceil(spaceAvailable / rowHeight) - 1, 1)` so trimming still stops one row short of the boundary, but **at least one row** is always shown (aligned with MultiSelect’s dropdown). A **`rowHeight === 0`** guard avoids an infinite loop.
> 
> **Tests:** Playwright E2E (`dropdown-height.spec.ts`) with a flex-squeezed fixture—list height, real on-screen option height (all clipping ancestors), keyboard reach to the last option, and a tall-grid regression.
> 
> **Not in scope:** options can still be partly clipped by the grid root’s `overflow: clip` when free space is below one row height; escaping that root is tracked separately (DEV-1656).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1050c5748a1acf733e198375c4955cd519bbafb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->