### PR TITLE
DEV-2515: Fix grids created in a container that has no layout yet

### DIFF
--- a/.changelogs/13208.json
+++ b/.changelogs/13208.json
@@ -1,0 +1,8 @@
+{
+    "issuesOrigin": "private",
+    "title": "Fixed misaligned column headers and frozen columns, and a grid that filled its container only after a click, when it was created in a container that had no size yet.",
+    "type": "fixed",
+    "issueOrPR": 13208,
+    "breaking": false,
+    "framework": "none"
+}

--- a/.claude/skills/handsontable-css-dev/SKILL.md
+++ b/.claude/skills/handsontable-css-dev/SKILL.md
@@ -22,6 +22,18 @@ No-icons variants: `ht-theme-main-no-icons`, `ht-theme-classic-no-icons`, `ht-th
 
 Theme customization is done entirely through CSS variables. These variables are the **public API** for theming. Renaming or removing a CSS custom property is a **breaking change** and requires a legacy compatibility path (keep the old variable working).
 
+## Cell padding must come from the variables, not from the cell
+
+`StylesHandler#getDefaultRowHeight()` computes
+`--ht-line-height + 2 * --ht-cell-vertical-padding + border-bottom-width`, and Walkontable sizes a
+table's scroll range from the summed row heights. Writing `padding` onto a `td` leaves the variable at
+the theme's value, so the engine computes a row height the cells do not have and the scroll range comes
+out wrong. Override `--ht-cell-vertical-padding` / `--ht-cell-horizontal-padding` and derive the `td`
+padding from them.
+
+A nested grid built inside a hidden container masks this: its styles cache is empty, the derived row
+height reads `null`, and the engine measures the DOM instead.
+
 ## Strict CSS/JS Separation
 
 Never mix CSS into JavaScript files. CSS and JS are always in separate files. This is enforced by convention and code review.

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -106,14 +106,26 @@ that necessary: `getTrimmingContainer` counts `overflow: hidden` and `getScrolla
 so the two can disagree for good, and a table in an iframe driven from the parent realm does exactly
 that — `MasterTable#alignOverlaysWithTrimmingContainer` misses it through a realm-bound `instanceof`
 and leaves the holder `overflow: visible`. Retrying such a table forever rebinds every listener on
-every draw, which also drops whichever scroll event is in flight.
+every draw, which also drops whichever scroll event is in flight. Re-arming the flag (through the
+public `updateMainScrollableElements`, which `updateSettings` calls whenever `height` moves to or from
+`''`) forgets the answer the previous series gave up on — otherwise the first retry of the new series
+matches its own stale answer and gives up at once, spending the retry the design counts on.
+
+Only a **full** draw resolves it. A fast draw has aligned nothing, so it must not judge a table
+nothing has laid out; no such draw can currently precede the first full one (`refreshAll()` returns
+while `drawn` is false, and a table built outside the layout stays undrawn until it joins it), so the
+gate in `Overlays#afterDraw` guards a state the settle test never has to answer for.
 
 Once it settles, the pass does **not** drop the sizes itself. It marks them, and
 `Overlays#beforeDraw` drops them on the way into the next draw that renders cells
 (`resetSizesMeasuredBeforeLayoutSettled`), so reset, re-measure and resize run in the order this
 cycle documents. Dropping them after a draw and asking for a redraw leaves them dropped: the request
 is a fast draw, and a draw that re-renders nothing never re-runs `markOversizedRows`. For the same
-reason a scroll-driven draw must not consume the mark — it stays pending for the next full draw. And
+reason a scroll-driven draw must not consume the mark — it stays pending for the next full draw, and
+so does a draw that got as far as the `beforeDraw` hook and had its render cancelled by `skipRender`
+(NestedRows does this; any user hook can). The mark is spent in `Overlays#afterDraw`, and only when
+the draw cycle reports that the band actually rendered (`confirmSizesRemeasured`); the drop itself is
+idempotent, so retaking it on the next draw costs one invalidation. And
 no redraw is requested from the settle frame at all: forcing one measures a DOM whose column widths
 have not settled, which records heights for rows that leave the band on the next draw, and those
 records survive (DEV-2515).
@@ -121,8 +133,13 @@ records survive (DEV-2515).
 The theme measurements have their own copy of the problem, on the core side: `StylesHandler` caches
 `getComputedStyle(rootElement)` once, so a grid built outside the flat tree has no theme variables and
 its default row height reads `null` — which makes every rendered row look oversized. The handler
-records whether its own caching pass ran against unresolved styles, and `TableView`'s `beforeRender`
-asks it (`recacheValuesMeasuredWithoutStyles`) rather than reading the `null`. Keying off the row
+records whether its own caching pass ran against unresolved styles, and `TableView#render` asks it
+(`recacheValuesMeasuredWithoutStyles`) rather than reading the `null` — **before** `_wt.draw()`, not
+from the engine's `beforeDraw` setting, which fires after `createCalculators()` and would leave that
+draw's row band built from the heights being dropped (the grid renders short for a frame and nothing
+schedules another draw). The drop stays pending until a draw has rendered the cells and re-measured
+them, which `afterRender` reports — the engine fires `onDraw` from no other kind of draw — so a
+`beforeViewRender` listener setting `skipRender` cannot spend it either. Keying off the row
 height instead wipes the caches on **every** draw of any page that loads no grid stylesheet, where
 that value never resolves. Note the two questions are deliberately different: the engine asks about
 geometry (`isRendered`, no boxes), the styles handler asks whether `getComputedStyle` resolves at all

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -80,6 +80,57 @@ Three more things that pass every functional test and only show up in a profile 
 
 When you add a new content-driven measurement, ask which tables actually render the content — measuring the master alone is the trap both of these exist to work around.
 
+## A table built outside the layout cannot read its own styles
+
+A container that generates no boxes — detached from the document, or a light-DOM child of a shadow
+host that no `<slot>` accepts yet — resolves `getComputedStyle()` to an **empty declaration** for
+itself and every ancestor, per the CSSOM specification (Chromium since 151; Firefox and Safari
+always). Every style-driven layout decision taken in that state therefore reads "no ancestor clips
+or scrolls", and the ones that pick a scroll container (`getTrimmingContainer`,
+`getScrollableElement`, `ScrollSync#computeScrollableElement`,
+`Overlay#updateMainScrollableElement`) hand the whole grid to the **window**.
+
+The same is true of every size such a table measures: the row heights and column widths it records
+describe a layout it never had, and a window-scrolled table records them for a different column band
+at a different width.
+
+The trimming container is re-resolved on every `adjustElementsSize`, so it heals by itself. Nothing
+else does. `ScrollSync` marks its state provisional when `geometryReader.isRendered()` was false at
+construction, and `Overlays#afterDraw` calls `resolveProvisionalLayout()` — after the overlays
+refreshed their trimming containers and the holder got its final overflow, which is why it cannot run
+in `beforeDraw` (the scrollable element would settle on the window again and clear the flag). While
+the answer is still the window although an element trims the table, the layout has not settled and
+the pass is retried on the next draw — but only while the resolved element keeps changing. It is
+checked before anything is rebound, so a pass that cannot settle costs one style read. Two rules make
+that necessary: `getTrimmingContainer` counts `overflow: hidden` and `getScrollableElement` does not,
+so the two can disagree for good, and a table in an iframe driven from the parent realm does exactly
+that — `MasterTable#alignOverlaysWithTrimmingContainer` misses it through a realm-bound `instanceof`
+and leaves the holder `overflow: visible`. Retrying such a table forever rebinds every listener on
+every draw, which also drops whichever scroll event is in flight.
+
+Once it settles, the pass does **not** drop the sizes itself. It marks them, and
+`Overlays#beforeDraw` drops them on the way into the next draw that renders cells
+(`resetSizesMeasuredBeforeLayoutSettled`), so reset, re-measure and resize run in the order this
+cycle documents. Dropping them after a draw and asking for a redraw leaves them dropped: the request
+is a fast draw, and a draw that re-renders nothing never re-runs `markOversizedRows`. For the same
+reason a scroll-driven draw must not consume the mark — it stays pending for the next full draw. And
+no redraw is requested from the settle frame at all: forcing one measures a DOM whose column widths
+have not settled, which records heights for rows that leave the band on the next draw, and those
+records survive (DEV-2515).
+
+The theme measurements have their own copy of the problem, on the core side: `StylesHandler` caches
+`getComputedStyle(rootElement)` once, so a grid built outside the flat tree has no theme variables and
+its default row height reads `null` — which makes every rendered row look oversized. The handler
+records whether its own caching pass ran against unresolved styles, and `TableView`'s `beforeRender`
+asks it (`recacheValuesMeasuredWithoutStyles`) rather than reading the `null`. Keying off the row
+height instead wipes the caches on **every** draw of any page that loads no grid stylesheet, where
+that value never resolves. Note the two questions are deliberately different: the engine asks about
+geometry (`isRendered`, no boxes), the styles handler asks whether `getComputedStyle` resolves at all
+— `display: none` reads its styles fine. The engine versions are stated once, above.
+
+Never guess a container from an empty style read, and never cache a layout decision taken while
+`isRendered()` is false without a way to retake it.
+
 ## Known Tech Debt
 
 - The DAO layer has been replaced by constructor injection + the `wire.ts` composition root (see the DI section above) — do not reintroduce DAO getters or `wot`-god-object passing.

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -125,7 +125,15 @@ reason a scroll-driven draw must not consume the mark — it stays pending for t
 so does a draw that got as far as the `beforeDraw` hook and had its render cancelled by `skipRender`
 (NestedRows does this; any user hook can). The mark is spent in `Overlays#afterDraw`, and only when
 the draw cycle reports that the band actually rendered (`confirmSizesRemeasured`); the drop itself is
-idempotent, so retaking it on the next draw costs one invalidation. And
+idempotent, so retaking it on the next draw costs one invalidation, and the two gates read the same
+fast/full question at different moments (the reset at draw entry, the render after
+`createCalculators` could downgrade it), so `ScrollSync` also refuses to spend a mark it never
+dropped — an escalated scroll draw satisfies the second gate without ever passing the first.
+
+What the drop covers is the engine's own record: the oversized-row heights and the column-width
+prefix sum. A rebuilt width cache re-asks `modifyColWidth`, so `AutoColumnSize` answers from its own
+map and a width it measured against no layout survives the settle — the narrow-container
+`AutoColumnSize` follow-up, filed separately. And
 no redraw is requested from the settle frame at all: forcing one measures a DOM whose column widths
 have not settled, which records heights for rows that leave the band on the next draw, and those
 records survive (DEV-2515).

--- a/handsontable/src/3rdparty/walkontable/src/domMeasure/geometryReader.ts
+++ b/handsontable/src/3rdparty/walkontable/src/domMeasure/geometryReader.ts
@@ -72,6 +72,15 @@ export interface GeometryReader {
   offsetParent(element: HTMLElement): HTMLElement | null;
 
   /**
+   * Checks whether the element takes part in the layout, so that its own and its ancestors' styles
+   * describe where it is rendered.
+   *
+   * @param {HTMLElement} element The element to check.
+   * @returns {boolean}
+   */
+  isRendered(element: HTMLElement): boolean;
+
+  /**
    * Reads `element.scrollWidth`.
    *
    * @param {HTMLElement} element The element to measure.

--- a/handsontable/src/3rdparty/walkontable/src/domMeasure/liveGeometryReader.ts
+++ b/handsontable/src/3rdparty/walkontable/src/domMeasure/liveGeometryReader.ts
@@ -90,6 +90,19 @@ export class LiveGeometryReader implements GeometryReader {
   }
 
   /**
+   * A box test, deliberately not a style test: `display: none` and `content-visibility: hidden`
+   * generate no boxes yet read their styles correctly, and this asks whether the geometry can be
+   * measured. Whether the styles resolve is `StylesHandler`'s question. See the unrendered-table
+   * section of `walkontable/AGENTS.md`.
+   *
+   * @param {HTMLElement} element The element to check.
+   * @returns {boolean}
+   */
+  isRendered(element: HTMLElement): boolean {
+    return element.isConnected && element.getClientRects().length > 0;
+  }
+
+  /**
    * @param {HTMLElement} element The element to measure.
    * @returns {number}
    */

--- a/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
@@ -387,9 +387,11 @@ class Overlays {
    */
   beforeDraw() {
     // Before anything measures: drops the sizes a previous draw took while the table had no settled
-    // layout, so this draw re-measures them and resizes from the results. Only on a draw that renders
-    // the cells – a fast draw re-renders nothing, so it cannot re-measure the row heights this drops,
-    // and taking the reset there would leave them dropped. It stays pending for the next full draw.
+    // layout, so this draw re-measures them and resizes from the results. Not on a fast draw – it
+    // re-renders nothing, so it cannot re-measure the row heights this drops, and taking the reset
+    // there would leave them dropped. The mark stays pending until `afterDraw` sees a draw that
+    // actually rendered the band (a `skipRender` hook cancels one that got this far), so the drop is
+    // simply retaken on the next draw that can re-measure.
     if (!this.isScrollDrivenDraw) {
       this.#scrollSync.resetSizesMeasuredBeforeLayoutSettled();
     }
@@ -403,8 +405,21 @@ class Overlays {
 
   /**
    * Runs logic for the overlays after the table is drawn.
+   *
+   * A fast draw never runs `alignOverlaysWithTrimmingContainer`, so the holder still carries the
+   * `overflow: visible` it was born with and the trimming container is whatever the last full draw
+   * left – a layout resolution taken from it would read a table that nothing has aligned yet. No such
+   * draw can currently precede the first full one (`refreshAll()` returns while `drawn` is false, and
+   * a table built outside the layout stays undrawn until it joins it), so the gate protects the
+   * settle test in `ScrollSync#resolveProvisionalLayout` from a state it never has to judge.
+   *
+   * @param {boolean} cellsRendered Whether this draw rendered the cell band. `false` for a fast
+   *                                (scroll) draw and for a draw whose `beforeDraw` hook set
+   *                                `skipRender`. Only a draw that rendered the band re-measured the
+   *                                sizes the reset on the way in dropped, so only it may spend the
+   *                                mark – otherwise the drop is retaken on the next draw.
    */
-  afterDraw() {
+  afterDraw(cellsRendered: boolean) {
     this.syncScrollWithMaster();
     this.#overlays.forEach((overlay) => {
       const hasRenderingStateChanged = overlay.hasRenderingStateChanged();
@@ -416,11 +431,19 @@ class Overlays {
       }
     });
 
+    if (cellsRendered) {
+      this.#scrollSync.confirmSizesRemeasured();
+    }
+
     // Runs after the overlays refreshed their trimming containers and the holder got its final
     // overflow, so a table born outside the layout can settle on the scrollable element and the sizes
     // it would have had if it had been rendered from the start. It cannot run in `beforeDraw`: both
-    // are still stale there, so the scrollable element would settle on the window again.
-    this.#scrollSync.resolveProvisionalLayout();
+    // are still stale there, so the scrollable element would settle on the window again. A fast draw
+    // is stale in the same way – it never aligns the overlays – so it must not resolve anything
+    // either; the flag survives to the next full draw.
+    if (!this.isScrollDrivenDraw) {
+      this.#scrollSync.resolveProvisionalLayout();
+    }
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
@@ -572,7 +572,7 @@ class Overlays {
     const isScrollTriggered = this.isScrollDrivenDraw &&
       (this.verticalScrolling || this.horizontalScrolling);
     // On a pure vertical scroll the bottom overlay (and its inline-start corner) render the same fixed
-    // rows over the same visible columns, so their DOM is unchanged – a full re-render is wasted work and
+    // rows over the same visible columns, so their DOM is unchanged - a full re-render is wasted work and
     // forces an expensive style/layout/paint of the clone subtree on every scroll frame. Reposition them
     // (fast draw) instead. Any horizontal scroll changes the visible columns, and a non-scroll redraw
     // (data, settings, resize) is not scroll-driven, so those paths still trigger a full re-render.
@@ -614,7 +614,7 @@ class Overlays {
    * Re-applies the column-header heights to the master and every header-bearing overlay after the
    * Handsontable-side render-size probe has measured content-driven header heights. The probe runs
    * after the draw completes (once the DOM is final), so the overlays first render at the provided
-   * height and are corrected here to match the master – a synchronous, hook-free reconcile that
+   * height and are corrected here to match the master - a synchronous, hook-free reconcile that
    * replaces the old mid-draw `markOversizedColumnHeaders` measurement. The frozen-overlay sync runs
    * last so a wrapped header inside the frozen region still wins, and the sizes are flushed to the DOM.
    */

--- a/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
@@ -182,6 +182,19 @@ class Overlays {
   }
 
   /**
+   * Whether the scrolling element was resolved while the table generated no boxes, so the answer was
+   * taken against nothing and a later draw still has to settle it.
+   *
+   * Covers that answer only, not the sizes measured in the same state. Goes false once a pass settles
+   * it, or once a pass gives up because the answer stopped changing.
+   *
+   * @returns {boolean}
+   */
+  get isScrollableElementProvisional() {
+    return this.#scrollSync.isScrollableElementProvisional;
+  }
+
+  /**
    * Walkontable instance's reference.
    *
    * @protected
@@ -373,6 +386,14 @@ class Overlays {
    * Runs logic for the overlays before the table is drawn.
    */
   beforeDraw() {
+    // Before anything measures: drops the sizes a previous draw took while the table had no settled
+    // layout, so this draw re-measures them and resizes from the results. Only on a draw that renders
+    // the cells – a fast draw re-renders nothing, so it cannot re-measure the row heights this drops,
+    // and taking the reset there would leave them dropped. It stays pending for the next full draw.
+    if (!this.isScrollDrivenDraw) {
+      this.#scrollSync.resetSizesMeasuredBeforeLayoutSettled();
+    }
+
     this.#scrollSync.setRenderingStateChanged(this.#overlays.reduce((acc, overlay) => {
       return overlay.hasRenderingStateChanged() || acc;
     }, false));
@@ -394,6 +415,12 @@ class Overlays {
         overlay.reset();
       }
     });
+
+    // Runs after the overlays refreshed their trimming containers and the holder got its final
+    // overflow, so a table born outside the layout can settle on the scrollable element and the sizes
+    // it would have had if it had been rendered from the start. It cannot run in `beforeDraw`: both
+    // are still stale there, so the scrollable element would settle on the window again.
+    this.#scrollSync.resolveProvisionalLayout();
   }
 
   /**
@@ -522,7 +549,7 @@ class Overlays {
     const isScrollTriggered = this.isScrollDrivenDraw &&
       (this.verticalScrolling || this.horizontalScrolling);
     // On a pure vertical scroll the bottom overlay (and its inline-start corner) render the same fixed
-    // rows over the same visible columns, so their DOM is unchanged - a full re-render is wasted work and
+    // rows over the same visible columns, so their DOM is unchanged – a full re-render is wasted work and
     // forces an expensive style/layout/paint of the clone subtree on every scroll frame. Reposition them
     // (fast draw) instead. Any horizontal scroll changes the visible columns, and a non-scroll redraw
     // (data, settings, resize) is not scroll-driven, so those paths still trigger a full re-render.
@@ -564,7 +591,7 @@ class Overlays {
    * Re-applies the column-header heights to the master and every header-bearing overlay after the
    * Handsontable-side render-size probe has measured content-driven header heights. The probe runs
    * after the draw completes (once the DOM is final), so the overlays first render at the provided
-   * height and are corrected here to match the master - a synchronous, hook-free reconcile that
+   * height and are corrected here to match the master – a synchronous, hook-free reconcile that
    * replaces the old mid-draw `markOversizedColumnHeaders` measurement. The frozen-overlay sync runs
    * last so a wrapped header inside the frozen region still wins, and the sizes are flushed to the DOM.
    */

--- a/handsontable/src/3rdparty/walkontable/src/overlay/scroll/scrollSync.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/scroll/scrollSync.ts
@@ -98,7 +98,8 @@ export class ScrollSync {
 
   /**
    * Whether the sizes measured before the layout settled still have to be dropped, which the next
-   * draw does on its way in.
+   * draw does on its way in. Stays set until a draw has rendered the cell band and re-measured them
+   * (`confirmSizesRemeasured`), so a draw whose `skipRender` hook cancels the render cannot spend it.
    *
    * @type {boolean}
    */
@@ -365,18 +366,31 @@ export class ScrollSync {
    * invalidated and resizes the elements from the results. Doing it the other way round – dropping
    * the sizes and then asking for a redraw – leaves the row heights dropped for good whenever that
    * redraw renders no cells.
+   *
+   * The mark is not spent here, because a draw that got this far can still render nothing: a
+   * `beforeDraw` hook that sets `skipRender` (NestedRows does this, and so can any user hook) cancels
+   * the cell render, and then `markOversizedRows` never runs to take the heights again. It is spent
+   * by `confirmSizesRemeasured()`, from the `afterDraw` of a draw that did render the band. The drop
+   * is idempotent, so repeating it on the next draw costs one invalidation.
    */
   resetSizesMeasuredBeforeLayoutSettled() {
     if (!this.#sizesMeasuredBeforeLayoutSettled) {
       return;
     }
 
-    this.#sizesMeasuredBeforeLayoutSettled = false;
-
     const wtViewport = this.#deps.getWtViewport();
 
     wtViewport.resetAllOversizedRows();
     wtViewport.invalidateColumnWidthCache();
+  }
+
+  /**
+   * Spends the mark left by `resolveProvisionalLayout()`, once a draw has rendered the cell band and
+   * therefore re-measured the sizes that `resetSizesMeasuredBeforeLayoutSettled()` dropped on its way
+   * in. Called from `Overlays#afterDraw`.
+   */
+  confirmSizesRemeasured() {
+    this.#sizesMeasuredBeforeLayoutSettled = false;
   }
 
   /**
@@ -387,9 +401,10 @@ export class ScrollSync {
    * the scrollable element resolves to the window, and the row heights and column widths describe a
    * layout the table never had.
    *
-   * Runs from `afterDraw`, so the overlays have already refreshed their trimming containers and the
-   * holder has its final overflow; in `beforeDraw` both are still stale and the scrollable element
-   * would settle on the window again. While the answer is still the window even though an element
+   * Runs from the `afterDraw` of a full draw, so the overlays have already refreshed their trimming
+   * containers and the holder has its final overflow; in `beforeDraw`, and on a fast draw that never
+   * aligned the overlays at all, both are still stale and the scrollable element would settle on the
+   * window again. While the answer is still the window even though an element
    * trims the table, the layout has not settled yet and the pass is retried on the next draw – but
    * only while the answer keeps changing. `getTrimmingContainer` counts `overflow: hidden` and
    * `getScrollableElement` does not, so the two can disagree permanently, and a table in an iframe
@@ -501,12 +516,18 @@ export class ScrollSync {
    * "no ancestor clips or scrolls" and hands the whole grid to the window. A provisional answer is
    * retaken on the next draw that finds the table rendered (see `Overlays#afterDraw`).
    *
+   * Re-arming the flag starts a fresh series of retries, so the answer an earlier series gave up on
+   * is forgotten with it: `updateMainScrollableElements()` is public and `updateSettings` calls it
+   * whenever `height` moves to or from `''`, so a grid that already gave up while it was outside the
+   * layout would otherwise match its own stale answer on the first retry and give up again at once.
+   *
    * @returns {HTMLElement | Window}
    */
   #takeScrollableElement(): HTMLElement | Window {
     const { wtTable, geometryReader } = this.#deps;
 
     this.#isScrollableElementProvisional = !geometryReader.isRendered(wtTable.wtRootElement);
+    this.#lastProvisionalScrollableElement = null;
 
     return this.#computeScrollableElement();
   }

--- a/handsontable/src/3rdparty/walkontable/src/overlay/scroll/scrollSync.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/scroll/scrollSync.ts
@@ -76,6 +76,35 @@ export class ScrollSync {
   #scrollableElement: HTMLElement | Window;
 
   /**
+   * Whether `#scrollableElement` was resolved while the table generated no boxes, which makes it an
+   * answer taken against nothing.
+   *
+   * Cleared by the first resolution pass that settles it, and also by a pass that gives up because the
+   * answer stopped changing – the two helpers behind it can disagree permanently. Covers the scrolling
+   * element only; the sizes measured in that state are tracked separately, by
+   * `#sizesMeasuredBeforeLayoutSettled`.
+   *
+   * @type {boolean}
+   */
+  #isScrollableElementProvisional = false;
+
+  /**
+   * The scrolling element the last non-settling resolution pass computed, so a pass that computes the
+   * same answer again can stop retrying.
+   *
+   * @type {HTMLElement | Window | null}
+   */
+  #lastProvisionalScrollableElement: HTMLElement | Window | null = null;
+
+  /**
+   * Whether the sizes measured before the layout settled still have to be dropped, which the next
+   * draw does on its way in.
+   *
+   * @type {boolean}
+   */
+  #sizesMeasuredBeforeLayoutSettled = false;
+
+  /**
    * Whether a vertical scroll happened in the current frame.
    *
    * @type {boolean}
@@ -129,7 +158,7 @@ export class ScrollSync {
    */
   constructor(deps: ScrollSyncDeps) {
     this.#deps = deps;
-    this.#scrollableElement = this.#computeScrollableElement();
+    this.#scrollableElement = this.#takeScrollableElement();
     this.#lastScrollX = this.#deps.rootWindow.scrollX;
     this.#lastScrollY = this.#deps.rootWindow.scrollY;
   }
@@ -141,6 +170,16 @@ export class ScrollSync {
    */
   get scrollableElement() {
     return this.#scrollableElement;
+  }
+
+  /**
+   * Whether the scrollable element was resolved against a table that had no layout at that moment,
+   * so the answer is provisional and has to be retaken once the table is rendered.
+   *
+   * @returns {boolean}
+   */
+  get isScrollableElementProvisional() {
+    return this.#isScrollableElementProvisional;
   }
 
   /**
@@ -320,6 +359,88 @@ export class ScrollSync {
   }
 
   /**
+   * Drops the sizes measured before the layout settled, if `resolveProvisionalLayout()` found any.
+   *
+   * Called from `Overlays#beforeDraw`, so the draw that follows re-measures the row heights it just
+   * invalidated and resizes the elements from the results. Doing it the other way round – dropping
+   * the sizes and then asking for a redraw – leaves the row heights dropped for good whenever that
+   * redraw renders no cells.
+   */
+  resetSizesMeasuredBeforeLayoutSettled() {
+    if (!this.#sizesMeasuredBeforeLayoutSettled) {
+      return;
+    }
+
+    this.#sizesMeasuredBeforeLayoutSettled = false;
+
+    const wtViewport = this.#deps.getWtViewport();
+
+    wtViewport.resetAllOversizedRows();
+    wtViewport.invalidateColumnWidthCache();
+  }
+
+  /**
+   * Settles the layout decisions and measurements of a table that was constructed while it had no
+   * layout – most often a light-DOM child of a shadow host whose `<slot>` renders later, or a subtree
+   * assembled before it was appended to the document. Such a table reads every ancestor style as an
+   * empty declaration and measures every size against nothing, so two things are wrong at once:
+   * the scrollable element resolves to the window, and the row heights and column widths describe a
+   * layout the table never had.
+   *
+   * Runs from `afterDraw`, so the overlays have already refreshed their trimming containers and the
+   * holder has its final overflow; in `beforeDraw` both are still stale and the scrollable element
+   * would settle on the window again. While the answer is still the window even though an element
+   * trims the table, the layout has not settled yet and the pass is retried on the next draw – but
+   * only while the answer keeps changing. `getTrimmingContainer` counts `overflow: hidden` and
+   * `getScrollableElement` does not, so the two can disagree permanently, and a table in an iframe
+   * driven from the parent realm does exactly that: `MasterTable#alignOverlaysWithTrimmingContainer`
+   * misses it with a realm-bound `instanceof` and leaves the holder `overflow: visible`. Retrying
+   * such a table forever would rebind every listener on every draw.
+   *
+   * Once it does settle, the sizes measured before it are marked for dropping, which the next draw
+   * does on its way in (`resetSizesMeasuredBeforeLayoutSettled`). Left in place they survive until
+   * something else redraws the grid, which is what made it fill short of its container and look like
+   * it needed a click to finish loading (DEV-2515).
+   */
+  resolveProvisionalLayout() {
+    if (!this.#isScrollableElementProvisional ||
+        !this.#deps.geometryReader.isRendered(this.#deps.wtTable.wtRootElement)) {
+      return;
+    }
+
+    const { rootWindow } = this.#deps;
+    const scrollableElement = this.#computeScrollableElement();
+    const settles = scrollableElement !== rootWindow ||
+      this.#deps.getTopOverlay().trimmingContainer === rootWindow;
+
+    if (!settles) {
+      // The answer is checked before anything is rebound, so a pass that cannot settle costs one
+      // style read. Retry only while the answer keeps changing: a repeated answer is what a
+      // permanent disagreement between the two helpers looks like, and rebinding the listeners on
+      // every draw would drop every in-flight scroll event for the instance's life.
+      this.#isScrollableElementProvisional = scrollableElement !== this.#lastProvisionalScrollableElement;
+      this.#lastProvisionalScrollableElement = scrollableElement;
+
+      return;
+    }
+
+    this.updateMainScrollableElements();
+
+    // The sizes are not dropped here. Dropping them after a draw leaves them dropped: the follow-up
+    // is a redraw request, and a draw that re-renders nothing never re-runs `markOversizedRows`, so
+    // the row heights this pass invalidated would never be taken again. The next draw drops them on
+    // its way in instead, so reset, re-measure and resize run in the order the draw cycle documents.
+    this.#sizesMeasuredBeforeLayoutSettled = true;
+
+    // No redraw is requested from here. The flag stays set until a draw consumes it, and settling
+    // means the root element went from no layout to a layout, which is a size change the grid already
+    // observes and redraws for. Forcing a draw from this frame instead measures a DOM whose column
+    // widths have not settled: it records row heights for rows that leave the band on the next draw,
+    // and those records survive – measured as 6 rendered rows and 56px of dead space where 9 rows
+    // belong.
+  }
+
+  /**
    * Update the main scrollable elements for all the overlays.
    */
   updateMainScrollableElements() {
@@ -332,7 +453,7 @@ export class ScrollSync {
       this.#deps.getBottomOverlay().updateMainScrollableElement();
     }
 
-    this.#scrollableElement = this.#computeScrollableElement();
+    this.#scrollableElement = this.#takeScrollableElement();
 
     this.#deps.registerListeners();
   }
@@ -374,14 +495,35 @@ export class ScrollSync {
   }
 
   /**
+   * Resolves the scrolling element and records whether the answer is provisional.
+   *
+   * A table outside the layout resolves every ancestor style to an empty declaration, which reads as
+   * "no ancestor clips or scrolls" and hands the whole grid to the window. A provisional answer is
+   * retaken on the next draw that finds the table rendered (see `Overlays#afterDraw`).
+   *
+   * @returns {HTMLElement | Window}
+   */
+  #takeScrollableElement(): HTMLElement | Window {
+    const { wtTable, geometryReader } = this.#deps;
+
+    this.#isScrollableElementProvisional = !geometryReader.isRendered(wtTable.wtRootElement);
+
+    return this.#computeScrollableElement();
+  }
+
+  /**
    * Computes the element that scrolls the table: the master holder when the trimming container clips
    * overflow, otherwise the nearest scrollable ancestor of the master TABLE.
+   *
+   * Answers the question and nothing else. Whether the answer is provisional is recorded by the
+   * callers, which is also where a provisional answer is acted on.
    *
    * @returns {HTMLElement | Window}
    */
   #computeScrollableElement(): HTMLElement | Window {
     const { wtTable, geometryReader } = this.#deps;
     const tableParentNode = wtTable.wtRootElement.parentNode;
+
     // Use nodeType === 1 instead of instanceof Element so the check works across realms (iframes).
     // Falls back to getScrollableElement when there is no element parent (null or detached).
     const isOverflowClip = tableParentNode !== null

--- a/handsontable/src/3rdparty/walkontable/src/overlay/scroll/scrollSync.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/scroll/scrollSync.ts
@@ -106,6 +106,17 @@ export class ScrollSync {
   #sizesMeasuredBeforeLayoutSettled = false;
 
   /**
+   * Whether a drop has run and is still waiting for a draw to re-measure what it invalidated. The
+   * mark above is spent only while this is set, so a draw that renders the cells without having
+   * dropped anything cannot spend it – which is what an entry-fast draw that `createCalculators`
+   * escalates to a full render does: it passed the reset gate as a scroll draw and the render gate
+   * as a full one.
+   *
+   * @type {boolean}
+   */
+  #sizesAwaitingRemeasure = false;
+
+  /**
    * Whether a vertical scroll happened in the current frame.
    *
    * @type {boolean}
@@ -367,6 +378,12 @@ export class ScrollSync {
    * the sizes and then asking for a redraw – leaves the row heights dropped for good whenever that
    * redraw renders no cells.
    *
+   * "Sizes" is the engine's own record of them: the oversized-row heights and the column-width
+   * prefix sum. A rebuilt width cache re-asks `wtTable.getColumnWidth`, so it re-enters
+   * `modifyColWidth` and `AutoColumnSize` answers from its own map – a width that plugin measured
+   * while the table had no layout is not dropped by this and outlives the settle. That gap is the
+   * narrow-container `AutoColumnSize` follow-up, filed separately.
+   *
    * The mark is not spent here, because a draw that got this far can still render nothing: a
    * `beforeDraw` hook that sets `skipRender` (NestedRows does this, and so can any user hook) cancels
    * the cell render, and then `markOversizedRows` never runs to take the heights again. It is spent
@@ -378,6 +395,8 @@ export class ScrollSync {
       return;
     }
 
+    this.#sizesAwaitingRemeasure = true;
+
     const wtViewport = this.#deps.getWtViewport();
 
     wtViewport.resetAllOversizedRows();
@@ -388,8 +407,18 @@ export class ScrollSync {
    * Spends the mark left by `resolveProvisionalLayout()`, once a draw has rendered the cell band and
    * therefore re-measured the sizes that `resetSizesMeasuredBeforeLayoutSettled()` dropped on its way
    * in. Called from `Overlays#afterDraw`.
+   *
+   * A draw that rendered the cells without having dropped anything spends nothing: the two gates read
+   * different values of the same fast/full question (the reset gate reads it at draw entry, the render
+   * gate after `createCalculators` could downgrade it), so an escalated scroll draw satisfies the
+   * second without ever passing the first.
    */
   confirmSizesRemeasured() {
+    if (!this.#sizesAwaitingRemeasure) {
+      return;
+    }
+
+    this.#sizesAwaitingRemeasure = false;
     this.#sizesMeasuredBeforeLayoutSettled = false;
   }
 

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -295,7 +295,7 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
     renderActiveSelections(table, ctx.runFastDraw);
   }
 
-  wtOverlays.afterDraw();
+  wtOverlays.afterDraw(!ctx.runFastDraw && ctx.performRedraw);
 
   table.deps.setDrawn(true);
 }

--- a/handsontable/src/3rdparty/walkontable/src/viewport/viewport.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/viewport.ts
@@ -399,6 +399,22 @@ class Viewport {
   }
 
   /**
+   * Drops every oversized-row record, not just the rendered band's, and marks the row-height cache
+   * stale so the next draw measures the rows again.
+   *
+   * `resetOversizedRows` deliberately wipes only the rendered band, because a record outside it is
+   * still the best height known for that row. That assumption breaks when the records were taken
+   * against a table with no layout: `getComputedStyle` returned nothing, so the default row height
+   * was unknown and every row was recorded oversized at a height it never had. Then the whole map
+   * has to go at once, or the rows outside the band keep inflating the scroll range for good.
+   */
+  resetAllOversizedRows() {
+    this.oversizedRows = {};
+    this.frozenOversizedRows.clear();
+    this.invalidateRowHeightCache();
+  }
+
+  /**
    * Hands the frozen-derived row records back to the ordinary oversized-row machinery, keeping their
    * heights but dropping their exemption from `resetOversizedRows`.
    *

--- a/handsontable/src/3rdparty/walkontable/test/unit/domMeasure/liveGeometryReader.unit.ts
+++ b/handsontable/src/3rdparty/walkontable/test/unit/domMeasure/liveGeometryReader.unit.ts
@@ -152,3 +152,38 @@ describe('LiveGeometryReader', () => {
     });
   });
 });
+
+describe('LiveGeometryReader#isRendered', () => {
+  /**
+   * jsdom performs no layout, so `getClientRects` is stubbed to describe the states the port
+   * distinguishes: a detached element, an element in the document but outside the flat tree (an
+   * unslotted light-DOM child of a shadow host), and a rendered one.
+   *
+   * @param {object} state The element state to report.
+   * @param {boolean} state.isConnected Whether the element is in a document.
+   * @param {number} state.rects How many boxes the element generates.
+   * @returns {HTMLElement} The element to measure.
+   */
+  const elementWith = ({ isConnected, rects }: { isConnected: boolean, rects: number }) => {
+    const el = document.createElement('div');
+
+    Object.defineProperty(el, 'isConnected', { value: isConnected });
+    el.getClientRects = () => ({ length: rects } as unknown as DOMRectList);
+
+    return el;
+  };
+
+  const reader = new LiveGeometryReader();
+
+  it('should report an element that is not in the document as not rendered', () => {
+    expect(reader.isRendered(elementWith({ isConnected: false, rects: 0 }))).toBe(false);
+  });
+
+  it('should report a connected element that generates no boxes as not rendered', () => {
+    expect(reader.isRendered(elementWith({ isConnected: true, rects: 0 }))).toBe(false);
+  });
+
+  it('should report a connected element that generates boxes as rendered', () => {
+    expect(reader.isRendered(elementWith({ isConnected: true, rects: 1 }))).toBe(true);
+  });
+});

--- a/handsontable/src/3rdparty/walkontable/test/unit/overlay/scrollSync.unit.ts
+++ b/handsontable/src/3rdparty/walkontable/test/unit/overlay/scrollSync.unit.ts
@@ -172,6 +172,17 @@ describe('ScrollSync#resolveProvisionalLayout', () => {
     expect(counters.resetAllOversizedRows).toBe(1);
   });
 
+  it('should not spend the mark on a draw that rendered the cells without dropping anything', () => {
+    const { scrollSync, counters, render } = createScrollSync({ trimmedByElement: false });
+
+    render();
+    scrollSync.resolveProvisionalLayout();
+    scrollSync.confirmSizesRemeasured();
+    scrollSync.resetSizesMeasuredBeforeLayoutSettled();
+
+    expect(counters.resetAllOversizedRows).toBe(1);
+  });
+
   it('should grant a fresh retry to a layout that is armed again', () => {
     const { scrollSync, counters, render, unrender } = createScrollSync({ trimmedByElement: true });
 

--- a/handsontable/src/3rdparty/walkontable/test/unit/overlay/scrollSync.unit.ts
+++ b/handsontable/src/3rdparty/walkontable/test/unit/overlay/scrollSync.unit.ts
@@ -72,6 +72,9 @@ describe('ScrollSync#resolveProvisionalLayout', () => {
       render: () => {
         rendered = true;
       },
+      unrender: () => {
+        rendered = false;
+      },
     };
   };
 
@@ -145,16 +148,49 @@ describe('ScrollSync#resolveProvisionalLayout', () => {
     expect(counters.resetAllOversizedRows).toBe(1);
   });
 
-  it('should drop the sizes once per settled layout', () => {
+  it('should keep dropping the sizes until a draw has rendered the cells', () => {
     const { scrollSync, counters, render } = createScrollSync({ trimmedByElement: false });
 
     render();
     scrollSync.resolveProvisionalLayout();
     scrollSync.resetSizesMeasuredBeforeLayoutSettled();
     scrollSync.resetSizesMeasuredBeforeLayoutSettled();
+
+    expect(counters.resetAllOversizedRows).toBe(2);
+  });
+
+  it('should drop the sizes once per settled layout', () => {
+    const { scrollSync, counters, render } = createScrollSync({ trimmedByElement: false });
+
+    render();
+    scrollSync.resolveProvisionalLayout();
+    scrollSync.resetSizesMeasuredBeforeLayoutSettled();
+    scrollSync.confirmSizesRemeasured();
+    scrollSync.resetSizesMeasuredBeforeLayoutSettled();
     scrollSync.resetSizesMeasuredBeforeLayoutSettled();
 
     expect(counters.resetAllOversizedRows).toBe(1);
+  });
+
+  it('should grant a fresh retry to a layout that is armed again', () => {
+    const { scrollSync, counters, render, unrender } = createScrollSync({ trimmedByElement: true });
+
+    render();
+    scrollSync.resolveProvisionalLayout();
+    scrollSync.resolveProvisionalLayout();
+
+    expect(scrollSync.isScrollableElementProvisional).toBe(false);
+
+    unrender();
+    scrollSync.updateMainScrollableElements();
+
+    expect(scrollSync.isScrollableElementProvisional).toBe(true);
+
+    render();
+    scrollSync.resolveProvisionalLayout();
+
+    expect(scrollSync.isScrollableElementProvisional).toBe(true);
+    expect(counters.registerListeners).toBe(1);
   });
 
   it('should drop nothing on a draw that follows no settled layout', () => {

--- a/handsontable/src/3rdparty/walkontable/test/unit/overlay/scrollSync.unit.ts
+++ b/handsontable/src/3rdparty/walkontable/test/unit/overlay/scrollSync.unit.ts
@@ -1,0 +1,176 @@
+import { ScrollSync, type ScrollSyncDeps } from '../../../src/overlay/scroll/scrollSync';
+
+describe('ScrollSync#resolveProvisionalLayout', () => {
+  /**
+   * Builds a ScrollSync whose table reports the state the arguments describe, and
+   * counts the work a resolution pass does.
+   *
+   * `trimmedByElement` is the disagreement the pass has to cope with: an element
+   * trims the table while the scrolling element resolves to the window. The two
+   * answers come from helpers with different rules - `getTrimmingContainer` counts
+   * `overflow: hidden`, `getScrollableElement` does not - so they can disagree for
+   * as long as the instance lives.
+   *
+   * @param {object} state The table state to report.
+   * @param {boolean} state.trimmedByElement Whether an element trims the table.
+   * @returns {object} The ScrollSync under test, the work counters, and a `render`
+   *                   call that puts the table into the layout.
+   */
+  const createScrollSync = ({ trimmedByElement }: { trimmedByElement: boolean }) => {
+    // Constructed while the table is not rendered, which is what makes the first
+    // answer provisional, then rendered - the sequence a table built into a
+    // container outside the layout goes through.
+    let rendered = false;
+    const rootWindow = window;
+    const counters = { registerListeners: 0, clearEvents: 0, overlayUpdates: 0, resetAllOversizedRows: 0 };
+    const overlay = {
+      updateMainScrollableElement: () => {
+        counters.overlayUpdates += 1;
+      },
+      needFullRender: false,
+      trimmingContainer: trimmedByElement ? document.createElement('div') : rootWindow,
+    };
+    // Detached elements: the root has no parent to clip, and the TABLE has no
+    // scrollable ancestor, so the resolved element is the window - the answer that
+    // disagrees with an element trimming container.
+    const wtTable = {
+      wtRootElement: document.createElement('div'),
+      TABLE: document.createElement('table'),
+      holder: document.createElement('div'),
+    };
+    const deps = {
+      rootWindow,
+      wtTable,
+      geometryReader: {
+        isRendered: () => rendered,
+        getComputedStyle: (element: Element) => rootWindow.getComputedStyle(element),
+      },
+      eventManager: {
+        clearEvents: () => {
+          counters.clearEvents += 1;
+        },
+      },
+      registerListeners: () => {
+        counters.registerListeners += 1;
+      },
+      refreshAll: () => {},
+      getDestroyed: () => false,
+      getTopOverlay: () => overlay,
+      getInlineStartOverlay: () => overlay,
+      getBottomOverlay: () => overlay,
+      getWtViewport: () => ({
+        resetAllOversizedRows: () => {
+          counters.resetAllOversizedRows += 1;
+        },
+        invalidateColumnWidthCache: () => {},
+      }),
+    } as unknown as ScrollSyncDeps;
+
+    return {
+      scrollSync: new ScrollSync(deps),
+      counters,
+      render: () => {
+        rendered = true;
+      },
+    };
+  };
+
+  it('should stop retrying when the resolved scrolling element repeats', () => {
+    const { scrollSync, render } = createScrollSync({ trimmedByElement: true });
+
+    expect(scrollSync.isScrollableElementProvisional).toBe(true);
+
+    // Rendered now, but the two helpers disagree - the shape a table in an iframe
+    // driven from the parent realm has, where the disagreement never goes away.
+    render();
+    scrollSync.resolveProvisionalLayout();
+
+    expect(scrollSync.isScrollableElementProvisional).toBe(true);
+
+    scrollSync.resolveProvisionalLayout();
+
+    // Second pass computes the same answer, so there is nothing left to wait for.
+    expect(scrollSync.isScrollableElementProvisional).toBe(false);
+
+    scrollSync.resolveProvisionalLayout();
+    scrollSync.resolveProvisionalLayout();
+
+    expect(scrollSync.isScrollableElementProvisional).toBe(false);
+  });
+
+  it('should rebind nothing while the layout has not settled', () => {
+    const { scrollSync, counters, render } = createScrollSync({ trimmedByElement: true });
+
+    render();
+    scrollSync.resolveProvisionalLayout();
+    scrollSync.resolveProvisionalLayout();
+    scrollSync.resolveProvisionalLayout();
+
+    // A pass that cannot settle used to rebind every listener first and re-arm
+    // itself afterwards, so it paid the full cost on every draw for ever.
+    expect(counters.registerListeners).toBe(0);
+    expect(counters.clearEvents).toBe(0);
+    expect(counters.overlayUpdates).toBe(0);
+    expect(counters.resetAllOversizedRows).toBe(0);
+  });
+
+  it('should rebind the listeners once when the layout settles', () => {
+    const { scrollSync, counters, render } = createScrollSync({ trimmedByElement: false });
+
+    render();
+    scrollSync.resolveProvisionalLayout();
+
+    expect(scrollSync.isScrollableElementProvisional).toBe(false);
+    expect(counters.registerListeners).toBe(1);
+    expect(counters.clearEvents).toBe(1);
+
+    scrollSync.resolveProvisionalLayout();
+
+    expect(counters.registerListeners).toBe(1);
+  });
+
+  it('should leave the sizes in place until a draw consumes the reset', () => {
+    const { scrollSync, counters, render } = createScrollSync({ trimmedByElement: false });
+
+    render();
+    scrollSync.resolveProvisionalLayout();
+
+    // Dropping them here instead leaves them dropped: the redraw this pass can ask
+    // for renders no cells, so `markOversizedRows` never runs and the row heights
+    // are never taken again. The next draw drops them on its way in.
+    expect(counters.resetAllOversizedRows).toBe(0);
+
+    scrollSync.resetSizesMeasuredBeforeLayoutSettled();
+
+    expect(counters.resetAllOversizedRows).toBe(1);
+  });
+
+  it('should drop the sizes once per settled layout', () => {
+    const { scrollSync, counters, render } = createScrollSync({ trimmedByElement: false });
+
+    render();
+    scrollSync.resolveProvisionalLayout();
+    scrollSync.resetSizesMeasuredBeforeLayoutSettled();
+    scrollSync.resetSizesMeasuredBeforeLayoutSettled();
+    scrollSync.resetSizesMeasuredBeforeLayoutSettled();
+
+    expect(counters.resetAllOversizedRows).toBe(1);
+  });
+
+  it('should drop nothing on a draw that follows no settled layout', () => {
+    const { scrollSync, counters } = createScrollSync({ trimmedByElement: false });
+
+    scrollSync.resetSizesMeasuredBeforeLayoutSettled();
+
+    expect(counters.resetAllOversizedRows).toBe(0);
+  });
+
+  it('should do nothing while the table is still not rendered', () => {
+    const { scrollSync, counters } = createScrollSync({ trimmedByElement: true });
+
+    scrollSync.resolveProvisionalLayout();
+
+    expect(scrollSync.isScrollableElementProvisional).toBe(true);
+    expect(counters.registerListeners).toBe(0);
+  });
+});

--- a/handsontable/src/__tests__/tableView.unit.js
+++ b/handsontable/src/__tests__/tableView.unit.js
@@ -139,3 +139,93 @@ describe('Overlays scroll hook deduplication', () => {
     expect(onAfterScrollHorizontally).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('Theme measurements cached against unresolved styles', () => {
+  let container;
+  let core;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (core) {
+      core.destroy();
+      core = null;
+    }
+
+    container.remove();
+  });
+
+  /**
+   * Builds a grid whose styles handler reports, once, that the theme values it cached were read
+   * against unresolved styles - the state a grid built outside the layout is in.
+   *
+   * @returns {object} The grid, the size-cache drop counter, and the order of the drop against the
+   *                   calculators of the same draw.
+   */
+  const createGridWithStaleThemeMeasurements = () => {
+    core = new Core(container, {
+      data: spreadsheetData(20, 5),
+      width: 300,
+      height: 200,
+      colHeaders: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+    core.init();
+
+    const viewport = core.view._wt.wtViewport;
+    const createCalculators = viewport.createCalculators.bind(viewport);
+    const order = [];
+    let staleReports = 1;
+
+    spyOn(core.stylesHandler, 'recacheValuesMeasuredWithoutStyles').and.callFake(() => {
+      staleReports -= 1;
+
+      return staleReports >= 0;
+    });
+    spyOn(viewport, 'resetAllOversizedRows').and.callFake(() => {
+      order.push('drop');
+    });
+    spyOn(viewport, 'createCalculators').and.callFake((...args) => {
+      order.push('calculators');
+
+      return createCalculators(...args);
+    });
+
+    return { core, order };
+  };
+
+  it('should drop the size caches before the draw that renders against the resolved styles builds its calculators', () => {
+    const { core: grid, order } = createGridWithStaleThemeMeasurements();
+
+    grid.render();
+
+    expect(order).toEqual(['drop', 'calculators']);
+  });
+
+  it('should keep the drop pending while a `beforeViewRender` listener cancels the render', () => {
+    const { core: grid, order } = createGridWithStaleThemeMeasurements();
+    let cancelRender = true;
+
+    grid.addHook('beforeViewRender', (isForced, skipRender) => {
+      if (cancelRender) {
+        cancelRender = false;
+        skipRender.skipRender = true;
+      }
+    });
+
+    grid.render();
+
+    expect(order).toEqual(['drop', 'calculators']);
+
+    grid.render();
+
+    expect(order.filter(step => step === 'drop').length).toBe(2);
+
+    grid.render();
+
+    expect(order.filter(step => step === 'drop').length).toBe(2);
+  });
+});

--- a/handsontable/src/styles/components/plugins/_filters.scss
+++ b/handsontable/src/styles/components/plugins/_filters.scss
@@ -72,6 +72,12 @@
       --ht-cell-horizontal-padding: calc(
               var(--ht-menu-item-horizontal-padding, 2px) +
               var(--ht-gap-size, 2px) * 2);
+      // The list's rows are shorter than the grid's. It has to be declared through the variable and
+      // not written straight onto the cells: `StylesHandler#getDefaultRowHeight()` derives the row
+      // height from the line height and this padding, and Walkontable sizes the list's scroll range
+      // from that sum. A literal padding here leaves the variable at the theme's value, so the list
+      // gets a scroll range computed from a row height it does not have (DEV-2515).
+      --ht-cell-vertical-padding: 4px;
 
       overflow: initial !important;
       width: calc(
@@ -105,7 +111,7 @@
 
         td {
           height: auto !important;
-          padding: 4px var(--ht-cell-horizontal-padding);
+          padding: var(--ht-cell-vertical-padding) var(--ht-cell-horizontal-padding);
         }
       }
     }

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -1533,9 +1533,40 @@ class TableView {
    *                            cycle will be skipped.
    */
   beforeRender(force: boolean, skipRender: boolean) {
+    this.#discardSizesMeasuredWithoutStyles();
+
     if (force) {
       this.hot.runHooks('beforeViewRender', this.hot.forceFullRender, skipRender);
     }
+  }
+
+  /**
+   * Discards the row heights measured from theme values that were cached while the grid's root
+   * element resolved no computed styles, on the first draw that finds them resolvable again.
+   *
+   * A grid whose theme variables were cached against unresolved styles has an unknown default row
+   * height, so every rendered row is recorded oversized at a height it never had, and nothing
+   * re-measures those records on its own (DEV-2515 – the theme half of the unrendered-table problem
+   * described in `walkontable/AGENTS.md`).
+   *
+   * The styles handler answers both halves, because it is what cached the values: whether an earlier
+   * pass read them against unresolved styles, and whether they resolve now. Gating on the unknown row
+   * height instead would wipe the caches on every draw of a page that loads no grid stylesheet at
+   * all, where that value never resolves.
+   *
+   * Runs in `beforeRender`, so this draw already measures against the real styles and nothing has to
+   * be undone afterwards.
+   */
+  #discardSizesMeasuredWithoutStyles() {
+    if (!this.hot.stylesHandler.recacheValuesMeasuredWithoutStyles()) {
+      return;
+    }
+
+    // `resetAllOversizedRows` already invalidates the row-height cache, so only the column widths are
+    // left to drop. `invalidateIndexSizesCache()` would invalidate the row heights a second time, and
+    // this is the same pair the engine-side reset performs.
+    this._wt.wtViewport.resetAllOversizedRows();
+    this.invalidateColumnWidthCache();
   }
 
   /**
@@ -1554,7 +1585,7 @@ class TableView {
       // Single-pass header reconcile: the probe has just measured content-driven column-header
       // heights (which the engine no longer measures mid-draw). If a header is taller than the
       // default, re-apply the heights so the overlays match the master. This is a synchronous,
-      // hook-free reconcile - it never calls `hot.render()`, so the render-hook counts are unchanged.
+      // hook-free reconcile – it never calls `hot.render()`, so the render-hook counts are unchanged.
       const defaultRowHeight = this.hot.stylesHandler.getDefaultRowHeight() ?? 0;
 
       if (this.renderSizeProbe.hasColumnHeaderTallerThan(defaultRowHeight)) {

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -134,6 +134,14 @@ class TableView {
    */
   renderSizeProbe = new RenderSizeProbe();
   /**
+   * Whether the sizes measured from theme values cached against unresolved styles still have to be
+   * dropped. Set by the first render that finds the styles resolvable again, and kept until a render
+   * has actually reached the cells and re-measured them (see `#discardSizesMeasuredWithoutStyles`).
+   *
+   * @type {boolean}
+   */
+  #sizesMeasuredWithoutStylesPending = false;
+  /**
    * Defines if the text should be selected during mousemove.
    *
    * @type {boolean}
@@ -208,6 +216,8 @@ class TableView {
       const isFullRender = this.hot.forceFullRender;
 
       this.hot.runHooks('beforeRender', isFullRender);
+
+      this.#discardSizesMeasuredWithoutStyles();
 
       this._wt.draw(!isFullRender);
       this.#updateScrollbarClassNames();
@@ -1533,8 +1543,6 @@ class TableView {
    *                            cycle will be skipped.
    */
   beforeRender(force: boolean, skipRender: boolean) {
-    this.#discardSizesMeasuredWithoutStyles();
-
     if (force) {
       this.hot.runHooks('beforeViewRender', this.hot.forceFullRender, skipRender);
     }
@@ -1554,11 +1562,19 @@ class TableView {
    * height instead would wipe the caches on every draw of a page that loads no grid stylesheet at
    * all, where that value never resolves.
    *
-   * Runs in `beforeRender`, so this draw already measures against the real styles and nothing has to
-   * be undone afterwards.
+   * Runs before `_wt.draw()`, not from the engine's `beforeDraw` setting: that setting fires after
+   * `createCalculators()`, so the rendered row band of that very draw would still be built from the
+   * heights this drops – the grid renders short for one frame and nothing schedules another draw. The
+   * drop stays pending (`#sizesMeasuredWithoutStylesPending`) until a draw has actually rendered the
+   * cells and re-measured them, which is what `afterRender` reports; a `beforeViewRender` listener
+   * that sets `skipRender` cancels the render, and then nothing takes the row heights again.
    */
   #discardSizesMeasuredWithoutStyles() {
-    if (!this.hot.stylesHandler.recacheValuesMeasuredWithoutStyles()) {
+    if (this.hot.stylesHandler.recacheValuesMeasuredWithoutStyles()) {
+      this.#sizesMeasuredWithoutStylesPending = true;
+    }
+
+    if (!this.#sizesMeasuredWithoutStylesPending) {
       return;
     }
 
@@ -1572,11 +1588,17 @@ class TableView {
   /**
    * `afterRender` callback.
    *
+   * The engine fires `onDraw` only from a draw that rendered the cell band, which is what spends the
+   * pending theme-measurement drop: the sizes it invalidated have just been taken again against the
+   * resolved styles (see `#discardSizesMeasuredWithoutStyles`).
+   *
    * @private
    * @param {boolean} force If `true` rendering was triggered by a change of settings or data or `false` if
    *                        rendering was triggered by scrolling or moving selection.
    */
   afterRender(force: boolean) {
+    this.#sizesMeasuredWithoutStylesPending = false;
+
     if (force) {
       // Measure the rendered grid while the DOM is final, before external `afterViewRender` listeners
       // may mutate it.

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -1578,9 +1578,11 @@ class TableView {
       return;
     }
 
-    // `resetAllOversizedRows` already invalidates the row-height cache, so only the column widths are
+    // `resetAllOversizedRows` already invalidates the row-height cache, so only the width cache is
     // left to drop. `invalidateIndexSizesCache()` would invalidate the row heights a second time, and
-    // this is the same pair the engine-side reset performs.
+    // this is the same pair the engine-side reset performs. Dropping the width cache re-asks
+    // `modifyColWidth`, so a width `AutoColumnSize` measured against no layout comes straight back –
+    // that is the narrow-container follow-up, not this pass.
     this._wt.wtViewport.resetAllOversizedRows();
     this.invalidateColumnWidthCache();
   }
@@ -1607,7 +1609,7 @@ class TableView {
       // Single-pass header reconcile: the probe has just measured content-driven column-header
       // heights (which the engine no longer measures mid-draw). If a header is taller than the
       // default, re-apply the heights so the overlays match the master. This is a synchronous,
-      // hook-free reconcile – it never calls `hot.render()`, so the render-hook counts are unchanged.
+      // hook-free reconcile - it never calls `hot.render()`, so the render-hook counts are unchanged.
       const defaultRowHeight = this.hot.stylesHandler.getDefaultRowHeight() ?? 0;
 
       if (this.renderSizeProbe.hasColumnHeaderTallerThan(defaultRowHeight)) {

--- a/handsontable/src/utils/__tests__/stylesHandler.unit.js
+++ b/handsontable/src/utils/__tests__/stylesHandler.unit.js
@@ -577,4 +577,52 @@ describe('StylesHandler', () => {
       expect(handler.getDefaultRowHeight()).toBeNull();
     });
   });
+  describe('recacheValuesMeasuredWithoutStyles', () => {
+    it('should report no re-read for a root element that resolved its styles from the start', () => {
+      const rootElement = createMockRootElement();
+
+      document.body.appendChild(rootElement);
+
+      const handler = new StylesHandler({
+        hot: createMockHot(),
+        rootElement,
+        rootDocument: document,
+      });
+
+      handler.useTheme('ht-theme-main');
+
+      expect(handler.recacheValuesMeasuredWithoutStyles()).toBe(false);
+
+      rootElement.remove();
+    });
+
+    it('should report no re-read while the root element still resolves no styles', () => {
+      const handler = new StylesHandler({
+        hot: createMockHot(),
+        rootElement: createMockRootElement(),
+        rootDocument: document,
+      });
+
+      handler.useTheme('ht-theme-main');
+
+      expect(handler.recacheValuesMeasuredWithoutStyles()).toBe(false);
+    });
+
+    it('should re-read the values once the root element resolves its styles, and only once', () => {
+      const rootElement = createMockRootElement();
+      const handler = new StylesHandler({
+        hot: createMockHot(),
+        rootElement,
+        rootDocument: document,
+      });
+
+      handler.useTheme('ht-theme-main');
+      document.body.appendChild(rootElement);
+
+      expect(handler.recacheValuesMeasuredWithoutStyles()).toBe(true);
+      expect(handler.recacheValuesMeasuredWithoutStyles()).toBe(false);
+
+      rootElement.remove();
+    });
+  });
 });

--- a/handsontable/src/utils/stylesHandler.ts
+++ b/handsontable/src/utils/stylesHandler.ts
@@ -43,6 +43,15 @@ export class StylesHandler {
   #rootComputedStyle: CSSStyleDeclaration | null = null;
 
   /**
+   * Whether the last caching pass ran while the root element resolved no computed styles, so every
+   * value it cached describes nothing.
+   *
+   * @type {boolean}
+   * @private
+   */
+  #cachedWithoutResolvedStyles = false;
+
+  /**
    * The root document of the instance.
    *
    * @type {Document}
@@ -235,6 +244,7 @@ export class StylesHandler {
    * Caches the computed style values for the root element and `td` element.
    */
   #cacheStylesheetValues() {
+    this.#cachedWithoutResolvedStyles = !this.#stylesResolve();
     this.#rootComputedStyle = getComputedStyle(this.#rootElement);
 
     const stylesForTD = this.#getStylesForTD([
@@ -327,6 +337,49 @@ export class StylesHandler {
   #clearCachedValues() {
     this.#computedStyles = {};
     this.#cssVars = {};
+  }
+
+  /**
+   * Checks whether the root element resolves computed styles, so that a value read from them
+   * describes how the grid is rendered.
+   *
+   * An element outside the flat tree resolves against nothing – `getComputedStyle()` yields an empty
+   * declaration, or a full property list of empty strings, depending on the engine. Reading `display`
+   * separates that from an element that merely generates no boxes, which reads its styles fine.
+   *
+   * @returns {boolean} `true` when the root element's computed styles resolve.
+   * @private
+   */
+  #stylesResolve(): boolean {
+    if (!this.#rootElement.isConnected) {
+      return false;
+    }
+
+    const elementWindow = this.#rootElement.ownerDocument.defaultView;
+
+    return elementWindow !== null && elementWindow.getComputedStyle(this.#rootElement).display !== '';
+  }
+
+  /**
+   * Re-reads the cached values when the last pass cached them against unresolved styles and the root
+   * element resolves them now.
+   *
+   * A grid built into an element outside the flat tree caches values that describe nothing, and every
+   * size derived from them – the default row height above all – is wrong. Re-reading them is only
+   * possible once the element resolves its styles, and it is only necessary if an earlier pass did
+   * not, so both are checked here rather than by the caller.
+   *
+   * @returns {boolean} `true` when the values were re-read, so sizes derived from the old ones have
+   *                    to be discarded too.
+   */
+  recacheValuesMeasuredWithoutStyles(): boolean {
+    if (!this.#cachedWithoutResolvedStyles || !this.#stylesResolve()) {
+      return false;
+    }
+
+    this.clearCache();
+
+    return true;
   }
 
   /**

--- a/tests/e2e/filters-value-list-scroll-range.spec.ts
+++ b/tests/e2e/filters-value-list-scroll-range.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '../fixtures/test';
+import { MenuScrollPage } from '../fixtures/pages/MenuScrollPage';
+
+/**
+ * The "filter by value" list is a nested Handsontable built while the dropdown is still
+ * hidden. Its scroll range comes from the summed row heights, and those are derived from
+ * `--ht-line-height` and `--ht-cell-vertical-padding` rather than measured off the DOM —
+ * so a stylesheet that shortens the list's cells by writing `padding` straight onto the
+ * `td` leaves the variable at the theme's value and the list ends up able to scroll past
+ * its last item (DEV-2515).
+ *
+ * `_filters.scss` did exactly that for 20 months. It stayed invisible because the list's
+ * styles cache was empty while the dropdown was hidden, so the row height read `null` and
+ * the engine measured the DOM instead. Once the cache works, the wrong number is the one
+ * that gets used: in horizon the list reported 505px of scroll range for 392px of content.
+ *
+ * The check is the invariant, not the numbers: every item is one row tall, so the range is
+ * the item count times the rendered row height. It holds in every theme.
+ */
+test.describe('filters by-value list', () => {
+  test('scroll range matches the number of items it holds', async({ page, theme, bundle }) => {
+    const grid = new MenuScrollPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.openDropdownMenu(1);
+
+    // Polled rather than slept on: `settleFrames()` is a two-frame wait, and the
+    // list measures itself over an unspecified number of frames after the menu
+    // opens. Waiting for the metrics to become readable removes that exposure and
+    // still fails if they never do.
+    await expect.poll(async () => {
+      const { itemCount, rowHeight } = await grid.readFilterValueListMetrics();
+
+      return itemCount > 0 && rowHeight > 0;
+    }).toBe(true);
+
+    const metrics = await grid.readFilterValueListMetrics();
+
+    expect(metrics.itemCount).toBeGreaterThan(0);
+    expect(metrics.rowHeight).toBeGreaterThan(0);
+
+    // The row height the engine derives from the theme variables has to be the height the
+    // cells actually render at. This is the assertion that catches the padding mismatch in
+    // whichever theme carries it: horizon computed 36 for rows rendered at 28.
+    expect(metrics.derivedRowHeight).toBe(metrics.rowHeight);
+
+    // Two pixels of tolerance for the list's own top and bottom border, and bounded
+    // below too: a range short of its content cannot reach the last item.
+    expect(metrics.scrollRange).toBeLessThanOrEqual(metrics.itemCount * metrics.rowHeight + 2);
+    expect(metrics.scrollRange).toBeGreaterThanOrEqual(metrics.itemCount * metrics.rowHeight - 2);
+  });
+});

--- a/tests/e2e/unlaid-out-init-scroll-sync.spec.ts
+++ b/tests/e2e/unlaid-out-init-scroll-sync.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from '../fixtures/test';
+import { UnlaidOutInitPage, type UnlaidOutMode } from '../fixtures/pages/UnlaidOutInitPage';
+
+/**
+ * Regression guard for a grid constructed into a container that is not in the
+ * layout yet (DEV-2515).
+ *
+ * Such a container has no layout boxes, and `getComputedStyle()` returns an
+ * empty declaration for it and for every ancestor. Walking that chain for an
+ * overflow container therefore finds nothing and resolves to the window, so the
+ * overlays bind to window scroll — and because the decision was taken once at
+ * construction, they stayed bound for the instance's whole life: the column
+ * headers and frozen columns did not move with the grid body, and virtualization
+ * rendered the whole data set.
+ *
+ * The fix retakes the decision on the first draw that finds the table rendered.
+ * The assertions describe the user-visible outcome (overlays aligned, rendered
+ * band bounded), not the internal state, so they hold however it is retaken.
+ *
+ * `unslotted` is the shape the reporting customer hit (a Stencil component whose
+ * `<slot>` renders a tick late). Chromium returns the empty declaration for an
+ * unslotted element since 151 — Firefox and Safari always did — so on the
+ * Chromium this suite pins, only the `detached` case can still reproduce the
+ * failure. Both are kept: they enter through the same construction path, and the
+ * customer's shape must be the one that is named.
+ */
+const MODES: UnlaidOutMode[] = ['detached', 'unslotted'];
+
+test.describe('grid built into a container that has no layout yet', () => {
+  for (const mode of MODES) {
+    test(`keeps the column headers and frozen columns aligned once the ${mode} container is laid out`, async ({
+      page, theme, bundle,
+    }) => {
+      const grid = new UnlaidOutInitPage(page, theme, bundle);
+
+      await grid.goto();
+      await grid.buildGrid(mode);
+
+      // Proves the grid really was built outside the layout — without it the
+      // scenario could degrade into "build a grid in a sized div" and still pass.
+      expect(await grid.hadNoLayoutAtInit()).toBe(true);
+
+      await grid.attach();
+      await grid.scrollGrid(300, 300);
+
+      // Before the fix both offsets equalled the full scroll distance (300px):
+      // the clones never moved, because they were following the window instead.
+      await grid.expectOverlaysAligned(300, 300);
+
+      const alignment = await grid.readOverlayAlignment();
+
+      // The container is 260px tall and rows are ~29px, so a viewport-sized band is
+      // about 10 rows and stays under 25 even with overscan; window-scroll mode
+      // rendered all 200. Anything looser tolerates a 2.5x over-render.
+      expect(alignment.renderedRows).toBeLessThan(25);
+      expect(alignment.renderedRows).toBeGreaterThan(0);
+      expect(alignment.scrollsWithWindow).toBe(false);
+    });
+
+    test(`fills its container without any interaction once the ${mode} container is laid out`, async ({
+      page, theme, bundle,
+    }) => {
+      const grid = new UnlaidOutInitPage(page, theme, bundle);
+
+      await grid.goto();
+      await grid.buildGrid(mode);
+
+      expect(await grid.hadNoLayoutAtInit()).toBe(true);
+
+      await grid.attach();
+
+      // Deliberately no scroll, click, or any other interaction: the grid has to
+      // be complete on its own. Row heights measured while the table had no
+      // layout used to survive here, and each later draw only re-measured the
+      // rows it rendered — so the grid filled short of its container and grew a
+      // couple of rows every time the user touched it.
+      // The last painted row reaches the container's bottom edge (negative means
+      // it extends past it, which is what a full viewport band looks like).
+      await grid.expectContainerFilled();
+
+      const alignment = await grid.readOverlayAlignment();
+
+      // Every row is at the default height, so the scroll range is the row count
+      // times that height. The border allowance is added once, not once per row:
+      // `rowCount * (rowHeight + 2)` left 400px of slack on 200 rows, and grew in
+      // the same direction as the defect it guards, so a regression leaving every
+      // row 1-2px too tall passed. Bounded below as well, because a range short of
+      // the content clips the bottom rows.
+      const rowHeight = alignment.defaultRowHeight;
+
+      expect(rowHeight).not.toBeNull();
+      expect(alignment.holderScrollRange).toBeLessThanOrEqual((alignment.rowCount + 1) * rowHeight! + 2);
+      expect(alignment.holderScrollRange).toBeGreaterThanOrEqual(alignment.rowCount * rowHeight!);
+    });
+
+    test(`settles the correction pass for good once the ${mode} container is laid out`, async ({
+      page, theme, bundle,
+    }) => {
+      const grid = new UnlaidOutInitPage(page, theme, bundle);
+
+      await grid.goto();
+      await grid.buildGrid(mode);
+
+      expect(await grid.hadNoLayoutAtInit()).toBe(true);
+      expect(await grid.readProvisionalLayout()).toBe(true);
+
+      await grid.attach();
+      await grid.expectContainerFilled();
+
+      // The pass has to be a one-off. While it re-armed itself it re-bound every
+      // overlay listener on every draw - so on every scroll frame, for the
+      // instance's whole life - and dropped whichever scroll event was in flight.
+      await expect.poll(async () => grid.readProvisionalLayout()).toBe(false);
+
+      const states = await grid.drawAndReadState(5);
+
+      expect(states.map(state => state.provisional)).toEqual([false, false, false, false, false]);
+
+      // A pass still running would keep wiping the row heights, so the scroll
+      // range would move from draw to draw instead of holding still.
+      expect(new Set(states.map(state => state.holderScrollRange)).size).toBe(1);
+    });
+  }
+
+  test('leaves a grid built into a laid-out container alone', async ({ page, theme, bundle }) => {
+    const grid = new UnlaidOutInitPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.buildGrid('laid-out');
+
+    // The control for the two cases above: nothing about this grid is provisional,
+    // so the correction pass must not engage at all - not on the first draw, and
+    // not on any later one.
+    expect(await grid.hadNoLayoutAtInit()).toBe(false);
+    expect(await grid.readProvisionalLayout()).toBe(false);
+
+    const states = await grid.drawAndReadState(5);
+
+    expect(states.map(state => state.provisional)).toEqual([false, false, false, false, false]);
+
+    await grid.expectContainerFilled();
+    await grid.scrollGrid(300, 300);
+    await grid.expectOverlaysAligned(300, 300);
+  });
+
+  test('restores the row heights of a grid that has frozen rows', async ({ page, theme, bundle }) => {
+    const grid = new UnlaidOutInitPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.useFrozenRows();
+    await grid.buildGrid('detached');
+
+    expect(await grid.hadNoLayoutAtInit()).toBe(true);
+
+    await grid.attach();
+
+    // Frozen rows keep their height records apart from the ordinary ones, and the
+    // correction pass clears both. A master draw cannot recreate a frozen-derived
+    // height, so clearing them without a re-measure would leave the grid short.
+    await expect.poll(async () => grid.readProvisionalLayout()).toBe(false);
+
+    const alignment = await grid.readOverlayAlignment();
+    const rowHeight = alignment.defaultRowHeight;
+
+    expect(rowHeight).not.toBeNull();
+
+    // `expectContainerFilled` does not apply here: the bottom overlay covers the
+    // last two rows, so the master band stops behind it rather than at the
+    // container's edge. It still may not stop short of it by more than that.
+    expect(alignment.deadSpaceBelowLastRow).toBeLessThanOrEqual(2 * rowHeight! + 2);
+    expect(alignment.deadSpaceBelowLastRow).toBeGreaterThanOrEqual(0);
+
+    // Records that were wiped and never taken again, or kept from the unlaid-out
+    // measurement, both show up here. The allowance covers the four frozen rows,
+    // whose bands add to the holder's range on top of the 200 data rows - measured
+    // at 5871px against 5830px of rows. Still far under the pre-fix inflation, which
+    // was more than double the content.
+    const frozenRows = 4;
+
+    expect(alignment.holderScrollRange)
+      .toBeLessThanOrEqual((alignment.rowCount + frozenRows) * rowHeight! + 2);
+    expect(alignment.holderScrollRange).toBeGreaterThanOrEqual(alignment.rowCount * rowHeight!);
+    expect(alignment.renderedRows).toBeLessThan(25);
+
+    await grid.scrollGrid(300, 300);
+    await grid.expectOverlaysAligned(300, 300);
+  });
+});

--- a/tests/e2e/unlaid-out-init-scroll-sync.spec.ts
+++ b/tests/e2e/unlaid-out-init-scroll-sync.spec.ts
@@ -23,8 +23,13 @@ import { UnlaidOutInitPage, type UnlaidOutMode } from '../fixtures/pages/UnlaidO
  * Chromium this suite pins, only the `detached` case can still reproduce the
  * failure. Both are kept: they enter through the same construction path, and the
  * customer's shape must be the one that is named.
+ *
+ * `hidden` is the third shape, and the mildest: a grid built inside a hidden tab
+ * or a closed modal reads its styles fine, so its scrolling element was already
+ * right — but it generates no boxes, so the correction engages anyway and has to
+ * leave the grid exactly as correct on reveal as the other two.
  */
-const MODES: UnlaidOutMode[] = ['detached', 'unslotted'];
+const MODES: UnlaidOutMode[] = ['detached', 'unslotted', 'hidden'];
 
 test.describe('grid built into a container that has no layout yet', () => {
   for (const mode of MODES) {

--- a/tests/fixtures/demo/unlaid-out-init.html
+++ b/tests/fixtures/demo/unlaid-out-init.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable e2e fixture — grid built into a container that has no layout yet</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back — a
+    // typo in the project config must be one red leg, never a silently
+    // mislabeled green one (nothing else asserts which file actually loaded).
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    // Written into <head> so the themed stylesheet is present before first render.
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    // 1:1 with the Puppeteer legs (umd = handsontable.js, full-min =
+    // handsontable.full.min.js, the exact file `test:production` loads).
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+    .box { width: 600px; height: 260px; }
+    .grid-root { width: 100%; height: 100%; overflow: hidden; }
+  </style>
+</head>
+<body>
+  <!--
+    E2E fixture for DEV-2515: a grid constructed into a container that is not in
+    the layout yet, so its own and its ancestors' `getComputedStyle()` reads
+    return an empty declaration. Walking that chain for an overflow container
+    finds nothing and resolves to the window, and because the decision was taken
+    once at construction the overlays stayed bound to window scroll for the
+    instance's whole life.
+
+    Two ways in, both taken by real applications:
+
+      detached   the container is built, the grid constructed into it, and only
+                 then is it appended to the document. What a framework that
+                 assembles a subtree before mounting it does.
+
+      unslotted  the container is a light-DOM child of a shadow host whose
+                 `<slot>` renders later, so it is outside the flat tree. The
+                 customer's case (a Stencil component), and what every async
+                 component framework does for a moment. Chromium returns the
+                 empty declaration here since 151, aligning with the CSSOM
+                 specification and with Firefox and Safari.
+
+    Nothing is built at parse time: the spec drives `buildGrid()` and `attach()`
+    itself, so the window before the container joins the layout is exact instead
+    of racing a timer.
+  -->
+  <div data-testid="status">idle</div>
+  <late-slot-host data-testid="host"></late-slot-host>
+  <div data-testid="detached-host"></div>
+
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The
+    // closing tag is split so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const PANE_MARKUP = `
+      <style>
+        :host { display: block; width: 600px; height: 260px; }
+        .pane { width: 100%; height: 100%; overflow: hidden; }
+      </style>
+      <div class="pane"><slot></slot></div>
+    `;
+
+    /**
+     * Attaches its shadow root synchronously on connect, but renders the `<slot>`
+     * only when the spec asks for it.
+     */
+    class LateSlotHost extends HTMLElement {
+      connectedCallback() {
+        if (!this.shadowRoot) {
+          this.attachShadow({ mode: 'open' });
+        }
+      }
+
+      renderSlot() {
+        this.shadowRoot.innerHTML = PANE_MARKUP;
+      }
+    }
+
+    customElements.define('late-slot-host', LateSlotHost);
+
+    const shadowHost = document.querySelector('[data-testid="host"]');
+    const detachedHost = document.querySelector('[data-testid="detached-host"]');
+    const status = document.querySelector('[data-testid="status"]');
+    const columns = ['id', 'campaign', 'region', 'owner', 'status', 'amount', 'currency', 'placement',
+      'start', 'end', 'impressions', 'clicks', 'rate', 'author', 'notes'];
+
+    // Set to `true` only when the container really had no layout boxes at
+    // construction time — the spec asserts it so a fixture regression cannot
+    // silently degrade the scenario into "build a grid in a sized div" and pass.
+    window.htWithoutLayoutAtInit = false;
+
+    let pendingAttach = null;
+
+    // Set by the spec before `buildGrid()` to add frozen rows, whose height records are kept apart
+    // from the ordinary ones and are wiped by the same correction pass.
+    window.htFrozenRows = false;
+
+
+    /**
+     * Builds the grid into a container that has no layout yet. `mode` selects how
+     * it is kept out of the layout, and the matching `attach()` puts it back in.
+     */
+    window.buildGrid = (mode) => {
+      const container = document.createElement('div');
+      let box = null;
+
+      container.className = `grid-root ht-theme-${window.htTheme}`;
+      container.setAttribute('data-testid', 'grid');
+
+      if (mode === 'unslotted') {
+        // The host has its shadow root but no `<slot>`, so the child it accepts
+        // is outside the flat tree and generates no boxes.
+        shadowHost.append(container);
+        pendingAttach = () => shadowHost.renderSlot();
+
+      } else if (mode === 'detached') {
+        box = document.createElement('div');
+        box.className = 'box';
+        box.append(container);
+        pendingAttach = () => detachedHost.append(box);
+
+      } else if (mode === 'hidden') {
+        box = document.createElement('div');
+        box.className = 'box';
+        box.style.display = 'none';
+        box.append(container);
+        detachedHost.append(box);
+        pendingAttach = () => {
+          box.style.display = '';
+        };
+
+      } else if (mode === 'laid-out') {
+        // The control: the same 600x260 box as `detached`, already in the layout before the grid is
+        // built, so nothing about it is provisional and no correction pass may engage. The box matters
+        // - a container left to fill the page width shows every column, so the holder has too little
+        // horizontal overflow for the spec's scroll to reach, and how much depends on the platform's
+        // font metrics.
+        box = document.createElement('div');
+        box.className = 'box';
+        box.append(container);
+        detachedHost.append(box);
+        pendingAttach = () => {};
+
+      } else {
+        throw new Error('Unknown build mode: ' + JSON.stringify(mode));
+      }
+
+      window.htWithoutLayoutAtInit = container.getClientRects().length === 0;
+
+      // No `width`/`height` setting: both are inherited from the container, which
+      // is what makes the holder the scrollable element once it has a size.
+      window.hot = new Handsontable(container, {
+        data: Array.from({ length: 200 }, (unused, row) => columns.reduce((rowData, column, columnIndex) => {
+          rowData[column] = column === 'id' ? row + 1 : `${column}-${row + 1}-${columnIndex}`;
+
+          return rowData;
+        }, {})),
+        colHeaders: columns,
+        columns: columns.map(column => ({ data: column })),
+        fixedColumnsStart: 2,
+        ...(window.htFrozenRows ? { fixedRowsTop: 2, fixedRowsBottom: 2 } : {}),
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+    };
+
+    /**
+     * Puts the grid's container into the layout the way its build mode requires.
+     */
+    window.attach = () => {
+      pendingAttach();
+      status.textContent = 'attached';
+    };
+
+    window.scrollGrid = (top, left) => {
+      const holder = window.hot.view._wt.wtTable.holder;
+
+      holder.scrollTop = top;
+      holder.scrollLeft = left;
+    };
+
+    /**
+     * Reports whether the overlays still hold a provisional answer for their scrolling element, which
+     * is what the correction pass clears when the layout settles.
+     */
+    window.readProvisionalLayout = () => window.hot.view._wt.wtOverlays.isScrollableElementProvisional;
+
+    /**
+     * Forces `count` full renders and reports the state after each, so a spec can tell a pass that
+     * settled from one that keeps re-running on every draw.
+     */
+    window.drawAndReadState = (count) => {
+      const states = [];
+
+      for (let draw = 0; draw < count; draw += 1) {
+        window.hot.render();
+        states.push({
+          provisional: window.readProvisionalLayout(),
+          holderScrollRange: window.hot.view._wt.wtTable.holder.scrollHeight,
+          renderedRows: window.hot.rootElement.querySelectorAll('.ht_master tbody tr').length,
+        });
+      }
+
+      return states;
+    };
+
+    /**
+     * Reports how far the frozen-column and column-header overlays sit from the
+     * cells they must stay aligned with, plus the size of the rendered row band.
+     */
+    window.readOverlayAlignment = () => {
+      const root = window.hot.rootElement;
+      const holder = window.hot.view._wt.wtTable.holder;
+      const masterRow = root.querySelector('.ht_master tbody tr');
+      const frozenRow = root.querySelector('.ht_clone_inline_start tbody tr');
+      const masterCell = root.querySelector('.ht_master tbody tr td:nth-child(5)');
+      const header = root.querySelector('.ht_clone_top thead th:nth-child(5)');
+
+      const rows = Array.from(root.querySelectorAll('.ht_master tbody tr'));
+      const lastRow = rows[rows.length - 1];
+      const rootBox = root.getBoundingClientRect();
+
+      return {
+        // Positive when the last painted row stops short of the container's bottom edge, which is
+        // the dead space that made the grid look like it still had rows to load.
+        deadSpaceBelowLastRow: lastRow
+          ? Math.round(rootBox.bottom - lastRow.getBoundingClientRect().bottom)
+          : Number.NaN,
+        holderScrollRange: holder.scrollHeight,
+        rowCount: window.hot.countRows(),
+        defaultRowHeight: window.hot.view._wt.wtSettings.getSetting('stylesHandler').getDefaultRowHeight(),
+        holderScrollTop: holder.scrollTop,
+        holderScrollLeft: holder.scrollLeft,
+        frozenColumnsOffset: masterRow && frozenRow
+          ? Math.abs(frozenRow.getBoundingClientRect().top - masterRow.getBoundingClientRect().top)
+          : Number.NaN,
+        columnHeadersOffset: masterCell && header
+          ? Math.abs(header.getBoundingClientRect().left - masterCell.getBoundingClientRect().left)
+          : Number.NaN,
+        renderedRows: root.querySelectorAll('.ht_master tbody tr').length,
+        scrollsWithWindow: window.hot.view.isVerticallyScrollableByWindow(),
+      };
+    };
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/unlaid-out-init.html
+++ b/tests/fixtures/demo/unlaid-out-init.html
@@ -42,7 +42,7 @@
     once at construction the overlays stayed bound to window scroll for the
     instance's whole life.
 
-    Two ways in, both taken by real applications:
+    Three ways in, all taken by real applications:
 
       detached   the container is built, the grid constructed into it, and only
                  then is it appended to the document. What a framework that
@@ -54,6 +54,12 @@
                  component framework does for a moment. Chromium returns the
                  empty declaration here since 151, aligning with the CSSOM
                  specification and with Firefox and Safari.
+
+      hidden     the container sits in a `display: none` box, as it does in a
+                 hidden tab or a closed modal. Its styles resolve, so its
+                 scrolling element was already right, but it generates no boxes
+                 - the correction engages on the geometry alone and must leave
+                 the grid just as correct on reveal.
 
     Nothing is built at parse time: the spec drives `buildGrid()` and `attach()`
     itself, so the window before the container joins the layout is exact instead

--- a/tests/fixtures/pages/MenuScrollPage.ts
+++ b/tests/fixtures/pages/MenuScrollPage.ts
@@ -131,6 +131,46 @@ export class MenuScrollPage {
       }, px);
   }
 
+  /**
+   * Measures the "filter by value" list: how many items it holds, how tall its rendered
+   * rows are, and the scroll range its holder reports.
+   *
+   * The list is a nested Handsontable built while the dropdown is still hidden, and its
+   * row height is derived from the theme variables rather than from the DOM, so the two
+   * can disagree — a list whose cells override `padding` directly ends up with a scroll
+   * range computed from a row height it does not have (DEV-2515).
+   */
+  async readFilterValueListMetrics(): Promise<{
+    itemCount: number, rowHeight: number, derivedRowHeight: number | null, scrollRange: number,
+  }> {
+    return this.page.evaluate(() => {
+      const hot = (window as unknown as {
+        hot: { getPlugin(name: string): {
+          components: Map<string, { getMultipleSelectElement(): { getItemsBox(): {
+            countRows(): number,
+            rootElement: HTMLElement,
+            view: { _wt: { wtSettings: { getSetting(name: string): {
+              getDefaultRowHeight(): number | null,
+            } } } },
+          } } }>,
+        } },
+      }).hot;
+      const list = hot.getPlugin('filters').components.get('filter_by_value')!
+        .getMultipleSelectElement().getItemsBox();
+      const holder = list.rootElement.querySelector('.ht_master .wtHolder') as HTMLElement;
+      // The second row, not the first: a table's first `tr` carries an extra border-top.
+      const rows = list.rootElement.querySelectorAll('.ht_master tbody tr');
+      const sampleRow = rows[1] ?? rows[0];
+
+      return {
+        itemCount: list.countRows(),
+        rowHeight: sampleRow ? Math.round(sampleRow.getBoundingClientRect().height) : 0,
+        derivedRowHeight: list.view._wt.wtSettings.getSetting('stylesHandler').getDefaultRowHeight(),
+        scrollRange: holder.scrollHeight,
+      };
+    });
+  }
+
   /** Scroll the window/page itself (must NOT close the menu). */
   async scrollPageBy(px: number): Promise<void> {
     await this.page.evaluate((delta) => {

--- a/tests/fixtures/pages/UnlaidOutInitPage.ts
+++ b/tests/fixtures/pages/UnlaidOutInitPage.ts
@@ -1,0 +1,223 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * How the fixture keeps the grid's container out of the layout while the grid is
+ * constructed: `detached` builds the subtree before appending it to the
+ * document, `unslotted` makes it a light-DOM child of a shadow host whose
+ * `<slot>` renders later.
+ */
+export type UnlaidOutMode = 'unslotted' | 'detached' | 'hidden' | 'laid-out';
+
+/**
+ * The overlay alignment read out of the fixture after a scroll.
+ */
+export interface OverlayAlignment {
+  deadSpaceBelowLastRow: number;
+  holderScrollRange: number;
+  rowCount: number;
+  defaultRowHeight: number | null;
+  holderScrollTop: number;
+  holderScrollLeft: number;
+  frozenColumnsOffset: number;
+  columnHeadersOffset: number;
+  renderedRows: number;
+  scrollsWithWindow: boolean;
+}
+
+/**
+ * State read after a forced render, used to tell a settled correction pass from
+ * one that re-runs on every draw.
+ */
+export interface DrawState {
+  provisional: boolean;
+  holderScrollRange: number;
+  renderedRows: number;
+}
+
+/**
+ * Page Object for the unlaid-out-init fixture (`unlaid-out-init.html`).
+ *
+ * The fixture builds the grid into a container that has no layout boxes yet, so
+ * the grid resolves its scrollable element against empty computed styles
+ * (DEV-2515). Nothing happens at navigation time — the spec drives
+ * `buildGrid()` and `attach()` so that window is exact.
+ */
+export class UnlaidOutInitPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly status: Locator;
+  readonly grid: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.status = page.getByTestId('status');
+    this.grid = page.getByTestId('grid');
+  }
+
+  /**
+   * Navigate to the fixture. Waits only for the document `load` event — the
+   * grid does not exist yet, so there is nothing to wait on in the DOM.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(`/tests/fixtures/demo/unlaid-out-init.html?theme=${this.theme}&bundle=${this.bundle}`);
+  }
+
+  /**
+   * Construct the grid while its container is still outside the layout.
+   *
+   * @param {UnlaidOutMode} mode How the container is kept out of the layout.
+   */
+  async buildGrid(mode: UnlaidOutMode): Promise<void> {
+    await this.page.evaluate(
+      buildMode => (window as unknown as { buildGrid(mode: string): void }).buildGrid(buildMode),
+      mode
+    );
+  }
+
+  /**
+   * Adds `fixedRowsTop` and `fixedRowsBottom` to the grid the next `buildGrid()`
+   * builds. Frozen rows keep their height records apart from the ordinary ones,
+   * and the correction pass wipes both.
+   */
+  async useFrozenRows(): Promise<void> {
+    await this.page.evaluate(() => {
+      (window as unknown as { htFrozenRows: boolean }).htFrozenRows = true;
+    });
+  }
+
+  /**
+   * Whether the overlays still hold a provisional answer for their scrolling
+   * element.
+   */
+  async readProvisionalLayout(): Promise<boolean> {
+    return this.page.evaluate(
+      () => (window as unknown as { readProvisionalLayout(): boolean }).readProvisionalLayout()
+    );
+  }
+
+  /**
+   * Forces `count` full renders and reports the state after each one.
+   *
+   * @param {number} count How many renders to force.
+   */
+  async drawAndReadState(count: number): Promise<DrawState[]> {
+    return this.page.evaluate(
+      drawCount => (window as unknown as { drawAndReadState(count: number): DrawState[] })
+        .drawAndReadState(drawCount),
+      count
+    );
+  }
+
+  /**
+   * Put the container into the layout - append the detached subtree, or render
+   * the host's `<slot>`.
+   */
+  async attach(): Promise<void> {
+    await this.page.evaluate(() => (window as unknown as { attach(): void }).attach());
+    await expect(this.status).toHaveText('attached');
+    await expect(this.grid.locator('.ht_master tbody td').first()).toBeVisible();
+  }
+
+  /**
+   * Scroll the grid's own holder and let the overlays follow.
+   *
+   * Polls until the holder reports the requested offsets. The grid resizes
+   * itself over a few frames after the container joins the layout, and until it
+   * does the holder does not scroll at all - a scroll that silently does nothing
+   * would leave every overlay trivially aligned and turn this into a false green.
+   */
+  async scrollGrid(top: number, left: number): Promise<void> {
+    await expect.poll(async () => this.page.evaluate(
+      ([scrollTop, scrollLeft]) => {
+        const api = window as unknown as {
+          scrollGrid(top: number, left: number): void,
+          readOverlayAlignment(): OverlayAlignment,
+        };
+
+        api.scrollGrid(scrollTop, scrollLeft);
+
+        return new Promise<[number, number]>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => {
+            const alignment = api.readOverlayAlignment();
+
+            resolve([alignment.holderScrollTop, alignment.holderScrollLeft]);
+          }));
+        });
+      },
+      [top, left]
+    )).toEqual([top, left]);
+  }
+
+  /**
+   * Waits until both overlay offsets settle within `tolerance` pixels, at a scroll
+   * position that is actually scrolled.
+   *
+   * The correction can redraw a frame after the container joins the layout, so a
+   * single sample can land mid-draw and read a transient offset. Polling removes
+   * that race.
+   *
+   * The scroll position is part of the polled value on purpose. Both offsets are
+   * trivially 0 at `scrollTop === 0`, so a future change that dropped the scroll
+   * offset - or a scroll that silently did nothing - would satisfy an assertion
+   * that only looked at the offsets.
+   *
+   * @param {number} expectedTop The holder scroll position the offsets must hold at.
+   * @param {number} expectedLeft The holder scroll position the offsets must hold at.
+   * @param {number} tolerance Largest offset, in pixels, still counted as aligned.
+   */
+  async expectOverlaysAligned(expectedTop: number, expectedLeft: number, tolerance = 1): Promise<void> {
+    await expect.poll(async () => {
+      const alignment = await this.readOverlayAlignment();
+
+      return {
+        holderScrollTop: alignment.holderScrollTop,
+        holderScrollLeft: alignment.holderScrollLeft,
+        aligned: Math.max(alignment.frozenColumnsOffset, alignment.columnHeadersOffset) <= tolerance
+      };
+    }).toEqual({ holderScrollTop: expectedTop, holderScrollLeft: expectedLeft, aligned: true });
+  }
+
+  /**
+   * Waits until the last painted row reaches the container's bottom edge, i.e. the
+   * grid fills the space it was given, and did not get there by rendering everything.
+   *
+   * Dead space at or below zero on its own is a false green: a grid that renders its
+   * whole data set - the pre-fix window-scroll state this is meant to catch - has
+   * strongly negative dead space and passes. The band size is what separates the two,
+   * so it is polled alongside. Dead space itself cannot be bounded from below,
+   * because overscan legitimately paints several rows past the container's edge.
+   *
+   * @param {number} maxRenderedRows Largest band, in rows, a filled viewport may have.
+   */
+  async expectContainerFilled(maxRenderedRows = 25): Promise<void> {
+    await expect.poll(async () => {
+      const { deadSpaceBelowLastRow, renderedRows } = await this.readOverlayAlignment();
+
+      return {
+        fills: deadSpaceBelowLastRow <= 0,
+        bandBounded: renderedRows > 0 && renderedRows <= maxRenderedRows
+      };
+    }).toEqual({ fills: true, bandBounded: true });
+  }
+
+  /**
+   * How far the frozen-column and column-header overlays sit from the cells they
+   * must stay aligned with, plus the size of the rendered row band.
+   */
+  async readOverlayAlignment(): Promise<OverlayAlignment> {
+    return this.page.evaluate(
+      () => (window as unknown as { readOverlayAlignment(): OverlayAlignment }).readOverlayAlignment()
+    );
+  }
+
+  /**
+   * Whether the container really had no layout boxes when the grid was built —
+   * proves the scenario was exercised rather than silently skipped.
+   */
+  async hadNoLayoutAtInit(): Promise<boolean> {
+    return this.page.evaluate(() => (window as unknown as { htWithoutLayoutAtInit: boolean }).htWithoutLayoutAtInit);
+  }
+}


### PR DESCRIPTION
### Context

The PR fixes a grid built into a container that is not in the layout yet binding its overlays to window scroll permanently, and measuring its sizes against nothing.

Such a container resolves `getComputedStyle()` to an empty declaration for itself and every ancestor — CSSOM behavior that Firefox and Safari always had and Chromium adopted in 151, which is what turned this into a field report. Two shapes reach it: a light-DOM child of a shadow host whose `<slot>` renders a tick later (the customer's Stencil component), and any subtree assembled before it is appended. Walkontable then finds no clipping or scrolling ancestor and binds the overlays to the window for the instance's life: column headers and frozen columns stop following the body, virtualization renders the whole data set, and the row heights are recorded at values the rows never had. Only `updateSettings({})` repaired it.

The fix:

1. **Engine** — `ScrollSync` marks its answer provisional when the table is not rendered; `Overlays#afterDraw` settles it. The pass resolves before rebinding anything and stops retrying when the answer repeats, because `getTrimmingContainer` and `getScrollableElement` can disagree permanently (a table in an iframe driven from the parent realm does). The stale sizes are marked, not dropped: `Overlays#beforeDraw` drops them on the way into the next draw that renders cells, so reset, re-measure and resize run in the documented order.
2. **Core** — `StylesHandler` records whether its caching pass ran against unresolved styles and re-reads on request; `TableView#beforeRender` asks that instead of keying off the `null` row height, which is a state that never resolves on a page with no grid stylesheet.
3. **CSS** — `_filters.scss` declares the by-value list's shorter cells through `--ht-cell-vertical-padding` instead of writing `padding` onto the `td`, so the derived row height matches what the cells render at. Rendered pixels unchanged.

Measured against develop, only the two target shapes change; a grid laid out from the start is identical, down to render and cache-invalidation counts. Nothing is added to `Handsontable.dom`, and no setting, hook, default, i18n file, wrapper or `.d.ts` is touched.

### How has this been tested?

New Playwright suite `tests/e2e/unlaid-out-init-scroll-sync.spec.ts` (fixture + page object): `detached` and `unslotted` construction plus a laid-out control, covering overlay alignment through a scroll, the container filling with no interaction, the pass settling for good, and a `fixedRowsTop`/`fixedRowsBottom` leg. `tests/e2e/filters-value-list-scroll-range.spec.ts` guards the list invariant. New unit specs pin the engine contract (`scrollSync.unit.ts`), the styles-handler transition, and the geometry port; the engine ones were mutation-checked in both directions.

```bash
cd tests && npx playwright test --project=e2e-main e2e/unlaid-out-init-scroll-sync.spec.ts
npm run test:unit --prefix handsontable -- --testPathPattern="scrollSync|stylesHandler|liveGeometryReader"
```

| Suite | Result |
| --- | --- |
| `eslint` / `stylelint` | 0 errors |
| `test:unit` | 3577 / 300 suites |
| `test:walkontable` | 816 specs, 0 failures |
| `test:e2e` (Jasmine) | 9627 specs, 0 failures |
| Playwright `e2e-main` | 287 passed |

`fill-handle-formulas` fails locally here and on a clean develop — it needs `tests/node_modules/hyperformula`.

**Argos**: build 5836's 8 changed `filters/entering-and-escaping-by-value-lists` frames are part 3's doing; the branch now matches released 18.0.0 exactly (393px range for 392px of content), so the next build should be clean.

Follow-ups filed separately: the narrow-container `AutoColumnSize` variant, and the menu tokens (`--ht-menu-item-vertical-padding`) carrying the same shape as part 3.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2515

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86cb0yqcx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches overlay scroll binding, the draw cycle, and row-height/width caches. A mistake here can misalign frozen panes, bind to window scroll, or leave a wrong scroll range for the instance lifetime.
> 
> **Overview**
> Grids built into a container that is not in the layout yet (detached subtree, unslotted light DOM, or `display: none`) no longer stay bound to **window scroll** or keep row heights measured against nothing. Frozen headers/columns follow the body, virtualization stays viewport-sized, and the grid fills its container without a click.
> 
> **Engine:** `ScrollSync` marks the scrollable element provisional when `isRendered()` is false, then `Overlays#afterDraw` settles it on a full draw. Retries stop when the answer repeats (iframe / `overflow: hidden` disagreement). Stale oversized-row and column-width records are dropped on the *next* cell-rendering draw, not in the settle frame.
> 
> **Core:** `StylesHandler` recaches theme variables that were read against empty computed styles; `TableView#render` drops derived sizes *before* `_wt.draw()` so that draw’s calculators use the real default row height.
> 
> **CSS:** Filter-by-value list padding now comes from `--ht-cell-vertical-padding` so derived row height matches the cells (scroll range no longer overshoots).
> 
> Covered by Playwright suites for unlaid-out init and the filter list, plus unit tests for `ScrollSync`, `StylesHandler`, and `LiveGeometryReader`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baa9b37f00245e7878fed61ef6362b7448b5207c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->