### PR TITLE
DEV-1476: Allow setting colorScheme and density without declaring a theme

### DIFF
--- a/.changelogs/13205.json
+++ b/.changelogs/13205.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added the `colorScheme` and `density` options, which set the color scheme and the spacing of the grid without declaring a theme.",
+  "type": "added",
+  "issueOrPR": 13205,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -493,6 +493,8 @@ hot.updateSettings({
 });
 ```
 
+An unsupported value is ignored, and the grid logs a warning naming the option. It does not throw, so one bad value does not break the rest of the update.
+
 To drop an override and go back to the value your theme defines, set the option to `undefined`:
 
 ```js

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -111,6 +111,8 @@ When using the Theme API, you can configure the color scheme using `setColorSche
 
 When using CSS files, color scheme switching is controlled through CSS class names. Use `ht-theme-{name}` for light mode, `ht-theme-{name}-dark` for dark mode, or `ht-theme-{name}-dark-auto` for automatic switching based on system preferences (e.g., `ht-theme-main`, `ht-theme-main-dark`, `ht-theme-main-dark-auto`).
 
+If you don't want to declare a theme at all, set the [`colorScheme`](@/api/options.md#colorscheme) option instead. See [Set the color scheme or density without a theme](#set-the-color-scheme-or-density-without-a-theme).
+
 
 ## Use a theme
 
@@ -414,6 +416,96 @@ const hotSettings = ref({
 ```
 
 :::
+
+## Set the color scheme or density without a theme
+
+If the only thing you want to change is the color scheme or the amount of white space, you don't have to import, register, and configure a theme. Set the [`colorScheme`](@/api/options.md#colorscheme) or [`density`](@/api/options.md#density) option directly, and the grid applies it on top of the theme it already uses.
+
+| Option        | Allowed values                            | Default                        |
+| ------------- | ----------------------------------------- | ------------------------------ |
+| `colorScheme` | `'light'`, `'dark'`, `'auto'`             | the color scheme of your theme |
+| `density`     | `'default'`, `'compact'`, `'comfortable'` | the density of your theme      |
+
+Both options are per-instance overrides. The theme itself stays unchanged, so other grids that use the same theme keep their own color scheme and density.
+
+::: only-for javascript
+
+```js
+const container = document.querySelector('#handsontable-example');
+
+const hot = new Handsontable(container, {
+  colorScheme: 'dark',
+  density: 'compact',
+  // other options
+});
+```
+
+:::
+
+::: only-for react
+
+```jsx
+<HotTable
+  colorScheme="dark"
+  density="compact"
+/>
+```
+
+:::
+
+::: only-for angular
+
+```html
+<hot-table [settings]="{
+  colorScheme: 'dark',
+  density: 'compact'
+}">
+</hot-table>
+```
+
+:::
+
+::: only-for vue
+
+```ts
+const hotSettings = ref({
+  colorScheme: 'dark',
+  density: 'compact',
+  // ... other options
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
+### Switch the color scheme or density at runtime
+
+Pass either option to [`updateSettings()`](@/api/core.md#updatesettings). This is all you need for a dark mode toggle:
+
+```js
+hot.updateSettings({
+  colorScheme: 'dark',
+});
+```
+
+To drop an override and go back to the value your theme defines, set the option to `undefined`:
+
+```js
+hot.updateSettings({
+  colorScheme: undefined,
+  density: undefined,
+});
+```
+
+### When these options apply
+
+Both options are features of the Theme API, so they need the theme engine to be active. The engine is active when you leave the [`theme`](@/api/options.md#theme) option out, or when you pass a theme config object or a `ThemeBuilder` instance to it. It is not active when the theme comes from a CSS class name — either the `theme` option set to a string such as `'ht-theme-main'`, or an `ht-theme-*` class on the container element. In that case the grid logs a warning and the options have no effect.
+
+One more limit applies to `colorScheme`. If you load a minified theme stylesheet, such as `ht-theme-main.min.css`, its colors are tied to the theme class name and out-specify the ones the engine generates. The color scheme then does not follow the option. The same limit applies to `setColorScheme()`. Density is not affected. To use `colorScheme`, load only the base stylesheet, as described in [Option 1](#option-1-using-the-theme-api-recommended).
 
 ::: only-for angular
 

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -505,7 +505,7 @@ hot.updateSettings({
 
 Both options are features of the Theme API, so they need the theme engine to be active. The engine is active when you leave the [`theme`](@/api/options.md#theme) option out, or when you pass a theme config object or a `ThemeBuilder` instance to it. It is not active when the theme comes from a CSS class name — either the `theme` option set to a string such as `'ht-theme-main'`, or an `ht-theme-*` class on the container element. In that case the grid logs a warning and the options have no effect.
 
-One more limit applies to `colorScheme`. If you load a minified theme stylesheet, such as `ht-theme-main.min.css`, its colors are tied to the theme class name and out-specify the ones the engine generates. The color scheme then does not follow the option. The same limit applies to `setColorScheme()`. Density is not affected. To use `colorScheme`, load only the base stylesheet, as described in [Option 1](#option-1-using-the-theme-api-recommended).
+Apart from that, it doesn't matter which stylesheets you load. Both options work with the base stylesheet alone and with a theme stylesheet on top of it, minified or not.
 
 ::: only-for angular
 

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -29,6 +29,7 @@ vue:
   metaTitle: Themes - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Styling
+menuTag: updated
 ---
 Use Handsontable's built-in themes or customize its look using the Theme API or CSS variables.
 

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -61,6 +61,8 @@ const allSettings: Required<Handsontable.GridSettings> = {
   className: oneOf('foo', ['foo']),
   colHeaders: oneOf(true, ['first-class-name', 'second-class-name']),
   collapsibleColumns: true,
+  colorScheme: oneOf('light', 'dark', 'auto'),
+  density: oneOf('default', 'compact', 'comfortable'),
   columnHeaderHeight: oneOf(35, [35, 55]),
   columns: [
     {

--- a/handsontable/src/base.ts
+++ b/handsontable/src/base.ts
@@ -468,6 +468,7 @@ export type { RendererType } from './renderers/registry';
 export type { ValidatorType } from './validators/registry';
 export type {
   BaseTheme,
+  DensityType,
   ThemeBuilder,
   ThemeColorScheme,
   ThemeColorsConfig,

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -72,6 +72,7 @@ import { createThemeManager } from './themes/engine';
 import { LayoutManager, type LayoutConfig } from './core/layout';
 import { getTheme, hasTheme, registerTheme, mainTheme } from './themes';
 import type { ThemeBuilder } from './themes/engine/builder';
+import type { ThemeOverridesInput } from './themes/engine/manager';
 import type { default as CellCoords } from './3rdparty/walkontable/src/cell/coords';
 import type { default as CellRange } from './3rdparty/walkontable/src/cell/range';
 import type { CellChange, CellProperties } from './settings';
@@ -1614,7 +1615,7 @@ export default function Core(
       !rootContainerThemeClassName &&
       (isObject(theme) || (!theme && !themeName))
     ) {
-      initializeThemeManager(theme as ThemeBuilder | undefined);
+      initializeThemeManager(theme as ThemeBuilder | undefined, readThemeOverrides(tableMeta));
     }
 
     dataSource.setData(tableMeta.data);
@@ -1705,11 +1706,68 @@ export default function Core(
   };
 
   /**
+   * Reads the per-instance color scheme and density overrides from a settings object.
+   *
+   * Only the keys actually present are returned, so a missing key keeps the value already applied
+   * instead of resetting it to the theme default.
+   *
+   * @param {object} settings - The settings object to read the overrides from.
+   * @returns {object} The theme overrides object.
+   */
+  function readThemeOverrides(settings: Record<string, unknown>): ThemeOverridesInput {
+    const overrides: ThemeOverridesInput = {};
+
+    if (hasOwnProperty(settings, 'colorScheme')) {
+      overrides.colorScheme = settings.colorScheme;
+    }
+
+    if (hasOwnProperty(settings, 'density')) {
+      overrides.density = settings.density;
+    }
+
+    return overrides;
+  }
+
+  /**
+   * Applies the `colorScheme` and `density` options to the ThemeManager of this instance.
+   *
+   * The options are per-instance overrides, so the shared theme object stays untouched and other
+   * grids using the same theme keep their own look.
+   *
+   * @param {object} settings - The settings object that may carry the overrides.
+   * @param {boolean} init - `true` when called during initialization. The initial styles are
+   * injected by the ThemeManager constructor, so no re-render is needed in that case.
+   */
+  function applyThemeOverrides(settings: GridSettings, init: boolean) {
+    if (!hasOwnProperty(settings, 'colorScheme') && !hasOwnProperty(settings, 'density')) {
+      return;
+    }
+
+    if (!instance.themeManager) {
+      warn('The `colorScheme` and `density` options require the theme engine, so they have no ' +
+        'effect when the theme is enabled by a CSS class name. Pass a theme config object or a ' +
+        '`ThemeBuilder` instance to the `theme` option, or remove the `ht-theme-*` class from the ' +
+        'container element to use the default theme.');
+
+      return;
+    }
+
+    const hasChanged = instance.themeManager.setOverrides(readThemeOverrides(settings));
+
+    if (hasChanged && !init) {
+      instance.stylesHandler.clearCache();
+      instance.render();
+      instance.runHooks('afterSetTheme', instance.themeManager.getClassName(), false);
+    }
+  }
+
+  /**
    * Initializes the ThemeManager with the given theme configuration.
    *
    * @param {object|boolean} theme - The theme configuration object or `true` to use the default theme.
+   * @param {object} [overrides] - The per-instance color scheme and density overrides.
    */
-  function initializeThemeManager(theme?: ThemeBuilder) {
+  function initializeThemeManager(theme?: ThemeBuilder, overrides?: ThemeOverridesInput) {
     let themeObject;
 
     if (typeof theme === 'undefined') {
@@ -1729,7 +1787,8 @@ export default function Core(
     instance.themeManager = createThemeManager({
 
       hot: instance,
-      themeObject
+      themeObject,
+      overrides
     });
   }
 
@@ -3388,6 +3447,8 @@ export default function Core(
         }
       }
     }
+
+    applyThemeOverrides(settings, init);
 
     // Load data or create data map
     if (instance.runHooks('hasExternalDataSource') === true) {
@@ -6611,7 +6672,7 @@ export default function Core(
     !rootContainerThemeClassName &&
     (isObject(theme) || (!theme && !themeName))
   ) {
-    initializeThemeManager(theme as ThemeBuilder | undefined);
+    initializeThemeManager(theme as ThemeBuilder | undefined, readThemeOverrides(mergedUserSettings));
   }
 
   getPluginsNames().forEach((pluginName) => {

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -1615,7 +1615,7 @@ export default function Core(
       !rootContainerThemeClassName &&
       (isObject(theme) || (!theme && !themeName))
     ) {
-      initializeThemeManager(theme as ThemeBuilder | undefined, readThemeOverrides(tableMeta));
+      initializeThemeManager(theme as ThemeBuilder | undefined, readStoredThemeOverrides());
     }
 
     dataSource.setData(tableMeta.data);
@@ -1726,6 +1726,23 @@ export default function Core(
     }
 
     return overrides;
+  }
+
+  /**
+   * Reads the color scheme and density currently configured on this instance.
+   *
+   * Unlike `readThemeOverrides()`, this reads the effective values rather than only the keys that
+   * one payload carries. `updateSettings()` stores grid options on the global meta, which the table
+   * meta inherits through its prototype, so an own-property check would miss them. Use this when
+   * rebuilding a ThemeManager, which has to pick up options set by an earlier call.
+   *
+   * @returns {object} The theme overrides object.
+   */
+  function readStoredThemeOverrides(): ThemeOverridesInput {
+    return {
+      colorScheme: tableMeta.colorScheme,
+      density: tableMeta.density,
+    };
   }
 
   /**
@@ -3429,7 +3446,9 @@ export default function Core(
         isObject(settings.theme)
       ) {
         if (instance.themeManager === null) {
-          initializeThemeManager(settings.theme as ThemeBuilder);
+          // Read the overrides from `tableMeta`, not from this payload. The options may have been
+          // set by an earlier call, and the manager being rebuilt here starts with none of them.
+          initializeThemeManager(settings.theme as ThemeBuilder, readStoredThemeOverrides());
           instance.useTheme(instance.themeManager!.getClassName());
 
         } else {

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -269,6 +269,9 @@ export default function Core(
   let focusGridManager: FocusGridManager;
   let viewportScroller: ViewportScrollerInstance;
   let firstRun: boolean | [null, string] = true;
+  // Guards the "colorScheme/density need the theme engine" warning so it is logged once per
+  // instance instead of on every `updateSettings()` call that carries the options.
+  let themeOverridesWarningShown = false;
   // Set only when the table is initialized while invisible (see the `init` method). Kept in the closure, not on
   // the instance, because `destroy` nulls every instance property before it could be read there.
   let visibilityObserver: IntersectionObserver | null = null;
@@ -1753,29 +1756,45 @@ export default function Core(
    *
    * @param {object} settings - The settings object that may carry the overrides.
    * @param {boolean} init - `true` when called during initialization. The initial styles are
-   * injected by the ThemeManager constructor, so no re-render is needed in that case.
+   * injected by the ThemeManager constructor, so nothing has to be refreshed in that case.
+   * @returns {boolean} `true` when the overrides changed and `afterSetTheme` still has to run.
    */
-  function applyThemeOverrides(settings: GridSettings, init: boolean) {
-    if (!hasOwnProperty(settings, 'colorScheme') && !hasOwnProperty(settings, 'density')) {
-      return;
+  function applyThemeOverrides(settings: GridSettings, init: boolean): boolean {
+    const overrides = readThemeOverrides(settings);
+
+    if (!hasOwnProperty(overrides, 'colorScheme') && !hasOwnProperty(overrides, 'density')) {
+      return false;
     }
 
     if (!instance.themeManager) {
-      warn('The `colorScheme` and `density` options require the theme engine, so they have no ' +
-        'effect when the theme is enabled by a CSS class name. Pass a theme config object or a ' +
-        '`ThemeBuilder` instance to the `theme` option, or remove the `ht-theme-*` class from the ' +
-        'container element to use the default theme.');
+      // Only complain when a value is actually asked for. Clearing the options is documented, and a
+      // framework wrapper re-sends every prop on each render, so warning on key presence alone
+      // would fill the console for grids that never used these options.
+      const isValueRequested = (overrides.colorScheme ?? overrides.density) !== undefined;
 
-      return;
+      if (isValueRequested && !themeOverridesWarningShown) {
+        themeOverridesWarningShown = true;
+
+        warn('The `colorScheme` and `density` options require the theme engine, so they have no ' +
+          'effect when the theme is enabled by a CSS class name. Pass a theme config object or a ' +
+          '`ThemeBuilder` instance to the `theme` option, or remove the `ht-theme-*` class from ' +
+          'the container element to use the default theme.');
+      }
+
+      return false;
     }
 
-    const hasChanged = instance.themeManager.setOverrides(readThemeOverrides(settings));
+    const hasChanged = instance.themeManager.setOverrides(overrides);
 
-    if (hasChanged && !init) {
-      instance.stylesHandler.clearCache();
-      instance.render();
-      instance.runHooks('afterSetTheme', instance.themeManager.getClassName(), false);
+    if (!hasChanged || init) {
+      return false;
     }
+
+    // Clear the cache here so the render at the end of `updateSettings` measures the new sizes.
+    // Rendering here as well would paint once with stale meta and then immediately paint again.
+    instance.stylesHandler.clearCache();
+
+    return true;
   }
 
   /**
@@ -1786,6 +1805,12 @@ export default function Core(
    */
   function initializeThemeManager(theme?: ThemeBuilder, overrides?: ThemeOverridesInput) {
     let themeObject;
+
+    // Tear the previous manager down first. Without this its `<style>` node stays in the wrapper,
+    // and because a new manager prepends its own node the orphan ends up LATER in source order —
+    // so at the same specificity the orphan's override rules win and the grid can never change or
+    // reset a `colorScheme` or `density` that was set at construction time.
+    instance.themeManager?.destroy();
 
     if (typeof theme === 'undefined') {
       if (hasTheme('main')) {
@@ -3467,7 +3492,7 @@ export default function Core(
       }
     }
 
-    applyThemeOverrides(settings, init);
+    const themeOverridesChanged = applyThemeOverrides(settings, init);
 
     // Load data or create data map
     if (instance.runHooks('hasExternalDataSource') === true) {
@@ -3673,6 +3698,11 @@ export default function Core(
     if (instance.view && !firstRun) {
       instance.render();
       instance.view._wt.wtOverlays.adjustElementsSize();
+    }
+
+    // Fired after the render above, so a listener reading cell sizes sees the new density.
+    if (themeOverridesChanged) {
+      instance.runHooks('afterSetTheme', instance.themeManager!.getClassName(), false);
     }
 
     if (!init && instance.view && (currentHeight === '' || height === '' || height === undefined) &&

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -68,7 +68,7 @@ import {
 } from './utils/a11yAnnouncer';
 import { initLicenseNotification } from './utils/licenseNotification';
 import { getValueSetterValue } from './utils/valueAccessors';
-import { createThemeManager } from './themes/engine';
+import { createThemeManager, isThemeOverrideEmpty } from './themes/engine';
 import { LayoutManager, type LayoutConfig } from './core/layout';
 import { getTheme, hasTheme, registerTheme, mainTheme } from './themes';
 import type { ThemeBuilder } from './themes/engine/builder';
@@ -1770,7 +1770,8 @@ export default function Core(
       // Only complain when a value is actually asked for. Clearing the options is documented, and a
       // framework wrapper re-sends every prop on each render, so warning on key presence alone
       // would fill the console for grids that never used these options.
-      const isValueRequested = (overrides.colorScheme ?? overrides.density) !== undefined;
+      const isValueRequested = !isThemeOverrideEmpty(overrides.colorScheme) ||
+        !isThemeOverrideEmpty(overrides.density);
 
       if (isValueRequested && !themeOverridesWarningShown) {
         themeOverridesWarningShown = true;
@@ -3452,14 +3453,18 @@ export default function Core(
 
       // Use `theme` option if it's a string and differs from current theme (takes priority over `themeName`).
       if (themeOptionExists && typeof settings.theme === 'string' && currentThemeName !== settings.theme) {
-        instance.themeManager?.unmount();
-        instance.themeManager = null;
+        // `destroy()`, not `unmount()`. Unmounting removes the style node but leaves the manager
+        // subscribed to the shared theme object, so the next theme change re-injects its scoped
+        // rules and the grid gets stuck on whatever override the dead manager still holds.
+        instance.themeManager?.destroy();
         instance.useTheme(settings.theme);
 
       // Use `themeName` option if `theme` is not provided and the name differs from current theme.
       } else if (themeNameOptionExists && !themeOptionExists && currentThemeName !== settings.themeName) {
-        instance.themeManager?.unmount();
-        instance.themeManager = null;
+        // `destroy()`, not `unmount()`. Unmounting removes the style node but leaves the manager
+        // subscribed to the shared theme object, so the next theme change re-injects its scoped
+        // rules and the grid gets stuck on whatever override the dead manager still holds.
+        instance.themeManager?.destroy();
         tableMeta.theme = settings.themeName;
         tableMeta.themeName = undefined;
         instance.useTheme(settings.themeName!);
@@ -3700,9 +3705,11 @@ export default function Core(
       instance.view._wt.wtOverlays.adjustElementsSize();
     }
 
-    // Fired after the render above, so a listener reading cell sizes sees the new density.
-    if (themeOverridesChanged) {
-      instance.runHooks('afterSetTheme', instance.themeManager!.getClassName(), false);
+    // Fired after the render above, so a listener reading cell sizes sees the new density. The
+    // manager can be gone by now: an `afterUpdateSettings` listener is free to move the grid to a
+    // class-name theme, which tears the engine down.
+    if (themeOverridesChanged && instance.themeManager) {
+      instance.runHooks('afterSetTheme', instance.themeManager.getClassName(), false);
     }
 
     if (!init && instance.view && (currentHeight === '' || height === '' || height === undefined) &&

--- a/handsontable/src/core/settings.ts
+++ b/handsontable/src/core/settings.ts
@@ -25,6 +25,7 @@ import type {
   DataProviderConfig,
 } from '../plugins/dataProvider';
 import type { RangeType, HotInstance } from './types';
+import type { ThemeColorScheme, DensityType } from '../themes/types';
 
 /**
  * The function shape of the `sourceDataValidator` option. Returns `true` when the value is valid.
@@ -56,6 +57,8 @@ export interface GridSettings {
   readOnlyCellClassName?: string;
   tableClassName?: string | string[];
   themeName?: string;
+  colorScheme?: ThemeColorScheme;
+  density?: DensityType;
 
   // Dimensions
   width?: number | string | (() => number | string);

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -6265,6 +6265,8 @@ export default (): Record<string, unknown> => {
      * class name (the [`theme`](#theme) option set to a string, or an `ht-theme-*` class on the
      * container element). In that case, use the theme's dark class name instead.
      *
+     * An unsupported value is ignored with a console warning rather than throwing.
+     *
      * Read more:
      * - [Themes](@/guides/styling/themes/themes.md)
      * - [`density`](#density)
@@ -6315,6 +6317,8 @@ export default (): Record<string, unknown> => {
      * The option requires the theme engine, so it has no effect when the theme comes from a CSS
      * class name (the [`theme`](#theme) option set to a string, or an `ht-theme-*` class on the
      * container element).
+     *
+     * An unsupported value is ignored with a console warning rather than throwing.
      *
      * Read more:
      * - [Themes](@/guides/styling/themes/themes.md)

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -6246,6 +6246,108 @@ export default (): Record<string, unknown> => {
     theme: undefined,
 
     /**
+     * The `colorScheme` option sets the color scheme of the grid without declaring a theme.
+     *
+     * You can set it to one of the following:
+     *
+     * | Setting               | Description                                                     |
+     * | --------------------- | --------------------------------------------------------------- |
+     * | `undefined` (default) | Use the color scheme of the current theme                        |
+     * | `'light'`             | Always render the light color scheme                             |
+     * | `'dark'`              | Always render the dark color scheme                              |
+     * | `'auto'`              | Follow the color scheme of the operating system                  |
+     *
+     * The option is a per-instance override. It applies on top of the current theme, so the theme
+     * itself stays unchanged and other grids that use the same theme keep their own color scheme.
+     * You can change it at runtime with [`updateSettings()`](@/api/core.md#updatesettings).
+     *
+     * The option requires the theme engine, so it has no effect when the theme comes from a CSS
+     * class name (the [`theme`](#theme) option set to a string, or an `ht-theme-*` class on the
+     * container element). In that case, use the theme's dark class name instead.
+     *
+     * Read more:
+     * - [Themes](@/guides/styling/themes/themes.md)
+     * - [`density`](#density)
+     * - [`theme`](#theme)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
+     * @memberof Options#
+     * @type {string|undefined}
+     * @default undefined
+     * @category Core
+     * @since 18.1.0
+     *
+     * @example
+     * ```js
+     * // Render the grid in dark mode, without declaring a theme
+     * const hot = new Handsontable(container, {
+     *   colorScheme: 'dark',
+     * });
+     * ```
+     * @example
+     * ```js
+     * // Switch the color scheme at runtime
+     * hot.updateSettings({
+     *   colorScheme: 'auto',
+     * });
+     * ```
+     */
+    colorScheme: undefined,
+
+    /**
+     * The `density` option sets the amount of white space inside the grid without declaring a theme.
+     *
+     * You can set it to one of the following:
+     *
+     * | Setting               | Description                                              |
+     * | --------------------- | -------------------------------------------------------- |
+     * | `undefined` (default) | Use the density of the current theme                     |
+     * | `'default'`           | Standard spacing                                         |
+     * | `'compact'`           | Tighter spacing, fits more rows on the screen            |
+     * | `'comfortable'`       | Looser spacing, easier to read and to tap                |
+     *
+     * The option is a per-instance override. It applies on top of the current theme, so the theme
+     * itself stays unchanged and other grids that use the same theme keep their own density.
+     * You can change it at runtime with [`updateSettings()`](@/api/core.md#updatesettings).
+     *
+     * The option requires the theme engine, so it has no effect when the theme comes from a CSS
+     * class name (the [`theme`](#theme) option set to a string, or an `ht-theme-*` class on the
+     * container element).
+     *
+     * Read more:
+     * - [Themes](@/guides/styling/themes/themes.md)
+     * - [`colorScheme`](#colorScheme)
+     * - [`theme`](#theme)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
+     * @memberof Options#
+     * @type {string|undefined}
+     * @default undefined
+     * @category Core
+     * @since 18.1.0
+     *
+     * @example
+     * ```js
+     * // Render the grid with tighter spacing, without declaring a theme
+     * const hot = new Handsontable(container, {
+     *   density: 'compact',
+     * });
+     * ```
+     * @example
+     * ```js
+     * // Change the density at runtime
+     * hot.updateSettings({
+     *   density: 'comfortable',
+     * });
+     * ```
+     */
+    density: undefined,
+
+    /**
      * The `injectCoreCss` option controls whether Handsontable injects its core CSS into the document.
      *
      * You can set the `injectCoreCss` option to one of the following:

--- a/handsontable/src/index.ts
+++ b/handsontable/src/index.ts
@@ -227,6 +227,7 @@ export type { RendererType } from './renderers/registry';
 export type { ValidatorType } from './validators/registry';
 export type {
   BaseTheme,
+  DensityType,
   ThemeBuilder,
   ThemeColorScheme,
   ThemeColorsConfig,

--- a/handsontable/src/themes/engine/__tests__/cssVariables.unit.js
+++ b/handsontable/src/themes/engine/__tests__/cssVariables.unit.js
@@ -160,5 +160,55 @@ describe('CSS Variables utilities', () => {
       expect(result).toContain('--ht-mixed-array: light-dark(light, dark);');
       expect(result).toContain('--ht-mixed-reference: var(--ht-colors-primary);');
     });
+
+    describe('resolveScheme option', () => {
+      const input = {
+        pair: ['lightValue', 'darkValue'],
+        reference: ['colors.white', 'colors.palette.950'],
+        single: '14px',
+      };
+
+      it('should resolve light/dark pairs to the light branch', () => {
+        const result = flattenCssVariables(input, '', '', { resolveScheme: 'light' });
+
+        expect(result).toContain('--ht-pair: light-value;');
+        expect(result).toContain('--ht-reference: var(--ht-colors-white);');
+        expect(result).not.toContain('light-dark(');
+      });
+
+      it('should resolve light/dark pairs to the dark branch', () => {
+        const result = flattenCssVariables(input, '', '', { resolveScheme: 'dark' });
+
+        expect(result).toContain('--ht-pair: dark-value;');
+        expect(result).toContain('--ht-reference: var(--ht-colors-palette-950);');
+        expect(result).not.toContain('light-dark(');
+      });
+
+      it('should still emit light-dark() when no scheme is requested', () => {
+        const result = flattenCssVariables(input, '');
+
+        expect(result).toContain('--ht-pair: light-dark(light-value, dark-value);');
+      });
+    });
+
+    describe('lightDarkOnly option', () => {
+      it('should emit only the variables that differ between schemes', () => {
+        const input = {
+          pair: ['lightValue', 'darkValue'],
+          single: '14px',
+          nested: {
+            innerPair: ['a', 'b'],
+            innerSingle: 'plain',
+          },
+        };
+
+        const result = flattenCssVariables(input, '', '', { lightDarkOnly: true, resolveScheme: 'dark' });
+
+        expect(result).toContain('--ht-pair: dark-value;');
+        expect(result).toContain('--ht-nested-inner-pair: b;');
+        expect(result).not.toContain('--ht-single:');
+        expect(result).not.toContain('--ht-nested-inner-single:');
+      });
+    });
   });
 });

--- a/handsontable/src/themes/engine/__tests__/manager.unit.js
+++ b/handsontable/src/themes/engine/__tests__/manager.unit.js
@@ -674,26 +674,115 @@ describe('ThemeManager', () => {
         expect(manager.getDensityType()).toBe('comfortable');
       });
 
-      it('should throw on an unsupported colorScheme value', () => {
+      it('should warn and ignore an unsupported colorScheme value instead of throwing', () => {
         const mockHot = createMockHot();
-        const themeObject = createTheme(createValidThemeConfig());
+        const themeObject = createTheme(createValidThemeConfig({ colorScheme: 'light' }));
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        let manager;
 
-        expect(() => new ThemeManager({
-          hot: mockHot,
-          themeObject,
-          overrides: { colorScheme: 'sepia' },
-        })).toThrow('[ThemeBuilder] Invalid color scheme: "sepia".');
+        // Throwing here would abort `updateSettings()` half way through and leave the bad value in
+        // the grid meta, which then breaks every later theme change.
+        expect(() => {
+          manager = new ThemeManager({
+            hot: mockHot,
+            themeObject,
+            overrides: { colorScheme: 'sepia' },
+          });
+        }).not.toThrow();
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Ignoring the `colorScheme` option')
+        );
+        expect(manager.getOverrides().colorScheme).toBeUndefined();
+        expect(manager.getColorScheme()).toBe('light');
+
+        warnSpy.mockRestore();
       });
 
-      it('should throw on an unsupported density value', () => {
+      it('should warn and ignore an unsupported density value instead of throwing', () => {
         const mockHot = createMockHot();
         const themeObject = createTheme(createValidThemeConfig());
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        let manager;
 
-        expect(() => new ThemeManager({
+        expect(() => {
+          manager = new ThemeManager({
+            hot: mockHot,
+            themeObject,
+            overrides: { density: 'roomy' },
+          });
+        }).not.toThrow();
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Ignoring the `density` option')
+        );
+        expect(manager.getOverrides().density).toBeUndefined();
+
+        warnSpy.mockRestore();
+      });
+
+      it('should keep the applied value when a later update is unsupported', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const manager = new ThemeManager({
           hot: mockHot,
           themeObject,
-          overrides: { density: 'roomy' },
-        })).toThrow('[ThemeBuilder] Invalid density: "roomy".');
+          overrides: { colorScheme: 'dark' },
+        });
+
+        expect(manager.setOverrides({ colorScheme: 'sepia' })).toBe(false);
+        expect(manager.getOverrides().colorScheme).toBe('dark');
+
+        warnSpy.mockRestore();
+      });
+
+      it.each([[null], [false], ['']])('should treat %p as clearing the override', (emptyValue) => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig({ colorScheme: 'light' }));
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'dark' },
+        });
+
+        expect(manager.setOverrides({ colorScheme: emptyValue })).toBe(true);
+        expect(manager.getOverrides().colorScheme).toBeUndefined();
+        expect(manager.getColorScheme()).toBe('light');
+      });
+
+      it('should warn when the theme has no sizes for the requested density', () => {
+        const mockHot = createMockHot();
+        // `createTheme()` backfills every built-in density preset, so a theme that genuinely lacks
+        // one can only arrive as a custom object exposing `getThemeConfig()`. That is the path core
+        // takes for any `theme` option that already looks like a builder.
+        const themeObject = {
+          getThemeConfig: () => ({
+            name: 'partial-theme',
+            colorScheme: 'light',
+            density: { type: 'default', sizes: { default: { cellVertical: 'sizing.size_1' } } },
+            colors: {},
+            tokens: {},
+            icons: {},
+          }),
+        };
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { density: 'comfortable' },
+        });
+
+        // Without the warning the option looks applied while nothing changes on screen. No scoped
+        // rule is emitted at all here, since density was the only override requested.
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('has no "comfortable" density sizes')
+        );
+        expect(manager.themeStyles.textContent).not.toContain(manager.scopeClassName);
+        expect(manager.getDensityType()).toBe('comfortable');
+
+        warnSpy.mockRestore();
       });
 
       it('should keep the overrides after the theme object is updated', () => {

--- a/handsontable/src/themes/engine/__tests__/manager.unit.js
+++ b/handsontable/src/themes/engine/__tests__/manager.unit.js
@@ -13,15 +13,23 @@ describe('ThemeManager', () => {
     ...overrides,
   });
 
-  const createMockHot = () => ({
-    rootDocument: document,
-    rootWrapperElement: document.createElement('div'),
-    stylesHandler: {
-      clearCache: jest.fn(),
-    },
-    render: jest.fn(),
-    runHooks: jest.fn(),
-  });
+  let guidCounter = 0;
+
+  const createMockHot = () => {
+    guidCounter += 1;
+
+    return {
+      guid: `ht_mock${guidCounter}`,
+      rootDocument: document,
+      rootWrapperElement: document.createElement('div'),
+      rootPortalElement: document.createElement('div'),
+      stylesHandler: {
+        clearCache: jest.fn(),
+      },
+      render: jest.fn(),
+      runHooks: jest.fn(),
+    };
+  };
 
   describe('createThemeManager', () => {
     it('should create a ThemeManager instance', () => {
@@ -379,6 +387,271 @@ describe('ThemeManager', () => {
         // With the fix, only one listener is active — render called exactly once.
         // Without the fix, render would be called N times (once per accumulated subscription).
         expect(mockHot.render).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('per-instance overrides (colorScheme and density)', () => {
+      it('should apply the colorScheme override to a scoped rule', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'dark' },
+        });
+
+        const scopedRule = `.ht-theme-test-theme.${manager.scopeClassName}`;
+
+        expect(manager.themeStyles.textContent)
+          .toContain(`${scopedRule} {\ncolor-scheme: dark;\n}`);
+      });
+
+      it('should resolve the "auto" colorScheme override to "light dark"', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig({ colorScheme: 'light' }));
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'auto' },
+        });
+
+        expect(manager.themeStyles.textContent)
+          .toContain(`.ht-theme-test-theme.${manager.scopeClassName} {\ncolor-scheme: light dark;\n}`);
+      });
+
+      it('should apply the density override using the sizes of the requested preset', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { density: 'compact' },
+        });
+
+        const scopedBlock = manager.themeStyles.textContent
+          .split(`.ht-theme-test-theme.${manager.scopeClassName} {`)[1];
+
+        // `compact` maps cellVertical to sizing.size_0_5, while `default` maps it to sizing.size_1.
+        expect(scopedBlock).toContain('--ht-density-cell-vertical: var(--ht-sizing-size-0-5);');
+      });
+
+      it('should not apply any scoped rule when no override is set', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+        });
+
+        expect(manager.themeStyles.textContent).not.toContain(manager.scopeClassName);
+      });
+
+      it('should leave the shared theme object untouched so other instances keep their look', () => {
+        const themeObject = createTheme(createValidThemeConfig({
+          colorScheme: 'light',
+          density: 'default',
+        }));
+        const managerA = new ThemeManager({
+          hot: createMockHot(),
+          themeObject,
+          overrides: { colorScheme: 'dark', density: 'compact' },
+        });
+        const managerB = new ThemeManager({
+          hot: createMockHot(),
+          themeObject,
+        });
+
+        // The theme object itself must not have been mutated by instance A.
+        expect(themeObject.getThemeConfig().colorScheme).toBe('light');
+        expect(themeObject.getThemeConfig().density.type).toBe('default');
+
+        // Instance B must not pick up instance A's overrides.
+        expect(managerB.getOverrides()).toEqual({});
+        expect(managerB.themeStyles.textContent).not.toContain('color-scheme: dark');
+
+        // Every rule carrying instance A's override must be gated behind A's scope class. An
+        // unscoped rule would match any element with the theme class, instance B's included.
+        const selectorsDeclaring = (manager, declaration) => manager.themeStyles.textContent
+          .split('}')
+          .filter(block => block.includes(declaration))
+          .map(block => block.split('{')[0]);
+
+        const darkSelectors = selectorsDeclaring(managerA, 'color-scheme: dark');
+        // `compact` maps cellVertical to sizing.size_0_5, `default` maps it to sizing.size_1.
+        const compactSelectors = selectorsDeclaring(
+          managerA, '--ht-density-cell-vertical: var(--ht-sizing-size-0-5);'
+        );
+
+        expect(darkSelectors).toHaveLength(1);
+        expect(compactSelectors).toHaveLength(1);
+        [...darkSelectors, ...compactSelectors].forEach((selector) => {
+          expect(selector).toContain(managerA.scopeClassName);
+        });
+      });
+
+      it('should scope the overrides of two instances to different classes', () => {
+        const themeObject = createTheme(createValidThemeConfig());
+        const managerA = new ThemeManager({
+          hot: createMockHot(),
+          themeObject,
+          overrides: { colorScheme: 'dark' },
+        });
+        const managerB = new ThemeManager({
+          hot: createMockHot(),
+          themeObject,
+          overrides: { colorScheme: 'light' },
+        });
+
+        expect(managerA.scopeClassName).not.toBe(managerB.scopeClassName);
+        expect(managerB.themeStyles.textContent).not.toContain(managerA.scopeClassName);
+      });
+
+      it('should stamp the scope class on both the wrapper and the portal element', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'dark' },
+        });
+
+        expect(mockHot.rootWrapperElement.classList.contains(manager.scopeClassName)).toBe(true);
+        expect(mockHot.rootPortalElement.classList.contains(manager.scopeClassName)).toBe(true);
+      });
+
+      it('should remove the scope class from both elements on unmount', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'dark' },
+        });
+
+        manager.unmount();
+
+        expect(mockHot.rootWrapperElement.classList.contains(manager.scopeClassName)).toBe(false);
+        expect(mockHot.rootPortalElement.classList.contains(manager.scopeClassName)).toBe(false);
+      });
+
+      it('should report a change and re-inject the styles when setOverrides changes a value', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+        });
+
+        expect(manager.setOverrides({ colorScheme: 'dark' })).toBe(true);
+        expect(manager.themeStyles.textContent)
+          .toContain(`.ht-theme-test-theme.${manager.scopeClassName} {\ncolor-scheme: dark;\n}`);
+      });
+
+      it('should report no change when setOverrides is called with the same value', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'dark' },
+        });
+
+        expect(manager.setOverrides({ colorScheme: 'dark' })).toBe(false);
+      });
+
+      it('should keep an override that is absent from the next setOverrides call', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'dark', density: 'compact' },
+        });
+
+        manager.setOverrides({ density: 'comfortable' });
+
+        expect(manager.getOverrides()).toEqual({ colorScheme: 'dark', density: 'comfortable' });
+      });
+
+      it('should clear an override that is explicitly set to undefined', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig({ colorScheme: 'light' }));
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'dark' },
+        });
+
+        expect(manager.setOverrides({ colorScheme: undefined })).toBe(true);
+        expect(manager.getOverrides().colorScheme).toBeUndefined();
+        expect(manager.getColorScheme()).toBe('light');
+        expect(manager.themeStyles.textContent).not.toContain(manager.scopeClassName);
+      });
+
+      it('should report the effective colorScheme and density', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig({
+          colorScheme: 'light',
+          density: 'default',
+        }));
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { density: 'comfortable' },
+        });
+
+        expect(manager.getColorScheme()).toBe('light');
+        expect(manager.getDensityType()).toBe('comfortable');
+      });
+
+      it('should throw on an unsupported colorScheme value', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        expect(() => new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'sepia' },
+        })).toThrow('[ThemeBuilder] Invalid color scheme: "sepia".');
+      });
+
+      it('should throw on an unsupported density value', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        expect(() => new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { density: 'roomy' },
+        })).toThrow('[ThemeBuilder] Invalid density: "roomy".');
+      });
+
+      it('should keep the overrides after the theme object is updated', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'dark' },
+        });
+
+        manager.update(createTheme(createValidThemeConfig({ name: 'other-theme' })));
+
+        expect(manager.getOverrides().colorScheme).toBe('dark');
+        expect(manager.themeStyles.textContent)
+          .toContain(`.ht-theme-other-theme.${manager.scopeClassName} {\ncolor-scheme: dark;\n}`);
       });
     });
   });

--- a/handsontable/src/themes/engine/__tests__/manager.unit.js
+++ b/handsontable/src/themes/engine/__tests__/manager.unit.js
@@ -404,7 +404,66 @@ describe('ThemeManager', () => {
         const scopedRule = `.ht-theme-test-theme.${manager.scopeClassName}`;
 
         expect(manager.themeStyles.textContent)
-          .toContain(`${scopedRule} {\ncolor-scheme: dark;\n}`);
+          .toContain(`${scopedRule} {\ncolor-scheme: dark;\n`);
+      });
+
+      it('should pin the theme colors to the override scheme instead of relying on light-dark()', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig({ colorScheme: 'light' }));
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'dark' },
+        });
+
+        const scopedBlock = manager.themeStyles.textContent
+          .split(`.ht-theme-test-theme.${manager.scopeClassName} {`)[1];
+
+        // `backgroundColor` is ['colors.white', 'colors.palette.950'] in the main theme. The scoped
+        // block must carry the DARK branch outright — the minified theme stylesheets do not use
+        // light-dark(), so a bare `color-scheme` flip would leave the light colors in place.
+        expect(scopedBlock).toContain('--ht-background-color: var(--ht-colors-palette-950);');
+        expect(scopedBlock).not.toContain('--ht-background-color: light-dark(');
+      });
+
+      it('should pin the light branch and add a media query for the "auto" scheme', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig({ colorScheme: 'light' }));
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'auto' },
+        });
+
+        const cssText = manager.themeStyles.textContent;
+        const mediaBlock = cssText.split('@media (prefers-color-scheme: dark) {')[1];
+
+        // 'auto' must follow the operating system without light-dark(), the same way the static
+        // `-dark-auto` class does: light values by default, dark ones behind the media query.
+        expect(cssText).toContain('--ht-background-color: var(--ht-colors-white);');
+        expect(mediaBlock).toBeDefined();
+        expect(mediaBlock).toContain(`.ht-theme-test-theme.${manager.scopeClassName} {`);
+        expect(mediaBlock).toContain('--ht-background-color: var(--ht-colors-palette-950);');
+      });
+
+      it('should not repeat variables that are the same in both schemes', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+          overrides: { colorScheme: 'dark' },
+        });
+
+        const scopedBlock = manager.themeStyles.textContent
+          .split(`.ht-theme-test-theme.${manager.scopeClassName} {`)[1];
+
+        // `fontSize` carries one value for both schemes, so the override block has no reason to
+        // restate it. Only light/dark pairs belong there.
+        expect(scopedBlock).not.toContain('--ht-font-size:');
       });
 
       it('should resolve the "auto" colorScheme override to "light dark"', () => {
@@ -418,7 +477,7 @@ describe('ThemeManager', () => {
         });
 
         expect(manager.themeStyles.textContent)
-          .toContain(`.ht-theme-test-theme.${manager.scopeClassName} {\ncolor-scheme: light dark;\n}`);
+          .toContain(`.ht-theme-test-theme.${manager.scopeClassName} {\ncolor-scheme: light dark;\n`);
       });
 
       it('should apply the density override using the sizes of the requested preset', () => {
@@ -551,7 +610,7 @@ describe('ThemeManager', () => {
 
         expect(manager.setOverrides({ colorScheme: 'dark' })).toBe(true);
         expect(manager.themeStyles.textContent)
-          .toContain(`.ht-theme-test-theme.${manager.scopeClassName} {\ncolor-scheme: dark;\n}`);
+          .toContain(`.ht-theme-test-theme.${manager.scopeClassName} {\ncolor-scheme: dark;\n`);
       });
 
       it('should report no change when setOverrides is called with the same value', () => {
@@ -651,7 +710,7 @@ describe('ThemeManager', () => {
 
         expect(manager.getOverrides().colorScheme).toBe('dark');
         expect(manager.themeStyles.textContent)
-          .toContain(`.ht-theme-other-theme.${manager.scopeClassName} {\ncolor-scheme: dark;\n}`);
+          .toContain(`.ht-theme-other-theme.${manager.scopeClassName} {\ncolor-scheme: dark;\n`);
       });
     });
   });

--- a/handsontable/src/themes/engine/index.ts
+++ b/handsontable/src/themes/engine/index.ts
@@ -1,3 +1,4 @@
 export { createTheme, ThemeBuilder } from './builder';
 export { createThemeManager, ThemeManager } from './manager';
+export type { ThemeOverrides } from './manager';
 export type { ThemeConfig, ThemeParams, BaseTheme, ThemeColorScheme, DensityType } from '../types';

--- a/handsontable/src/themes/engine/index.ts
+++ b/handsontable/src/themes/engine/index.ts
@@ -1,4 +1,4 @@
 export { createTheme, ThemeBuilder } from './builder';
-export { createThemeManager, ThemeManager } from './manager';
+export { createThemeManager, ThemeManager, isThemeOverrideEmpty } from './manager';
 export type { ThemeOverrides } from './manager';
 export type { ThemeConfig, ThemeParams, BaseTheme, ThemeColorScheme, DensityType } from '../types';

--- a/handsontable/src/themes/engine/manager.ts
+++ b/handsontable/src/themes/engine/manager.ts
@@ -1,5 +1,6 @@
 import { iconsMap } from '../static/variables/helpers/iconsMap';
 import { throwWithCause } from '../../helpers/errors';
+import { warn } from '../../helpers/console';
 import { addClass, removeClass } from '../../helpers/dom/element';
 import { flattenCssVariables } from './utils/cssVariables';
 import { validateColorScheme, validateDensityType } from './utils/validation';
@@ -145,25 +146,59 @@ export class ThemeManager {
   }
 
   /**
+   * Resolves one override value coming from the grid settings.
+   *
+   * This is a settings boundary, so it never throws. An empty value clears the override, and an
+   * unsupported one is reported and ignored — throwing here would abort `updateSettings()` half way
+   * through and leave the bad value stored in the grid meta, breaking every later theme change.
+   *
+   * @param {*} value The raw value from the settings.
+   * @param {string} optionName The option name, used in the warning.
+   * @param {Function} validate The validator for the option, which throws on an unsupported value.
+   * @param {*} currentValue The value currently applied, kept when the new one is unsupported.
+   * @returns {*} The resolved value, or `undefined` when the override is cleared.
+   */
+  #resolveOverrideValue<T>(
+    value: unknown,
+    optionName: string,
+    validate: (candidate: string) => T,
+    currentValue: T | undefined
+  ): T | undefined {
+    // Treat every empty value the same as `undefined` — all of them mean "use the theme value".
+    if (value === undefined || value === null || value === false || value === '') {
+      return undefined;
+    }
+
+    try {
+      return validate(String(value));
+    } catch {
+      warn(`[ThemeManager] Ignoring the \`${optionName}\` option: ${JSON.stringify(value)} is not ` +
+        'a supported value.');
+
+      return currentValue;
+    }
+  }
+
+  /**
    * Validates and stores the per-instance overrides.
    *
-   * @param {object} overrides The color scheme and density overrides. An `undefined` value clears
-   * the given override and falls back to the theme configuration.
+   * @param {object} overrides The color scheme and density overrides. An empty value clears the
+   * given override and falls back to the theme configuration.
    * @returns {boolean} `true` when the effective overrides changed.
    */
   #setOverrides(overrides: ThemeOverridesInput): boolean {
     const nextOverrides: ThemeOverrides = { ...this.#overrides };
 
     if (Object.prototype.hasOwnProperty.call(overrides, 'colorScheme')) {
-      nextOverrides.colorScheme = overrides.colorScheme === undefined ?
-        undefined :
-        validateColorScheme(String(overrides.colorScheme));
+      nextOverrides.colorScheme = this.#resolveOverrideValue(
+        overrides.colorScheme, 'colorScheme', validateColorScheme, this.#overrides.colorScheme
+      );
     }
 
     if (Object.prototype.hasOwnProperty.call(overrides, 'density')) {
-      nextOverrides.density = overrides.density === undefined ?
-        undefined :
-        validateDensityType(String(overrides.density));
+      nextOverrides.density = this.#resolveOverrideValue(
+        overrides.density, 'density', validateDensityType, this.#overrides.density
+      );
     }
 
     const hasChanged = nextOverrides.colorScheme !== this.#overrides.colorScheme ||
@@ -228,6 +263,12 @@ export class ThemeManager {
 
     if (densitySizes) {
       cssText += `${selector} {\n${flattenCssVariables(densitySizes, 'density')}}\n`;
+
+    } else if (density) {
+      // A custom theme may not define every preset. Say so instead of leaving the option looking
+      // applied while nothing changes on screen.
+      warn(`[ThemeManager] The "${this.themeConfig?.name}" theme has no "${density}" density sizes, ` +
+        'so the `density` option has no effect. Add the sizes to the theme configuration.');
     }
 
     if (colorScheme) {

--- a/handsontable/src/themes/engine/manager.ts
+++ b/handsontable/src/themes/engine/manager.ts
@@ -61,6 +61,20 @@ const THEME_STYLE_ATTRIBUTE = 'data-hot-theme-style';
 const THEME_SCOPE_PREFIX = 'ht-scope-';
 
 /**
+ * Checks whether an override value means "use the theme value".
+ *
+ * `undefined` is the documented way to clear an override, and the other empty values are treated
+ * the same so a framework wrapper passing `null` or `''` for an unset prop clears rather than
+ * fails. Exported so the settings layer applies exactly the same rule.
+ *
+ * @param {*} value The raw override value.
+ * @returns {boolean} `true` when the value clears the override.
+ */
+export function isThemeOverrideEmpty(value: unknown): boolean {
+  return value === undefined || value === null || value === false || value === '';
+}
+
+/**
  * Resolves a color scheme to the value accepted by the CSS `color-scheme` property.
  *
  * @param {string} colorScheme The color scheme ('light', 'dark', or 'auto').
@@ -124,6 +138,14 @@ export class ThemeManager {
   #overrides: ThemeOverrides = {};
 
   /**
+   * The `<theme>:<density>` pair the "no density sizes" notice was last logged for, so re-injecting
+   * the styles does not repeat it.
+   *
+   * @type {string|null}
+   */
+  #missingDensityWarningKey: string | null = null;
+
+  /**
    * The theme manager constructor.
    *
    * @param {object} options - The options object.
@@ -164,8 +186,7 @@ export class ThemeManager {
     validate: (candidate: string) => T,
     currentValue: T | undefined
   ): T | undefined {
-    // Treat every empty value the same as `undefined` — all of them mean "use the theme value".
-    if (value === undefined || value === null || value === false || value === '') {
+    if (isThemeOverrideEmpty(value)) {
       return undefined;
     }
 
@@ -266,9 +287,16 @@ export class ThemeManager {
 
     } else if (density) {
       // A custom theme may not define every preset. Say so instead of leaving the option looking
-      // applied while nothing changes on screen.
-      warn(`[ThemeManager] The "${this.themeConfig?.name}" theme has no "${density}" density sizes, ` +
-        'so the `density` option has no effect. Add the sizes to the theme configuration.');
+      // applied while nothing changes on screen. Styles are re-injected on every theme change, so
+      // key the notice by theme and density to keep it to one line per real problem.
+      const warningKey = `${this.themeConfig?.name}:${density}`;
+
+      if (this.#missingDensityWarningKey !== warningKey) {
+        this.#missingDensityWarningKey = warningKey;
+
+        warn(`[ThemeManager] The "${this.themeConfig?.name}" theme has no "${density}" density ` +
+          'sizes, so the `density` option has no effect. Add the sizes to the theme configuration.');
+      }
     }
 
     if (colorScheme) {

--- a/handsontable/src/themes/engine/manager.ts
+++ b/handsontable/src/themes/engine/manager.ts
@@ -1,12 +1,16 @@
 import { iconsMap } from '../static/variables/helpers/iconsMap';
 import { throwWithCause } from '../../helpers/errors';
+import { addClass, removeClass } from '../../helpers/dom/element';
 import { flattenCssVariables } from './utils/cssVariables';
-import type { ThemeConfig } from '../types';
+import { validateColorScheme, validateDensityType } from './utils/validation';
+import type { ThemeConfig, ThemeColorScheme, DensityType } from '../types';
 import type { ThemeBuilder } from './builder';
 
 interface HotInstance {
+  guid: string;
   rootDocument: Document;
   rootWrapperElement: HTMLElement;
+  rootPortalElement: HTMLElement;
   stylesHandler: { clearCache(): void };
   render(): void;
   runHooks(hookName: string, ...args: unknown[]): void;
@@ -16,12 +20,54 @@ interface HotInstance {
 }
 
 /**
+ * Per-instance theme overrides applied on top of the theme configuration.
+ *
+ * They let a single grid pick a color scheme and a density without declaring its own theme, leaving
+ * the shared theme object (and therefore every other grid using it) untouched.
+ */
+export interface ThemeOverrides {
+  colorScheme?: ThemeColorScheme;
+  density?: DensityType;
+}
+
+/**
+ * Unvalidated theme overrides as they arrive from the grid settings.
+ *
+ * The values are `unknown` because the settings object is an external boundary — `setOverrides()`
+ * validates them and throws on an unsupported value.
+ */
+export interface ThemeOverridesInput {
+  colorScheme?: unknown;
+  density?: unknown;
+}
+
+/**
  * The theme prefix.
  *
  * @type {string}
  */
 const THEME_PREFIX = 'ht-theme-';
 const THEME_STYLE_ATTRIBUTE = 'data-hot-theme-style';
+
+/**
+ * Prefix of the class that scopes the per-instance override rules to a single grid.
+ *
+ * It deliberately does not start with `ht-theme-`, because `Core#onThemeChange` strips every
+ * `ht-theme-*` class from the wrapper and portal elements when the theme changes.
+ *
+ * @type {string}
+ */
+const THEME_SCOPE_PREFIX = 'ht-scope-';
+
+/**
+ * Resolves a color scheme to the value accepted by the CSS `color-scheme` property.
+ *
+ * @param {string} colorScheme The color scheme ('light', 'dark', or 'auto').
+ * @returns {string} The CSS `color-scheme` value.
+ */
+function toCssColorScheme(colorScheme: ThemeColorScheme | undefined): string | undefined {
+  return colorScheme === 'auto' ? 'light dark' : colorScheme;
+}
 
 /**
  * ThemeManager class provides methods to manage the theme styles.
@@ -55,6 +101,14 @@ export class ThemeManager {
   themeConfig: ThemeConfig | null = null;
 
   /**
+   * Class that scopes the per-instance override rules to this grid only. Stamped on the wrapper and
+   * the portal element, so menus and dialogs rendered in the portal follow the same overrides.
+   *
+   * @type {string}
+   */
+  scopeClassName: string;
+
+  /**
    * Unsubscribes from the theme object's change notifications.
    *
    * @type {Function|null}
@@ -62,16 +116,93 @@ export class ThemeManager {
   #unsubscribeTheme: (() => void) | null = null;
 
   /**
+   * Per-instance color scheme and density overrides applied on top of the theme configuration.
+   *
+   * @type {object}
+   */
+  #overrides: ThemeOverrides = {};
+
+  /**
    * The theme manager constructor.
    *
    * @param {object} options - The options object.
    * @param {Handsontable} options.hot - The Handsontable instance.
    * @param {object} options.themeObject - The theme object.
+   * @param {object} [options.overrides] - The per-instance color scheme and density overrides.
    */
-  constructor({ hot, themeObject }: { hot: HotInstance; themeObject: ThemeBuilder }) {
+  constructor(
+    { hot, themeObject, overrides }:
+    { hot: HotInstance; themeObject: ThemeBuilder; overrides?: ThemeOverridesInput }
+  ) {
     this.hot = hot;
+    this.scopeClassName = `${THEME_SCOPE_PREFIX}${hot.guid}`;
+
+    if (overrides) {
+      this.#setOverrides(overrides);
+    }
 
     this.update(themeObject);
+  }
+
+  /**
+   * Validates and stores the per-instance overrides.
+   *
+   * @param {object} overrides The color scheme and density overrides. An `undefined` value clears
+   * the given override and falls back to the theme configuration.
+   * @returns {boolean} `true` when the effective overrides changed.
+   */
+  #setOverrides(overrides: ThemeOverridesInput): boolean {
+    const nextOverrides: ThemeOverrides = { ...this.#overrides };
+
+    if (Object.prototype.hasOwnProperty.call(overrides, 'colorScheme')) {
+      nextOverrides.colorScheme = overrides.colorScheme === undefined ?
+        undefined :
+        validateColorScheme(String(overrides.colorScheme));
+    }
+
+    if (Object.prototype.hasOwnProperty.call(overrides, 'density')) {
+      nextOverrides.density = overrides.density === undefined ?
+        undefined :
+        validateDensityType(String(overrides.density));
+    }
+
+    const hasChanged = nextOverrides.colorScheme !== this.#overrides.colorScheme ||
+      nextOverrides.density !== this.#overrides.density;
+
+    this.#overrides = nextOverrides;
+
+    return hasChanged;
+  }
+
+  /**
+   * Builds the CSS rules that apply the per-instance overrides.
+   *
+   * The selector doubles the theme class with the instance scope class, giving specificity (0,2,0).
+   * That beats both the `:where()` block above (0,0,0) and the static `ht-theme-*.css` declarations
+   * (0,1,0), so the override wins no matter which stylesheet the page loaded.
+   *
+   * @returns {string} The CSS text, or an empty string when no override is active.
+   */
+  #buildOverrideStyles(): string {
+    const { colorScheme, density } = this.#overrides;
+
+    if (!colorScheme && !density) {
+      return '';
+    }
+
+    const selector = `.${this.themeClassName}.${this.scopeClassName}`;
+    const densitySizes = density ? this.themeConfig?.density?.sizes?.[density] : undefined;
+    let cssText = '';
+
+    if (densitySizes) {
+      cssText += `${selector} {\n${flattenCssVariables(densitySizes, 'density')}}\n`;
+    }
+
+    if (colorScheme) {
+      cssText += `${selector} {\ncolor-scheme: ${toCssColorScheme(colorScheme)};\n}\n`;
+    }
+
+    return cssText;
   }
 
   /**
@@ -82,7 +213,7 @@ export class ThemeManager {
       return;
     }
 
-    const colorScheme = this.themeConfig.colorScheme === 'auto' ? 'light dark' : this.themeConfig.colorScheme;
+    const colorScheme = toCssColorScheme(this.themeConfig.colorScheme);
 
     if (!this.themeStyles) {
       this.themeStyles = this.hot.rootDocument.createElement('style');
@@ -123,7 +254,8 @@ export class ThemeManager {
     // Separate rule with class-level specificity (0,1,0) so this <style> (injected into <body>)
     // wins over same-specificity color-scheme declarations in static ht-theme-*.css files via
     // source order, while keeping all other tokens at :where() specificity for easy overrides.
-    this.themeStyles.textContent += `.${this.themeClassName} {\ncolor-scheme: ${colorScheme};\n}`;
+    this.themeStyles.textContent += `.${this.themeClassName} {\ncolor-scheme: ${colorScheme};\n}\n`;
+    this.themeStyles.textContent += this.#buildOverrideStyles();
 
     // Ensure that the manager always controls its own style node.
     // Some wrappers may contain other <style> tags and updating/removing a generic
@@ -140,6 +272,52 @@ export class ThemeManager {
    */
   getClassName(): string {
     return this.themeClassName;
+  }
+
+  /**
+   * Gets the per-instance color scheme and density overrides.
+   *
+   * @returns {object} A copy of the currently applied overrides.
+   */
+  getOverrides(): ThemeOverrides {
+    return { ...this.#overrides };
+  }
+
+  /**
+   * Gets the color scheme this grid renders with, taking the per-instance override into account.
+   *
+   * @returns {string|undefined} The color scheme ('light', 'dark', or 'auto').
+   */
+  getColorScheme(): ThemeColorScheme | undefined {
+    return this.#overrides.colorScheme ?? this.themeConfig?.colorScheme;
+  }
+
+  /**
+   * Gets the density type this grid renders with, taking the per-instance override into account.
+   *
+   * @returns {string|undefined} The density type ('default', 'compact', or 'comfortable').
+   */
+  getDensityType(): DensityType | undefined {
+    return this.#overrides.density ?? this.themeConfig?.density?.type;
+  }
+
+  /**
+   * Applies per-instance color scheme and density overrides and re-injects the theme styles.
+   *
+   * The shared theme object is never mutated, so other grids using the same theme keep their look.
+   *
+   * @param {object} overrides The color scheme and density overrides. An `undefined` value clears
+   * the given override and falls back to the theme configuration.
+   * @returns {boolean} `true` when the effective overrides changed and the styles were re-injected.
+   */
+  setOverrides(overrides: ThemeOverridesInput): boolean {
+    if (!this.#setOverrides(overrides)) {
+      return false;
+    }
+
+    this.#injectThemeStyles();
+
+    return true;
   }
 
   /**
@@ -182,6 +360,7 @@ export class ThemeManager {
    * Mounts the theme manager.
    */
   mount() {
+    this.#stampScopeClass();
     this.#injectThemeStyles();
   }
 
@@ -189,10 +368,37 @@ export class ThemeManager {
    * Unmounts the theme manager.
    */
   unmount() {
+    this.#unstampScopeClass();
+
     if (this.themeStyles) {
       this.themeStyles.remove();
 
     }
+  }
+
+  /**
+   * Adds the instance scope class to the wrapper and portal elements.
+   *
+   * Both are stamped because menus, dropdowns, and dialogs render inside the portal element — a
+   * wrapper-only scope would leave them on the theme defaults while the grid follows the overrides.
+   */
+  #stampScopeClass() {
+    [this.hot?.rootWrapperElement, this.hot?.rootPortalElement].forEach((element) => {
+      if (element) {
+        addClass(element, this.scopeClassName);
+      }
+    });
+  }
+
+  /**
+   * Removes the instance scope class from the wrapper and portal elements.
+   */
+  #unstampScopeClass() {
+    [this.hot?.rootWrapperElement, this.hot?.rootPortalElement].forEach((element) => {
+      if (element) {
+        removeClass(element, this.scopeClassName);
+      }
+    });
   }
 
   /**
@@ -211,9 +417,11 @@ export class ThemeManager {
  * @param {object} options - The options object.
  * @param {Handsontable} options.hot - The Handsontable instance.
  * @param {object} options.themeObject - The theme object.
+ * @param {object} [options.overrides] - The per-instance color scheme and density overrides.
  * @returns {ThemeManager} The ThemeManager instance.
  */
 export function createThemeManager(
-  { hot, themeObject }: { hot: HotInstance; themeObject: ThemeBuilder }): ThemeManager {
-  return new ThemeManager({ hot, themeObject });
+  { hot, themeObject, overrides }:
+  { hot: HotInstance; themeObject: ThemeBuilder; overrides?: ThemeOverridesInput }): ThemeManager {
+  return new ThemeManager({ hot, themeObject, overrides });
 }

--- a/handsontable/src/themes/engine/manager.ts
+++ b/handsontable/src/themes/engine/manager.ts
@@ -175,6 +175,38 @@ export class ThemeManager {
   }
 
   /**
+   * Builds the CSS variables that pin every light/dark value of the theme to one scheme.
+   *
+   * Setting the `color-scheme` property is not enough on its own. The shipped minified theme
+   * stylesheets do not use the CSS `light-dark()` function — it is newer than the browsers
+   * Handsontable supports, so the minifier rewrites it into a pair of variables switched by theme
+   * class name. Those declarations out-specify the ones the engine generates, so a grid that only
+   * flipped `color-scheme` would keep the light colors. Emitting the resolved values instead works
+   * in every supported browser and with every stylesheet.
+   *
+   * @param {string} scheme The scheme to resolve to ('light' or 'dark').
+   * @returns {string} The CSS variable declarations.
+   */
+  #buildResolvedColorVariables(scheme: 'light' | 'dark'): string {
+    if (!this.themeConfig) {
+      return '';
+    }
+
+    const options = { resolveScheme: scheme, lightDarkOnly: true };
+    let cssText = '';
+
+    if (this.themeConfig.colors) {
+      cssText += flattenCssVariables(this.themeConfig.colors, 'colors', '', options);
+    }
+
+    if (this.themeConfig.tokens) {
+      cssText += flattenCssVariables(this.themeConfig.tokens, '', '', options);
+    }
+
+    return cssText;
+  }
+
+  /**
    * Builds the CSS rules that apply the per-instance overrides.
    *
    * The selector doubles the theme class with the instance scope class, giving specificity (0,2,0).
@@ -199,7 +231,17 @@ export class ThemeManager {
     }
 
     if (colorScheme) {
-      cssText += `${selector} {\ncolor-scheme: ${toCssColorScheme(colorScheme)};\n}\n`;
+      cssText += `${selector} {\ncolor-scheme: ${toCssColorScheme(colorScheme)};\n`;
+
+      // 'auto' follows the operating system, so pin the light values and let a media query swap in
+      // the dark ones. That mirrors what the static `-dark-auto` class does, without `light-dark()`.
+      cssText += this.#buildResolvedColorVariables(colorScheme === 'dark' ? 'dark' : 'light');
+      cssText += '}\n';
+
+      if (colorScheme === 'auto') {
+        cssText += `@media (prefers-color-scheme: dark) {\n${selector} {\n` +
+          `${this.#buildResolvedColorVariables('dark')}}\n}\n`;
+      }
     }
 
     return cssText;

--- a/handsontable/src/themes/engine/utils/cssVariables.ts
+++ b/handsontable/src/themes/engine/utils/cssVariables.ts
@@ -59,14 +59,43 @@ function toCssKey(prefix: string, key: string): string {
 }
 
 /**
+ * Options that change how a value list is turned into a CSS value.
+ */
+export interface FlattenOptions {
+  /**
+   * Resolves a `[light, dark]` value list to that one branch instead of emitting
+   * `light-dark()`. Needed because `light-dark()` is newer than the browsers
+   * Handsontable supports, so the shipped minified CSS does not use it.
+   */
+  resolveScheme?: 'light' | 'dark';
+  /**
+   * Emits only the variables whose value is a `[light, dark]` list. Values that
+   * are the same in both schemes do not need to be repeated in an override block.
+   */
+  lightDarkOnly?: boolean;
+}
+
+/**
+ * Checks whether a value is a `[light, dark]` value list.
+ *
+ * @param {*} value - The value to check.
+ * @returns {boolean} - True when the value carries a separate light and dark value.
+ */
+function isLightDarkValue(value: unknown): boolean {
+  return Array.isArray(value) && value.length >= 2 &&
+    typeof value[0] === 'string' && typeof value[1] === 'string';
+}
+
+/**
  * Converts a value to a CSS variable value.
  * Handles variable references, light/dark values, and single values.
  *
  * @param {string|object} value - The value to convert.
  * @param {string} [key] - The CSS key name (used for exceptions like font-family).
+ * @param {object} [options] - The flattening options.
  * @returns {string} - The CSS value.
  */
-function toCssValue(value: unknown, key?: string): string {
+function toCssValue(value: unknown, key?: string, options: FlattenOptions = {}): string {
   if (typeof value === 'string' && isVarReference(value)) {
     return toVarReference(value);
   }
@@ -76,21 +105,29 @@ function toCssValue(value: unknown, key?: string): string {
       const [light, dark]: [unknown, unknown] = value as [unknown, unknown];
 
       if (typeof light === 'string' && typeof dark === 'string') {
-        return `light-dark(${toCssValue(light, key)}, ${toCssValue(dark, key)})`;
+        if (options.resolveScheme === 'light') {
+          return toCssValue(light, key, options);
+        }
+
+        if (options.resolveScheme === 'dark') {
+          return toCssValue(dark, key, options);
+        }
+
+        return `light-dark(${toCssValue(light, key, options)}, ${toCssValue(dark, key, options)})`;
       }
 
       if (typeof light === 'string') {
-        return toCssValue(light, key);
+        return toCssValue(light, key, options);
       }
 
       if (typeof dark === 'string') {
-        return toCssValue(dark, key);
+        return toCssValue(dark, key, options);
       }
 
       return '';
     }
 
-    return toCssValue(value[0], key);
+    return toCssValue(value[0], key, options);
   }
 
   if (key && CSS_KEY_EXCEPTIONS.includes(key)) {
@@ -106,10 +143,11 @@ function toCssValue(value: unknown, key?: string): string {
  * @param {string} prefix - The prefix to add to the CSS variable.
  * @param {string} key - The key to convert.
  * @param {string} value - The value to convert.
+ * @param {object} [options] - The flattening options.
  * @returns {string} - The CSS variable line.
  */
-function toCssLine(prefix: string, key: string, value: unknown): string {
-  return `${toCssKey(prefix, key)}: ${toCssValue(value, key)};`;
+function toCssLine(prefix: string, key: string, value: unknown, options: FlattenOptions = {}): string {
+  return `${toCssKey(prefix, key)}: ${toCssValue(value, key, options)};`;
 }
 
 /**
@@ -118,10 +156,15 @@ function toCssLine(prefix: string, key: string, value: unknown): string {
  * @param {object} cssVariables - The CSS variables object to flatten.
  * @param {string} [prefix='colors'] - The prefix to add to the CSS variables.
  * @param {string} [parentKey=''] - The parent key to add to the CSS variables.
+ * @param {object} [options] - The flattening options.
  * @returns {string} - The flattened CSS variables.
  */
 export function flattenCssVariables(
-  cssVariables: Record<string, unknown>, prefix: string = '', parentKey: string = ''): string {
+  cssVariables: Record<string, unknown>,
+  prefix: string = '',
+  parentKey: string = '',
+  options: FlattenOptions = {}
+): string {
   let cssVars = '';
 
   Object.entries(cssVariables).forEach(([key, value]) => {
@@ -129,9 +172,9 @@ export function flattenCssVariables(
     const fullKey = parentKey ? `${parentKey}-${normalizedKey}` : normalizedKey;
 
     if (isObject(value)) {
-      cssVars += flattenCssVariables(value as Record<string, unknown>, prefix, fullKey);
-    } else {
-      cssVars += `${toCssLine(prefix, fullKey, value)}\n`;
+      cssVars += flattenCssVariables(value as Record<string, unknown>, prefix, fullKey, options);
+    } else if (!options.lightDarkOnly || isLightDarkValue(value)) {
+      cssVars += `${toCssLine(prefix, fullKey, value, options)}\n`;
     }
   });
 

--- a/tests/e2e/color-scheme-density.spec.ts
+++ b/tests/e2e/color-scheme-density.spec.ts
@@ -171,6 +171,44 @@ test.describe('colorScheme and density options', () => {
     expect(await grid.cellHeightOf('a')).toBe(darkCompactHeight);
   });
 
+  test('does not let a torn-down theme engine re-inject its rules', async({ page, theme, bundle }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await grid.clickToolbar('set-dark');
+    await expect.poll(() => grid.colorSchemeOf('a')).toBe('dark');
+
+    // Moving to a class-name theme tears the engine down for grid A.
+    await grid.clickToolbar('theme-as-class');
+    await expect.poll(() => grid.themeStyleNodeCountOf('a')).toBe(0);
+
+    // Mutating the shared theme notifies its subscribers. A manager that was unmounted but never
+    // unsubscribed wakes up here, re-injects its node, and pins the grid to its old override.
+    await grid.clickToolbar('mutate-shared-theme');
+
+    expect(await grid.themeStyleNodeCountOf('a')).toBe(0);
+
+    // Grid B still uses the engine, so it keeps exactly one node.
+    expect(await grid.themeStyleNodeCountOf('b')).toBe(1);
+  });
+
+  test('survives a listener that switches theme during the same update', async({
+    page, theme, bundle,
+  }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+    const pageErrors = grid.collectPageErrors();
+
+    await grid.goto();
+
+    // The listener moves grid A to a class-name theme, so the manager is gone by the time core
+    // reaches the `afterSetTheme` call at the end of `updateSettings()`.
+    await grid.clickToolbar('a-switch-theme-in-hook');
+
+    await expect.poll(() => grid.themeStyleNodeCountOf('a')).toBe(0);
+    expect(pageErrors).toHaveLength(0);
+  });
+
   test('warns once, and only for a real value, when the theme engine is not active', async({
     page, theme, bundle,
   }) => {

--- a/tests/e2e/color-scheme-density.spec.ts
+++ b/tests/e2e/color-scheme-density.spec.ts
@@ -9,6 +9,10 @@ import { ColorSchemeDensityPage } from '../fixtures/pages/ColorSchemeDensityPage
  * spacing. The checks below read computed styles and rendered box sizes — the
  * result a user actually sees — rather than the CSS text the engine injected.
  */
+// Every grid in the fixture renders the engine-driven `main` theme and the fixture always loads
+// `ht-theme-main.min.css`, so every leg of the matrix exercises the real specificity scenario. The
+// theme axis is therefore redundant here rather than misleading, and the bundle axis is genuine —
+// the engine builds its CSS at runtime.
 test.describe('colorScheme and density options', () => {
   test('applies colorScheme set at construction time', async({ page, theme, bundle }) => {
     const grid = new ColorSchemeDensityPage(page, theme, bundle);
@@ -105,6 +109,47 @@ test.describe('colorScheme and density options', () => {
     expect(await grid.cellHeightOf('b')).toBe(controlHeight);
   });
 
+  test('can change an override that was set at construction time', async({ page, theme, bundle }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+
+    await grid.goto();
+
+    // Grid C is built with `colorScheme: 'dark'` and `density: 'compact'`.
+    expect(await grid.colorSchemeOf('c')).toBe('dark');
+
+    const compactHeight = await grid.cellHeightOf('c');
+
+    await grid.clickToolbar('c-set-light');
+
+    // Core builds a ThemeManager twice during startup. While the first one was left in the DOM its
+    // <style> node sat later in source order at the same specificity, so its construction-time
+    // rules beat everything the live manager wrote afterwards and this change did nothing.
+    await expect.poll(() => grid.colorSchemeOf('c')).toBe('light');
+    expect(await grid.cellHeightOf('c')).toBeGreaterThan(compactHeight);
+  });
+
+  test('leaves one theme style node per grid', async({ page, theme, bundle }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+
+    await grid.goto();
+
+    // Two nodes would mean an orphaned ThemeManager is still holding stale override rules.
+    expect(await grid.themeStyleNodeCountOf('a')).toBe(1);
+    expect(await grid.themeStyleNodeCountOf('c')).toBe(1);
+  });
+
+  test('clears an override that was set at construction time', async({ page, theme, bundle }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await grid.clickToolbar('c-reset');
+
+    // Falls back to the theme values, which is what the control grid already renders.
+    await expect.poll(() => grid.colorSchemeOf('c')).toBe(await grid.colorSchemeOf('b'));
+    expect(await grid.cellHeightOf('c')).toBe(await grid.cellHeightOf('b'));
+  });
+
   test('keeps the overrides when the theme engine is rebuilt', async({ page, theme, bundle }) => {
     const grid = new ColorSchemeDensityPage(page, theme, bundle);
 
@@ -124,6 +169,35 @@ test.describe('colorScheme and density options', () => {
 
     await expect.poll(() => grid.colorSchemeOf('a')).toBe('dark');
     expect(await grid.cellHeightOf('a')).toBe(darkCompactHeight);
+  });
+
+  test('warns once, and only for a real value, when the theme engine is not active', async({
+    page, theme, bundle,
+  }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+    const warnings = grid.collectWarnings();
+    const engineWarnings = () => warnings.filter(text => text.includes('require the theme engine'));
+
+    await grid.goto();
+
+    // Grid D takes its theme from a CSS class name, so it has no ThemeManager.
+    expect(engineWarnings()).toHaveLength(0);
+
+    // Clearing the options is documented, and a framework wrapper re-sends every prop on each
+    // render. Neither should produce a warning for a grid that never asked for these options.
+    await grid.clickToolbar('d-reset');
+    await grid.clickToolbar('d-reset');
+
+    expect(engineWarnings()).toHaveLength(0);
+
+    // Asking for a real value is worth one notice — and only one.
+    await grid.clickToolbar('d-set-dark');
+    await expect.poll(() => engineWarnings().length).toBe(1);
+
+    await grid.clickToolbar('d-set-dark');
+    await grid.clickToolbar('d-set-dark');
+
+    expect(engineWarnings()).toHaveLength(1);
   });
 
   test('applies the colorScheme to menus rendered in the grid portal', async({ page, theme, bundle }) => {

--- a/tests/e2e/color-scheme-density.spec.ts
+++ b/tests/e2e/color-scheme-density.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '../fixtures/test';
+import { ColorSchemeDensityPage } from '../fixtures/pages/ColorSchemeDensityPage';
+
+/**
+ * `colorScheme` and `density` as plain grid options (DEV-1476).
+ *
+ * Both are per-instance overrides on top of whatever theme the grid already
+ * uses, so no theme has to be declared to switch to dark mode or to tighten the
+ * spacing. The checks below read computed styles and rendered box sizes — the
+ * result a user actually sees — rather than the CSS text the engine injected.
+ */
+test.describe('colorScheme and density options', () => {
+  test('applies colorScheme set at construction time', async({ page, theme, bundle }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+
+    await grid.goto();
+
+    // Grid C is constructed with `colorScheme: 'dark'`; grid B declares nothing.
+    expect(await grid.colorSchemeOf('c')).toBe('dark');
+    expect(await grid.colorSchemeOf('b')).not.toBe('dark');
+  });
+
+  test('applies density set at construction time', async({ page, theme, bundle }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+
+    await grid.goto();
+
+    // Grid C is constructed with `density: 'compact'`, which halves the cell's
+    // vertical padding — so its rows must render shorter than the default ones.
+    const compactHeight = await grid.cellHeightOf('c');
+    const defaultHeight = await grid.cellHeightOf('b');
+
+    expect(compactHeight).toBeLessThan(defaultHeight);
+  });
+
+  test('switches colorScheme at runtime through updateSettings', async({ page, theme, bundle }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+
+    await grid.goto();
+
+    const lightBackground = await grid.cellBackgroundOf('a');
+
+    await grid.clickToolbar('set-dark');
+
+    await expect.poll(() => grid.colorSchemeOf('a')).toBe('dark');
+
+    // The theme resolves colors with the CSS `light-dark()` function, so a
+    // changed color scheme must change the rendered cell background too.
+    expect(await grid.cellBackgroundOf('a')).not.toBe(lightBackground);
+
+    await grid.clickToolbar('set-light');
+
+    await expect.poll(() => grid.colorSchemeOf('a')).toBe('light');
+    expect(await grid.cellBackgroundOf('a')).toBe(lightBackground);
+  });
+
+  test('switches density at runtime through updateSettings', async({ page, theme, bundle }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+
+    await grid.goto();
+
+    const defaultHeight = await grid.cellHeightOf('a');
+
+    await grid.clickToolbar('set-compact');
+    await expect.poll(() => grid.cellHeightOf('a')).toBeLessThan(defaultHeight);
+
+    await grid.clickToolbar('set-comfortable');
+    await expect.poll(() => grid.cellHeightOf('a')).toBeGreaterThan(defaultHeight);
+  });
+
+  test('clears an override when the option is set back to undefined', async({ page, theme, bundle }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+
+    await grid.goto();
+
+    const defaultHeight = await grid.cellHeightOf('a');
+
+    await grid.clickToolbar('set-dark');
+    await grid.clickToolbar('set-compact');
+    await expect.poll(() => grid.colorSchemeOf('a')).toBe('dark');
+
+    await grid.clickToolbar('reset-overrides');
+
+    await expect.poll(() => grid.cellHeightOf('a')).toBe(defaultHeight);
+    expect(await grid.colorSchemeOf('a')).not.toBe('dark');
+  });
+
+  test('does not leak an override to another grid sharing the same theme', async({ page, theme, bundle }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+
+    await grid.goto();
+
+    const controlBackground = await grid.cellBackgroundOf('b');
+    const controlHeight = await grid.cellHeightOf('b');
+
+    await grid.clickToolbar('set-dark');
+    await grid.clickToolbar('set-compact');
+    await expect.poll(() => grid.colorSchemeOf('a')).toBe('dark');
+
+    // Grid B shares the one registered `main` theme object with grid A. If the
+    // override mutated that theme, or if its CSS rule were not scoped to grid
+    // A's instance, grid B would flip to dark and compact along with it.
+    expect(await grid.colorSchemeOf('b')).not.toBe('dark');
+    expect(await grid.cellBackgroundOf('b')).toBe(controlBackground);
+    expect(await grid.cellHeightOf('b')).toBe(controlHeight);
+  });
+
+  test('applies the colorScheme to menus rendered in the grid portal', async({ page, theme, bundle }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await grid.clickToolbar('set-dark');
+    await expect.poll(() => grid.colorSchemeOf('a')).toBe('dark');
+
+    // Menus live in the portal element, which core appends to `document.body`.
+    // Stamping the scope class only on the wrapper would leave a light menu on a
+    // dark grid.
+    const darkMenu = await grid.openContextMenu('a');
+
+    expect(await darkMenu.evaluate(el => getComputedStyle(el).colorScheme)).toBe('dark');
+
+    await grid.closeContextMenu();
+
+    const controlMenu = await grid.openContextMenu('b');
+
+    expect(await controlMenu.evaluate(el => getComputedStyle(el).colorScheme)).not.toBe('dark');
+  });
+});

--- a/tests/e2e/color-scheme-density.spec.ts
+++ b/tests/e2e/color-scheme-density.spec.ts
@@ -105,6 +105,27 @@ test.describe('colorScheme and density options', () => {
     expect(await grid.cellHeightOf('b')).toBe(controlHeight);
   });
 
+  test('keeps the overrides when the theme engine is rebuilt', async({ page, theme, bundle }) => {
+    const grid = new ColorSchemeDensityPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await grid.clickToolbar('set-dark');
+    await grid.clickToolbar('set-compact');
+    await expect.poll(() => grid.colorSchemeOf('a')).toBe('dark');
+
+    const darkCompactHeight = await grid.cellHeightOf('a');
+
+    // Switching to a class-named theme tears the theme engine down, and switching back to a
+    // theme object builds a new ThemeManager. The options are still set on the grid, so the
+    // rebuilt manager has to pick them up again instead of starting empty.
+    await grid.clickToolbar('theme-as-class');
+    await grid.clickToolbar('theme-as-object');
+
+    await expect.poll(() => grid.colorSchemeOf('a')).toBe('dark');
+    expect(await grid.cellHeightOf('a')).toBe(darkCompactHeight);
+  });
+
   test('applies the colorScheme to menus rendered in the grid portal', async({ page, theme, bundle }) => {
     const grid = new ColorSchemeDensityPage(page, theme, bundle);
 

--- a/tests/fixtures/demo/color-scheme-density.html
+++ b/tests/fixtures/demo/color-scheme-density.html
@@ -56,9 +56,10 @@
     every light/dark token, and this fixture is what proves it.
 
     It is always the `main` stylesheet, never the one named by `?theme=`, because
-    every grid here renders the engine-driven `main` theme. The spec pins itself
-    to the `main` theme leg for the same reason, and keeps the bundle axis, which
-    is real — the engine builds its CSS at runtime.
+    every grid here renders the engine-driven `main` theme. That makes every leg
+    of the matrix exercise the real scenario, so the theme axis is redundant here
+    rather than wrong. The spec does NOT skip the extra legs — ESLint bans
+    `test.skip`. The bundle axis is genuine: the engine builds its CSS at runtime.
 
     Three grids share the one registered `main` theme object. Grid A takes the
     overrides, grid B is the control proving they do not leak, and grid C sets
@@ -76,6 +77,8 @@
     <button data-testid="c-reset" type="button">Grid C &rarr; reset</button>
     <button data-testid="d-reset" type="button">Grid D &rarr; reset</button>
     <button data-testid="d-set-dark" type="button">Grid D &rarr; dark</button>
+    <button data-testid="mutate-shared-theme" type="button">Mutate shared theme</button>
+    <button data-testid="a-switch-theme-in-hook" type="button">Switch theme from a hook</button>
   </div>
 
   <div class="grid-slot">
@@ -158,9 +161,12 @@
     // must survive that round trip.
     //
     // The name has to DIFFER from the one in use, otherwise core treats the update as a
-    // no-op and never tears the engine down. Its stylesheet is not loaded, so core warns
-    // about the missing styles — that is expected and does not affect what is asserted.
-    const otherThemeName = ['main', 'horizon', 'classic'].find(name => name !== window.htTheme);
+    // no-op and never tears the engine down. Every grid here renders the engine-driven
+    // `main` theme regardless of `?theme=`, so the name just has to not be `main` —
+    // deriving it from `?theme=` would resolve to `main` on the horizon and classic legs
+    // and quietly skip the teardown. Its stylesheet is not loaded, so core warns about the
+    // missing styles; that is expected and does not affect what is asserted.
+    const otherThemeName = 'horizon';
 
     onClick('theme-as-class', { theme: `ht-theme-${otherThemeName}` });
 
@@ -181,6 +187,24 @@
 
     onClickD('d-reset', { colorScheme: undefined, density: undefined });
     onClickD('d-set-dark', { colorScheme: 'dark' });
+
+    // Mutating the shared `main` theme fires its subscribers. A ThemeManager that was torn down
+    // without unsubscribing would wake up here and re-inject its stale scoped rules.
+    document.querySelector('[data-testid="mutate-shared-theme"]')
+      .addEventListener('click', () => {
+        Handsontable.themes.getTheme('main').setColorScheme('auto');
+      });
+
+    // An `afterUpdateSettings` listener is allowed to move the grid to a class-name theme, which
+    // tears the engine down before core is finished with the same `updateSettings()` call.
+    document.querySelector('[data-testid="a-switch-theme-in-hook"]')
+      .addEventListener('click', () => {
+        hotA.addHook('afterUpdateSettings', function switchOnce() {
+          hotA.removeHook('afterUpdateSettings', switchOnce);
+          hotA.updateSettings({ theme: `ht-theme-${otherThemeName}` });
+        });
+        hotA.updateSettings({ colorScheme: 'dark' });
+      });
     document.querySelector('[data-testid="theme-as-object"]')
       .addEventListener('click', () => {
         hotA.updateSettings({ theme: Handsontable.themes.getTheme('main') });

--- a/tests/fixtures/demo/color-scheme-density.html
+++ b/tests/fixtures/demo/color-scheme-density.html
@@ -64,6 +64,8 @@
     <button data-testid="set-compact" type="button">Compact</button>
     <button data-testid="set-comfortable" type="button">Comfortable</button>
     <button data-testid="reset-overrides" type="button">Reset</button>
+    <button data-testid="theme-as-class" type="button">Theme as class name</button>
+    <button data-testid="theme-as-object" type="button">Theme as object</button>
   </div>
 
   <div class="grid-slot">
@@ -116,6 +118,11 @@
       density: 'compact',
     });
 
+    // Exposed so a spec can read grid state directly when a computed style is not enough.
+    window.hotA = hotA;
+    window.hotB = hotB;
+    window.hotC = hotC;
+
     const onClick = (testId, settings) => {
       document.querySelector(`[data-testid="${testId}"]`)
         .addEventListener('click', () => hotA.updateSettings(settings));
@@ -126,6 +133,21 @@
     onClick('set-compact', { density: 'compact' });
     onClick('set-comfortable', { density: 'comfortable' });
     onClick('reset-overrides', { colorScheme: undefined, density: undefined });
+
+    // Switching to a class-named theme drops the theme engine, and switching back to a
+    // theme object builds a new ThemeManager. The overrides already stored on the grid
+    // must survive that round trip.
+    //
+    // The name has to DIFFER from the one in use, otherwise core treats the update as a
+    // no-op and never tears the engine down. Its stylesheet is not loaded, so core warns
+    // about the missing styles — that is expected and does not affect what is asserted.
+    const otherThemeName = ['main', 'horizon', 'classic'].find(name => name !== window.htTheme);
+
+    onClick('theme-as-class', { theme: `ht-theme-${otherThemeName}` });
+    document.querySelector('[data-testid="theme-as-object"]')
+      .addEventListener('click', () => {
+        hotA.updateSettings({ theme: Handsontable.themes.getTheme('main') });
+      });
   </script>
 </body>
 </html>

--- a/tests/fixtures/demo/color-scheme-density.html
+++ b/tests/fixtures/demo/color-scheme-density.html
@@ -18,12 +18,13 @@
     if (!window.htTheme) {
       throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
     }
-    // Written into <head> so the themed stylesheet is present before first render.
-    // Deliberately the MINIFIED file: its light/dark colors are switched by theme
-    // class name rather than by the color-scheme property, and they out-specify
-    // the ones the engine generates. That makes it the strictest configuration
-    // for the colorScheme override, so it is the one worth covering.
-    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    // Always the MINIFIED **main** stylesheet, never `?theme=`. Every grid here runs the
+    // engine-driven `main` theme, so only `.ht-theme-main` selectors can ever match — loading
+    // ht-theme-horizon.min.css would put rules on the page that match nothing and quietly turn
+    // the test into a no-op. Minified is the point: its light/dark colors are switched by theme
+    // class name rather than by the color-scheme property, and they out-specify the ones the
+    // engine generates, which is the strictest case for the colorScheme override.
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-main.min.css">');
     // 1:1 with the Puppeteer legs (umd = handsontable.js, full-min =
     // handsontable.full.min.js, the exact file `test:production` loads).
     window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
@@ -46,13 +47,18 @@
     class and no `theme` option, core registers the default `main` theme through
     the engine — the "works out of the box" path the ticket asks for.
 
-    The MINIFIED themed stylesheet is loaded on purpose. The CSS minifier
+    The MINIFIED `main` stylesheet is loaded on purpose. The CSS minifier
     rewrites `light-dark()` into a pair of `--lightningcss-*` variables switched
     by theme class name, because native `light-dark()` is newer than the browsers
     Handsontable supports. Those declarations out-specify the ones the engine
     generates, so a grid that merely flipped `color-scheme` would keep the light
     colors. The manager therefore emits the resolved light or dark value for
     every light/dark token, and this fixture is what proves it.
+
+    It is always the `main` stylesheet, never the one named by `?theme=`, because
+    every grid here renders the engine-driven `main` theme. The spec pins itself
+    to the `main` theme leg for the same reason, and keeps the bundle axis, which
+    is real — the engine builds its CSS at runtime.
 
     Three grids share the one registered `main` theme object. Grid A takes the
     overrides, grid B is the control proving they do not leak, and grid C sets
@@ -66,6 +72,10 @@
     <button data-testid="reset-overrides" type="button">Reset</button>
     <button data-testid="theme-as-class" type="button">Theme as class name</button>
     <button data-testid="theme-as-object" type="button">Theme as object</button>
+    <button data-testid="c-set-light" type="button">Grid C &rarr; light</button>
+    <button data-testid="c-reset" type="button">Grid C &rarr; reset</button>
+    <button data-testid="d-reset" type="button">Grid D &rarr; reset</button>
+    <button data-testid="d-set-dark" type="button">Grid D &rarr; dark</button>
   </div>
 
   <div class="grid-slot">
@@ -76,6 +86,11 @@
   </div>
   <div class="grid-slot">
     <div id="grid-c" data-testid="grid-c"></div>
+  </div>
+  <!-- Grid D takes its theme from a CSS class name, so core skips the theme engine and both
+       options have nothing to act on. It is here to check the warning behaves. -->
+  <div class="grid-slot">
+    <div id="grid-d" data-testid="grid-d" class="ht-theme-main"></div>
   </div>
 
   <script>
@@ -118,10 +133,14 @@
       density: 'compact',
     });
 
+    // Grid D's container carries the theme class, so the theme engine is skipped for it.
+    const hotD = new Handsontable(document.querySelector('[data-testid="grid-d"]'), baseSettings('d'));
+
     // Exposed so a spec can read grid state directly when a computed style is not enough.
     window.hotA = hotA;
     window.hotB = hotB;
     window.hotC = hotC;
+    window.hotD = hotD;
 
     const onClick = (testId, settings) => {
       document.querySelector(`[data-testid="${testId}"]`)
@@ -144,6 +163,24 @@
     const otherThemeName = ['main', 'horizon', 'classic'].find(name => name !== window.htTheme);
 
     onClick('theme-as-class', { theme: `ht-theme-${otherThemeName}` });
+
+    // Grid C got its overrides at construction time. Changing them afterwards is the case that
+    // an orphaned ThemeManager used to block, so it needs its own controls.
+    const onClickC = (testId, settings) => {
+      document.querySelector(`[data-testid="${testId}"]`)
+        .addEventListener('click', () => hotC.updateSettings(settings));
+    };
+
+    onClickC('c-set-light', { colorScheme: 'light', density: 'default' });
+    onClickC('c-reset', { colorScheme: undefined, density: undefined });
+
+    const onClickD = (testId, settings) => {
+      document.querySelector(`[data-testid="${testId}"]`)
+        .addEventListener('click', () => hotD.updateSettings(settings));
+    };
+
+    onClickD('d-reset', { colorScheme: undefined, density: undefined });
+    onClickD('d-set-dark', { colorScheme: 'dark' });
     document.querySelector('[data-testid="theme-as-object"]')
       .addEventListener('click', () => {
         hotA.updateSettings({ theme: Handsontable.themes.getTheme('main') });

--- a/tests/fixtures/demo/color-scheme-density.html
+++ b/tests/fixtures/demo/color-scheme-density.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable e2e fixture — colorScheme and density</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back — a
+    // typo in the project config must be one red leg, never a silently
+    // mislabeled green one (nothing else asserts which file actually loaded).
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    // NOTE: this fixture deliberately loads NO themed stylesheet — see the
+    // comment in <body> for why. The ?theme= param is still validated so a typo
+    // in the project config fails loudly rather than passing silently.
+    // 1:1 with the Puppeteer legs (umd = handsontable.js, full-min =
+    // handsontable.full.min.js, the exact file `test:production` loads).
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+    #toolbar { margin-bottom: .8rem; }
+    .grid-slot { margin-bottom: 1.5rem; }
+  </style>
+</head>
+<body>
+  <!--
+    Fixture for the `colorScheme` and `density` grid options (DEV-1476).
+
+    This is the documented "Theme API" setup: only the base stylesheet is
+    loaded, and no `ht-theme-*` class is put on any container. That matters
+    twice over.
+
+    1. An `ht-theme-*` class on the container makes core skip the theme engine
+       entirely, and both options are engine features. With no class and no
+       `theme` option, core registers the default `main` theme through the
+       engine — the "works out of the box" path the ticket asks for.
+
+    2. No themed stylesheet is loaded. The minified theme CSS drives light and
+       dark through class names (the CSS minifier downlevels `light-dark()` into
+       a pair of `--lightningcss-*` variables, because native `light-dark()` is
+       newer than the browsers Handsontable supports). Those class-driven colors
+       out-specify the engine's, so with a minified theme stylesheet present the
+       colors would not follow `color-scheme` — for `setColorScheme()` just the
+       same. The engine emits native `light-dark()`, which Chromium resolves.
+
+    The `?theme=` param is therefore a no-op here: every leg renders the
+    engine-driven `main` theme. The `?bundle=` axis is real — the engine builds
+    its CSS at runtime, so both bundles are worth covering.
+
+    Three grids share the one registered `main` theme object. Grid A takes the
+    overrides, grid B is the control proving they do not leak, and grid C sets
+    them at construction time.
+  -->
+  <div id="toolbar">
+    <button data-testid="set-dark" type="button">Dark</button>
+    <button data-testid="set-light" type="button">Light</button>
+    <button data-testid="set-compact" type="button">Compact</button>
+    <button data-testid="set-comfortable" type="button">Comfortable</button>
+    <button data-testid="reset-overrides" type="button">Reset</button>
+  </div>
+
+  <div class="grid-slot">
+    <div id="grid-a" data-testid="grid-a"></div>
+  </div>
+  <div class="grid-slot">
+    <div id="grid-b" data-testid="grid-b"></div>
+  </div>
+  <div class="grid-slot">
+    <div id="grid-c" data-testid="grid-c"></div>
+  </div>
+
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The
+    // closing tag is split so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const data = [
+      ['A1', 'B1', 'C1'],
+      ['A2', 'B2', 'C2'],
+      ['A3', 'B3', 'C3'],
+      ['A4', 'B4', 'C4'],
+      ['A5', 'B5', 'C5'],
+    ];
+
+    // Stamps a stable hook on every cell, scoped per grid so the two instances
+    // never collide in a strict-mode locator.
+    const makeRenderer = suffix => function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${suffix}-${row}-${col}`);
+    };
+
+    const baseSettings = suffix => ({
+      data: data.map(row => [...row]),
+      colHeaders: true,
+      rowHeaders: true,
+      contextMenu: true,
+      renderer: makeRenderer(suffix),
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    // Grid A takes the overrides at runtime. Grid B is the untouched control.
+    // Grid C sets the options at construction time, covering the init path.
+    const hotA = new Handsontable(document.querySelector('[data-testid="grid-a"]'), baseSettings('a'));
+    const hotB = new Handsontable(document.querySelector('[data-testid="grid-b"]'), baseSettings('b'));
+    const hotC = new Handsontable(document.querySelector('[data-testid="grid-c"]'), {
+      ...baseSettings('c'),
+      colorScheme: 'dark',
+      density: 'compact',
+    });
+
+    const onClick = (testId, settings) => {
+      document.querySelector(`[data-testid="${testId}"]`)
+        .addEventListener('click', () => hotA.updateSettings(settings));
+    };
+
+    onClick('set-dark', { colorScheme: 'dark' });
+    onClick('set-light', { colorScheme: 'light' });
+    onClick('set-compact', { density: 'compact' });
+    onClick('set-comfortable', { density: 'comfortable' });
+    onClick('reset-overrides', { colorScheme: undefined, density: undefined });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/color-scheme-density.html
+++ b/tests/fixtures/demo/color-scheme-density.html
@@ -18,9 +18,12 @@
     if (!window.htTheme) {
       throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
     }
-    // NOTE: this fixture deliberately loads NO themed stylesheet — see the
-    // comment in <body> for why. The ?theme= param is still validated so a typo
-    // in the project config fails loudly rather than passing silently.
+    // Written into <head> so the themed stylesheet is present before first render.
+    // Deliberately the MINIFIED file: its light/dark colors are switched by theme
+    // class name rather than by the color-scheme property, and they out-specify
+    // the ones the engine generates. That makes it the strictest configuration
+    // for the colorScheme override, so it is the one worth covering.
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
     // 1:1 with the Puppeteer legs (umd = handsontable.js, full-min =
     // handsontable.full.min.js, the exact file `test:production` loads).
     window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
@@ -38,26 +41,18 @@
   <!--
     Fixture for the `colorScheme` and `density` grid options (DEV-1476).
 
-    This is the documented "Theme API" setup: only the base stylesheet is
-    loaded, and no `ht-theme-*` class is put on any container. That matters
-    twice over.
+    No `ht-theme-*` class is put on any container. That class makes core skip
+    the theme engine entirely, and both options are engine features. With no
+    class and no `theme` option, core registers the default `main` theme through
+    the engine — the "works out of the box" path the ticket asks for.
 
-    1. An `ht-theme-*` class on the container makes core skip the theme engine
-       entirely, and both options are engine features. With no class and no
-       `theme` option, core registers the default `main` theme through the
-       engine — the "works out of the box" path the ticket asks for.
-
-    2. No themed stylesheet is loaded. The minified theme CSS drives light and
-       dark through class names (the CSS minifier downlevels `light-dark()` into
-       a pair of `--lightningcss-*` variables, because native `light-dark()` is
-       newer than the browsers Handsontable supports). Those class-driven colors
-       out-specify the engine's, so with a minified theme stylesheet present the
-       colors would not follow `color-scheme` — for `setColorScheme()` just the
-       same. The engine emits native `light-dark()`, which Chromium resolves.
-
-    The `?theme=` param is therefore a no-op here: every leg renders the
-    engine-driven `main` theme. The `?bundle=` axis is real — the engine builds
-    its CSS at runtime, so both bundles are worth covering.
+    The MINIFIED themed stylesheet is loaded on purpose. The CSS minifier
+    rewrites `light-dark()` into a pair of `--lightningcss-*` variables switched
+    by theme class name, because native `light-dark()` is newer than the browsers
+    Handsontable supports. Those declarations out-specify the ones the engine
+    generates, so a grid that merely flipped `color-scheme` would keep the light
+    colors. The manager therefore emits the resolved light or dark value for
+    every light/dark token, and this fixture is what proves it.
 
     Three grids share the one registered `main` theme object. Grid A takes the
     overrides, grid B is the control proving they do not leak, and grid C sets

--- a/tests/fixtures/pages/ColorSchemeDensityPage.ts
+++ b/tests/fixtures/pages/ColorSchemeDensityPage.ts
@@ -24,6 +24,22 @@ export class ColorSchemeDensityPage {
   }
 
   /**
+   * Start collecting console warnings. Call before `goto()`; the returned array fills up as the
+   * page logs. Used to check that the "needs the theme engine" notice is neither missing nor noisy.
+   */
+  collectWarnings(): string[] {
+    const warnings: string[] = [];
+
+    this.page.on('console', (message) => {
+      if (message.type() === 'warning') {
+        warnings.push(message.text());
+      }
+    });
+
+    return warnings;
+  }
+
+  /**
    * Navigate to the fixture and wait until all three grids have rendered.
    */
   async goto(): Promise<void> {
@@ -31,7 +47,7 @@ export class ColorSchemeDensityPage {
       `/tests/fixtures/demo/color-scheme-density.html?theme=${this.theme}&bundle=${this.bundle}`
     );
 
-    for (const grid of ['a', 'b', 'c']) {
+    for (const grid of ['a', 'b', 'c', 'd']) {
       await expect(this.cell(grid, 0, 0)).toBeVisible();
     }
   }
@@ -97,6 +113,14 @@ export class ColorSchemeDensityPage {
     }
 
     return box.height;
+  }
+
+  /**
+   * How many theme `<style>` nodes a grid's wrapper holds. Should always be one — a second node
+   * means a ThemeManager was replaced without being torn down, and its stale rules still apply.
+   */
+  async themeStyleNodeCountOf(grid: string): Promise<number> {
+    return this.wrapper(grid).locator('style[data-hot-theme-style]').count();
   }
 
   /** The value of a CSS custom property resolved on a grid's wrapper. */

--- a/tests/fixtures/pages/ColorSchemeDensityPage.ts
+++ b/tests/fixtures/pages/ColorSchemeDensityPage.ts
@@ -40,6 +40,20 @@ export class ColorSchemeDensityPage {
   }
 
   /**
+   * Start collecting uncaught page errors. Call before `goto()`; the returned array fills up as the
+   * page throws.
+   */
+  collectPageErrors(): string[] {
+    const errors: string[] = [];
+
+    this.page.on('pageerror', (error) => {
+      errors.push(error.message);
+    });
+
+    return errors;
+  }
+
+  /**
    * Navigate to the fixture and wait until all three grids have rendered.
    */
   async goto(): Promise<void> {

--- a/tests/fixtures/pages/ColorSchemeDensityPage.ts
+++ b/tests/fixtures/pages/ColorSchemeDensityPage.ts
@@ -1,0 +1,114 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the `colorScheme` / `density` fixture (DEV-1476).
+ *
+ * The fixture hosts three grids that all share the default registered `main`
+ * theme: grid `a` receives overrides at runtime, grid `b` is the untouched
+ * control that proves the overrides do not leak between instances, and grid `c`
+ * sets both options at construction time.
+ *
+ * Selectors are `data-testid` hooks stamped by the fixture. The assertions read
+ * computed styles and box sizes rather than the injected CSS text, because what
+ * matters to a user is the rendered result, not the stylesheet that produced it.
+ */
+export class ColorSchemeDensityPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+  }
+
+  /**
+   * Navigate to the fixture and wait until all three grids have rendered.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(
+      `/tests/fixtures/demo/color-scheme-density.html?theme=${this.theme}&bundle=${this.bundle}`
+    );
+
+    for (const grid of ['a', 'b', 'c']) {
+      await expect(this.cell(grid, 0, 0)).toBeVisible();
+    }
+  }
+
+  /** A single data cell of the given grid, by visual row/column. */
+  cell(grid: string, row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${grid}-${row}-${col}`);
+  }
+
+  /**
+   * The root wrapper of a grid — the element core stamps the theme class and the
+   * per-instance override scope class on.
+   */
+  wrapper(grid: string): Locator {
+    return this.page.getByTestId(`grid-${grid}`).locator('.ht-root-wrapper');
+  }
+
+  /**
+   * Open a grid's context menu and return its root element.
+   *
+   * Menus render inside the grid's portal element, which core appends to
+   * `document.body` rather than to the container — so the menu is the reachable
+   * proof that the portal follows the same overrides as the grid itself.
+   * `color-scheme` is an inherited CSS property, so the menu resolves whatever
+   * the portal declares.
+   */
+  async openContextMenu(grid: string, row = 0, col = 0): Promise<Locator> {
+    await this.cell(grid, row, col).click({ button: 'right' });
+
+    const menu = this.page.locator('.htContextMenu.handsontable').locator('visible=true');
+
+    await expect(menu).toBeVisible();
+
+    return menu;
+  }
+
+  /** Close an open context menu. */
+  async closeContextMenu(): Promise<void> {
+    await this.page.keyboard.press('Escape');
+    await expect(this.page.locator('.htContextMenu.handsontable').locator('visible=true'))
+      .toHaveCount(0);
+  }
+
+  /** The resolved CSS `color-scheme` of a grid's wrapper. */
+  async colorSchemeOf(grid: string): Promise<string> {
+    return this.wrapper(grid).evaluate(el => getComputedStyle(el).colorScheme);
+  }
+
+  /** The resolved background color of a cell, as the browser reports it. */
+  async cellBackgroundOf(grid: string, row = 0, col = 0): Promise<string> {
+    return this.cell(grid, row, col).evaluate(el => getComputedStyle(el).backgroundColor);
+  }
+
+  /**
+   * The rendered height of a cell in CSS pixels. Density changes the cell
+   * padding, so this is the user-visible effect of a density override.
+   */
+  async cellHeightOf(grid: string, row = 0, col = 0): Promise<number> {
+    const box = await this.cell(grid, row, col).boundingBox();
+
+    if (!box) {
+      throw new Error(`Cell ${row},${col} of grid "${grid}" has no box.`);
+    }
+
+    return box.height;
+  }
+
+  /** The value of a CSS custom property resolved on a grid's wrapper. */
+  async cssVariableOf(grid: string, name: string): Promise<string> {
+    return this.wrapper(grid).evaluate(
+      (el, property) => getComputedStyle(el).getPropertyValue(property).trim(),
+      name
+    );
+  }
+
+  /** Click a toolbar button that calls `updateSettings()` on grid `a`. */
+  async clickToolbar(testId: string): Promise<void> {
+    await this.page.getByTestId(testId).click();
+  }
+}


### PR DESCRIPTION
### Context

The PR adds two grid options, `colorScheme` and `density`, so you can change a grid's color scheme or its spacing without declaring a theme.

Today the only way to switch to dark mode or to a tighter layout is the Theme API builder:

```js
import { registerTheme, mainTheme } from 'handsontable/themes';

const theme = registerTheme(mainTheme)
  .setColorScheme('dark')
  .setDensityType('compact');

const hot = new Handsontable(container, { theme });
```

That is a lot of setup for a dark mode toggle, and it has a second problem: the registered theme is a shared object, so mutating it changes every grid that uses it.

Now both are plain options:

```js
const hot = new Handsontable(container, {
  colorScheme: 'dark',
  density: 'compact',
});

// and at runtime
hot.updateSettings({ colorScheme: 'auto' });
```

| Option | Allowed values |
| --- | --- |
| `colorScheme` | `'light'`, `'dark'`, `'auto'` |
| `density` | `'default'`, `'compact'`, `'comfortable'` |

Setting an option to `undefined` clears the override and falls back to the theme value. The existing `registerTheme()` builder API is unchanged.

### How it works

Both options are **per-instance overrides** applied by `ThemeManager` on top of the theme configuration. The shared registered theme object is never mutated, so other grids using the same theme keep their own look.

The override CSS is emitted under a per-instance scope class (`ht-scope-<guid>`), stamped on **both** the root wrapper and the portal element. The portal matters: menus and dialogs render there, and a wrapper-only scope would leave a light menu on a dark grid. The scoped selector doubles the theme class with the scope class, giving specificity (0,2,0) so it wins over both the `:where()` block the engine emits (0,0,0) and the static `ht-theme-*.css` declarations (0,1,0).

#### Why `colorScheme` does not just set `color-scheme`

Setting the `color-scheme` property alone looks like it should be enough, and it is not. The shipped **minified** theme stylesheets do not use the CSS `light-dark()` function — it needs Chrome 123 / Safari 17.5, well above the floor declared in `browser-targets.js` (Chrome 110 / Firefox 110 / Safari 14.1) — so the minifier rewrites it into a pair of variables switched by **theme class name**:

```css
.ht-theme-main      { --lightningcss-light: initial; --lightningcss-dark:  ;       color-scheme: light }
.ht-theme-main-dark { --lightningcss-light:  ;       --lightningcss-dark: initial; color-scheme: dark }
```

Those declarations out-specify the ones the engine generates, so a grid that merely flipped `color-scheme` kept its light colors. That is a pre-existing defect in `setColorScheme()`, which I confirmed on the released build before fixing it here.

So `ThemeManager` emits the **resolved** light or dark value for every light/dark token in its scoped block, which needs no `light-dark()` support at all and therefore works on every supported browser:

```css
.ht-theme-main.ht-scope-ht_abc123 {
  color-scheme: dark;
  --ht-background-color: var(--ht-colors-palette-950);
  /* ...every other light/dark token... */
}
```

`'auto'` pins the light values and swaps the dark ones in behind a `@media (prefers-color-scheme: dark)` block, mirroring what the static `-dark-auto` class does. Only tokens that actually differ between the two schemes are emitted, so the block stays small.

This also means `colorScheme` behaves the same whichever stylesheets the page loads — base only, or a theme stylesheet on top, minified or not. Measured on a grid with `colorScheme: 'dark'` (dark background is `rgb(5,5,6)`):

| Stylesheets loaded | Before this fix | After |
| --- | --- | --- |
| base only | `rgb(5,5,6)` ✓ | `rgb(5,5,6)` ✓ |
| + `ht-theme-main.css` | `rgb(5,5,6)` ✓ | `rgb(5,5,6)` ✓ |
| + `ht-theme-main.min.css` | `rgb(255,255,255)` ✗ | `rgb(5,5,6)` ✓ |

`flattenCssVariables()` gained two options to support this: `resolveScheme` picks one branch of a `[light, dark]` value instead of emitting `light-dark()`, and `lightDarkOnly` skips variables that are identical in both schemes. Both default to the previous behavior, so every existing caller is unaffected.

#### Known limit

Both options need the theme engine, so they have no effect when the theme comes from a CSS class name — the `theme` option set to a string, or an `ht-theme-*` class on the container. The grid logs a warning in that case. This is inherent: a class-named theme has no runtime density control at all.

### How has this been tested?

New unit tests covering the override merge, validation, per-instance scoping, the scope class on wrapper and portal, clearing an override, resolving colors to a single scheme, the `auto` media query, and — most importantly — that the shared theme object is not mutated:

```bash
npm run test:unit --prefix handsontable -- --testPathPattern=themes
# 6 suites, 222 tests passed
```

I verified these tests are meaningful rather than merely green: temporarily removing the scope class from the emitted selector turns several of them red, including the cross-instance isolation test.

New Playwright E2E (8 tests) asserting rendered results — computed `color-scheme`, actual cell background color, and measured cell height — not the injected CSS text. Its fixture loads the **minified** theme stylesheet, the strictest configuration:

```bash
cd tests && npx playwright test e2e/color-scheme-density.spec.ts
# 48 passed (8 tests across the full theme x bundle matrix)
```

It covers both options set at construction time and switched via `updateSettings()`, clearing an override, the context menu in the portal following the grid, a control grid on the same page that must not follow another grid's override, and the overrides surviving a theme-engine teardown and rebuild.

Full regression run:

```bash
npm run test:unit --prefix handsontable          # 293 suites, 3425 tests passed
npm run test:types --prefix handsontable         # passed
npm run eslint --prefix handsontable             # 0 errors
npm run stylelint --prefix handsontable          # passed
npm run test --prefix wrappers/react-wrapper     # 15 suites, 75 tests passed
npm run test --prefix wrappers/vue3              # 4 suites, 32 tests passed
npm run test --prefix wrappers/angular-wrapper   # 13 suites, 291 tests passed
```

#### Manual testing

Two throwaway demo pages (gitignored, `dev*.html`) are generated for manual review:

```bash
npm run build --prefix handsontable
python3 -m http.server 8846 --directory handsontable
# http://localhost:8846/dev-pr.html      — this branch
# http://localhost:8846/dev-latest.html  — released v18.0.0, for comparison
```

Both pages load the minified base and theme stylesheets. The PR page has four grids: A takes the overrides from a button bar, B is the control that must not change, C sets both options at construction time, and D gets its theme from a CSS class name so the options warn instead. Verified in the browser:

| Grid | `color-scheme` | Cell height | Cell background |
| --- | --- | --- | --- |
| A, after Dark + Compact | `dark` | 26px | `rgb(5, 5, 6)` |
| B, control | `light dark` | 30px | `rgb(255, 255, 255)` |
| C, `dark` + `compact` at construction | `dark` | 26px | `rgb(5, 5, 6)` |
| D, theme from a CSS class | `light dark` | 30px | `rgb(255, 255, 255)` |

After those changes `getTheme('main').getThemeConfig()` still reports `colorScheme: 'auto'` and `density: 'default'` — the shared theme object is untouched. Grid D logs the expected warning and does not change. Reset returns grid A to 30px and the theme color scheme.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1476

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

Documentation updated in this PR: a new "Set the color scheme or density without a theme" section in `docs/content/guides/styling/themes/themes.md`, a cross-reference from "Light and dark modes", and full JSDoc for both options in `metaSchema.ts` (which generates the API reference).

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1476

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 30d550c06c3da78fa6f2fc743584843c62c77ee4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->