### PR TITLE
DEV-2582: Clear momentum-scroll timers on overlay clones on destroy

### DIFF
--- a/.changelogs/13120.json
+++ b/.changelogs/13120.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed an error thrown on touch devices when the grid was destroyed while a momentum scroll was still coasting.",
+  "type": "fixed",
+  "issueOrPR": 13120,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/overlay/regions/_base.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/regions/_base.ts
@@ -595,6 +595,15 @@ export abstract class Overlay {
    * Destroy overlay instance.
    */
   destroy() {
+    // Every clone owns its own `Event` instance, and only the master's is reached by
+    // `CoreAbstract#destroy()`. Destroying it here clears the timers the clone armed - the 200 ms
+    // momentum-scroll timer (registered on touch devices), plus the double-click and long-press
+    // ones. Left pending, the momentum timer fires after `Core#destroy()` and calls
+    // `runHooks('afterMomentumScroll')` on a destroyed instance, which throws (issue #13120).
+    if (this.clone instanceof Clone) {
+      this.clone.wtEvent.destroy();
+    }
+
     this.clone?.eventManager.destroy(); // todo check if it is good place for that operation
   }
 }

--- a/handsontable/src/3rdparty/walkontable/test/unit/overlay/cloneEventTeardown.unit.js
+++ b/handsontable/src/3rdparty/walkontable/test/unit/overlay/cloneEventTeardown.unit.js
@@ -1,0 +1,114 @@
+import Handsontable from '../../../../../base';
+
+describe('Overlay clone event teardown', () => {
+  let container;
+  let hot;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+
+    if (hot && !hot.isDestroyed) {
+      hot.destroy();
+    }
+
+    hot = null;
+    container.remove();
+  });
+
+  /**
+   * Builds a grid that owns every overlay type (so each one creates a clone).
+   *
+   * @returns {object} The Handsontable instance.
+   */
+  function build() {
+    hot = new Handsontable(container, {
+      data: [['a1', 'b1'], ['a2', 'b2']],
+      colHeaders: true,
+      rowHeaders: true,
+      fixedRowsTop: 1,
+      fixedRowsBottom: 1,
+      fixedColumnsStart: 1,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    return hot;
+  }
+
+  /**
+   * Collects the master `Event` instance plus the one owned by every overlay clone.
+   *
+   * @returns {Array} The `Event` instances.
+   */
+  function collectEvents() {
+    const wt = hot.view._wt;
+
+    return [wt.wtEvent, ...wt.wtOverlays.getOverlays().map(overlay => overlay?.clone?.wtEvent)]
+      .filter(Boolean);
+  }
+
+  it('should create a separate `Event` instance for every overlay clone', () => {
+    build();
+
+    const wt = hot.view._wt;
+    const clonesWithEvent = wt.wtOverlays.getOverlays()
+      .filter(overlay => overlay?.clone?.wtEvent);
+
+    expect(clonesWithEvent.length).toBeGreaterThan(0);
+    expect(collectEvents().length).toBe(clonesWithEvent.length + 1);
+  });
+
+  it('should not run the momentum-scroll timer of an overlay clone after the instance is destroyed', () => {
+    build();
+
+    const events = collectEvents();
+
+    jest.useFakeTimers();
+
+    // What a momentum (flick) scroll does on a touch device: the holder `scroll` listener fires on
+    // the master table and on every overlay clone, and each one arms its own 200 ms timer.
+    events.forEach(event => event.onHolderScroll());
+
+    hot.destroy();
+
+    // Before the fix every clone timer survived `destroy()`, and firing it reached
+    // `runHooks('afterMomentumScroll')` on a destroyed instance, which throws.
+    expect(() => jest.advanceTimersByTime(250)).not.toThrow();
+  });
+
+  it('should tolerate the overlays being torn down twice', () => {
+    build();
+
+    const wt = hot.view._wt;
+
+    // `Overlays#refreshAll()` tears the overlays down on its own when the table is detached from
+    // the DOM, so `Core#destroy()` can be the second teardown of the same overlays.
+    expect(() => {
+      wt.wtOverlays.destroy();
+      hot.destroy();
+    }).not.toThrow();
+  });
+
+  it('should destroy the `Event` instance of every overlay clone on teardown', () => {
+    build();
+
+    const wt = hot.view._wt;
+    const cloneEvents = wt.wtOverlays.getOverlays()
+      .map(overlay => overlay?.clone?.wtEvent)
+      .filter(Boolean);
+
+    // `Event#destroy()` is what clears the momentum-scroll, double-click and long-press timers,
+    // so a clone whose `Event` is never destroyed leaks all three past `Core#destroy()`.
+    const destroySpies = cloneEvents.map(event => jest.spyOn(event, 'destroy'));
+
+    hot.destroy();
+
+    destroySpies.forEach((spy) => {
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
### Context

The PR fixes an uncaught error on touch devices when the grid is destroyed while a momentum (flick) scroll is still coasting:

```
Error: The "runHooks" method cannot be called because this Handsontable instance has been destroyed
```

It reproduces when the grid is unmounted during or shortly after a flick-scroll — the user flicks the grid and immediately navigates away, or a React component holding `<HotTable>` unmounts while the scroll is still coasting.

**Root cause.** Every overlay clone builds its own `Event` instance (`walkontable/src/core/clone.ts`). On touch devices that clone's holder gets a `scroll` listener which arms a 200 ms momentum-scroll timer.

`Event#destroy()` clears that timer, but the overlay teardown only destroyed the clone's `eventManager`, never its `wtEvent` — so `Event#destroy()` was called **zero times** for clones. Only the master's was reached, through `CoreAbstract#destroy()`.

The surviving timer then fires after the instance is gone:

`event.ts` timer → `getSetting('onAfterMomentumScroll')` → `tableView.ts` → `Core.runHooks` → throw.

With `fixedRowsTop: 1` and `fixedColumnsStart: 1` there are 5 overlay clones, so the error appears 5 times.

**Fix.** Destroy the clone's `Event` in `Overlay#destroy()` (`walkontable/src/overlay/regions/_base.ts`). This also clears the clones' double-click and long-press timers, which had the same lifetime problem.

Two notes for review:

- The linked issue quotes old `.mjs` paths. The engine has since moved to TypeScript and been restructured, but the defect survived the move unchanged.
- The narrowing uses `instanceof Clone` rather than a cast. `WalkontableInstance['wtEvent']` is typed as a loose union (`WalkontableEvent | Record<string, unknown>`), and `Clone` — already imported in this file, and what actually constructs the clone a few lines above — types `wtEvent` properly.

### How has this been tested?

Four new Jest unit tests. Two of them are red before the fix and green after (verified by reverting the source change and re-running): the momentum timer firing post-destroy, and the clone `Event#destroy()` never being called. A third covers a double teardown, which `Overlays#refreshAll()` can trigger when the table is detached from the DOM.

```bash
npm run test:unit --prefix handsontable --testPathPattern=cloneEventTeardown
```

Regression runs:

```bash
# Walkontable browser suite — 816 specs, 0 failures.
# Matched against a 0-failure baseline with the fix reverted.
npm run test:walkontable --prefix handsontable

# Full Jest unit suite — 3555 pass. The 5 failures in 3 suites are pre-existing
# and unrelated (they need build-time env vars for version / release date);
# confirmed identical with the fix reverted.
npm run test:unit --prefix handsontable

npm run eslint --prefix handsontable   # 0 errors
npx tsc --noEmit -p handsontable/tsconfig.json
```

Not run: the legacy Jasmine E2E suite. The walkontable browser suite already tears down a real grid 816 times over the changed path, so CI's full matrix is the right place for that check.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2582
2. #13120

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2582

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5358eee568b74893eb2e0c47c623046083bc03d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->