### PR TITLE
DEV-1968: Build the Component Source artifact on official releases

### DIFF
--- a/.github/workflows/componentsource.yml
+++ b/.github/workflows/componentsource.yml
@@ -1,14 +1,35 @@
 name: Component Source
 
+# Builds the "component source" deliverable — a small demo bundle (example page
+# plus the released `handsontable.full.min.js`) that GitHub serves as a ZIP.
+#
+# Chained off `Publish` rather than hooked straight to the `release` event: the
+# artifact embeds the released dist file, so it can only be assembled AFTER
+# `Publish` has pushed that version to npm.
 on:
   workflow_run:
     workflows: ['Publish']
     types: [completed]
-    branches: ['release/**']
+    # Everything-but-develop, NOT an allow-list of branch patterns. A `Publish`
+    # run's `head_branch` is a BRANCH for RC pushes (`release/18.0.0`) but the
+    # TAG for release events (`18.0.0`), so the old `branches: ['release/**']`
+    # allow-list never matched a stable release and silently skipped the
+    # deliverable for every official version (DEV-1968). `develop` is excluded
+    # because its chained `experimental` publish is not a customer deliverable.
+    # The job's `if` re-checks everything else.
+    branches-ignore:
+      - develop
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to package. Defaults to the current `latest` on npm.'
+        required: false
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}
+  # `github.event.inputs` rather than the `inputs` context: this line is
+  # evaluated for `workflow_run` events too, where `inputs` is not populated.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.event.inputs.version || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -18,22 +39,102 @@ jobs:
   build-componentsource:
     name: Build component source artifact
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    # A manual dispatch always runs. An automatic run needs a green `Publish`
+    # run that actually pushed a customer-facing version to npm: a `release`
+    # event (stable release, or the first RC) or a push to a release branch
+    # (every later RC).
+    if: |
+      github.event_name == 'workflow_dispatch' || (
+        github.event.workflow_run.conclusion == 'success' && (
+          github.event.workflow_run.event == 'release' || (
+            github.event.workflow_run.event == 'push' &&
+            startsWith(github.event.workflow_run.head_branch, 'release/')
+          )
+        )
+      )
     steps:
+      # Checks out the default branch on purpose — `.nvmrc` is the only repo
+      # file this job reads, and the version now comes from npm (see below).
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Use Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: '.nvmrc'
 
-      - name: Read Handsontable version
+      - name: Resolve published version
         id: version
+        env:
+          TRIGGER_EVENT: ${{ github.event.workflow_run.event }}
+          TRIGGER_REF: ${{ github.event.workflow_run.head_branch }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION=$(node -e 'console.log(require("./hot.config.js").HOT_VERSION)')
-          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+
+          # Never read `hot.config.js`: on the commit a `Publish` run starts
+          # from, it still holds the PREVIOUS version — the bump is committed
+          # during that run. Reading it made every RC artifact one RC stale.
+          # The release tag and npm's dist-tags are the only sources that name
+          # what was actually published (`--tag latest` for stable, `--tag rc`
+          # for release candidates).
+          if [ -n "${INPUT_VERSION}" ]; then
+            VERSION="${INPUT_VERSION}"
+            SOURCE="workflow_dispatch input"
+
+          elif [ "${TRIGGER_EVENT}" = 'release' ]; then
+            # For a release event `head_branch` carries the release TAG. Strip an
+            # optional `v` prefix exactly the way publish.yml does (`${TAG#v}`).
+            TAG="${TRIGGER_REF#v}"
+
+            if [ "${TAG}" = "${TAG%%-*}" ]; then
+              # Stable release, e.g. `18.0.0` — the tag is the published version.
+              VERSION="${TAG}"
+              SOURCE="release tag"
+            else
+              # First RC: the tag is `18.0.0-rc`, which does NOT carry the `rcN`
+              # suffix npm actually got.
+              VERSION="$(npm view handsontable dist-tags.rc)"
+              SOURCE="npm dist-tag 'rc' (prerelease tag ${TRIGGER_REF})"
+            fi
+
+          elif [ -n "${TRIGGER_EVENT}" ]; then
+            # A push to a release branch — every RC after the first.
+            VERSION="$(npm view handsontable dist-tags.rc)"
+            SOURCE="npm dist-tag 'rc'"
+
+          else
+            VERSION="$(npm view handsontable dist-tags.latest)"
+            SOURCE="npm dist-tag 'latest'"
+          fi
+
+          if [ -z "${VERSION}" ]; then
+            echo "::error::Could not resolve a version to package (source: ${SOURCE})"
+            exit 1
+          fi
+
+          echo "Packaging handsontable@${VERSION} (resolved from ${SOURCE})"
+          echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the version to be readable on npm
+        env:
+          HOT_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          set -euo pipefail
+
+          # `Publish` completing does not guarantee the new version is already
+          # readable across the npm registry, and this job starts seconds later.
+          for attempt in $(seq 1 20); do
+            if npm view "handsontable@${HOT_VERSION}" version > /dev/null 2>&1; then
+              echo "handsontable@${HOT_VERSION} is on npm"
+              exit 0
+            fi
+
+            echo "Attempt ${attempt}/20: handsontable@${HOT_VERSION} not on npm yet, retrying in 15s"
+            sleep 15
+          done
+
+          echo "::error::handsontable@${HOT_VERSION} never became readable on npm"
+          exit 1
 
       - name: Assemble demo artifact
         env:
@@ -82,12 +183,47 @@ jobs:
           </html>
           HTML
 
-          curl -fL --retry 3 --retry-delay 2 \
-            "https://cdn.jsdelivr.net/npm/handsontable@${HOT_VERSION}/dist/handsontable.full.min.js" \
-            -o "$EX/handsontable.full.min.js"
+          JS_DEST="$EX/handsontable.full.min.js"
+
+          # The npm registry first: it is the origin jsDelivr itself pulls from,
+          # so it is ready the moment `Publish` finishes. jsDelivr is the
+          # fallback only — the stable publish purges its cache
+          # (publish.yml -> purge-jsdelivr-cache.mjs), which left the CDN cold
+          # exactly when this job ran and returned a 503 on 18.0.0 (DEV-1968).
+          download_from_npm() {
+            local tmp
+            tmp="$(mktemp -d)"
+
+            npm pack "handsontable@${HOT_VERSION}" --pack-destination "$tmp" > /dev/null || return 1
+            tar -xzf "$tmp"/handsontable-*.tgz -C "$tmp" package/dist/handsontable.full.min.js || return 1
+            mv "$tmp/package/dist/handsontable.full.min.js" "$JS_DEST" || return 1
+          }
+
+          download_from_jsdelivr() {
+            curl -fL --retry 10 --retry-all-errors --retry-delay 5 --retry-max-time 300 \
+              "https://cdn.jsdelivr.net/npm/handsontable@${HOT_VERSION}/dist/handsontable.full.min.js" \
+              -o "$JS_DEST"
+          }
+
+          if ! download_from_npm; then
+            echo "::warning::Could not fetch handsontable@${HOT_VERSION} from npm, falling back to jsDelivr"
+            download_from_jsdelivr
+          fi
+
+          # A CDN error page is a few hundred bytes and `curl -f` does not always
+          # catch it. The real file is over 1.5 MB, so guard the floor.
+          SIZE="$(wc -c < "$JS_DEST" | tr -d '[:space:]')"
+
+          if [ "${SIZE}" -lt 500000 ]; then
+            echo "::error::handsontable.full.min.js is only ${SIZE} bytes — the download is not the real dist file"
+            exit 1
+          fi
+
+          echo "Bundled handsontable.full.min.js (${SIZE} bytes)"
 
       - name: Upload component source artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: componentsource-${{ steps.version.outputs.value }}
           path: componentsource-build
+          if-no-files-found: error

--- a/.github/workflows/componentsource.yml
+++ b/.github/workflows/componentsource.yml
@@ -10,15 +10,21 @@ on:
   workflow_run:
     workflows: ['Publish']
     types: [completed]
-    # Everything-but-develop, NOT an allow-list of branch patterns. A `Publish`
-    # run's `head_branch` is a BRANCH for RC pushes (`release/18.0.0`) but the
-    # TAG for release events (`18.0.0`), so the old `branches: ['release/**']`
-    # allow-list never matched a stable release and silently skipped the
-    # deliverable for every official version (DEV-1968). `develop` is excluded
-    # because its chained `experimental` publish is not a customer deliverable.
-    # The job's `if` re-checks everything else.
-    branches-ignore:
-      - develop
+    # DELIBERATELY UNFILTERED. A `Publish` run's `head_branch` is a BRANCH for RC
+    # pushes (`release/18.0.0`) but the TAG for release events (`18.0.0`), and the
+    # old `branches: ['release/**']` allow-list therefore never matched a stable
+    # release — the deliverable was silently skipped for every official version
+    # (DEV-1968). Whether a `branches`/`branches-ignore` filter passes a
+    # tag-valued `head_branch` at all is unspecified (tag filtering for
+    # `workflow_run` is not supported), so ANY filter here risks re-creating that
+    # exact silent miss. Gating lives in the job's `if` instead, where the rules
+    # are explicit and testable. Excluding develop was already redundant:
+    # publish.yml's `push` trigger covers release/** only and `release` is
+    # tag-based, so a develop `head_branch` can only arrive as `workflow_run`
+    # (the chained `experimental` publish) or `workflow_dispatch` — and neither
+    # passes either arm of that `if`. Cost is a handful of instantly-skipped
+    # runs; the benefit is that a release can no longer be missed by a filter
+    # whose behavior on tags is unspecified.
   workflow_dispatch:
     inputs:
       version:
@@ -68,24 +74,43 @@ jobs:
           TRIGGER_EVENT: ${{ github.event.workflow_run.event }}
           TRIGGER_REF: ${{ github.event.workflow_run.head_branch }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
           SHOULD_BUILD=true
-          # Release line this run belongs to (`18.0.0`), set only when the
-          # version was resolved through the shared `rc` dist-tag.
+          # Release line (`18.0.0`) when this run shipped a candidate rather than
+          # a stable version. Empty on the stable and manual-dispatch paths.
           LINE=''
 
-          npm_has() {
-            npm view "handsontable@$1" version > /dev/null 2>&1
+          # The oracle publish.yml's `rc-check` uses (publish.yml:545-556): a
+          # NON-PRERELEASE GitHub release for the line. It must be this and not
+          # npm — the GitHub release is created before `stable-publish` pushes to
+          # npm, so an npm probe would disagree with `rc-check` inside that
+          # window and upload a stale candidate.
+          stable_release_exists() {
+            local count
+            count=$(gh release list --repo "${GH_REPO}" --json tagName,isPrerelease \
+              --jq "[.[] | select(.tagName == \"$1\" and (.isPrerelease | not))] | length")
+
+            [ "${count:-0}" -gt 0 ]
+          }
+
+          # Highest N among the `<line>-rcN` git tags. publish.yml creates that
+          # tag through the GitHub API *before* publishing (publish.yml:719-723),
+          # so it names the candidate THIS run shipped. npm's `rc` dist-tag
+          # cannot: it is one mutable global pointer, shared by every release
+          # line, and may still read the previous RC while the new one is live.
+          highest_rc_number() {
+            gh api "repos/${GH_REPO}/git/matching-refs/tags/$1-rc" --jq '.[].ref' \
+              | sed -n "s|^refs/tags/$1-rc\([0-9]\{1,\}\)\$|\1|p" \
+              | sort -n | tail -n 1
           }
 
           # Never read `hot.config.js`: on the commit a `Publish` run starts
           # from, it still holds the PREVIOUS version — the bump is committed
           # during that run. Reading it made every RC artifact one RC stale.
-          # The release tag and npm's dist-tags are the only sources that name
-          # what was actually published (`--tag latest` for stable, `--tag rc`
-          # for release candidates).
           if [ -n "${INPUT_VERSION}" ]; then
             VERSION="${INPUT_VERSION}"
             SOURCE="workflow_dispatch input"
@@ -100,50 +125,39 @@ jobs:
               VERSION="${TAG}"
               SOURCE="release tag"
             else
-              # First RC: the tag is `18.0.0-rc`, which does NOT carry the `rcN`
-              # suffix npm actually got.
-              VERSION="$(npm view handsontable dist-tags.rc)"
-              SOURCE="npm dist-tag 'rc' (prerelease tag ${TRIGGER_REF})"
+              # First RC. The tag is `18.0.0-rc`, without the `rcN` npm got.
               LINE="${TAG%%-*}"
             fi
 
           elif [ -n "${TRIGGER_EVENT}" ]; then
-            # A push to a release branch — every RC after the first. Such a run
-            # goes green even when it published NOTHING: publish.yml's
-            # `rc-check` sets `allowed=false` once a stable release exists for
-            # the line, which skips rc-build/rc-test/rc-publish while `rc-check`
-            # itself succeeds. Mirror that guard here, or a later backport push
-            # to a closed release branch would re-upload a stale candidate.
+            # A push to a release branch — every RC after the first.
             LINE="${TRIGGER_REF#release/}"
-
-            if npm_has "${LINE}"; then
-              echo "::notice::Stable ${LINE} is already published, so publish.yml's rc-check blocked the RC publish and this run published nothing — no artifact to build."
-              SHOULD_BUILD=false
-              VERSION=''
-              SOURCE='n/a'
-            else
-              VERSION="$(npm view handsontable dist-tags.rc)"
-              SOURCE="npm dist-tag 'rc'"
-            fi
 
           else
             VERSION="$(npm view handsontable dist-tags.latest)"
             SOURCE="npm dist-tag 'latest'"
           fi
 
-          # `rc` is ONE dist-tag shared by every release line. Whenever the
-          # version came from it, check the candidate belongs to the line that
-          # triggered this run — otherwise a push on one branch would package
-          # another line's candidate.
-          if [ "${SHOULD_BUILD}" = true ] && [ -n "${LINE}" ]; then
-            case "${VERSION}" in
-              "${LINE}-"*)
-                ;;
-              *)
-                echo "::notice::npm dist-tag 'rc' is '${VERSION}', which is not a candidate for the ${LINE} line — no artifact to build."
-                SHOULD_BUILD=false
-                ;;
-            esac
+          if [ -n "${LINE}" ]; then
+            # A release-branch push goes green even when it published NOTHING:
+            # `rc-check` sets `allowed=false` once the line has a stable release,
+            # skipping rc-build/rc-test/rc-publish while `rc-check` itself
+            # succeeds. Without this, a later backport push to a closed release
+            # branch would re-upload a stale candidate.
+            if stable_release_exists "${LINE}"; then
+              echo "::notice::${LINE} already has a stable GitHub release, so publish.yml's rc-check blocked the RC publish and this run published nothing — no artifact to build."
+              SHOULD_BUILD=false
+            else
+              RC_NUMBER="$(highest_rc_number "${LINE}")"
+
+              if [ -z "${RC_NUMBER}" ]; then
+                echo "::error::No ${LINE}-rcN git tag exists, so the candidate this run published cannot be identified"
+                exit 1
+              fi
+
+              VERSION="${LINE}-rc${RC_NUMBER}"
+              SOURCE="highest ${LINE}-rcN git tag"
+            fi
           fi
 
           if [ "${SHOULD_BUILD}" != true ]; then
@@ -151,6 +165,9 @@ jobs:
             exit 0
           fi
 
+          # Reachable on every remaining path. Never downgrade this to a notice:
+          # a green run with no artifact is invisible, and that invisibility is
+          # how DEV-1968 went unnoticed for two releases.
           if [ -z "${VERSION}" ]; then
             echo "::error::Could not resolve a version to package (source: ${SOURCE})"
             exit 1

--- a/.github/workflows/componentsource.yml
+++ b/.github/workflows/componentsource.yml
@@ -40,6 +40,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read # list the triggering `Publish` run's artifacts
 
 jobs:
   build-componentsource:
@@ -59,8 +60,9 @@ jobs:
         )
       )
     steps:
-      # Checks out the default branch on purpose — `.nvmrc` is the only repo
-      # file this job reads, and the version now comes from npm (see below).
+      # Checks out the default branch on purpose. `.nvmrc` is the only repo file
+      # this job reads; the version comes from the triggering run (see below),
+      # never from the working tree.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js
@@ -71,103 +73,65 @@ jobs:
       - name: Resolve published version
         id: version
         env:
-          TRIGGER_EVENT: ${{ github.event.workflow_run.event }}
-          TRIGGER_REF: ${{ github.event.workflow_run.head_branch }}
+          TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
-          SHOULD_BUILD=true
-          # Release line (`18.0.0`) when this run shipped a candidate rather than
-          # a stable version. Empty on the stable and manual-dispatch paths.
-          LINE=''
-
-          # The oracle publish.yml's `rc-check` uses (publish.yml:545-556): a
-          # NON-PRERELEASE GitHub release for the line. It must be this and not
-          # npm — the GitHub release is created before `stable-publish` pushes to
-          # npm, so an npm probe would disagree with `rc-check` inside that
-          # window and upload a stale candidate.
-          stable_release_exists() {
-            local count
-            count=$(gh release list --repo "${GH_REPO}" --json tagName,isPrerelease \
-              --jq "[.[] | select(.tagName == \"$1\" and (.isPrerelease | not))] | length")
-
-            [ "${count:-0}" -gt 0 ]
-          }
-
-          # Highest N among the `<line>-rcN` git tags. publish.yml creates that
-          # tag through the GitHub API *before* publishing (publish.yml:719-723),
-          # so it names the candidate THIS run shipped. npm's `rc` dist-tag
-          # cannot: it is one mutable global pointer, shared by every release
-          # line, and may still read the previous RC while the new one is live.
-          highest_rc_number() {
-            gh api "repos/${GH_REPO}/git/matching-refs/tags/$1-rc" --jq '.[].ref' \
-              | sed -n "s|^refs/tags/$1-rc\([0-9]\{1,\}\)\$|\1|p" \
-              | sort -n | tail -n 1
-          }
-
-          # Never read `hot.config.js`: on the commit a `Publish` run starts
-          # from, it still holds the PREVIOUS version — the bump is committed
-          # during that run. Reading it made every RC artifact one RC stale.
           if [ -n "${INPUT_VERSION}" ]; then
             VERSION="${INPUT_VERSION}"
             SOURCE="workflow_dispatch input"
 
-          elif [ "${TRIGGER_EVENT}" = 'release' ]; then
-            # For a release event `head_branch` carries the release TAG. Strip an
-            # optional `v` prefix exactly the way publish.yml does (`${TAG#v}`).
-            TAG="${TRIGGER_REF#v}"
+          elif [ -n "${TRIGGER_RUN_ID}" ]; then
+            # Every publish path uploads the very tarballs it publishes as
+            # `npm_packs_<version>` — first RC, later RCs and stable alike
+            # (publish.yml:203, 339, 655, 1430, 1495) — and the publish steps
+            # download that same artifact to run `npm publish`. So its name is a
+            # per-run record of exactly what THIS run shipped. Every other
+            # candidate oracle drifts:
+            #   * `hot.config.js` at the run's commit still holds the PREVIOUS
+            #     version; the bump is committed during the run.
+            #   * npm's `rc` dist-tag is one mutable global pointer, shared by
+            #     every release line, and can lag the publish that just happened.
+            #   * the highest `<line>-rcN` git tag is written in `rc-build`,
+            #     which is BEFORE the `approvers` environment gate on
+            #     `rc-publish`; publish.yml has no concurrency group, so a later
+            #     push can tag rcN+1 while rcN still awaits approval, and
+            #     "highest" would then name another run's candidate.
+            VERSIONS="$(gh api "repos/${GH_REPO}/actions/runs/${TRIGGER_RUN_ID}/artifacts" \
+              --paginate --jq '.artifacts[].name' \
+              | sed -n 's/^npm_packs_//p' | sort -u)"
+            COUNT="$(printf '%s\n' "${VERSIONS}" | grep -c . || true)"
 
-            if [ "${TAG}" = "${TAG%%-*}" ]; then
-              # Stable release, e.g. `18.0.0` — the tag is the published version.
-              VERSION="${TAG}"
-              SOURCE="release tag"
-            else
-              # First RC. The tag is `18.0.0-rc`, without the `rcN` npm got.
-              LINE="${TAG%%-*}"
+            if [ "${COUNT}" -eq 0 ]; then
+              # No packs means the run published nothing. The common case is
+              # `rc-check` setting `allowed=false` once the line has a stable
+              # release, which skips rc-build/rc-test/rc-publish while
+              # `rc-check` itself succeeds — leaving a GREEN run that shipped
+              # nothing. Building from it would upload a stale candidate.
+              echo "::notice::Publish run ${TRIGGER_RUN_ID} uploaded no npm_packs_* artifact, so it published nothing (for example rc-check blocked the RC build) — no artifact to build."
+              echo "should-build=false" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
 
-          elif [ -n "${TRIGGER_EVENT}" ]; then
-            # A push to a release branch — every RC after the first.
-            LINE="${TRIGGER_REF#release/}"
+            if [ "${COUNT}" -gt 1 ]; then
+              echo "::error::Publish run ${TRIGGER_RUN_ID} has npm_packs artifacts for more than one version, so the published version is ambiguous: $(printf '%s' "${VERSIONS}" | tr '\n' ' ')"
+              exit 1
+            fi
+
+            VERSION="${VERSIONS}"
+            SOURCE="npm_packs_* artifact on Publish run ${TRIGGER_RUN_ID}"
 
           else
             VERSION="$(npm view handsontable dist-tags.latest)"
             SOURCE="npm dist-tag 'latest'"
           fi
 
-          if [ -n "${LINE}" ]; then
-            # A release-branch push goes green even when it published NOTHING:
-            # `rc-check` sets `allowed=false` once the line has a stable release,
-            # skipping rc-build/rc-test/rc-publish while `rc-check` itself
-            # succeeds. Without this, a later backport push to a closed release
-            # branch would re-upload a stale candidate.
-            if stable_release_exists "${LINE}"; then
-              echo "::notice::${LINE} already has a stable GitHub release, so publish.yml's rc-check blocked the RC publish and this run published nothing — no artifact to build."
-              SHOULD_BUILD=false
-            else
-              RC_NUMBER="$(highest_rc_number "${LINE}")"
-
-              if [ -z "${RC_NUMBER}" ]; then
-                echo "::error::No ${LINE}-rcN git tag exists, so the candidate this run published cannot be identified"
-                exit 1
-              fi
-
-              VERSION="${LINE}-rc${RC_NUMBER}"
-              SOURCE="highest ${LINE}-rcN git tag"
-            fi
-          fi
-
-          if [ "${SHOULD_BUILD}" != true ]; then
-            echo "should-build=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Reachable on every remaining path. Never downgrade this to a notice:
-          # a green run with no artifact is invisible, and that invisibility is
-          # how DEV-1968 went unnoticed for two releases.
+          # Reachable on every path. Never downgrade this to a notice: a green
+          # run with no artifact is invisible, and that invisibility is how
+          # DEV-1968 went unnoticed for two releases.
           if [ -z "${VERSION}" ]; then
             echo "::error::Could not resolve a version to package (source: ${SOURCE})"
             exit 1

--- a/.github/workflows/componentsource.yml
+++ b/.github/workflows/componentsource.yml
@@ -71,6 +71,15 @@ jobs:
         run: |
           set -euo pipefail
 
+          SHOULD_BUILD=true
+          # Release line this run belongs to (`18.0.0`), set only when the
+          # version was resolved through the shared `rc` dist-tag.
+          LINE=''
+
+          npm_has() {
+            npm view "handsontable@$1" version > /dev/null 2>&1
+          }
+
           # Never read `hot.config.js`: on the commit a `Publish` run starts
           # from, it still holds the PREVIOUS version — the bump is committed
           # during that run. Reading it made every RC artifact one RC stale.
@@ -95,16 +104,51 @@ jobs:
               # suffix npm actually got.
               VERSION="$(npm view handsontable dist-tags.rc)"
               SOURCE="npm dist-tag 'rc' (prerelease tag ${TRIGGER_REF})"
+              LINE="${TAG%%-*}"
             fi
 
           elif [ -n "${TRIGGER_EVENT}" ]; then
-            # A push to a release branch — every RC after the first.
-            VERSION="$(npm view handsontable dist-tags.rc)"
-            SOURCE="npm dist-tag 'rc'"
+            # A push to a release branch — every RC after the first. Such a run
+            # goes green even when it published NOTHING: publish.yml's
+            # `rc-check` sets `allowed=false` once a stable release exists for
+            # the line, which skips rc-build/rc-test/rc-publish while `rc-check`
+            # itself succeeds. Mirror that guard here, or a later backport push
+            # to a closed release branch would re-upload a stale candidate.
+            LINE="${TRIGGER_REF#release/}"
+
+            if npm_has "${LINE}"; then
+              echo "::notice::Stable ${LINE} is already published, so publish.yml's rc-check blocked the RC publish and this run published nothing — no artifact to build."
+              SHOULD_BUILD=false
+              VERSION=''
+              SOURCE='n/a'
+            else
+              VERSION="$(npm view handsontable dist-tags.rc)"
+              SOURCE="npm dist-tag 'rc'"
+            fi
 
           else
             VERSION="$(npm view handsontable dist-tags.latest)"
             SOURCE="npm dist-tag 'latest'"
+          fi
+
+          # `rc` is ONE dist-tag shared by every release line. Whenever the
+          # version came from it, check the candidate belongs to the line that
+          # triggered this run — otherwise a push on one branch would package
+          # another line's candidate.
+          if [ "${SHOULD_BUILD}" = true ] && [ -n "${LINE}" ]; then
+            case "${VERSION}" in
+              "${LINE}-"*)
+                ;;
+              *)
+                echo "::notice::npm dist-tag 'rc' is '${VERSION}', which is not a candidate for the ${LINE} line — no artifact to build."
+                SHOULD_BUILD=false
+                ;;
+            esac
+          fi
+
+          if [ "${SHOULD_BUILD}" != true ]; then
+            echo "should-build=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           if [ -z "${VERSION}" ]; then
@@ -113,9 +157,11 @@ jobs:
           fi
 
           echo "Packaging handsontable@${VERSION} (resolved from ${SOURCE})"
+          echo "should-build=true" >> "$GITHUB_OUTPUT"
           echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Wait for the version to be readable on npm
+        if: steps.version.outputs.should-build == 'true'
         env:
           HOT_VERSION: ${{ steps.version.outputs.value }}
         run: |
@@ -137,6 +183,7 @@ jobs:
           exit 1
 
       - name: Assemble demo artifact
+        if: steps.version.outputs.should-build == 'true'
         env:
           HOT_VERSION: ${{ steps.version.outputs.value }}
         run: |
@@ -222,6 +269,7 @@ jobs:
           echo "Bundled handsontable.full.min.js (${SIZE} bytes)"
 
       - name: Upload component source artifact
+        if: steps.version.outputs.should-build == 'true'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: componentsource-${{ steps.version.outputs.value }}


### PR DESCRIPTION
### Context

The PR fixes the `Component Source` workflow, which never built its artifact for an official release. The deliverable was silently missing for every stable version, including 18.0.0.

There were two independent causes.

**1. The trigger could not match a stable release.** The workflow waited on `workflow_run` from `Publish` with `branches: ['release/**']`. A `Publish` run's `head_branch` is a branch only for RC pushes (`release/18.0.0`) — for a `release` event it carries the **tag** (`18.0.0`), which never matches that allow-list.

Evidence from the 18.0.0 release:

| `Publish` run | Event | `head_branch` | Conclusion | Component Source ran? |
|---|---|---|---|---|
| `28431654718` (06-30 08:41) | `release` | `18.0.0` | success | **no** |
| `27610213255` (06-16 10:09) | `release` | `18.0.0-rc` | success | **no** |
| `28430639792` (06-30 08:22) | `push` | `release/18.0.0` | cancelled | created, then skipped |

`Component Source` has only ever had 10 runs. The last automatic one was 06-30 at 08:33 (skipped). The stable release finished at 08:41 and produced nothing.

**2. The release's own push could not rescue it.** `stable-prepare` commits the version bump and pushes it to `release/18.0.0` (`publish.yml:1161`), which is a valid `Publish` trigger — but that push uses `secrets.GITHUB_TOKEN`, and GitHub never starts a workflow run from a `GITHUB_TOKEN` push. Confirmed in the data: the last push-event `Publish` run was 08:22:50, before the release.

Separately, the failure in the linked run was a jsDelivr `503` (`curl: (22)`). That has a specific cause: `stable-publish` purges the jsDelivr cache right after publishing (`publish.yml:1572` → `purge-jsdelivr-cache.mjs`), leaving the CDN cold exactly when this job runs. The old `curl --retry 3 --retry-delay 2` gave up after about 6 seconds and wrote a 455-byte error page.

**What this PR changes**

- **Trigger** — the ref filter is removed entirely and the job's `if` is the only gate. A filter is what dropped the deliverable, and whether a `branches`/`branches-ignore` filter passes a *tag*-valued `head_branch` is unspecified (tag filtering for `workflow_run` is not supported), so any filter here risks the same silent miss. Excluding develop was already redundant: publish.yml's `push` trigger covers `release/**` only and `release` is tag-based, so a develop `head_branch` can only arrive as `workflow_run` or `workflow_dispatch`, and neither passes the `if`.
- **Version** — taken from the **triggering run's own `npm_packs_<version>` artifact**, one rule for stable, first RC and later RCs alike. Every publish path uploads the exact tarballs it publishes under that name (`publish.yml:203`, `339`, `655`, `1430`, `1495`), and the publish steps download that same artifact to run `npm publish`, so the name is a per-run record of what the run actually shipped. Every other candidate oracle drifts: `hot.config.js` at the run's commit still holds the *previous* version (which is why RC artifacts were one RC stale — the run that published `rc5` uploaded `componentsource-18.0.0-rc4`); npm's `rc` dist-tag is one mutable global pointer shared across release lines and can lag the publish; and the highest `<line>-rcN` git tag is written in `rc-build`, *before* the `approvers` gate on `rc-publish`, with no concurrency group on `Publish` — so a later push can tag `rcN+1` while `rcN` still awaits approval.
- **Download** — the npm registry first, jsDelivr as fallback. npm is the origin jsDelivr itself pulls from, so it is ready the moment `Publish` finishes and is unaffected by the cache purge.
- **Guards** — waits for the version to be readable on npm, rejects a bundled file under 500 KB (which is what the original 455-byte error page was), and sets `if-no-files-found: error`.
- **No-op when a green run published nothing** — a push to `release/**` can leave `Publish` green having shipped nothing, because `rc-check` sets `allowed=false` once the line has a stable release and only the skipped jobs depend on it. No separate guard is needed: such a run uploads no `npm_packs_*` artifact, so the step emits a `::notice::`, sets `should-build=false`, and the run stays green with nothing uploaded. The manual dispatch bypasses this by design.
- **Loud failures** — an unresolvable or empty version fails the job with `::error::` on every path. A green run that quietly produces no artifact is invisible, and that invisibility is how this bug survived two releases.
- **Escape hatch** — an optional `version` input, so a missed release can still be packaged by hand.

### Test evidence (required for source changes)

No library source is touched — the diff is one CI workflow file (`.github/workflows/componentsource.yml`), so the commit carries a `Refactor-only:` trailer and the test-presence gate passes. `workflow_run` workflows only ever run from the default branch, so this cannot be exercised on a PR branch; it was validated by replaying the new logic against real production data instead.

- Unit tests added/modified (`*.unit.js`): none — no library source changed
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none — no library source changed
- Type tests (`*.types.ts`) updated if public API changed: none — no public API change
- For a bug fix — the spec that fails without this fix: not expressible as a repo spec (the defect is a GitHub Actions trigger filter). Covered instead by the trigger replay below, which fails on the old workflow and passes on the new one.
- Demo page / recorded trace (for UI changes): n/a — no UI change

Three validation suites were run locally. Each extracts the real steps from the workflow YAML, so it tests the shipped file rather than a copy.

**1. Trigger layer — replay against all 282 real `Publish` runs** (fetched from the Actions API), comparing the old ref filter plus job `if` against the new unfiltered trigger:

```
PASS  stable release 18.0.0 job did NOT start under the old trigger
PASS  stable release 18.0.0 job DOES start under the new trigger
PASS  every green stable-release run starts the job (n=3)
PASS  none of them started it before
PASS  RC release-branch pushes still reach the job (n=39) — no trigger regression
PASS  every develop Publish run is workflow_run or workflow_dispatch (n=104)
PASS  no develop Publish run is a release event or a push
PASS  experimental develop publishes still never build, with NO ref filter
PASS  no non-green Publish run ever reaches the job (n=109)
PASS  only release events and release-branch pushes reach the job
ALL ASSERTIONS PASSED

Cost of dropping the ref filter: 236 of 282 historical Publish runs
would have created a Component Source run that skips immediately (no runner time).
```

The two develop assertions are what justify removing the filter rather than narrowing it. Note the limit of this replay: it validates the *job `if`*, which is real logic. It cannot validate GitHub's own ref-filter behavior on a tag-valued `head_branch` — which is precisely why there is no filter left to validate.

**2. Version resolution, no-op and failure paths** — 21 cases against the extracted `Resolve published version` step. Fake cases shadow `gh` on `PATH` to serve a chosen artifact set. The last five hit the **live Actions API for real historical `Publish` runs**, which is the strongest evidence available short of doing a release:

```
--- the version is whatever THIS Publish run uploaded as npm_packs_* ---
PASS  stable release run (the DEV-1968 case)               -> 18.0.0
PASS  first-RC run                                         -> 18.0.0-rc1
PASS  later-RC run                                         -> 18.0.0-rc5
PASS  double-digit RC needs no numeric sorting             -> 18.0.0-rc10

--- concurrent runs / tag races can no longer mislead us ---
PASS  run shipped rc5 while rc6 tag exists                 -> 18.0.0-rc5
PASS  run shipped rc6                                      -> 18.0.0-rc6
PASS  17.1.1 run while 18.1.0 RCs exist                    -> 17.1.1-rc1

--- green Publish that published nothing ---
PASS  green run, no npm_packs artifact                     -> no build
PASS  green run, no artifacts at all                       -> no build

--- ambiguous or missing version must fail loudly, not exit green ---
PASS  two npm_packs versions on one run                    -> hard failure (exit 1)
PASS  dispatch when npm latest is empty                    -> hard failure (exit 1)

--- manual dispatch ignores the triggering-run oracle entirely ---
PASS  dispatch, explicit version                           -> 17.0.1
PASS  dispatch, old version after stable                   -> 16.2.0
PASS  input overrides the run's artifact                   -> 16.2.0
PASS  dispatch, no input -> npm latest                     -> 18.0.0

--- live Actions API against real historical Publish runs ---
PASS  real stable run 28431654718                          -> 18.0.0
PASS  real first-RC run 27610213255                        -> 18.0.0-rc1
PASS  real RC push run 28153016668                         -> 18.0.0-rc5
PASS  real RC push run 27950003566                         -> 18.0.0-rc2
PASS  cancelled run resolves rc6 (if-gate blocks it)       -> 18.0.0-rc6
PASS  that run is not green                                -> conclusion=cancelled, if-gate blocks it
ALL RESOLVE CASES PASSED
```

`real stable run 28431654718` is the exact run this ticket exists for — it produced no artifact before and now resolves `18.0.0`. The `run shipped rc5 while rc6 tag exists` pair shows two concurrent runs each getting their own correct artifact.

The last two lines record a caveat worth knowing: `npm_packs_*` proves a **build**, not a **publish**. The cancelled run `28430639792` uploaded `npm_packs_18.0.0-rc6` and never published rc6 — that is also where the stray `18.0.0-rc6` git tag came from. Safety comes from the job `if` requiring `conclusion == 'success'`, which is asserted rather than assumed, with the npm-readiness poll as a second backstop. Both hard-failure cases assert a non-zero exit *and* an `::error::` line, so a refactor cannot quietly downgrade either to a notice.

**3. Artifact assembly end-to-end, plus fault injection** (the extracted `Assemble demo artifact` step; the last two cases shadow `npm`/`curl` on `PATH` to force each failure):

```
PASS  stable 18.0.0 (the release case)             exit=0 js=1722134 bytes
PASS  RC 18.0.0-rc5                                exit=0 js=1722150 bytes
PASS  older stable 17.1.0                          exit=0 js=1816541 bytes
PASS  version that does not exist                  exit=16 (failed loudly, as intended)
ALL ASSEMBLE CASES PASSED

PASS  npm outage -> jsDelivr fallback succeeded (1722134 bytes)
PASS  455-byte error page -> size guard failed the job (exit=1)
ALL SAFETY-NET CASES PASSED
```

The second safety-net case is the exact failure from the linked run: the guard now fails the job instead of uploading a broken artifact.

**Static checks** — `actionlint` 1.7.12 reports no findings. To confirm it really inspects the expressions (rather than treating them as opaque strings), a deliberately corrupted copy was linted and correctly rejected:

```
undefined function "startsWithTypo". available functions are ... [expression]
```

### Commands run

```bash
# actionlint (expression + workflow schema)
actionlint .github/workflows/componentsource.yml
# -> exit 0, no findings

# YAML parses
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/componentsource.yml'))"
# -> YAML OK

# 1. trigger replay vs 282 real Publish runs
node simulate.mjs          # -> ALL ASSERTIONS PASSED

# 2. version resolution, no-op and failure paths — 21 cases
bash test-resolve.sh       # -> ALL RESOLVE CASES PASSED

# 3. assembly end-to-end + fault injection
bash test-assemble.sh      # -> ALL ASSEMBLE CASES PASSED
bash test-fallback.sh      # -> ALL SAFETY-NET CASES PASSED
```

`eslint`, `stylelint`, `build`, `test:unit` and `test:e2e` were not run: the diff is a single YAML workflow file, so none of them have anything to act on.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1968

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

None of the published packages are affected. The change is CI/tooling only, so the changelog check passes on path rules and no `.changelogs/` entry is required.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
- [ ] This change needs a manual QA pass

### Reviewer notes

Two things worth knowing before merge.

1. **This has no effect until it is on `develop`.** `workflow_run` workflows always run from the default branch. If this is not merged before the next release, the artifact will be missed again.
2. **One behavior is intentionally dropped.** A manual `workflow_dispatch` of *`Publish`* no longer builds an artifact. The current `publish.yml` gates every publish job on `release`, `push` or `workflow_run`, so a dispatched `Publish` run publishes nothing; building from it would package a version that was not just released. One historical run (from when a dispatch pre-release arm still existed) matched that shape. Dispatching *`Component Source`* itself still works, and now takes an optional version.

3. **The trigger is unfiltered on purpose.** Every completed `Publish` run now creates a `Component Source` run, and most skip instantly — 236 of 282 historically. That is the deliberate price of not depending on how GitHub treats a tag-valued `head_branch` in a ref filter. Please do not "tidy" a `branches`/`branches-ignore` filter back in; the workflow comment explains why, and re-adding one can silently skip a release with every test still green.

4. **`npm_packs_*` proves a build, not a publish.** The cancelled run `28430639792` uploaded `npm_packs_18.0.0-rc6` and never published rc6 (it also left the stray `18.0.0-rc6` git tag). The job `if` requiring `conclusion == 'success'` is what makes the oracle safe, so please keep it — a failed or rejected `rc-publish` cannot leave a green run. The npm-readiness poll is the second backstop.

After merge, confirmation arrives in stages: the next RC push proves the chain still fires, and the next stable release proves the fix. If anything is still wrong, the manual dispatch is the backstop.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1968
