### PR TITLE
DEV-2587: Fix columnSummary destination rows when rows are trimmed (#11674)

### DIFF
--- a/.changelogs/11674.json
+++ b/.changelogs/11674.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed the `columnSummary` plugin reporting destination rows as out of bounds, writing results into the wrong row, throwing when the destination row was hidden, and shrinking its default calculation range, when another plugin trimmed rows (for example after collapsing a `nestedRows` group).",
+  "title": "Fixed the `columnSummary` plugin misbehaving when another plugin trimmed rows (for example a collapsed `nestedRows` group): false out-of-bounds warnings, results written into the wrong row, a crash when the destination row was hidden, and hidden summary rows being counted as data by other summaries.",
   "type": "fixed",
   "issueOrPR": 11674,
   "breaking": false,

--- a/.changelogs/11674.json
+++ b/.changelogs/11674.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed the `columnSummary` plugin reporting destination rows as out of bounds, writing results into the wrong row, and shrinking its default calculation range, when another plugin trimmed rows (for example after collapsing a `nestedRows` group).",
+  "title": "Fixed the `columnSummary` plugin reporting destination rows as out of bounds, writing results into the wrong row, throwing when the destination row was hidden, and shrinking its default calculation range, when another plugin trimmed rows (for example after collapsing a `nestedRows` group).",
   "type": "fixed",
   "issueOrPR": 11674,
   "breaking": false,

--- a/.changelogs/11674.json
+++ b/.changelogs/11674.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the `columnSummary` plugin reporting destination rows as out of bounds, writing results into the wrong row, and shrinking its default calculation range, when another plugin trimmed rows (for example after collapsing a `nestedRows` group).",
+  "type": "fixed",
+  "issueOrPR": 11674,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -978,6 +978,9 @@ describe('ColumnSummarySpec', () => {
 
       data.push({ a: 'TOTAL', b: null });
 
+      // installed before the grid so init-time warnings land inside the spied window
+      const warnSpy = spyOnConsoleWarn();
+
       handsontable({
         data,
         height: 400,
@@ -1018,8 +1021,6 @@ describe('ColumnSummarySpec', () => {
           ];
         },
       });
-
-      const warnSpy = spyOn(console, 'warn');
 
       await waitForNextAnimationFrames(2);
 
@@ -1164,6 +1165,37 @@ describe('ColumnSummarySpec', () => {
     // 10 + 2 + 3, without the hidden subtotal of 6 added on top
     expect(getDataAtCell(hot().toVisualRow(4), 0)).toEqual(15);
   });
+
+  it('should build the default `ranges` from the physical row count when rows are already trimmed (#11674)',
+    async() => {
+      handsontable({
+        data: [[1], [2], [3], [4], [null]],
+        trimRows: [1, 2],
+        columnSummary() {
+          return [
+            {
+              // no `ranges`, so the default range is built while rows 1 and 2 are already trimmed
+              destinationRow: 4,
+              destinationColumn: 0,
+              type: 'sum',
+              forceNumeric: true,
+            },
+          ];
+        },
+      });
+
+      await waitForNextAnimationFrames(2);
+
+      const plugin = getPlugin('ColumnSummary');
+
+      // 5 physical rows, so the default range spans them all - not the 3 visible ones
+      expect(plugin.endpoints.getAllEndpoints()[0].ranges).toEqual([[0, 4]]);
+
+      // force a recalculation and check the sum covers the trimmed rows too
+      await setDataAtCell(0, 0, 10);
+
+      expect(getDataAtCell(hot().toVisualRow(4), 0)).toEqual(19);
+    });
 
   describe('maxRows options set', () => {
     it('should apply summary operation only on rows which are < maxRows', async() => {

--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -972,6 +972,114 @@ describe('ColumnSummarySpec', () => {
       expect(spec().$container.find('.columnSummaryResult').size()).toEqual(3);
       expect(spec().$container.find('.htDimmed').size()).toEqual(3);
     });
+
+    it('should keep the grand-total endpoint working when a nested group is collapsed (#11674)', async() => {
+      const data = getDataForColumnSummary();
+
+      data.push({ a: 'TOTAL', b: null });
+
+      handsontable({
+        data,
+        height: 400,
+        width: 400,
+        rowHeaders: true,
+        nestedRows: true,
+        columnSummary() {
+          return [
+            {
+              destinationRow: 0,
+              destinationColumn: 1,
+              type: 'sum',
+              forceNumeric: true,
+              ranges: [[1, 3]],
+            },
+            {
+              destinationRow: 4,
+              destinationColumn: 1,
+              type: 'sum',
+              forceNumeric: true,
+              ranges: [[5, 6]],
+            },
+            {
+              destinationRow: 7,
+              destinationColumn: 1,
+              type: 'sum',
+              forceNumeric: true,
+              ranges: [[8, 9]],
+            },
+            {
+              // physical row 10 - the grand-total row at the bottom
+              destinationRow: 10,
+              destinationColumn: 1,
+              type: 'sum',
+              forceNumeric: true,
+              ranges: [[1, 3], [5, 6], [8, 9]],
+            },
+          ];
+        },
+      });
+
+      const warnSpy = spyOn(console, 'warn');
+
+      await waitForNextAnimationFrames(2);
+
+      expect(getDataAtCell(10, 1)).toEqual(4251);
+
+      getPlugin('nestedRows').collapsingUI.collapseChildren(0);
+
+      await waitForNextAnimationFrames(2);
+
+      expect(getDataAtCell(7, 1)).toEqual(4251);
+
+      await setDataAtCell(2, 1, 0);
+
+      expect(warnSpy).not.toHaveBeenCalledWith(warnMessage);
+      // the edited row belongs to the second group, so its subtotal and the grand total drop by 363
+      expect(getDataAtCell(1, 1)).toEqual(3633);
+      expect(getDataAtCell(7, 1)).toEqual(3888);
+    });
+
+    it('should resolve `reversedRowCoords` against the physical row count when a group is collapsed (#11674)',
+      async() => {
+        const data = getDataForColumnSummary();
+
+        data.push({ a: 'TOTAL', b: null });
+
+        handsontable({
+          data,
+          height: 400,
+          width: 400,
+          rowHeaders: true,
+          nestedRows: true,
+          columnSummary() {
+            return [
+              {
+                destinationRow: 0,
+                reversedRowCoords: true,
+                destinationColumn: 1,
+                type: 'sum',
+                forceNumeric: true,
+                ranges: [[1, 3], [5, 6], [8, 9]],
+              },
+            ];
+          },
+        });
+
+        await waitForNextAnimationFrames(2);
+
+        expect(getDataAtCell(10, 1)).toEqual(4251);
+
+        getPlugin('nestedRows').collapsingUI.collapseChildren(0);
+
+        await waitForNextAnimationFrames(2);
+
+        // force a recalculation while the group stays collapsed
+        await setDataAtCell(2, 1, 0);
+
+        // the result stays in the last physical row instead of jumping to the row that is now `countRows() - 1`
+        expect(getDataAtCell(7, 1)).toEqual(3888);
+        expect(getDataAtCell(4, 1)).toEqual('7');
+      });
   });
 
   describe('maxRows options set', () => {

--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -1126,6 +1126,45 @@ describe('ColumnSummarySpec', () => {
       });
   });
 
+  it('should not count a trimmed summary row as data in another summary (#11674)', async() => {
+    handsontable({
+      data: [[1], [2], [3], [null], [null]],
+      columnSummary: [
+        {
+          destinationRow: 3,
+          destinationColumn: 0,
+          type: 'sum',
+          forceNumeric: true,
+          ranges: [[0, 2]],
+        },
+        {
+          // no `ranges`, so the default range spans every physical row - including row 3, which
+          // holds the subtotal above
+          destinationRow: 4,
+          destinationColumn: 0,
+          type: 'sum',
+          forceNumeric: true,
+        },
+      ],
+      trimRows: true,
+    });
+
+    await waitForNextAnimationFrames(2);
+
+    expect(getDataAtCell(3, 0)).toEqual(6);
+    expect(getDataAtCell(4, 0)).toEqual(6);
+
+    getPlugin('trimRows').trimRow(3);
+
+    await waitForNextAnimationFrames(2);
+
+    // the subtotal row is hidden now, so its `columnSummaryResult` class is unreadable
+    await setDataAtCell(0, 0, 10);
+
+    // 10 + 2 + 3, without the hidden subtotal of 6 added on top
+    expect(getDataAtCell(hot().toVisualRow(4), 0)).toEqual(15);
+  });
+
   describe('maxRows options set', () => {
     it('should apply summary operation only on rows which are < maxRows', async() => {
       const rows = 9;

--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -1080,6 +1080,50 @@ describe('ColumnSummarySpec', () => {
         expect(getDataAtCell(7, 1)).toEqual(3888);
         expect(getDataAtCell(4, 1)).toEqual('7');
       });
+
+    it('should not throw when the destination row itself is trimmed, and recover once it is visible (#11674)',
+      async() => {
+        handsontable({
+          data: getDataForColumnSummary(),
+          height: 400,
+          width: 400,
+          rowHeaders: true,
+          nestedRows: true,
+          columnSummary() {
+            return [
+              {
+                // physical row 3 - the last child of the first group, so collapsing that group hides it
+                destinationRow: 3,
+                destinationColumn: 1,
+                type: 'sum',
+                forceNumeric: true,
+                ranges: [[8, 9]],
+              },
+            ];
+          },
+        });
+
+        await waitForNextAnimationFrames(2);
+
+        expect(getDataAtCell(3, 1)).toEqual(149);
+
+        getPlugin('nestedRows').collapsingUI.collapseChildren(0);
+
+        await waitForNextAnimationFrames(2);
+
+        // visual row 5 is physical row 8 while the first group is collapsed. Recalculating towards a
+        // hidden destination used to throw in `DataMap.set`.
+        await setDataAtCell(5, 1, 0);
+
+        getPlugin('nestedRows').collapsingUI.expandChildren(0);
+
+        await waitForNextAnimationFrames(2);
+
+        // the next recalculation with the row visible writes the up-to-date result
+        await setDataAtCell(9, 1, 4);
+
+        expect(getDataAtCell(3, 1)).toEqual(4);
+      });
   });
 
   describe('maxRows options set', () => {

--- a/handsontable/src/plugins/columnSummary/columnSummary.ts
+++ b/handsontable/src/plugins/columnSummary/columnSummary.ts
@@ -503,6 +503,10 @@ export class ColumnSummary extends BasePlugin {
     // A trimmed row has no visual coordinates, so its cell meta - and with it the
     // `columnSummaryResult` class - cannot be read. Fall back to the endpoint destinations, or a
     // hidden summary row is summed as plain data and inflates every summary covering it.
+    //
+    // The two tests are deliberately exclusive, not OR-ed: a *visible* destination cell still holds
+    // the user's own value on the first calculation pass, before any result was written, and that
+    // value counts towards the summary. Three long-standing specs pin that behavior.
     const isSummaryResult = visualRowIndex !== null
       ? ((this.hot.getCellMetaTransient(visualRowIndex, col).className as string) || '')
         .indexOf('columnSummaryResult') > -1

--- a/handsontable/src/plugins/columnSummary/columnSummary.ts
+++ b/handsontable/src/plugins/columnSummary/columnSummary.ts
@@ -499,13 +499,16 @@ export class ColumnSummary extends BasePlugin {
     let cellValue: number | string | null = (visualRowIndex !== null
       ? this.hot.getDataAtCell(visualRowIndex, col)
       : this.hot.getSourceDataAtCell(row, col)) as number | string | null;
-    let cellClassName = '';
 
-    if (visualRowIndex !== null) {
-      cellClassName = (this.hot.getCellMetaTransient(visualRowIndex, col).className as string) || '';
-    }
+    // A trimmed row has no visual coordinates, so its cell meta - and with it the
+    // `columnSummaryResult` class - cannot be read. Fall back to the endpoint destinations, or a
+    // hidden summary row is summed as plain data and inflates every summary covering it.
+    const isSummaryResult = visualRowIndex !== null
+      ? ((this.hot.getCellMetaTransient(visualRowIndex, col).className as string) || '')
+        .indexOf('columnSummaryResult') > -1
+      : this.endpoints!.isSummaryDestination(row, col);
 
-    if (cellClassName.indexOf('columnSummaryResult') > -1) {
+    if (isSummaryResult) {
       return null;
     }
 

--- a/handsontable/src/plugins/columnSummary/endpoints.ts
+++ b/handsontable/src/plugins/columnSummary/endpoints.ts
@@ -123,18 +123,52 @@ class Endpoints {
   }
 
   /**
-   * Returns the number of rows an endpoint may address, that is the number of physical rows capped
-   * by the `maxRows` setting.
+   * Returns the number of physical rows the dataset holds, ignoring trimming.
    *
    * Endpoint destination rows and calculation ranges are physical indexes, so they must never be
    * compared against `countRows()` - that counts only the *visible* rows and shrinks whenever a
-   * plugin trims rows (NestedRows collapsing a group, TrimRows, the Filters plugin). With nothing
-   * trimmed this returns exactly `countRows()`.
+   * plugin trims rows (NestedRows collapsing a group, TrimRows, the Filters plugin).
+   *
+   * @returns {number}
+   */
+  countPhysicalRows(): number {
+    return this.hot.rowIndexMapper.getNumberOfIndexes();
+  }
+
+  /**
+   * Returns the number of rows an endpoint may address, that is the physical row count capped by
+   * `maxRows`. Used for the settings defaults that need a row count rather than a bounds check.
+   *
+   * A non-finite or negative `maxRows` is treated as no cap.
    *
    * @returns {number}
    */
   countAddressableRows(): number {
-    return Math.min(this.hot.rowIndexMapper.getNumberOfIndexes(), this.hot.getSettings().maxRows ?? Infinity);
+    const { maxRows } = this.hot.getSettings();
+    const cap = Number.isFinite(maxRows) && (maxRows as number) >= 0 ? (maxRows as number) : Infinity;
+
+    return Math.min(this.countPhysicalRows(), cap);
+  }
+
+  /**
+   * Checks whether an endpoint points outside the table.
+   *
+   * A *trimmed* destination row is not out of bounds - the row exists, it is only hidden - so it is
+   * deliberately not reported here. A row that is visible but sits past `maxRows` is out of bounds,
+   * because the grid renders no cell for it.
+   *
+   * @param {object} endpoint Contains the endpoint information.
+   * @param {number} [rowOffset=0] Row offset to apply before the check.
+   * @param {number} [colOffset=0] Column offset to apply before the check.
+   * @returns {boolean}
+   */
+  isEndpointOutOfBounds(endpoint: EndpointConfig, rowOffset = 0, colOffset = 0): boolean {
+    const destinationRow = endpoint.destinationRow! + rowOffset;
+    const destinationVisualRow = this.hot.toVisualRow(destinationRow);
+
+    return destinationRow >= this.countPhysicalRows() ||
+      endpoint.destinationColumn! + colOffset >= this.hot.countCols() ||
+      (destinationVisualRow !== null && destinationVisualRow >= this.hot.countRows());
   }
 
   /**
@@ -475,15 +509,7 @@ class Endpoints {
    */
   resetAllEndpoints(endpoints = this.getAllEndpoints(), useOffset = true) {
     const anyEndpointOutOfRange = endpoints.some((endpoint: EndpointConfig) => {
-      const alterRowOffset = endpoint.alterRowOffset || 0;
-      const alterColOffset = endpoint.alterColumnOffset || 0;
-
-      if (endpoint.destinationRow! + alterRowOffset >= this.countAddressableRows() ||
-          endpoint.destinationColumn! + alterColOffset >= this.hot.countCols()) {
-        return true;
-      }
-
-      return false;
+      return this.isEndpointOutOfBounds(endpoint, endpoint.alterRowOffset || 0, endpoint.alterColumnOffset || 0);
     });
 
     if (anyEndpointOutOfRange) {
@@ -650,8 +676,7 @@ class Endpoints {
    * @param {boolean} [render=false] `true` if it needs to render the table afterwards.
    */
   setEndpointValue(endpoint: EndpointConfig, source: string | undefined, render = false) {
-    if (endpoint.destinationRow! >= this.countAddressableRows() ||
-        endpoint.destinationColumn! >= this.hot.countCols()) {
+    if (this.isEndpointOutOfBounds(endpoint)) {
       this.throwOutOfBoundsWarning();
 
       return;
@@ -673,8 +698,10 @@ class Endpoints {
 
     endpoint.result = roundFloat(endpoint.result, endpoint.roundFloat) as string | number;
 
-    // A trimmed destination row has no cell to write to. The result is still calculated and kept on
-    // the endpoint, so it lands in the cell on the next refresh once the row is visible again.
+    // A trimmed destination row has no cell to write to - writing one throws in `DataMap.set`. The
+    // result stays on the endpoint; the cell keeps its previous value until the next recalculation
+    // that runs while the row is visible. Nothing re-runs the endpoints on untrim, so a destination
+    // hidden at the moment of a change shows a stale value until then.
     if (destinationVisualRow !== null) {
       if (render) {
         this.hot.setDataAtCell(

--- a/handsontable/src/plugins/columnSummary/endpoints.ts
+++ b/handsontable/src/plugins/columnSummary/endpoints.ts
@@ -89,11 +89,11 @@ class Endpoints {
    */
   cellsToSetCache: [number, number | undefined, unknown][] = [];
   /**
-   * Physical `row,column` keys of every endpoint destination, built once per refresh pass.
-   * Used to keep summary results out of other summaries when their row is trimmed and the
+   * Destination columns keyed by physical destination row, built once per refresh pass. Used to
+   * keep summary results out of other summaries when their row is trimmed and the
    * `columnSummaryResult` class is unreachable.
    */
-  #summaryDestinations: Set<string> | null = null;
+  #summaryDestinations: Map<number, Set<number>> | null = null;
 
   /**
    * Initializes the endpoints manager with a reference to the ColumnSummary plugin and the summary endpoint configuration.
@@ -145,13 +145,20 @@ class Endpoints {
    * Returns the number of rows an endpoint may address, that is the physical row count capped by
    * `maxRows`. Used for the settings defaults that need a row count rather than a bounds check.
    *
-   * A non-finite or negative `maxRows` is treated as no cap.
+   * `maxRows` is normalized the same way `DataMap#getLength` does it: `0` or less means zero rows,
+   * anything falsy means no cap.
    *
    * @returns {number}
    */
   countAddressableRows(): number {
-    const { maxRows } = this.hot.getSettings();
-    const cap = Number.isFinite(maxRows) && (maxRows as number) >= 0 ? (maxRows as number) : Infinity;
+    const maxRows = this.hot.getSettings().maxRows as number | undefined;
+    let cap;
+
+    if ((maxRows ?? 0) < 0 || maxRows === 0) {
+      cap = 0;
+    } else {
+      cap = maxRows || Infinity;
+    }
 
     return Math.min(this.countPhysicalRows(), cap);
   }
@@ -191,11 +198,26 @@ class Endpoints {
   }
 
   /**
-   * Drops the cached endpoint destinations. Called when a refresh pass starts, because the settings
-   * may be a function that returns different endpoints each time it runs.
+   * Records the destinations of the endpoints a refresh pass is about to calculate.
+   *
+   * The resolved endpoints are passed in rather than read through `getAllEndpoints()`, which would
+   * re-invoke a settings function and could describe a different layout than the pass is working on.
+   *
+   * @param {object[]} endpoints The endpoints the current pass will calculate.
    */
-  invalidateSummaryDestinations() {
-    this.#summaryDestinations = null;
+  cacheSummaryDestinations(endpoints: EndpointConfig[]) {
+    this.#summaryDestinations = new Map();
+
+    arrayEach(endpoints, (endpoint: EndpointConfig) => {
+      let columns = this.#summaryDestinations!.get(endpoint.destinationRow!);
+
+      if (columns === undefined) {
+        columns = new Set();
+        this.#summaryDestinations!.set(endpoint.destinationRow!, columns);
+      }
+
+      columns.add(endpoint.destinationColumn!);
+    });
   }
 
   /**
@@ -211,12 +233,10 @@ class Endpoints {
    */
   isSummaryDestination(physicalRow: number, column: number): boolean {
     if (this.#summaryDestinations === null) {
-      this.#summaryDestinations = new Set(
-        this.getAllEndpoints().map(endpoint => `${endpoint.destinationRow},${endpoint.destinationColumn}`)
-      );
+      this.cacheSummaryDestinations(this.getAllEndpoints());
     }
 
-    return this.#summaryDestinations.has(`${physicalRow},${column}`);
+    return this.#summaryDestinations!.get(physicalRow)?.has(column) === true;
   }
 
   /**
@@ -568,10 +588,12 @@ class Endpoints {
    * Calculate and refresh all defined endpoints.
    */
   refreshAllEndpoints() {
-    this.cellsToSetCache = [];
-    this.invalidateSummaryDestinations();
+    const endpoints = this.getAllEndpoints();
 
-    arrayEach(this.getAllEndpoints(), (value: EndpointConfig) => {
+    this.cellsToSetCache = [];
+    this.cacheSummaryDestinations(endpoints);
+
+    arrayEach(endpoints, (value: EndpointConfig) => {
       this.currentEndpoint = value;
       this.plugin.calculate(value as unknown as Parameters<typeof this.plugin.calculate>[0]);
       this.setEndpointValue(value, 'init');
@@ -591,10 +613,11 @@ class Endpoints {
    * @param {Array} changes Array of changes from the `afterChange` hook.
    */
   refreshChangedEndpoints(changes: unknown[][]) {
+    const endpoints = this.getAllEndpoints();
     const needToRefresh: number[] = [];
 
     this.cellsToSetCache = [];
-    this.invalidateSummaryDestinations();
+    this.cacheSummaryDestinations(endpoints);
 
     arrayEach(changes, (value: unknown, key: number, changesObj: unknown[]) => {
       const change = value as unknown[];
@@ -603,7 +626,7 @@ class Endpoints {
         return;
       }
 
-      arrayEach(this.getAllEndpoints(), (endpoint: EndpointConfig, j: number) => {
+      arrayEach(endpoints, (endpoint: EndpointConfig, j: number) => {
         if (this.hot.propToCol((changesObj[key] as unknown[])[1] as string | number) === endpoint.sourceColumn &&
           needToRefresh.indexOf(j) === -1) {
           needToRefresh.push(j);
@@ -612,7 +635,7 @@ class Endpoints {
     });
 
     arrayEach(needToRefresh, (value: number) => {
-      this.refreshEndpoint(this.getEndpoint(value));
+      this.refreshEndpoint(endpoints[value]);
     });
 
     if (this.cellsToSetCache.length) {
@@ -628,17 +651,18 @@ class Endpoints {
    * @param {Set<number>|number[]} visualColumns Visual column indexes to match against.
    */
   refreshEndpointsBySourceColumns(visualColumns: Set<number> | number[]) {
-    this.invalidateSummaryDestinations();
-
     const columnsSet = visualColumns instanceof Set ? visualColumns : new Set(visualColumns);
-    const matched = this.getAllEndpoints()
-      .filter(endpoint => columnsSet.has(endpoint.sourceColumn!));
+    const endpoints = this.getAllEndpoints();
+    const matched = endpoints.filter(endpoint => columnsSet.has(endpoint.sourceColumn!));
 
     if (matched.length === 0) {
       return;
     }
 
     this.cellsToSetCache = [];
+    // Every endpoint is cached, not just the matched ones - a summary result must stay excluded from
+    // the ranges of the endpoints being refreshed, whatever their own source column is.
+    this.cacheSummaryDestinations(endpoints);
 
     arrayEach(matched, (endpoint) => {
       this.refreshEndpoint(endpoint as EndpointConfig);

--- a/handsontable/src/plugins/columnSummary/endpoints.ts
+++ b/handsontable/src/plugins/columnSummary/endpoints.ts
@@ -123,6 +123,21 @@ class Endpoints {
   }
 
   /**
+   * Returns the number of rows an endpoint may address, that is the number of physical rows capped
+   * by the `maxRows` setting.
+   *
+   * Endpoint destination rows and calculation ranges are physical indexes, so they must never be
+   * compared against `countRows()` - that counts only the *visible* rows and shrinks whenever a
+   * plugin trims rows (NestedRows collapsing a group, TrimRows, the Filters plugin). With nothing
+   * trimmed this returns exactly `countRows()`.
+   *
+   * @returns {number}
+   */
+  countAddressableRows(): number {
+    return Math.min(this.hot.rowIndexMapper.getNumberOfIndexes(), this.hot.getSettings().maxRows ?? Infinity);
+  }
+
+  /**
    * Get an array with all the endpoints.
    *
    * @returns {Array}
@@ -169,7 +184,7 @@ class Endpoints {
     arrayEach(settingsArray, (val: EndpointConfig) => {
       const newEndpoint: EndpointConfig = {};
 
-      this.assignSetting(val, newEndpoint, 'ranges', [[0, this.hot.countRows() - 1]]);
+      this.assignSetting(val, newEndpoint, 'ranges', [[0, this.countAddressableRows() - 1]]);
       this.assignSetting(val, newEndpoint, 'reversedRowCoords', false);
       this.assignSetting(val, newEndpoint, 'destinationRow', new Error(`
         You must provide a destination row for the Column Summary plugin in order to work properly!
@@ -219,7 +234,7 @@ class Endpoints {
     } else {
       /* eslint-disable no-lonely-if */
       if (name === 'destinationRow' && endpoint.reversedRowCoords) {
-        endpoint[name] = this.hot.countRows() - (settings[name] as number) - 1;
+        endpoint[name] = this.countAddressableRows() - (settings[name] as number) - 1;
 
       } else {
         endpoint[name] = settings[name];
@@ -463,7 +478,7 @@ class Endpoints {
       const alterRowOffset = endpoint.alterRowOffset || 0;
       const alterColOffset = endpoint.alterColumnOffset || 0;
 
-      if (endpoint.destinationRow! + alterRowOffset >= this.hot.countRows() ||
+      if (endpoint.destinationRow! + alterRowOffset >= this.countAddressableRows() ||
           endpoint.destinationColumn! + alterColOffset >= this.hot.countCols()) {
         return true;
       }
@@ -612,9 +627,16 @@ class Endpoints {
   resetEndpointValue(endpoint: EndpointConfig, useOffset = true) {
     const alterRowOffset = endpoint.alterRowOffset || 0;
     const alterColOffset = endpoint.alterColumnOffset || 0;
+    const destinationVisualRow = this.hot.toVisualRow(endpoint.destinationRow! + (useOffset ? alterRowOffset : 0));
+
+    // The destination row is trimmed (for example it sits inside a collapsed NestedRows group), so
+    // there is no cell to clear.
+    if (destinationVisualRow === null) {
+      return;
+    }
 
     this.cellsToSetCache.push([
-      this.hot.toVisualRow(endpoint.destinationRow! + (useOffset ? alterRowOffset : 0)),
+      destinationVisualRow,
       this.hot.toVisualColumn(endpoint.destinationColumn! + (useOffset ? alterColOffset : 0)),
       ''
     ]);
@@ -628,9 +650,8 @@ class Endpoints {
    * @param {boolean} [render=false] `true` if it needs to render the table afterwards.
    */
   setEndpointValue(endpoint: EndpointConfig, source: string | undefined, render = false) {
-    const visualEndpointRowIndex = this.hot.toVisualRow(endpoint.destinationRow!);
-
-    if (endpoint.destinationRow! >= this.hot.countRows() || endpoint.destinationColumn! >= this.hot.countCols()) {
+    if (endpoint.destinationRow! >= this.countAddressableRows() ||
+        endpoint.destinationColumn! >= this.hot.countCols()) {
       this.throwOutOfBoundsWarning();
 
       return;
@@ -652,10 +673,16 @@ class Endpoints {
 
     endpoint.result = roundFloat(endpoint.result, endpoint.roundFloat) as string | number;
 
-    if (render) {
-      this.hot.setDataAtCell(visualEndpointRowIndex, endpoint.destinationColumn!, endpoint.result, 'ColumnSummary.set');
-    } else {
-      this.cellsToSetCache.push([visualEndpointRowIndex, endpoint.destinationColumn, endpoint.result]);
+    // A trimmed destination row has no cell to write to. The result is still calculated and kept on
+    // the endpoint, so it lands in the cell on the next refresh once the row is visible again.
+    if (destinationVisualRow !== null) {
+      if (render) {
+        this.hot.setDataAtCell(
+          destinationVisualRow, endpoint.destinationColumn!, endpoint.result, 'ColumnSummary.set'
+        );
+      } else {
+        this.cellsToSetCache.push([destinationVisualRow, endpoint.destinationColumn, endpoint.result]);
+      }
     }
 
     endpoint.alterRowOffset = undefined;

--- a/handsontable/src/plugins/columnSummary/endpoints.ts
+++ b/handsontable/src/plugins/columnSummary/endpoints.ts
@@ -88,6 +88,12 @@ class Endpoints {
    * @default {[]}
    */
   cellsToSetCache: [number, number | undefined, unknown][] = [];
+  /**
+   * Physical `row,column` keys of every endpoint destination, built once per refresh pass.
+   * Used to keep summary results out of other summaries when their row is trimmed and the
+   * `columnSummaryResult` class is unreachable.
+   */
+  #summaryDestinations: Set<string> | null = null;
 
   /**
    * Initializes the endpoints manager with a reference to the ColumnSummary plugin and the summary endpoint configuration.
@@ -182,6 +188,35 @@ class Endpoints {
     }
 
     return this.endpoints;
+  }
+
+  /**
+   * Drops the cached endpoint destinations. Called when a refresh pass starts, because the settings
+   * may be a function that returns different endpoints each time it runs.
+   */
+  invalidateSummaryDestinations() {
+    this.#summaryDestinations = null;
+  }
+
+  /**
+   * Checks whether a physical cell holds the result of an endpoint.
+   *
+   * `getCellValue` normally recognizes a result by its `columnSummaryResult` class, but cell meta is
+   * addressed by visual coordinates, so a trimmed row has no readable class. Without this check a
+   * hidden summary row is summed as if it were plain data and inflates every summary covering it.
+   *
+   * @param {number} physicalRow Physical row index.
+   * @param {number} column Column index.
+   * @returns {boolean}
+   */
+  isSummaryDestination(physicalRow: number, column: number): boolean {
+    if (this.#summaryDestinations === null) {
+      this.#summaryDestinations = new Set(
+        this.getAllEndpoints().map(endpoint => `${endpoint.destinationRow},${endpoint.destinationColumn}`)
+      );
+    }
+
+    return this.#summaryDestinations.has(`${physicalRow},${column}`);
   }
 
   /**
@@ -534,6 +569,7 @@ class Endpoints {
    */
   refreshAllEndpoints() {
     this.cellsToSetCache = [];
+    this.invalidateSummaryDestinations();
 
     arrayEach(this.getAllEndpoints(), (value: EndpointConfig) => {
       this.currentEndpoint = value;
@@ -558,6 +594,7 @@ class Endpoints {
     const needToRefresh: number[] = [];
 
     this.cellsToSetCache = [];
+    this.invalidateSummaryDestinations();
 
     arrayEach(changes, (value: unknown, key: number, changesObj: unknown[]) => {
       const change = value as unknown[];
@@ -591,6 +628,8 @@ class Endpoints {
    * @param {Set<number>|number[]} visualColumns Visual column indexes to match against.
    */
   refreshEndpointsBySourceColumns(visualColumns: Set<number> | number[]) {
+    this.invalidateSummaryDestinations();
+
     const columnsSet = visualColumns instanceof Set ? visualColumns : new Set(visualColumns);
     const matched = this.getAllEndpoints()
       .filter(endpoint => columnsSet.has(endpoint.sourceColumn!));


### PR DESCRIPTION
### Context

The PR fixes a `columnSummary` total row that stops working as soon as a `nestedRows` group is collapsed, reported in #11674.

**What goes wrong, in steps:**

1. In `columnSummary`, `destinationRow` and `ranges` are **physical** row indexes — positions in the raw data array.
2. Several places in `endpoints.ts` compared them against `hot.countRows()`, which counts only the rows that are currently **visible**.
3. Collapsing a `nestedRows` group trims its children, so `countRows()` shrinks while the physical dataset stays the same size.
4. A total row at the bottom of the data now has a physical index bigger than `countRows()`. The guard decides it is off the table, logs *"One of the Column Summary plugins' destination points you provided is beyond the table boundaries!"*, and skips it. The total goes stale.

Three more symptoms came out of the same confusion while investigating:

- **Silent wrong-row write.** With `reversedRowCoords: true` the plugin computes `countRows() - N - 1` and treats the answer as a physical index. After a collapse that number points at a **different, visible row** — in the added test the grand total was written into another group's header row, overwriting its value, with no warning at all.
- **Uncaught exception.** When the destination row was itself trimmed, `toVisualRow()` returned `null` and the plugin still called `setDataAtCell(null, …)`, throwing `TypeError: Cannot set properties of null` out of `DataMap.set`.
- **Hidden summary rows counted as data.** `getCellValue()` recognizes a summary result by its `columnSummaryResult` class, but cell meta is addressed by *visual* coordinates, so a trimmed row has no readable class. A hidden summary row was therefore summed as if it were plain data, inflating every summary whose range covered it.

### The fix

Bounds checking now runs through one predicate, `Endpoints#isEndpointOutOfBounds()`, which separates the three cases that `countRows()` had conflated:

- the physical row does not exist at all — out of bounds, warn;
- the row exists but is **trimmed** — not out of bounds, it is just hidden, so skip the write silently;
- the row is visible but sits past `maxRows` — out of bounds, the grid renders no cell for it.

When nothing is trimmed this is exactly equivalent to the old `destinationRow >= countRows()` test, so **behavior is unchanged for every setup that does not trim rows.**

For the last symptom, `getCellValue()` falls back to `Endpoints#isSummaryDestination()` when the row is trimmed. The destination set is built once per refresh pass and invalidated at the three batch entry points, so function-typed settings are not re-invoked per cell.

The settings defaults (the implicit `ranges`, and the `reversedRowCoords` conversion) use `countAddressableRows()` — the physical row count capped by `maxRows`. `countRows()` was silently carrying that cap, and dropping it breaks the existing "maxRows options set" spec. A non-finite or negative `maxRows` is treated as no cap.

### Behavior changes to note

Two, both visible only when rows are trimmed:

1. **Default calculation range.** When an endpoint declares no `ranges`, the default now spans the whole dataset rather than a visible-row-count prefix. The old value was an arbitrary physical prefix rather than anything meaningful. The `maxRows` cap still applies.
2. **`reversedRowCoords` under Filters / TrimRows.** It now resolves against the physical row count, so the summary pins to the last *physical* row. Previously it followed the last *visible* row, which under a filter meant the result was written over whatever data row happened to sit at the bottom of the filtered view. Pinning is what makes the `nestedRows` case correct, but it is a change for Filters users with function-typed settings — flagging it explicitly for a reviewer decision.

### Known limitation, not addressed here

Nothing re-runs the endpoints when rows are untrimmed — `columnSummary` registers no hook for expand, untrim or filter. So a destination row that was hidden at the moment of a change keeps a stale value, **and misses its `readOnly` / `columnSummaryResult` styling**, until the next recalculation that happens while it is visible. Both recover together at that point. This is pre-existing and orthogonal to this fix; there is no single generic untrim hook to attach to, and a naive `rowIndexMapper` listener would loop back on itself because the refresh writes through `setDataAtCell`. Worth its own ticket.

### How has this been tested?

Four cases added to `handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js`, all four verified red against `origin/develop` and green with the change:

- a grand-total row at the bottom of a nested dataset stays correct after collapsing a group;
- `reversedRowCoords: true` resolves against the physical row count, so the total stays in the last physical row instead of overwriting another group's header row;
- a destination row that is itself trimmed no longer throws, and picks up the correct value on the next recalculation once it is visible;
- a trimmed summary row is not counted as data by another summary that covers it.

```bash
npm run test:e2e --prefix handsontable -- --testPathPattern='columnSummary|nestedRows|trimRows|filters|hiddenRows'   # 920 specs, 0 failures
npm run test:unit --prefix handsontable                                                                              # 3597 tests, 0 failures
npm run eslint --prefix handsontable                                                                                 # 0 errors
npm run stylelint --prefix handsontable                                                                              # clean
npm run test:types --prefix handsontable                                                                             # clean
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #11674
2. DEV-2587

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2587

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches columnSummary calculation, bounds, and write paths used with NestedRows/TrimRows/Filters. Behavior of default ranges and reversedRowCoords changes when rows are trimmed; untrimmed tables should match previous behavior.
> 
> **Overview**
> Fixes `columnSummary` treating trimmed rows as missing. Destination rows and default ranges are physical indexes, but they were compared against `countRows()`, so collapsing a NestedRows group (or TrimRows/Filters) produced false out-of-bounds warnings, wrote results into the wrong visible row when `reversedRowCoords` was on, and crashed when writing to a hidden destination.
> 
> Bounds checks now use `isEndpointOutOfBounds()` against the physical row count (still capped by `maxRows`). Writes and resets skip trimmed destinations instead of calling `setDataAtCell(null, …)`. Hidden summary cells are excluded from other summaries via a per-refresh destination cache, because `columnSummaryResult` cell meta is not readable without visual coordinates.
> 
> Default `ranges` and `reversedRowCoords` now resolve against physical (maxRows-capped) length, so totals stay on the last physical row rather than the last visible one. Specs cover collapse, reversed coords, hidden destinations, and trimmed subtotals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cf10236783dec26a27d927bc8b63d6ef0ed3dc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->