### PR TITLE
DEV-2578: Compose preview packages with the release packaging script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,10 @@ jobs:
           npm run build:umd.min
           npm run build:languages
           npm run build:languages.min
+          # dist/themes/** comes only from these two tasks. Without them the artifact
+          # is not the full UMD output, and the preview package ships no theme bundles.
+          npm run build:themes-umd
+          npm run build:themes-umd.min
       - run: tar -zcf dist.tar.gz ./handsontable/dist ./handsontable/styles
       - name: Upload the Handsontable UMD build artifact.
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # https://github.com/actions/upload-artifact/releases/tag/v7.0.0
@@ -76,7 +80,10 @@ jobs:
           npm run build:languages.es
           npm run build:languages
           npm run build:languages.min
-          npm run postbuild
+          # This job composes an intentionally incomplete tree (no UMD dist/, no
+          # theme CSS), so it opts out of the strict packaging checks. It is the
+          # only site allowed to do so — see prepare-package-for-publish.mjs.
+          npm run postbuild:partial
       - run: tar -zcf tmp.tar.gz ./handsontable/tmp
       - name: Upload the Handsontable ES + CJS build artifact.
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # https://github.com/actions/upload-artifact/releases/tag/v7.0.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -117,16 +117,18 @@ jobs:
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # https://github.com/actions/download-artifact/releases/tag/v8.0.0
         with:
           name: handsontable-build-umd
-      - name: Merge dist and styles into the preview package
+      # `npm run postbuild` (prepare-package-for-publish) does the merging itself:
+      # it copies the `handsontable.copy` list into tmp/ AND regenerates the exports
+      # map from the merged tree. It must run here, after the UMD dist/ and the theme
+      # CSS land — the map baked into the es-cjs artifact was globbed when only the
+      # base stylesheet existed, so copying the files in by hand shipped stylesheets
+      # that resolved with ERR_PACKAGE_PATH_NOT_EXPORTED (DEV-2578). Wrappers link
+      # against handsontable/tmp, so this precedes the wrapper build.
+      - name: Compose the preview package
         if: env.HOT_PREBUILT == 'true'
         run: |
           tar -zxf dist.tar.gz ./handsontable/dist ./handsontable/styles && rm dist.tar.gz
-          rm -rf handsontable/tmp/dist
-          cp -R handsontable/dist handsontable/tmp/dist
-          # Merge the CSS into tmp/styles instead of replacing the directory —
-          # tmp/styles also holds the generated handsontableStyles.{js,mjs,d.ts}
-          # module that utils/stylesHandler imports at runtime.
-          cp -R handsontable/styles/. handsontable/tmp/styles/
+          cd handsontable && npm run postbuild
       - name: Build wrapper packages (handsontable prebuilt)
         if: env.HOT_PREBUILT == 'true'
         run: npm run all build -- --e examples visual-tests handsontable

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -68,7 +68,9 @@ jobs:
             npm run in handsontable build:languages
             npm run in handsontable build:languages.min
           fi
-          npm run in handsontable postbuild
+          # Composes a tree for the screenshot runs, not for publishing (no theme UMD
+          # bundles on the fallback path), so it skips the packaging checks.
+          npm run in handsontable postbuild:partial
 
       - name: Download the Angular wrapper build artifact
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # https://github.com/actions/download-artifact/releases/tag/v8.0.0

--- a/handsontable/package.json
+++ b/handsontable/package.json
@@ -51,6 +51,7 @@
     "watch": "node scripts/run.mjs --sequential watch",
     "build": "node scripts/run.mjs --parallel build",
     "postbuild": "node scripts/run.mjs prepare-package-for-publish",
+    "postbuild:partial": "node scripts/run.mjs prepare-package-for-publish.partial",
     "build:sequential": "node scripts/run.mjs --sequential build",
     "build:commonjs": "node scripts/run.mjs build:commonjs",
     "build:es": "node scripts/run.mjs build:es",

--- a/handsontable/scripts/prepare-package-for-publish.mjs
+++ b/handsontable/scripts/prepare-package-for-publish.mjs
@@ -26,6 +26,7 @@ const {
  */
 const IS_PARTIAL = process.argv.includes('--partial');
 const COMPLETENESS_ERRORS = [];
+const COPY_DESTINATIONS = [];
 
 /**
  * Report a file that the package definition promises but the composed tree does not hold.
@@ -95,16 +96,23 @@ FILES_TO_COPY.forEach((fileToCopy) => {
 
     const to = path.resolve(`${TARGET_PATH}${file.replace('../', '')}`);
 
+    COPY_DESTINATIONS.push(to);
+
     if (fse.existsSync(from)) {
       fse.copySync(from, to, { overwrite: true });
-
-      if (!fse.existsSync(to)) {
-        reportIncompleteness(`The copied file or directory did not land in the package: ${to}`);
-      }
     } else {
-      reportIncompleteness(`The copy source file or directory does not exist: ${from}`);
+      // Not an error on its own: a caller may compose from artifacts that already carry the
+      // entry (the preview job extracts a `tmp/` built elsewhere). What the package holds is
+      // checked below, on the destination side.
+      displayWarningMessage(`The copy source file or directory does not exist: ${from}`);
     }
   });
+});
+
+COPY_DESTINATIONS.forEach((destination) => {
+  if (!fse.existsSync(destination)) {
+    reportIncompleteness(`The package does not hold a file the copy list declares: ${destination}`);
+  }
 });
 
 /**

--- a/handsontable/scripts/prepare-package-for-publish.mjs
+++ b/handsontable/scripts/prepare-package-for-publish.mjs
@@ -14,6 +14,33 @@ const {
 } = handsontable;
 
 /**
+ * The script composes the publishable package tree for every channel – the npm release, the
+ * `next`/`experimental` builds and the pkg.pr.new previews - so `handsontable.copy` and
+ * `handsontable.exports` are the single definition of what that tree holds and how it is
+ * addressed. By default the script enforces that definition and fails on an incomplete tree.
+ *
+ * `--partial` downgrades the completeness checks to warnings. Exactly one caller composes an
+ * intentionally incomplete tree (the ES + CJS build job, which runs before the UMD bundles and
+ * the theme stylesheets exist); everything else must build the whole package. Skipping the
+ * checks is what let a preview package ship 18 stylesheets with 2 of them in the exports map.
+ */
+const IS_PARTIAL = process.argv.includes('--partial');
+const COMPLETENESS_ERRORS = [];
+
+/**
+ * Report a file that the package definition promises but the composed tree does not hold.
+ *
+ * @param {string} message The message to be reported.
+ */
+function reportIncompleteness(message) {
+  if (IS_PARTIAL) {
+    displayWarningMessage(message);
+  } else {
+    COMPLETENESS_ERRORS.push(message);
+  }
+}
+
+/**
  * Generate thin .d.mts wrapper files for every .d.ts so the `import` condition
  * in the exports map can reference explicitly-ESM type declarations.
  *
@@ -26,7 +53,7 @@ const {
  * files handle all internal resolution under their own CJS context.
  *
  * This step runs here (not only in downlevel-dts.mjs) because CI may call
- * `npm run postbuild` after partial build steps without running downlevel:types.
+ * `npm run postbuild:partial` after partial build steps without running downlevel:types.
  */
 glob.sync('./**/*.d.ts', { cwd: TARGET_PATH, nodir: true }).forEach((dtsFile) => {
   const mtsPath = path.resolve(TARGET_PATH, dtsFile.replace(/\.d\.ts$/, '.d.mts'));
@@ -70,8 +97,12 @@ FILES_TO_COPY.forEach((fileToCopy) => {
 
     if (fse.existsSync(from)) {
       fse.copySync(from, to, { overwrite: true });
+
+      if (!fse.existsSync(to)) {
+        reportIncompleteness(`The copied file or directory did not land in the package: ${to}`);
+      }
     } else {
-      displayWarningMessage(`The copy source file or directory does not exist: ${from}`);
+      reportIncompleteness(`The copy source file or directory does not exist: ${from}`);
     }
   });
 });
@@ -96,6 +127,10 @@ const groupedExports = EXPORTS_RULES.flatMap((rule) => {
 
   const rules = {};
   const foundFiles = glob.sync(`${rule}`, { cwd: TARGET_PATH, nodir: true });
+
+  if (foundFiles.length === 0) {
+    reportIncompleteness(`The exports rule matches no file in "${TARGET_PATH}": ${rule}`);
+  }
 
   foundFiles.forEach((filePath) => {
     if (!filePath.startsWith('./dist/') && regexpJSFiles.test(filePath)) {
@@ -170,6 +205,17 @@ if (EXPORTS_ERRORS.length > 0) {
   const FILES_LIST = `${EXPORTS_ERRORS.map(msg => `- ${msg}`).join('\n')}`;
 
   displayErrorMessage(`The following exports point to the non-existing files:\n${FILES_LIST}`);
+  process.exit(1);
+}
+
+if (COMPLETENESS_ERRORS.length > 0) {
+  const FILES_LIST = `${COMPLETENESS_ERRORS.map(msg => `- ${msg}`).join('\n')}`;
+
+  displayErrorMessage(
+    `The composed package is incomplete:\n${FILES_LIST}\n\n` +
+    'Build the missing artifacts, or run `npm run postbuild:partial` if this tree is ' +
+    'intentionally incomplete.'
+  );
   process.exit(1);
 }
 

--- a/handsontable/scripts/tasks.json
+++ b/handsontable/scripts/tasks.json
@@ -8,6 +8,11 @@
       "cmd": "node scripts/prepare-package-for-publish.mjs",
       "deps": []
     },
+    "prepare-package-for-publish.partial": {
+      "cmd": "node scripts/prepare-package-for-publish.mjs --partial",
+      "deps": [],
+      "note": "Composes the package without the strict completeness checks. Only the ES + CJS build job may use it – it runs before the UMD bundles and the theme stylesheets exist."
+    },
 
     "build:styles": {
       "cmd": "cross-env-shell BABEL_ENV=commonjs NODE_ENV=styles-development env-cmd -f ../hot.config.js rspack",

--- a/handsontable/test/__tests__/previewPackaging.unit.js
+++ b/handsontable/test/__tests__/previewPackaging.unit.js
@@ -70,17 +70,34 @@ describe('preview package composition', () => {
       expect(umdJob).toContain('npm run build:themes-umd.min\n');
     });
 
-    it('should keep the ES + CJS job the only caller that skips the packaging checks', () => {
-      // That job composes a tree without the UMD bundles and the theme stylesheets on purpose. Any
-      // other opt-out means an incomplete package can be published without CI saying a word.
+    it('should compose a publishable package only where the whole package exists', () => {
+      // Both directions matter. A job composing a partial tree with the strict script fails on
+      // every run; a job composing the published tree with the partial script publishes whatever
+      // happens to be there. Both are spelled out, so a new call site has to pick one on purpose.
       const workflowsPath = resolve(__dirname, '../../../.github/workflows');
-      const callers = fse.readdirSync(workflowsPath)
-        .filter(fileName => fileName.endsWith('.yml'))
-        .filter(fileName => readRepoFile(`.github/workflows/${fileName}`).includes('postbuild:partial'));
+      const callers = { strict: [], partial: [] };
 
-      expect(callers).toEqual(['build.yml']);
-      expect(extractJob(readRepoFile('.github/workflows/build.yml'), 'es-cjs'))
-        .toContain('npm run postbuild:partial');
+      fse.readdirSync(workflowsPath)
+        .filter(fileName => fileName.endsWith('.yml'))
+        .forEach((fileName) => {
+          const steps = readRepoFile(`.github/workflows/${fileName}`)
+            .split('\n')
+            .filter(line => !/^\s*#/.test(line));
+
+          steps.forEach((line) => {
+            if (/\bpostbuild:partial\b/.test(line)) {
+              callers.partial.push(fileName);
+            } else if (/\bpostbuild\b/.test(line)) {
+              callers.strict.push(fileName);
+            }
+          });
+        });
+
+      // Only the preview publish composes a complete package.
+      expect(callers.strict).toEqual(['integration.yml']);
+      // The ES + CJS build runs before the UMD bundles and the theme stylesheets exist; the
+      // visual runs compose a tree for screenshots that never reaches a registry.
+      expect(callers.partial.sort()).toEqual(['build.yml', 'visual.yml']);
     });
 
     it('should compose the preview package after the artifacts land and before the publish', () => {

--- a/handsontable/test/__tests__/previewPackaging.unit.js
+++ b/handsontable/test/__tests__/previewPackaging.unit.js
@@ -1,0 +1,154 @@
+import { spawnSync } from 'child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { resolve, join } from 'path';
+
+import fse from 'fs-extra';
+
+const SCRIPT_PATH = resolve(__dirname, '../../scripts/prepare-package-for-publish.mjs');
+
+const readRepoFile = relativePath => readFileSync(resolve(__dirname, '../../../', relativePath), 'utf8');
+
+/**
+ * Extract a single job's YAML block from a workflow file.
+ *
+ * @param {string} workflow The workflow file content.
+ * @param {string} jobId The job key to extract.
+ * @returns {string}
+ */
+function extractJob(workflow, jobId) {
+  const match = workflow.match(new RegExp(`\\n {2}${jobId}:\\n([\\s\\S]*?)(?=\\n {2}[a-z][\\w-]*:\\n|$)`));
+
+  expect(match).not.toBeNull();
+
+  // Comments describe the steps in the same words the steps use, so they are dropped before any
+  // step ordering is read off the text.
+  return match[1].split('\n').filter(line => !/^\s*#/.test(line)).join('\n');
+}
+
+/**
+ * Compose a throwaway package tree and run the packaging script against it.
+ *
+ * @param {object} handsontableConfig The `handsontable` key of the fixture package.json.
+ * @param {object} tmpFiles A map of `tmp/`-relative paths to file contents.
+ * @param {string[]} args Extra CLI arguments for the script.
+ * @returns {{ status: number, output: string }}
+ */
+function runOnFixture(handsontableConfig, tmpFiles, args = []) {
+  const cwd = mkdtempSync(join(tmpdir(), 'hot-packaging-'));
+
+  try {
+    fse.writeJsonSync(join(cwd, 'package.json'), {
+      name: 'handsontable-fixture',
+      handsontable: handsontableConfig,
+    });
+
+    Object.entries(tmpFiles).forEach(([filePath, content]) => {
+      fse.outputFileSync(join(cwd, 'tmp', filePath), content);
+    });
+
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, ...args], { cwd, encoding: 'utf8' });
+
+    return {
+      status: result.status,
+      output: `${result.stdout}${result.stderr}`,
+    };
+
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+describe('preview package composition', () => {
+  describe('CI wiring', () => {
+    it('should build the theme UMD bundles in the UMD job', () => {
+      // dist/themes/** is emitted only by these two tasks. Without them the UMD artifact is not
+      // the full UMD output, and every package composed from it ships no theme bundles.
+      const umdJob = extractJob(readRepoFile('.github/workflows/build.yml'), 'umd');
+
+      expect(umdJob).toContain('npm run build:themes-umd\n');
+      expect(umdJob).toContain('npm run build:themes-umd.min\n');
+    });
+
+    it('should keep the ES + CJS job the only caller that skips the packaging checks', () => {
+      // That job composes a tree without the UMD bundles and the theme stylesheets on purpose. Any
+      // other opt-out means an incomplete package can be published without CI saying a word.
+      const workflowsPath = resolve(__dirname, '../../../.github/workflows');
+      const callers = fse.readdirSync(workflowsPath)
+        .filter(fileName => fileName.endsWith('.yml'))
+        .filter(fileName => readRepoFile(`.github/workflows/${fileName}`).includes('postbuild:partial'));
+
+      expect(callers).toEqual(['build.yml']);
+      expect(extractJob(readRepoFile('.github/workflows/build.yml'), 'es-cjs'))
+        .toContain('npm run postbuild:partial');
+    });
+
+    it('should compose the preview package after the artifacts land and before the publish', () => {
+      const previewJob = extractJob(readRepoFile('.github/workflows/integration.yml'), 'preview-packages');
+      const extractIndex = previewJob.indexOf('tar -zxf dist.tar.gz');
+      const composeIndex = previewJob.indexOf('npm run postbuild');
+      const publishIndex = previewJob.indexOf('pkg-pr-new publish');
+
+      expect(extractIndex).toBeGreaterThan(-1);
+      expect(composeIndex).toBeGreaterThan(extractIndex);
+      expect(publishIndex).toBeGreaterThan(composeIndex);
+    });
+
+    it('should not touch the composed package after the composition step', () => {
+      // The exports map describes the tree as it looked when the script ran. Copying files in
+      // afterwards is what shipped previews whose theme stylesheets were absent from the map.
+      const previewJob = extractJob(readRepoFile('.github/workflows/integration.yml'), 'preview-packages');
+      const afterCompose = previewJob.slice(
+        previewJob.indexOf('npm run postbuild'),
+        previewJob.indexOf('pkg-pr-new publish')
+      );
+
+      expect(afterCompose).not.toMatch(/\b(cp|mv|rsync)\b[^\n]*handsontable\/tmp/);
+    });
+  });
+
+  describe('completeness checks', () => {
+    const EXPORTS_ONE_RULE = ['./styles/**/*.+(css)'];
+
+    it('should fail when a copied file or directory is missing', () => {
+      const { status, output } = runOnFixture(
+        { copy: ['dist/themes'], exports: EXPORTS_ONE_RULE, fields: ['name'] },
+        { 'styles/ht-theme-main.css': '' }
+      );
+
+      expect(status).toBe(1);
+      expect(output).toContain('dist/themes');
+      expect(output).toContain('postbuild:partial');
+    });
+
+    it('should fail when an exports rule matches no file', () => {
+      const { status, output } = runOnFixture(
+        { copy: [], exports: EXPORTS_ONE_RULE, fields: ['name'] },
+        { 'index.js': '' }
+      );
+
+      expect(status).toBe(1);
+      expect(output).toContain('./styles/**/*.+(css)');
+    });
+
+    it('should pass on a complete tree', () => {
+      const { status } = runOnFixture(
+        { copy: [], exports: EXPORTS_ONE_RULE, fields: ['name'] },
+        { 'styles/ht-theme-main.css': '' }
+      );
+
+      expect(status).toBe(0);
+    });
+
+    it('should downgrade the checks to warnings in the partial mode', () => {
+      const { status, output } = runOnFixture(
+        { copy: ['dist/themes'], exports: EXPORTS_ONE_RULE, fields: ['name'] },
+        { 'index.js': '' },
+        ['--partial']
+      );
+
+      expect(status).toBe(0);
+      expect(output).toContain('WARNING');
+    });
+  });
+});


### PR DESCRIPTION
### Context

The PR fixes the pkg.pr.new preview packages, which shipped an `exports` map generated **before** the theme stylesheets and the UMD bundles were merged into the package. `import 'handsontable/styles/ht-theme-main.min.css'` against any PR build failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` even though the file was in the tarball, and no preview carried `dist/themes/` bundles at all. Any demo, repro or integration test pinned to a PR preview could not load a theme through the package, so a PR's visual changes could not be shown.

Measured before the fix — preview for PR #13201 vs. the published `handsontable@experimental`:

| tree | export keys | theme + icon CSS keys | `dist/themes` files |
|---|---|---|---|
| npm `experimental` `0.0.0-next-dca019a-20260820` | 271 | 16 | 34 |
| pkg.pr.new 13201 | 217 | 0 | 0 |

Two independent causes, both in CI:

1. **A stale map.** `build.yml`'s `es-cjs` job runs `npm run postbuild` while `styles/` holds only the base stylesheet and `dist/` only `languages/`. That map is frozen into the artifact. The preview job then copied the real `dist/` and `styles/` over the extracted tree with `cp -R` and published — files arrived, entries did not.
2. **No theme bundles anywhere.** `dist/themes/**` is emitted only by `build:themes-umd` / `build:themes-umd.min`, which are in the `build` pipeline but were not in the UMD job, so `handsontable-build-umd` — the only artifact in the repo carrying `handsontable/dist` — never held them.

Nothing reported either, because `prepare-package-for-publish.mjs` validated one direction only (map entry → file exists) and merely warned when a `handsontable.copy` source was missing.

The fix is structural rather than a patch on the copy commands: the preview job now composes the package with the same script the release uses, and that script enforces the package definition instead of silently accepting an incomplete tree.

- **`prepare-package-for-publish.mjs` is strict by default.** It fails when a `handsontable.copy` source does not exist, when a copied entry did not land in `tmp/`, or when a string rule in `handsontable.exports` matches no file. `--partial` downgrades those three to warnings.
- **`build.yml`** — the `umd` job builds `build:themes-umd` and `build:themes-umd.min`, so the artifact matches the release definition of the UMD output for all of its consumers. The `es-cjs` job composes an intentionally incomplete tree and is the single caller allowed to opt out, through the new `postbuild:partial` script; a unit test keeps it the only one.
- **`integration.yml`** — the preview job drops the hand-rolled merge and runs `npm run postbuild` after the artifacts land and before the publish. The script copies the `handsontable.copy` list *and* regenerates the map from the merged tree.

After the change the preview and release packages come out of the same composer under the same rules. As a side effect the preview stops shipping `dist/hyperformula/**` and `handsontable.js.map`, which the release copy list excludes.

Out of scope, worth a follow-up: `emitted-types.yml` keeps a hand-rolled merge that does `rm -rf handsontable/tmp/styles` before copying, which deletes the generated `handsontableStyles.{js,mjs}` module. Harmless there today — that job only typechecks emitted declarations.

### How has this been tested?

**Composed tree matches the published package exactly.** After a full local build, the composed `handsontable/tmp/` file list was compared with the `handsontable@experimental` tarball: **3492 files on both sides, identical set**. The regenerated map reports 271 export keys, 16 theme/icon CSS keys and 34 `dist/themes` keys — the same numbers as the published package, against 217 / 0 / 0 in the current preview.

```bash
npm run build --prefix handsontable
node -e "const k=Object.keys(require('./handsontable/tmp/package.json').exports); console.log(k.length, k.filter(x=>/ht-theme|ht-icon/.test(x)).length, k.filter(x=>x.includes('dist/themes')).length)"
# 271 16 34
```

**The strict checks were exercised against a real incomplete tree**, not only fixtures:

```bash
mv handsontable/dist/themes /tmp/themes-bak
npm run postbuild --prefix handsontable          # exit 1: "The composed package is incomplete: … dist/themes"
npm run postbuild:partial --prefix handsontable  # exit 0, warning only
mv /tmp/themes-bak handsontable/dist/themes
npm run postbuild --prefix handsontable          # exit 0
```

**Automated:**

- New `handsontable/test/__tests__/previewPackaging.unit.js` — 8 tests. Four assert the CI wiring (the UMD job builds the theme bundles; `build.yml` is the only workflow using `postbuild:partial`; the preview job composes after the artifacts land and before the publish; nothing copies into `handsontable/tmp` afterwards). Four exercise the strict and partial modes against throwaway package trees.
- `npm run test:unit --prefix handsontable` — full suite green.
- `npm run eslint --prefix handsontable` — clean.

**Every implicit caller of the now-strict `postbuild` was enumerated** (`npm run all build` in `publish.yml`, `build-all.yml`, `docs-*`; `npm run build --prefix handsontable` in `emitted-types.yml` and the Angular typecheck action). All build Handsontable in full from source, so none is affected; `integration.yml`'s wrapper build excludes `handsontable` and never triggers it.

**End-to-end** — this PR's own preview package can be checked once CI publishes it, since `test.yml` calls `integration.yml` by local path:

```bash
curl -sL -o pr.tgz "https://pkg.pr.new/handsontable@<this PR>"
tar -xzf pr.tgz -O package/package.json > pkg.json
node -e "const k=Object.keys(require('./pkg.json').exports); console.log(k.length, k.filter(x=>/ht-theme|ht-icon/.test(x)).length, k.filter(x=>x.includes('dist/themes')).length)"
# expected: 271 16 34
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2578

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2578

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI packaging and npm export composition for all PR previews; incorrect wiring would break consumer imports again, but scope is build/publish scripts rather than runtime product logic.
> 
> **Overview**
> Fixes **DEV-2578** by aligning pkg.pr.new preview packages with release packaging so theme CSS imports and **`dist/themes`** UMD bundles work from PR builds.
> 
> **`prepare-package-for-publish.mjs`** now **fails by default** when the composed `tmp/` tree is incomplete (missing **`handsontable.copy`** destinations or export globs that match nothing). **`--partial`** / **`postbuild:partial`** keeps those as warnings for jobs that intentionally ship a partial tree.
> 
> **CI:** the UMD build job adds **`build:themes-umd`** / **`.min`**; the ES+CJS job and visual workflow use **`postbuild:partial`**. The integration preview job **drops manual `cp` merges** and runs strict **`npm run postbuild`** after UMD **`dist/`** and theme **`styles/`** land, so the **`exports`** map is regenerated from the merged tree before **`pkg-pr-new publish`**.
> 
> New **`previewPackaging.unit.js`** tests lock in workflow wiring and completeness behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b408220ddc731f46695ac7a5d61d69f96e1f9b29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->