### PR TITLE
DEV-2573: Point README live-demo badges at demos.handsontable.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You can also use [Yarn](https://yarnpkg.com/package/handsontable), [NuGet](https
 
   ```
 
-[![Static Badge](https://img.shields.io/badge/Live%20demo%20on%20StackBlitz-1a42e8?style=for-the-badge)](https://stackblitz.com/edit/handsontable-readme-example?file=src%2Fmain.js)
+[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/d/363m496zr4/)
 
 ### CDN-based setup
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You can also use [Yarn](https://yarnpkg.com/package/handsontable), [NuGet](https
 
   ```
 
-[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/d/363m496zr4/)
+[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/?example=javascript)
 
 ### CDN-based setup
 

--- a/handsontable/README.md
+++ b/handsontable/README.md
@@ -114,7 +114,7 @@ You can also use [Yarn](https://yarnpkg.com/package/handsontable), [NuGet](https
 
   ```
 
-[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/d/363m496zr4/)
+[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/?example=javascript)
 
 ### CDN-based setup
 

--- a/handsontable/README.md
+++ b/handsontable/README.md
@@ -114,7 +114,7 @@ You can also use [Yarn](https://yarnpkg.com/package/handsontable), [NuGet](https
 
   ```
 
-[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://handsontable.com/docs/demo/)
+[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/d/363m496zr4/)
 
 ### CDN-based setup
 

--- a/wrappers/angular-wrapper/README.md
+++ b/wrappers/angular-wrapper/README.md
@@ -128,7 +128,7 @@ export class HotTableWrapperComponent {
 }
 ```
 
-[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/?example=angular&v=18.0.0)
+[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/?example=angular)
 
 </div>
 

--- a/wrappers/angular-wrapper/README.md
+++ b/wrappers/angular-wrapper/README.md
@@ -128,7 +128,7 @@ export class HotTableWrapperComponent {
 }
 ```
 
-[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://handsontable.com/docs/angular-data-grid/demo)
+[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/?example=angular&v=18.0.0)
 
 </div>
 

--- a/wrappers/react-wrapper/README.md
+++ b/wrappers/react-wrapper/README.md
@@ -116,7 +116,7 @@ const ExampleComponent = () => {
 };
 ```
 
-[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://handsontable.com/docs/react-data-grid/demo)
+[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/d/5x45f1o3qn/)
 
 </div>
 

--- a/wrappers/react-wrapper/README.md
+++ b/wrappers/react-wrapper/README.md
@@ -116,7 +116,7 @@ const ExampleComponent = () => {
 };
 ```
 
-[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/d/5x45f1o3qn/)
+[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/?example=react-js)
 
 </div>
 

--- a/wrappers/vue3/README.md
+++ b/wrappers/vue3/README.md
@@ -130,7 +130,7 @@ Use this data grid as you would any other component in your application. [Option
 </script>
 ```
 
-[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/d/3g3uq4y44y/)
+[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/?example=vue)
 
 </div>
 

--- a/wrappers/vue3/README.md
+++ b/wrappers/vue3/README.md
@@ -130,7 +130,7 @@ Use this data grid as you would any other component in your application. [Option
 </script>
 ```
 
-[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://handsontable.com/docs/javascript-data-grid/vue3-basic-example/)
+[![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://demos.handsontable.com/d/3g3uq4y44y/)
 
 </div>
 


### PR DESCRIPTION
### Context

The PR changes every README's "Live demo" badge to point at [demos.handsontable.com](https://demos.handsontable.com), our own demo runner, instead of StackBlitz and the docs demo pages. demos.handsontable.com is now the canonical destination for live demos, so the public face of each package should link there.

Each badge points at the corresponding example in [handsontable/examples](https://github.com/handsontable/examples), which the runner serves directly through its `?example=<folder>` deep link. These are the same general-purpose feature-tour demos that power `handsontable.com/docs/demo` — they are maintained in that repository, tracked in git, and reviewed like any other code, so a README link cannot be broken by someone editing a saved demo.

Five READMEs carry a live-demo badge — one more than the task listed. `handsontable/README.md` is a separate, divergent file from the root `README.md`, and it is the one npm publishes for the `handsontable` package, so it had its own badge pointing somewhere else again.

| README | Was | Now | Example source |
| --- | --- | --- | --- |
| `README.md` (GitHub landing page) | StackBlitz (`handsontable-readme-example`) | https://demos.handsontable.com/?example=javascript | [`examples/javascript`](https://github.com/handsontable/examples/tree/master/examples/javascript) |
| `handsontable/README.md` (npm `handsontable`) | `handsontable.com/docs/demo/` | https://demos.handsontable.com/?example=javascript | [`examples/javascript`](https://github.com/handsontable/examples/tree/master/examples/javascript) |
| `wrappers/react-wrapper/README.md` | `handsontable.com/docs/react-data-grid/demo` | https://demos.handsontable.com/?example=react-js | [`examples/react-js`](https://github.com/handsontable/examples/tree/master/examples/react-js) |
| `wrappers/vue3/README.md` | `handsontable.com/docs/javascript-data-grid/vue3-basic-example/` | https://demos.handsontable.com/?example=vue | [`examples/vue`](https://github.com/handsontable/examples/tree/master/examples/vue) |
| `wrappers/angular-wrapper/README.md` | `handsontable.com/docs/angular-data-grid/demo` | https://demos.handsontable.com/?example=angular | [`examples/angular`](https://github.com/handsontable/examples/tree/master/examples/angular) |

`react-js` was chosen over `react` because the React wrapper README's snippet is JSX, and `react-js` is the JavaScript variant — it uses `HotTable` with `HotColumn` children exactly as the README shows. Both variants exist and both work.

No `v=` parameter is pinned on any of the five links. The runner resolves the current release itself and rewrites the URL (`?example=javascript` became `?example=javascript&v=18.0.0` on load), and every example in the repository depends on `handsontable@latest`. Pinning would mean bumping five READMEs on every release for no benefit.

The badge label was `Live demo on StackBlitz` in the root README; it is now `View live demo`, matching the other four. No `stackblitz` reference remains in any README (`git grep -in stackblitz -- '*README.md'` is empty).

### How has this been tested?

Docs-only change; no source touched, so no unit or E2E tests apply. Both CI gates pass by path: `.github/scripts/lib/changelog-gate.mjs` and `presence-gate.mjs` both exclude `.md`, so this needs neither a changelog entry nor a test.

Every link was opened in a real browser and confirmed to render a working Handsontable grid — the JavaScript, React and Vue 3 examples bundle in-browser; the Angular one runs a container dev server and was given time to finish booting.

```bash
# all five distinct URLs return 200
for e in javascript react-js vue angular; do
  printf "%-12s " "$e"
  curl -s -o /dev/null -w "%{http_code}\n" "https://demos.handsontable.com/?example=$e"
done

# no stale StackBlitz links remain in any README
git grep -in stackblitz -- '*README.md'
```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2573

### Affected project(s):

- [x] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [x] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

### Follow-up, not in this PR

The task asked whether the same StackBlitz link appears in docs pages or npm package descriptions. It does not — but StackBlitz shows up in the docs site in two places that are **features, not stale links**, and migrating either is its own task:

1. **"Edit on StackBlitz" on every docs example** — `docs/public/example-tabs.js` plus the `framework-loader` docs plugin (`parseDocsExampleHtmlForStackBlitz`, `mergeCompanionHtmlForStackBlitz`). This is the interactive-editing affordance for all framework tabs across the docs. Worth noting that the runner already serves every docs-guide example under its own `?docs=<content-path>` route, so a migration path exists.
2. **"Open in StackBlitz" in the AI theme builder guide** — `docs/content/guides/ai-tools/ai-theme-builder/ai-theme-builder.md`, which documents a button rendered by the theme builder itself.

Also checked and found clean: no separate React 19 / Vue 2 / Angular wrapper repositories exist in the `handsontable` org — every wrapper lives in this monorepo, so there are no other wrapper READMEs to update. The `CHANGELOG.md` and `changelog-14` docs pages mention StackBlitz in historical entries and were deliberately left alone. HyperFormula has its own StackBlitz links, which are a different product and out of scope.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2573

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1eb0efe3bd8657060d2daf71cf2496276f7276e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->