### PR TITLE
DEV-2585: Fix memory leak where Formulas added a sheet on every data load

### DIFF
--- a/.changelogs/13215.json
+++ b/.changelogs/13215.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a memory leak where each `loadData()` or `updateData()` call added another formula engine sheet, so repeated data loads kept slowing the grid down.",
+  "type": "fixed",
+  "issueOrPR": 13215,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/hfApi.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/hfApi.spec.js
@@ -19,6 +19,58 @@ describe('Formulas general', () => {
   });
 
   describe('Sheet switching', () => {
+    it('should store the sheet name using the engine\'s casing', async() => {
+      const hfInstance1 = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
+
+      hfInstance1.addSheet('Test Sheet');
+
+      handsontable({
+        data: [['1', '2', '=A1+B1']],
+        formulas: {
+          engine: hfInstance1,
+          // The engine matches names without regard to case, so this points at `Test Sheet`.
+          sheetName: 'test sheet',
+        },
+      });
+
+      expect(getPlugin('formulas').sheetName).toBe('Test Sheet');
+    });
+
+    it('should not switch sheets on `updateSettings` when `sheetName` differs only in case', async() => {
+      const hfInstance1 = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
+
+      hfInstance1.addSheet('Test Sheet');
+
+      handsontable({
+        data: [['1', '2', '=A1+B1']],
+        formulas: {
+          engine: hfInstance1,
+          sheetName: 'test sheet',
+        },
+      });
+
+      let switchCount = 0;
+
+      addHook('afterLoadData', (_data, _initialLoad, source) => {
+        if (source === 'Formulas.switchSheet') {
+          switchCount += 1;
+        }
+      });
+
+      // Passing the same lowercase name again must not count as a change of sheet.
+      await updateSettings({
+        formulas: {
+          engine: hfInstance1,
+          sheetName: 'test sheet',
+        },
+      });
+
+      // The configured name and the stored name point at the same sheet, so nothing should switch.
+      expect(switchCount).toBe(0);
+      expect(getPlugin('formulas').sheetName).toBe('Test Sheet');
+      expect(getDataAtCell(0, 2)).toBe(3);
+    });
+
     it('should allow switching sheets stored in HF by modifying the `sheetName` property in `updateSettings`', async() => {
       const hfInstance1 = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
 

--- a/handsontable/src/plugins/formulas/__tests__/memoryLeak.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/memoryLeak.spec.js
@@ -45,6 +45,107 @@ describe('Formulas memory leak check', () => {
     }
   });
 
+  it('should reuse the already-owned sheet on every `loadData` call (no `sheetName` configured)', async() => {
+    const hot = handsontable({
+      data: [['1', '2', '=A1+B1']],
+      formulas: {
+        engine: HyperFormula,
+      },
+    });
+    const { engine } = hot.getPlugin('formulas');
+
+    expect(engine.getSheetNames().length).toBe(1);
+
+    for (let i = 0; i < 5; i++) {
+      hot.loadData([['1', '2', '=A1+B1']]);
+    }
+
+    expect(engine.getSheetNames().length).toBe(1);
+    expect(engine.getSheetId(hot.getPlugin('formulas').sheetName)).toBe(hot.getPlugin('formulas').sheetId);
+    expect(hot.getDataAtCell(0, 2)).toBe(3);
+  });
+
+  it('should reuse the already-owned sheet on every `updateData` call (no `sheetName` configured)', async() => {
+    const hot = handsontable({
+      data: [['1', '2', '=A1+B1']],
+      formulas: {
+        engine: HyperFormula,
+      },
+    });
+    const { engine } = hot.getPlugin('formulas');
+
+    expect(engine.getSheetNames().length).toBe(1);
+
+    for (let i = 0; i < 5; i++) {
+      hot.updateData([['1', '2', '=A1+B1']]);
+    }
+
+    expect(engine.getSheetNames().length).toBe(1);
+    expect(hot.getDataAtCell(0, 2)).toBe(3);
+  });
+
+  it('should not retain the previous data in the engine after reloading the data', async() => {
+    const hot = handsontable({
+      data: [['1', '2', '=A1+B1']],
+      formulas: {
+        engine: HyperFormula,
+      },
+    });
+    const { engine } = hot.getPlugin('formulas');
+
+    hot.loadData([['10', '20', '=A1+B1']]);
+
+    const allSheetsSerialized = engine.getSheetNames()
+      .map(name => engine.getSheetSerialized(engine.getSheetId(name)));
+
+    // Only the current data may be present anywhere in the engine.
+    expect(allSheetsSerialized).toEqual([[['10', '20', '=A1+B1']]]);
+  });
+
+  it('should keep using the sheet pointed to by the `sheetName` option across data loads', async() => {
+    const hot = handsontable({
+      data: [['1', '2', '=A1+B1']],
+      formulas: {
+        engine: HyperFormula,
+        sheetName: 'MySheet',
+      },
+    });
+    const { engine } = hot.getPlugin('formulas');
+
+    hot.loadData([['1', '2', '=A1+B1']]);
+    hot.updateData([['1', '2', '=A1+B1']]);
+
+    expect(engine.getSheetNames()).toEqual(['MySheet']);
+    expect(hot.getPlugin('formulas').sheetName).toBe('MySheet');
+  });
+
+  it('should give each grid its own sheet when they share a single engine', async() => {
+    const hfInstance = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
+    const hot1 = handsontable({
+      data: [['1', '2', '=A1+B1']],
+      formulas: {
+        engine: hfInstance,
+      },
+    });
+    const hot2 = spec().$container2.handsontable({
+      data: [['3', '4', '=A1+B1']],
+      formulas: {
+        engine: hfInstance,
+      },
+    }).data('handsontable');
+
+    expect(hfInstance.getSheetNames().length).toBe(2);
+
+    hot1.loadData([['1', '2', '=A1+B1']]);
+    hot2.loadData([['3', '4', '=A1+B1']]);
+
+    // Reloading the data must not add sheets, and must not make the two grids share one sheet.
+    expect(hfInstance.getSheetNames().length).toBe(2);
+    expect(hot1.getPlugin('formulas').sheetId).not.toBe(hot2.getPlugin('formulas').sheetId);
+    expect(hot1.getDataAtCell(0, 2)).toBe(3);
+    expect(hot2.getDataAtCell(0, 2)).toBe(7);
+  });
+
   it('should detach listeners from the engine after table destroying (one shared HF instances)', async() => {
     const hfInstance1 = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
     const hot1 = handsontable({

--- a/handsontable/src/plugins/formulas/__tests__/memoryLeak.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/memoryLeak.spec.js
@@ -57,7 +57,7 @@ describe('Formulas memory leak check', () => {
     expect(engine.getSheetNames().length).toBe(1);
 
     for (let i = 0; i < 5; i++) {
-      hot.loadData([['1', '2', '=A1+B1']]);
+      await loadData([['1', '2', '=A1+B1']]);
     }
 
     expect(engine.getSheetNames().length).toBe(1);
@@ -77,7 +77,7 @@ describe('Formulas memory leak check', () => {
     expect(engine.getSheetNames().length).toBe(1);
 
     for (let i = 0; i < 5; i++) {
-      hot.updateData([['1', '2', '=A1+B1']]);
+      await updateData([['1', '2', '=A1+B1']]);
     }
 
     expect(engine.getSheetNames().length).toBe(1);
@@ -93,7 +93,7 @@ describe('Formulas memory leak check', () => {
     });
     const { engine } = hot.getPlugin('formulas');
 
-    hot.loadData([['10', '20', '=A1+B1']]);
+    await loadData([['10', '20', '=A1+B1']]);
 
     const allSheetsSerialized = engine.getSheetNames()
       .map(name => engine.getSheetSerialized(engine.getSheetId(name)));
@@ -112,8 +112,8 @@ describe('Formulas memory leak check', () => {
     });
     const { engine } = hot.getPlugin('formulas');
 
-    hot.loadData([['1', '2', '=A1+B1']]);
-    hot.updateData([['1', '2', '=A1+B1']]);
+    await loadData([['1', '2', '=A1+B1']]);
+    await updateData([['1', '2', '=A1+B1']]);
 
     expect(engine.getSheetNames()).toEqual(['MySheet']);
     expect(hot.getPlugin('formulas').sheetName).toBe('MySheet');
@@ -175,6 +175,53 @@ describe('Formulas memory leak check', () => {
     expect(hfInstance.getSheetSerialized(hot1SheetId)).toEqual([['1', '2', '=A1+B1']]);
     expect(hot1.getDataAtCell(0, 2)).toBe(3);
     expect(hot2.getDataAtCell(0, 2)).toBe(70);
+  });
+
+  it('should follow a rename of its own sheet when `sheetName` differs from it only in case', async() => {
+    const hfInstance = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
+
+    hfInstance.addSheet('Sheet1');
+
+    // The engine matches sheet names without looking at the case, but keeps the casing it was
+    // given. So the plugin can hold `sheet1` while the engine reports the name as `Sheet1`.
+    const hot = handsontable({
+      data: [['1', '2', '=A1+B1']],
+      formulas: {
+        engine: hfInstance,
+        sheetName: 'sheet1',
+      },
+    });
+
+    hfInstance.renameSheet(hfInstance.getSheetId('sheet1'), 'Renamed');
+
+    expect(hot.getPlugin('formulas').sheetName).toBe('Renamed');
+    expect(hfInstance.doesSheetExist(hot.getPlugin('formulas').sheetName)).toBe(true);
+
+    // A sheet name left pointing at nothing makes the formulas stop resolving.
+    await setDataAtCell(0, 0, '10');
+
+    expect(hot.getDataAtCell(0, 2)).toBe(12);
+  });
+
+  it('should not leave the previous data in the engine when the new data cannot be written', async() => {
+    // The engine caps this sheet at 2 rows, so a 3-row load cannot be written to it.
+    const hfInstance = HyperFormula.buildEmpty({
+      licenseKey: 'internal-use-in-handsontable',
+      maxRows: 2,
+    });
+    const hot = handsontable({
+      data: [['1', '2'], ['3', '4']],
+      formulas: {
+        engine: hfInstance,
+      },
+    });
+    const { sheetId } = hot.getPlugin('formulas');
+
+    await loadData([['10', '20'], ['30', '40'], ['50', '60']]);
+
+    expect(hfInstance.isItPossibleToReplaceSheetContent(sheetId, hot.getSourceDataArray())).toBe(false);
+    // The sheet is reused now, so it must not keep serving the data from before the load.
+    expect(hfInstance.getSheetSerialized(sheetId)).not.toEqual([['1', '2'], ['3', '4']]);
   });
 
   it('should detach listeners from the engine after table destroying (one shared HF instances)', async() => {

--- a/handsontable/src/plugins/formulas/__tests__/memoryLeak.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/memoryLeak.spec.js
@@ -146,6 +146,37 @@ describe('Formulas memory leak check', () => {
     expect(hot2.getDataAtCell(0, 2)).toBe(7);
   });
 
+  it('should not overwrite another grid\'s sheet after an engine-wide sheet rename', async() => {
+    const hfInstance = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
+    const hot1 = handsontable({
+      data: [['1', '2', '=A1+B1']],
+      formulas: {
+        engine: hfInstance,
+      },
+    });
+    const hot2 = spec().$container2.handsontable({
+      data: [['3', '4', '=A1+B1']],
+      formulas: {
+        engine: hfInstance,
+      },
+    }).data('handsontable');
+
+    const hot1SheetId = hot1.getPlugin('formulas').sheetId;
+
+    // `sheetRenamed` is engine-wide, so it reaches every attached instance. Renaming the first
+    // grid's sheet must not repoint the second grid at it.
+    hfInstance.renameSheet(hot1SheetId, 'Renamed');
+
+    expect(hot2.getPlugin('formulas').sheetId).not.toBe(hot1SheetId);
+
+    hot2.loadData([['30', '40', '=A1+B1']]);
+
+    // The first grid's sheet must still hold the first grid's data.
+    expect(hfInstance.getSheetSerialized(hot1SheetId)).toEqual([['1', '2', '=A1+B1']]);
+    expect(hot1.getDataAtCell(0, 2)).toBe(3);
+    expect(hot2.getDataAtCell(0, 2)).toBe(70);
+  });
+
   it('should detach listeners from the engine after table destroying (one shared HF instances)', async() => {
     const hfInstance1 = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
     const hot1 = handsontable({

--- a/handsontable/src/plugins/formulas/__tests__/memoryLeak.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/memoryLeak.spec.js
@@ -224,6 +224,38 @@ describe('Formulas memory leak check', () => {
     expect(hfInstance.getSheetSerialized(sheetId)).not.toEqual([['1', '2'], ['3', '4']]);
   });
 
+  it('should redraw the grids that depend on a sheet whose new data could not be written', async() => {
+    const hfInstance = HyperFormula.buildEmpty({
+      licenseKey: 'internal-use-in-handsontable',
+      maxRows: 2,
+    });
+
+    handsontable({
+      data: [['1'], ['2']],
+      formulas: {
+        engine: hfInstance,
+        sheetName: 'SheetA',
+      },
+    });
+
+    const hot2 = spec().$container2.handsontable({
+      data: [['=SheetA!A1']],
+      formulas: {
+        engine: hfInstance,
+        sheetName: 'SheetB',
+      },
+    }).data('handsontable');
+
+    expect(hot2.getCell(0, 0).textContent).toBe('1');
+
+    // Three rows cannot be written to a sheet capped at two, so `SheetA` gets emptied.
+    await loadData([['10'], ['20'], ['30']]);
+
+    // The other grid reads `SheetA`, so it has to be redrawn instead of keeping the old `1`.
+    // A reference to an emptied cell renders blank.
+    expect(hot2.getCell(0, 0).textContent).toBe('');
+  });
+
   it('should detach listeners from the engine after table destroying (one shared HF instances)', async() => {
     const hfInstance1 = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
     const hot1 = handsontable({

--- a/handsontable/src/plugins/formulas/engine/register.ts
+++ b/handsontable/src/plugins/formulas/engine/register.ts
@@ -280,15 +280,20 @@ export function registerNamedExpressions(
 }
 
 /**
- * Sets up a new sheet.
+ * Sets up the sheet to work on. An existing sheet is reused; a new one is added only when there is
+ * nothing to reuse.
  *
  * @param {object} engineInstance The engine instance.
- * @param {string} sheetName The new sheet name.
+ * @param {string} [sheetName] The sheet name to use. When omitted (or `null`), a new sheet is added.
  * @returns {*}
  */
-export function setupSheet(engineInstance: HyperFormulaEngine, sheetName: string) {
-  if (isUndefined(sheetName) || !engineInstance.doesSheetExist(sheetName)) {
-    sheetName = engineInstance.addSheet(sheetName);
+export function setupSheet(engineInstance: HyperFormulaEngine, sheetName?: string | null) {
+  if (sheetName === undefined || sheetName === null) {
+    return engineInstance.addSheet();
+  }
+
+  if (!engineInstance.doesSheetExist(sheetName)) {
+    return engineInstance.addSheet(sheetName);
   }
 
   return sheetName;

--- a/handsontable/src/plugins/formulas/engine/register.ts
+++ b/handsontable/src/plugins/formulas/engine/register.ts
@@ -285,7 +285,7 @@ export function registerNamedExpressions(
  *
  * @param {object} engineInstance The engine instance.
  * @param {string} [sheetName] The sheet name to use. When omitted (or `null`), a new sheet is added.
- * @returns {*}
+ * @returns {string}
  */
 export function setupSheet(engineInstance: HyperFormulaEngine, sheetName?: string | null) {
   if (sheetName === undefined || sheetName === null) {

--- a/handsontable/src/plugins/formulas/engine/types.ts
+++ b/handsontable/src/plugins/formulas/engine/types.ts
@@ -5,6 +5,7 @@
 export interface HyperFormulaEngine {
   doesSheetExist(sheetName: string): boolean;
   getSheetId(sheetName: string): number;
+  getSheetName(sheetId: number): string | undefined;
   addSheet(sheetName?: string): string;
   setSheetContent(sheetId: number | null, data: unknown[][]): unknown[];
   getSheetSerialized(sheetId: number | null): unknown[][];

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -1366,7 +1366,10 @@ export class Formulas extends BasePlugin {
         // while the grid already shows the new one. Empty it instead of serving stale values.
         this.#internalOperationPending = true;
 
-        this.engine!.setSheetContent(this.sheetId, [[]]);
+        const dependentCells = this.engine!.setSheetContent(this.sheetId, [[]]);
+
+        // Emptying the sheet changes what the grids reading it compute, so they need a redraw.
+        this.renderDependentSheets(dependentCells);
 
         this.#internalOperationPending = false;
 

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -356,7 +356,10 @@ export class Formulas extends BasePlugin {
   #onEngineSheetRenamed = (oldDisplayName: string, newDisplayName: string) => {
     // The event is engine-wide, so it also reaches instances that do not own the renamed sheet.
     // Repointing those would make them operate on a sheet belonging to another instance.
-    if (oldDisplayName === this.sheetName) {
+    // Sheet ids are compared rather than names: the engine matches names without looking at the
+    // case but keeps the casing it was given, so `sheetName` may differ in case from the event's
+    // display names. The rename is already applied here, so the new name resolves to the same id.
+    if (this.engine?.getSheetId(newDisplayName) === this.sheetId) {
       this.#updateSheetNameAndSheetId(newDisplayName);
     }
 
@@ -1349,6 +1352,18 @@ export class Formulas extends BasePlugin {
         this.renderDependentSheets(dependentCells);
 
         this.#internalOperationPending = false;
+
+      } else {
+        // The sheet is reused, so leaving it untouched would keep the previous data in the engine
+        // while the grid already shows the new one. Empty it instead of serving stale values.
+        this.#internalOperationPending = true;
+
+        this.engine!.setSheetContent(this.sheetId, [[]]);
+
+        this.#internalOperationPending = false;
+
+        warn('The loaded data could not be passed to the formula engine, so the formulas were ' +
+          'cleared. It most likely exceeds the engine\'s `maxRows` or `maxColumns` limit.');
       }
 
     } else if (this.sheetName !== null) {

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -661,7 +661,10 @@ export class Formulas extends BasePlugin {
       pluginSettings !== undefined &&
       typeof pluginSettings !== 'boolean' &&
       pluginSettings.sheetName !== undefined &&
-      pluginSettings.sheetName !== this.sheetName
+      // Sheet ids are compared rather than names, because `sheetName` holds the engine's casing
+      // while the setting keeps the one it was written with. An unknown name has no id, which
+      // still differs from the current one and lets `switchSheet` report it.
+      this.engine?.getSheetId(pluginSettings.sheetName) !== this.sheetId
     ) {
       this.switchSheet(pluginSettings.sheetName);
     }
@@ -709,8 +712,13 @@ export class Formulas extends BasePlugin {
    * @param {string} [sheetName] The new sheet name.
    */
   #updateSheetNameAndSheetId(sheetName: string) {
-    this.sheetName = sheetName;
-    this.sheetId = this.engine?.getSheetId(this.sheetName) ?? null;
+    const sheetId = this.engine?.getSheetId(sheetName) ?? null;
+
+    // Store the name the engine itself reports. The engine matches names without regard to case
+    // but keeps the casing it was given, so the name passed here may differ from the engine's own.
+    // Keeping them in step makes every exact-string reader of `sheetName` safe by construction.
+    this.sheetName = (sheetId === null ? null : this.engine?.getSheetName(sheetId)) ?? sheetName;
+    this.sheetId = sheetId;
   }
 
   /**

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -354,7 +354,12 @@ export class Formulas extends BasePlugin {
    * @param {string} newDisplayName The new name of the sheet.
    */
   #onEngineSheetRenamed = (oldDisplayName: string, newDisplayName: string) => {
-    this.#updateSheetNameAndSheetId(newDisplayName);
+    // The event is engine-wide, so it also reaches instances that do not own the renamed sheet.
+    // Repointing those would make them operate on a sheet belonging to another instance.
+    if (oldDisplayName === this.sheetName) {
+      this.#updateSheetNameAndSheetId(newDisplayName);
+    }
+
     this.hot.runHooks('afterSheetRenamed', oldDisplayName, newDisplayName);
   };
 

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -1320,7 +1320,10 @@ export class Formulas extends BasePlugin {
 
     const formulasSettings = this.hot.getSettings()[PLUGIN_KEY];
     const settingsSheetName = isFormulasSettingsObject(formulasSettings) ? formulasSettings.sheetName : undefined;
-    const sheetName = setupSheet(this.engine, settingsSheetName!);
+    // Fall back to the sheet this instance already owns. Without it every `loadData`/`updateData`
+    // call adds a sheet and abandons the previous one - with its whole dependency graph - inside
+    // the engine, which the engine then recalculates on every subsequent call.
+    const sheetName = setupSheet(this.engine, settingsSheetName ?? this.sheetName);
 
     this.#updateSheetNameAndSheetId(sheetName);
 


### PR DESCRIPTION
### Context

The PR fixes a memory leak in the Formulas plugin: every `loadData()` / `updateData()` call asked HyperFormula for a brand-new sheet instead of reusing the one the plugin already owns.

`setupSheet()` in `handsontable/src/plugins/formulas/engine/register.ts` only reused a sheet when the caller passed a `sheetName`. `#onAfterLoadData` passed the `formulas.sheetName` setting straight through, and that setting is optional — so for anyone who did not set it (the common case) every data load took the `addSheet()` branch. The plugin then repointed itself at the new sheet and walked away from the old one, which stayed in the engine with all of its cells and its whole dependency graph. Nothing ever removed it.

The reported slowdown is the same bug seen from the other side. The `sheetAdded` listener registered in `registerEngine()` runs `rebuildAndRecalculate()` across **every** sheet the engine holds, so call *n* paid for *n* sheets — per-call cost grew linearly, and a whole session grew quadratically.

Measured before the fix, on 100 `loadData()` calls over 100 rows x 5 columns with one formula column. Released 14.5.0 and `develop` behaved identically:

| Measured after | 1 call | 100 calls |
|---|---|---|
| Sheets left in the engine | 2 | **101** |
| Rows retained across all sheets | 200 | **10,100** |
| `ScalarFormulaVertex` instances | 200 | **10,100** |
| `ValueCellVertex` instances | 800 | **40,400** |
| Reachable heap after a forced GC | 25.8 MB | **35.9 MB** |

Within that same 100-call run, per-call time rose from 26.5 ms (average of the first five calls) to 86.5 ms (average of the last five) — 3.3x, growing in step with the sheet count.

Two controls pinned it to this code path: with the plugin removed, time stayed flat and the heap stayed bounded; with `sheetName` set, the sheet count stayed at 1 and time stayed flat.

`setupSheet()` now reuses the sheet the plugin already owns and adds one only when there is nothing to reuse. Grids that share a single engine still get one sheet each, because the fallback is the calling plugin instance's own `sheetName`.

No public API changes and no default setting changes. Three observable differences, all of them the point of the fix:

- `formulas.sheetName` / `getSheetNames()` no longer grow an incrementing list of abandoned sheets across data loads.
- With `formulas.sheetName` unset, a `switchSheet('X')` followed by a user `loadData()` now writes into `X`. Before, the load abandoned `X` and created a new sheet.
- `plugin.sheetName` now reports the engine's own casing. The engine matches sheet names without regard to case but keeps the casing it was given, so a configured `sheetName: 'sheet1'` against an engine sheet named `Sheet1` used to leave the plugin holding `'sheet1'`.

Not addressed here, and pre-existing: a configured `sheetName` still wins over an earlier `switchSheet()` on the next data load, which silently un-switches it.

#### Second commit: guarding the rename handler

Reusing the sheet raised the stakes on a separate, pre-existing defect, so this PR closes that too.

HyperFormula's `sheetRenamed` event is engine-wide, and every plugin instance attached to a shared engine subscribes to it. `#onEngineSheetRenamed` handled the event unconditionally, repointing its own `sheetName` / `sheetId` at the renamed sheet even when it did not own that sheet. Before this PR the mis-pointer was survivable on a data load, because `loadData` created a fresh sheet anyway. With the sheet now reused, the same mis-pointer made one grid's `loadData` overwrite another grid's sheet — real data loss.

`#onEngineSheetRenamed` now updates the pointer only when the renamed sheet is the one the instance owns. The `afterSheetRenamed` hook still runs on every instance, so that observable behavior is unchanged.

#### Third commit: keeping `sheetName` in step with the engine

`#updateSheetNameAndSheetId` now stores the name the engine reports rather than the one it was handed, so every exact-string reader of `sheetName` is correct by construction. Doing it there rather than in `setupSheet` covers `switchSheet()` as well.

That change on its own would have regressed `updatePlugin`, which compared the configured `sheetName` to `this.sheetName` as exact strings: re-passing the same name in a different case counted as a change of sheet and fired a real `switchSheet`, reloading the data from the engine on every `updateSettings`. It now compares sheet ids. There is a test for it.

#### Fourth commit: redrawing dependent grids on a failed load

The branch that empties a reused sheet discarded the `setSheetContent` return value and never called `renderDependentSheets`, unlike the path that writes the new data. A grid reading that sheet through a cross-sheet formula kept showing the old value until something else triggered a render. Found by Cursor Bugbot.

### How has this been tested?

Seven cases added to the existing `memoryLeak.spec.js`, covering sheet reuse across `loadData`, sheet reuse across `updateData`, no stale data left anywhere in the engine after a reload, the configured-`sheetName` path still being honoured, two grids sharing one engine keeping separate sheets, one grid's data surviving a rename of its sheet followed by the other grid reloading, and a dependent grid being redrawn when the sheet it reads is emptied by a failed load.

Each case was written before its fix and confirmed to fail for the right reason: 6 sheets instead of 1 and 4 instead of 2 for the leak, and for the rename case, the second grid's values landing in the first grid's sheet (`'30'` where `'1'` belonged, with the first grid then reading `70` instead of `3`).

Two more cases in `hfApi.spec.js` for the third commit: `sheetName` reporting the engine's casing, and `updateSettings` not switching sheets when the configured name differs from the stored one only in case. The second was confirmed failing (one switch instead of none) before the `updatePlugin` id comparison went in.

The two pre-existing rename tests still pass unchanged — `hooks.spec.js` renames a sheet the grid does not own and asserts the hook still fires, and `formulas.spec.js` renames the grid's own sheet and asserts the pointer follows it.

```bash
# The added cases
npm run test:e2e --prefix handsontable -- --testPathPattern=memoryLeak

# The whole Formulas suite -- 343 specs, 0 failures
npm run test:e2e --prefix handsontable -- --testPathPattern=formulas

# Full unit suite -- 3596 tests, 0 failures
npm run test:unit --prefix handsontable

# Full E2E suite -- 9638 specs, 0 failures
npm run test:e2e --prefix handsontable

# Lint
npm run eslint --prefix handsontable
```

`npm run build --prefix handsontable` also passes, including `build:types`. The emitted declaration for the widened parameter is `setupSheet(engineInstance: HyperFormulaEngine, sheetName?: string | null): string`, so existing callers passing a `string` are unaffected.

Also verified in a real browser against a UMD build of this branch, driving the reporter's own reproduction (100 `loadData()` calls). Same harness and same machine as the "before" numbers above:

| After 100 `loadData()` calls | `develop` | This branch |
|---|---|---|
| Sheets in the engine | 101 | **1** |
| Rows retained across all sheets | 10,100 | **100** |
| `ScalarFormulaVertex` instances | 10,100 | **100** |
| `ValueCellVertex` instances | 40,400 | **400** |
| Reachable heap after a forced GC | 35.9 MB | **28.0 MB** |
| Per-call time, average of the last 5 | 86.5 ms | **6.8 ms** |

Retention is now flat in the number of data loads, and the 100th `loadData()` is roughly 13x faster. The engine ends up holding fewer vertices than `develop` did after a *single* load (200 / 800), because the old code abandoned the initial sheet too.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2585
2. Fixes #11165

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

No documentation change is needed: no public API or option changed, and no guide documented the old sheet-per-load behavior.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2585
