### PR TITLE
DEV-2588: Stop passing the grid's maxRows/maxCols to the formulas engine

### DIFF
--- a/.changelogs/10672.json
+++ b/.changelogs/10672.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed a `Sheet size limit exceeded` error thrown when several grids shared one HyperFormula instance and one of them set `maxRows`.",
+  "title": "Fixed a `Sheet size limit exceeded` error thrown when grids sharing one HyperFormula instance used different `maxRows` values. The grid's `maxRows` and `maxCols` no longer limit the engine, so an oversized insert is now capped at the limit instead of being rejected.",
   "type": "fixed",
   "issueOrPR": 10672,
   "breaking": false,

--- a/.changelogs/10672.json
+++ b/.changelogs/10672.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a `Sheet size limit exceeded` error thrown when several grids shared one HyperFormula instance and one of them set `maxRows`.",
+  "type": "fixed",
+  "issueOrPR": 10672,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -1666,7 +1666,7 @@ describe('Formulas general', () => {
   });
 
   describe('hyperformula alter operation blocks', () => {
-    it('should block creating too many rows', async() => {
+    it('should cap row creation at `maxRows`, like a grid without the plugin', async() => {
       handsontable({
         data: [],
         formulas: {
@@ -1676,6 +1676,24 @@ describe('Formulas general', () => {
         },
         // TODO: Temporarily overwrite the default value due to https://github.com/handsontable/handsontable/issues/7840
         maxRows: 10000
+      });
+
+      await alter('insert_row_above', 0, 20000);
+
+      // `maxRows` is no longer forwarded to the engine (GH #10672), so the engine stops cancelling the
+      // whole insert and `dataMap.createRow` caps it at `maxRows` — the same as without the plugin.
+      expect(countRows()).toEqual(10000);
+    });
+
+    it('should still block creating more rows than the engine allows', async() => {
+      handsontable({
+        data: [],
+        formulas: {
+          engine: {
+            hyperformula: HyperFormula,
+            maxRows: 10
+          }
+        },
       });
 
       await alter('insert_row_above', 0, 20000);

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -1666,7 +1666,7 @@ describe('Formulas general', () => {
   });
 
   describe('hyperformula alter operation blocks', () => {
-    it('should block creating too many rows', async() => {
+    it('should cap row creation at `maxRows`, like a grid without the plugin', async() => {
       handsontable({
         data: [],
         formulas: {
@@ -1680,7 +1680,9 @@ describe('Formulas general', () => {
 
       await alter('insert_row_above', 0, 20000);
 
-      expect(countRows()).toEqual(0);
+      // The engine no longer carries the grid's `maxRows` (GH #10672), so it stops cancelling the whole
+      // insert and `dataMap.createRow` caps it at `maxRows` - the same as a grid without the plugin.
+      expect(countRows()).toEqual(10000);
     });
 
     it('should block creating too many columns', async() => {

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -1666,7 +1666,7 @@ describe('Formulas general', () => {
   });
 
   describe('hyperformula alter operation blocks', () => {
-    it('should cap row creation at `maxRows`, like a grid without the plugin', async() => {
+    it('should block creating too many rows', async() => {
       handsontable({
         data: [],
         formulas: {
@@ -1676,24 +1676,6 @@ describe('Formulas general', () => {
         },
         // TODO: Temporarily overwrite the default value due to https://github.com/handsontable/handsontable/issues/7840
         maxRows: 10000
-      });
-
-      await alter('insert_row_above', 0, 20000);
-
-      // `maxRows` is no longer forwarded to the engine (GH #10672), so the engine stops cancelling the
-      // whole insert and `dataMap.createRow` caps it at `maxRows` — the same as without the plugin.
-      expect(countRows()).toEqual(10000);
-    });
-
-    it('should still block creating more rows than the engine allows', async() => {
-      handsontable({
-        data: [],
-        formulas: {
-          engine: {
-            hyperformula: HyperFormula,
-            maxRows: 10
-          }
-        },
       });
 
       await alter('insert_row_above', 0, 20000);

--- a/handsontable/src/plugins/formulas/__tests__/initialization.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/initialization.spec.js
@@ -986,21 +986,25 @@ describe('Formulas general', () => {
       expect(getPlugin('formulas').engine.getConfig().maxRows).toBe(Infinity);
     });
 
-    it('should keep `maxRows` and `maxColumns` passed in the engine config', async() => {
+    it('should not apply the engine config\'s `maxRows` to a grid that outgrows it', async() => {
       handsontable({
+        data: createSpreadsheetData(100, 2),
         formulas: {
           engine: {
             hyperformula: HyperFormula,
-            maxRows: 123,
-            maxColumns: 45,
+            maxRows: 10,
           }
         }
       });
 
-      const { engine } = getPlugin('formulas');
+      // The grid's own `maxRows` still wins at creation, as it always has, so the 100 rows fit.
+      expect(getPlugin('formulas').engine.getConfig().maxRows).toBe(Infinity);
+      expect(countRows()).toBe(100);
 
-      expect(engine.getConfig().maxRows).toBe(123);
-      expect(engine.getConfig().maxColumns).toBe(45);
+      // ...and the update path must not resurrect the engine config's value either.
+      await updateSettings({ maxRows: Infinity });
+
+      expect(getPlugin('formulas').engine.getConfig().maxRows).toBe(Infinity);
     });
 
     it('should not throw `Sheet size limit exceeded` when a grid with a low `maxRows` shares an engine' +
@@ -1030,7 +1034,8 @@ describe('Formulas general', () => {
       // Before the fix this threw `SheetSizeLimitExceededError`.
       await updateSettings({ maxRows: 2 });
 
-      expect(engine.getConfig().maxRows).not.toBe(2);
+      // 40000 is HyperFormula's own default, untouched by either grid.
+      expect(engine.getConfig().maxRows).toBe(40000);
       expect(engine.getSheetDimensions(engine.getSheetId('Sheet2')).height).toBe(5);
     });
 

--- a/handsontable/src/plugins/formulas/__tests__/initialization.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/initialization.spec.js
@@ -950,28 +950,88 @@ describe('Formulas general', () => {
       expect(getPlugin('formulas').engine.updateConfig).not.toHaveBeenCalled();
     });
 
-    it('should update HyperFormula\'s settings if the new Handsontable settings would change them', async() => {
+    it('should not forward `maxRows` and `maxColumns` to the engine (GH #10672)', async() => {
       handsontable({
         formulas: {
           engine: HyperFormula
         }
       });
 
-      spyOn(getPlugin('formulas').engine, 'updateConfig').and.callThrough();
+      const { engine } = getPlugin('formulas');
+      const initialMaxRows = engine.getConfig().maxRows;
+      const initialMaxColumns = engine.getConfig().maxColumns;
+
+      spyOn(engine, 'updateConfig').and.callThrough();
 
       await updateSettings({
         maxColumns: 27
       });
 
-      expect(getPlugin('formulas').engine.updateConfig).toHaveBeenCalledTimes(1);
-      expect(getPlugin('formulas').engine.getConfig().maxColumns).toEqual(27);
-
       await updateSettings({
         maxRows: 27
       });
 
-      expect(getPlugin('formulas').engine.updateConfig).toHaveBeenCalledTimes(2);
-      expect(getPlugin('formulas').engine.getConfig().maxRows).toEqual(27);
+      expect(engine.updateConfig).not.toHaveBeenCalled();
+      expect(engine.getConfig().maxRows).toBe(initialMaxRows);
+      expect(engine.getConfig().maxColumns).toBe(initialMaxColumns);
+    });
+
+    it('should leave an engine created from a class unbounded by rows', async() => {
+      handsontable({
+        formulas: {
+          engine: HyperFormula
+        }
+      });
+
+      expect(getPlugin('formulas').engine.getConfig().maxRows).toBe(Infinity);
+    });
+
+    it('should keep `maxRows` and `maxColumns` passed in the engine config', async() => {
+      handsontable({
+        formulas: {
+          engine: {
+            hyperformula: HyperFormula,
+            maxRows: 123,
+            maxColumns: 45,
+          }
+        }
+      });
+
+      const { engine } = getPlugin('formulas');
+
+      expect(engine.getConfig().maxRows).toBe(123);
+      expect(engine.getConfig().maxColumns).toBe(45);
+    });
+
+    it('should not throw `Sheet size limit exceeded` when a grid with a low `maxRows` shares an engine' +
+      ' with a taller one (GH #10672)', async() => {
+      const engine = HyperFormula.buildEmpty({
+        licenseKey: 'internal-use-in-handsontable',
+      });
+
+      handsontable({
+        data: [['1'], ['2']],
+        maxRows: 2,
+        formulas: {
+          engine,
+          sheetName: 'Sheet1'
+        }
+      });
+
+      spec().$container2.handsontable({
+        data: [['a'], ['b'], ['c'], ['d'], ['e']],
+        formulas: {
+          engine,
+          sheetName: 'Sheet2'
+        }
+      }).data('handsontable');
+
+      // The React wrapper re-sends every prop on each render, so `maxRows` is always in the payload.
+      // Before the fix this threw `SheetSizeLimitExceededError`.
+      await updateSettings({ maxRows: 2 });
+
+      expect(engine.getConfig().maxRows).not.toBe(2);
+      expect(engine.getSheetDimensions(engine.getSheetId('Sheet2')).height).toBe(5);
     });
 
     it('should not update `sheetName` if `updateSettings` contains one that doesn\'t exist in the engine', async() => {

--- a/handsontable/src/plugins/formulas/__tests__/initialization.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/initialization.spec.js
@@ -986,7 +986,7 @@ describe('Formulas general', () => {
       expect(getPlugin('formulas').engine.getConfig().maxRows).toBe(Infinity);
     });
 
-    it('should not apply the engine config\'s `maxRows` to a grid that outgrows it', async() => {
+    it('should not bound the engine by a `maxRows` set in the engine config', async() => {
       handsontable({
         data: createSpreadsheetData(100, 2),
         formulas: {
@@ -997,14 +997,53 @@ describe('Formulas general', () => {
         }
       });
 
-      // The grid's own `maxRows` still wins at creation, as it always has, so the 100 rows fit.
+      // Dead config before GH #10672 and dead config now - the 100 rows have to fit either way.
       expect(getPlugin('formulas').engine.getConfig().maxRows).toBe(Infinity);
       expect(countRows()).toBe(100);
 
-      // ...and the update path must not resurrect the engine config's value either.
       await updateSettings({ maxRows: Infinity });
 
       expect(getPlugin('formulas').engine.getConfig().maxRows).toBe(Infinity);
+    });
+
+    it('should let a raised `maxRows` add rows again (GH #10672)', async() => {
+      handsontable({
+        data: [['1'], ['2']],
+        maxRows: 2,
+        formulas: {
+          engine: HyperFormula
+        }
+      });
+
+      await updateSettings({ maxRows: 100 });
+      await alter('insert_row_below', 1, 5);
+
+      expect(countRows()).toBe(7);
+    });
+
+    it('should not throw `Sheet size limit exceeded` when the next grid reuses the first grid\'s' +
+      ' engine (GH #10672)', async() => {
+      const hot1 = handsontable({
+        data: [['1'], ['2']],
+        maxRows: 2,
+        formulas: {
+          engine: HyperFormula,
+          sheetName: 'Sheet1'
+        }
+      });
+
+      // The sharing style the formulas guide recommends.
+      const hot2 = spec().$container2.handsontable({
+        data: [['a'], ['b'], ['c'], ['d'], ['e']],
+        formulas: {
+          engine: hot1.getPlugin('formulas').engine,
+          sheetName: 'Sheet2'
+        }
+      }).data('handsontable');
+
+      const { engine } = hot2.getPlugin('formulas');
+
+      expect(engine.getSheetDimensions(engine.getSheetId('Sheet2')).height).toBe(5);
     });
 
     it('should not throw `Sheet size limit exceeded` when a grid with a low `maxRows` shares an engine' +

--- a/handsontable/src/plugins/formulas/engine/__tests__/settings.unit.js
+++ b/handsontable/src/plugins/formulas/engine/__tests__/settings.unit.js
@@ -1,0 +1,74 @@
+import {
+  DEFAULT_SETTINGS,
+  getEngineSettingsOverrides,
+  getEngineSettingsWithDefaultsAndOverrides,
+  getEngineSettingsWithOverrides,
+} from '../settings';
+
+/**
+ * `maxRows` and `maxColumns` are per-instance display limits in Handsontable, but engine-wide in
+ * HyperFormula. Forwarding them meant that with a shared engine the smallest limit of any attached
+ * grid clamped every sheet, and HyperFormula threw `SheetSizeLimitExceededError` on the next
+ * `updateConfig`. See GH #10672.
+ */
+describe('Formulas engine settings', () => {
+  describe('getEngineSettingsOverrides', () => {
+    it('should not forward `maxRows` to the engine', () => {
+      const overrides = getEngineSettingsOverrides({ maxRows: 2 });
+
+      expect(overrides.maxRows).toBeUndefined();
+      expect('maxRows' in overrides).toBe(false);
+    });
+
+    it('should not forward `maxColumns` to the engine', () => {
+      const overrides = getEngineSettingsOverrides({ maxColumns: 2 });
+
+      expect(overrides.maxColumns).toBeUndefined();
+      expect('maxColumns' in overrides).toBe(false);
+    });
+
+    it('should still forward the plugin language', () => {
+      const overrides = getEngineSettingsOverrides({
+        formulas: { language: { langCode: 'plPL' } }
+      });
+
+      expect(overrides.language).toBe('plPL');
+    });
+  });
+
+  describe('getEngineSettingsWithDefaultsAndOverrides', () => {
+    it('should leave an engine created by Handsontable unbounded by rows', () => {
+      expect(DEFAULT_SETTINGS.maxRows).toBe(Infinity);
+      expect(getEngineSettingsWithDefaultsAndOverrides({}).maxRows).toBe(Infinity);
+    });
+
+    it('should not let the grid\'s `maxRows` clamp the engine', () => {
+      const settings = getEngineSettingsWithDefaultsAndOverrides({ maxRows: 2, maxColumns: 3 });
+
+      expect(settings.maxRows).toBe(Infinity);
+      expect(settings.maxColumns).toBeUndefined();
+    });
+
+    it('should keep `maxRows` and `maxColumns` declared in the engine config', () => {
+      const settings = getEngineSettingsWithDefaultsAndOverrides({
+        maxRows: 2,
+        maxColumns: 3,
+        formulas: {
+          engine: { hyperformula: () => {}, maxRows: 123, maxColumns: 45 }
+        }
+      });
+
+      expect(settings.maxRows).toBe(123);
+      expect(settings.maxColumns).toBe(45);
+    });
+  });
+
+  describe('getEngineSettingsWithOverrides', () => {
+    it('should not produce a `maxRows` change on every `updateSettings`', () => {
+      const settings = getEngineSettingsWithOverrides({ maxRows: 2, maxColumns: 3 });
+
+      expect(settings.maxRows).toBeUndefined();
+      expect(settings.maxColumns).toBeUndefined();
+    });
+  });
+});

--- a/handsontable/src/plugins/formulas/engine/__tests__/settings.unit.js
+++ b/handsontable/src/plugins/formulas/engine/__tests__/settings.unit.js
@@ -1,33 +1,30 @@
 import {
-  DEFAULT_SETTINGS,
   getEngineSettingsOverrides,
   getEngineSettingsWithDefaultsAndOverrides,
   getEngineSettingsWithOverrides,
+  haveEngineSettingsChanged,
 } from '../settings';
 
 /**
  * `maxRows` and `maxColumns` are per-instance display limits in Handsontable, but engine-wide in
- * HyperFormula. Forwarding them meant that with a shared engine the smallest limit of any attached
- * grid clamped every sheet, and HyperFormula threw `SheetSizeLimitExceededError` on the next
- * `updateConfig`. See GH #10672.
+ * HyperFormula. Syncing them on `updateSettings` clamped every sheet the engine holds, so with a
+ * shared engine the smallest limit of any attached grid made HyperFormula throw
+ * `SheetSizeLimitExceededError`. See GH #10672.
+ *
+ * An engine the plugin creates itself is private to one grid, so it is still bounded at creation.
  */
 describe('Formulas engine settings', () => {
+  const engineConfig = { hyperformula: () => {}, maxRows: 123, maxColumns: 45 };
+
   describe('getEngineSettingsOverrides', () => {
-    it('should not forward `maxRows` to the engine', () => {
-      const overrides = getEngineSettingsOverrides({ maxRows: 2 });
+    it('should not carry `maxRows` or `maxColumns`', () => {
+      const overrides = getEngineSettingsOverrides({ maxRows: 2, maxColumns: 3 });
 
-      expect(overrides.maxRows).toBeUndefined();
       expect('maxRows' in overrides).toBe(false);
-    });
-
-    it('should not forward `maxColumns` to the engine', () => {
-      const overrides = getEngineSettingsOverrides({ maxColumns: 2 });
-
-      expect(overrides.maxColumns).toBeUndefined();
       expect('maxColumns' in overrides).toBe(false);
     });
 
-    it('should still forward the plugin language', () => {
+    it('should still carry the plugin language', () => {
       const overrides = getEngineSettingsOverrides({
         formulas: { language: { langCode: 'plPL' } }
       });
@@ -36,38 +33,46 @@ describe('Formulas engine settings', () => {
     });
   });
 
-  describe('getEngineSettingsWithDefaultsAndOverrides', () => {
-    it('should leave an engine created by Handsontable unbounded by rows', () => {
-      expect(DEFAULT_SETTINGS.maxRows).toBe(Infinity);
-      expect(getEngineSettingsWithDefaultsAndOverrides({}).maxRows).toBe(Infinity);
+  describe('getEngineSettingsWithOverrides (used on every `updateSettings`)', () => {
+    it('should not carry the grid\'s `maxRows` or `maxColumns`', () => {
+      const settings = getEngineSettingsWithOverrides({ maxRows: 2, maxColumns: 3 });
+
+      expect('maxRows' in settings).toBe(false);
+      expect('maxColumns' in settings).toBe(false);
     });
 
-    it('should not let the grid\'s `maxRows` clamp the engine', () => {
-      const settings = getEngineSettingsWithDefaultsAndOverrides({ maxRows: 2, maxColumns: 3 });
+    it('should not carry `maxRows` or `maxColumns` declared in the engine config either', () => {
+      const settings = getEngineSettingsWithOverrides({ formulas: { engine: engineConfig } });
 
-      expect(settings.maxRows).toBe(Infinity);
-      expect(settings.maxColumns).toBeUndefined();
+      expect('maxRows' in settings).toBe(false);
+      expect('maxColumns' in settings).toBe(false);
     });
 
-    it('should keep `maxRows` and `maxColumns` declared in the engine config', () => {
-      const settings = getEngineSettingsWithDefaultsAndOverrides({
-        maxRows: 2,
-        maxColumns: 3,
-        formulas: {
-          engine: { hyperformula: () => {}, maxRows: 123, maxColumns: 45 }
-        }
-      });
+    it('should report no change for a grid whose `maxRows` differs from the engine\'s', () => {
+      const settings = getEngineSettingsWithOverrides({ maxRows: 2 });
 
-      expect(settings.maxRows).toBe(123);
-      expect(settings.maxColumns).toBe(45);
+      expect(haveEngineSettingsChanged({ maxRows: 40000 }, settings)).toBe(false);
     });
   });
 
-  describe('getEngineSettingsWithOverrides', () => {
-    it('should not produce a `maxRows` change on every `updateSettings`', () => {
-      const settings = getEngineSettingsWithOverrides({ maxRows: 2, maxColumns: 3 });
+  describe('getEngineSettingsWithDefaultsAndOverrides (used only when the plugin creates the engine)', () => {
+    it('should still bound the created engine by the grid\'s `maxRows`', () => {
+      expect(getEngineSettingsWithDefaultsAndOverrides({ maxRows: 2 }).maxRows).toBe(2);
+    });
 
-      expect(settings.maxRows).toBeUndefined();
+    it('should leave the created engine unbounded when the grid sets no `maxRows`', () => {
+      expect(getEngineSettingsWithDefaultsAndOverrides({ maxRows: Infinity }).maxRows).toBe(Infinity);
+    });
+
+    it('should let the grid\'s limits win over the engine config, as before', () => {
+      const settings = getEngineSettingsWithDefaultsAndOverrides({
+        maxRows: 2,
+        formulas: { engine: engineConfig }
+      });
+
+      expect(settings.maxRows).toBe(2);
+      // `maxColumns` is not a Handsontable option, so it resolves to `undefined` and HyperFormula
+      // falls back to its own default. Preserved deliberately - see the note in `settings.ts`.
       expect(settings.maxColumns).toBeUndefined();
     });
   });

--- a/handsontable/src/plugins/formulas/engine/__tests__/settings.unit.js
+++ b/handsontable/src/plugins/formulas/engine/__tests__/settings.unit.js
@@ -7,11 +7,9 @@ import {
 
 /**
  * `maxRows` and `maxColumns` are per-instance display limits in Handsontable, but engine-wide in
- * HyperFormula. Syncing them on `updateSettings` clamped every sheet the engine holds, so with a
- * shared engine the smallest limit of any attached grid made HyperFormula throw
- * `SheetSizeLimitExceededError`. See GH #10672.
- *
- * An engine the plugin creates itself is private to one grid, so it is still bounded at creation.
+ * HyperFormula, so passing them on made the smallest limit of any attached grid clamp every sheet the
+ * engine holds and HyperFormula throw `SheetSizeLimitExceededError`. They now never reach the engine,
+ * at creation or on update. See GH #10672.
  */
 describe('Formulas engine settings', () => {
   const engineConfig = { hyperformula: () => {}, maxRows: 123, maxColumns: 45 };
@@ -55,25 +53,33 @@ describe('Formulas engine settings', () => {
     });
   });
 
-  describe('getEngineSettingsWithDefaultsAndOverrides (used only when the plugin creates the engine)', () => {
-    it('should still bound the created engine by the grid\'s `maxRows`', () => {
-      expect(getEngineSettingsWithDefaultsAndOverrides({ maxRows: 2 }).maxRows).toBe(2);
+  describe('getEngineSettingsWithDefaultsAndOverrides (used when the plugin creates the engine)', () => {
+    it('should not bound the created engine by the grid\'s `maxRows`', () => {
+      expect(getEngineSettingsWithDefaultsAndOverrides({ maxRows: 2 }).maxRows).toBe(Infinity);
     });
 
-    it('should leave the created engine unbounded when the grid sets no `maxRows`', () => {
-      expect(getEngineSettingsWithDefaultsAndOverrides({ maxRows: Infinity }).maxRows).toBe(Infinity);
+    it('should leave the created engine unbounded, not capped at HyperFormula\'s 40000', () => {
+      expect(getEngineSettingsWithDefaultsAndOverrides({}).maxRows).toBe(Infinity);
     });
 
-    it('should let the grid\'s limits win over the engine config, as before', () => {
+    it('should not bound the created engine by the engine config either', () => {
       const settings = getEngineSettingsWithDefaultsAndOverrides({
         maxRows: 2,
         formulas: { engine: engineConfig }
       });
 
-      expect(settings.maxRows).toBe(2);
-      // `maxColumns` is not a Handsontable option, so it resolves to `undefined` and HyperFormula
-      // falls back to its own default. Preserved deliberately - see the note in `settings.ts`.
-      expect(settings.maxColumns).toBeUndefined();
+      expect(settings.maxRows).toBe(Infinity);
+      // Left unset so HyperFormula falls back to its own default, exactly as before - `maxColumns` was
+      // read from a Handsontable option that does not exist (the option is `maxCols`).
+      expect('maxColumns' in settings).toBe(false);
+    });
+
+    it('should keep passing through non-size engine settings', () => {
+      const settings = getEngineSettingsWithDefaultsAndOverrides({
+        formulas: { engine: { hyperformula: () => {}, useStats: true } }
+      });
+
+      expect(settings.useStats).toBe(true);
     });
   });
 });

--- a/handsontable/src/plugins/formulas/engine/settings.ts
+++ b/handsontable/src/plugins/formulas/engine/settings.ts
@@ -5,6 +5,10 @@ export const DEFAULT_LICENSE_KEY = 'internal-use-in-handsontable';
 export const DEFAULT_SETTINGS = {
   licenseKey: DEFAULT_LICENSE_KEY,
 
+  // HyperFormula's own default is 40000. Handsontable's `maxRows` used to be forwarded here, and it
+  // defaults to `Infinity`, so engines created by Handsontable have always been unbounded. Keep it.
+  maxRows: Infinity,
+
   useArrayArithmetic: true,
   useColumnIndex: false,
   useStats: false,
@@ -33,6 +37,10 @@ export const DEFAULT_SETTINGS = {
 /**
  * Gets a set of engine settings to be applied on top of the provided settings, based on user's Handsontable settings.
  *
+ * `maxRows` and `maxColumns` are deliberately not forwarded. They are per-instance display limits in
+ * Handsontable, but engine-wide in HyperFormula, so with a shared engine the smallest one clamped every
+ * sheet and threw `SheetSizeLimitExceededError`. See GH #10672.
+ *
  * @param {object} hotSettings Handsontable settings object.
  * @returns {object} Object containing the overriding options.
  */
@@ -40,8 +48,6 @@ export function getEngineSettingsOverrides(hotSettings: Record<string, unknown>)
   const pluginSetting = hotSettings[PLUGIN_KEY] as Record<string, unknown> | undefined;
 
   return {
-    maxColumns: hotSettings.maxColumns,
-    maxRows: hotSettings.maxRows,
     language: (pluginSetting?.language as Record<string, unknown> | undefined)?.langCode
   };
 }

--- a/handsontable/src/plugins/formulas/engine/settings.ts
+++ b/handsontable/src/plugins/formulas/engine/settings.ts
@@ -5,10 +5,6 @@ export const DEFAULT_LICENSE_KEY = 'internal-use-in-handsontable';
 export const DEFAULT_SETTINGS = {
   licenseKey: DEFAULT_LICENSE_KEY,
 
-  // HyperFormula's own default is 40000. Handsontable's `maxRows` used to be forwarded here, and it
-  // defaults to `Infinity`, so engines created by Handsontable have always been unbounded. Keep it.
-  maxRows: Infinity,
-
   useArrayArithmetic: true,
   useColumnIndex: false,
   useStats: false,
@@ -35,11 +31,30 @@ export const DEFAULT_SETTINGS = {
 };
 
 /**
- * Gets a set of engine settings to be applied on top of the provided settings, based on user's Handsontable settings.
+ * Size limits that Handsontable applies to one grid, but HyperFormula applies to a whole engine.
+ * They may be set when the engine is created, and never synced afterwards - see GH #10672.
+ */
+const ENGINE_SIZE_SETTINGS = ['maxRows', 'maxColumns'];
+
+/**
+ * Drops the engine-wide size limits from a set of settings.
  *
- * `maxRows` and `maxColumns` are deliberately not forwarded. They are per-instance display limits in
- * Handsontable, but engine-wide in HyperFormula, so with a shared engine the smallest one clamped every
- * sheet and threw `SheetSizeLimitExceededError`. See GH #10672.
+ * @param {object} engineSettings Engine settings.
+ * @returns {object}
+ */
+function dropEngineSizeSettings(engineSettings: Record<string, unknown>) {
+  return Object.keys(engineSettings)
+    .reduce<Record<string, unknown>>((obj, key) => {
+      if (!ENGINE_SIZE_SETTINGS.includes(key)) {
+        obj[key] = engineSettings[key];
+      }
+
+      return obj;
+    }, {});
+}
+
+/**
+ * Gets a set of engine settings to be applied on top of the provided settings, based on user's Handsontable settings.
  *
  * @param {object} hotSettings Handsontable settings object.
  * @returns {object} Object containing the overriding options.
@@ -98,12 +113,21 @@ export function getEngineSettingsWithDefaultsAndOverrides(hotSettings: Record<st
   return {
     ...DEFAULT_SETTINGS,
     ...userSettings,
-    ...overrides
+    ...overrides,
+    // The engine created here belongs to this grid alone, so bounding it by the grid's own limits is
+    // safe. `maxColumns` is not a Handsontable option - the option is `maxCols` - so it always resolves
+    // to `undefined`; kept as-is to leave the created engine's configuration exactly as it was.
+    maxColumns: hotSettings.maxColumns,
+    maxRows: hotSettings.maxRows,
   };
 }
 
 /**
  * Get engine settings from a Handsontable settings object with overrides.
+ *
+ * Meant to be used on *every* `updateSettings`, so it must never carry the engine-wide size limits:
+ * the engine it updates may be shared with other grids, and shrinking it below what their sheets
+ * already hold makes HyperFormula throw `SheetSizeLimitExceededError`. See GH #10672.
  *
  * @param {object} hotSettings Handsontable settings object.
  * @returns {object}
@@ -115,10 +139,10 @@ export function getEngineSettingsWithOverrides(hotSettings: Record<string, unkno
   const userSettings = cleanEngineSettings(engine?.hyperformula ? engine : {});
   const overrides = getEngineSettingsOverrides(hotSettings);
 
-  return {
+  return dropEngineSizeSettings({
     ...userSettings,
     ...overrides
-  };
+  });
 }
 
 /**

--- a/handsontable/src/plugins/formulas/engine/settings.ts
+++ b/handsontable/src/plugins/formulas/engine/settings.ts
@@ -5,6 +5,10 @@ export const DEFAULT_LICENSE_KEY = 'internal-use-in-handsontable';
 export const DEFAULT_SETTINGS = {
   licenseKey: DEFAULT_LICENSE_KEY,
 
+  // HyperFormula's own default is 40000. Handsontable used to pass its `maxRows` here, and that
+  // defaults to `Infinity`, so an engine the plugin builds has never been bounded. Keep it that way.
+  maxRows: Infinity,
+
   useArrayArithmetic: true,
   useColumnIndex: false,
   useStats: false,
@@ -31,8 +35,12 @@ export const DEFAULT_SETTINGS = {
 };
 
 /**
- * Size limits that Handsontable applies to one grid, but HyperFormula applies to a whole engine.
- * They may be set when the engine is created, and never synced afterwards - see GH #10672.
+ * Size limits that Handsontable applies to a single grid, but HyperFormula applies to a whole engine.
+ *
+ * They are never passed to the engine. Any engine can end up shared - the guide recommends reusing
+ * one grid's engine in the next grid - and bounding a shared engine by one grid's display limit makes
+ * HyperFormula throw `SheetSizeLimitExceededError` over another grid's taller sheet. Handsontable
+ * enforces `maxRows`/`maxCols` on its own data anyway. See GH #10672.
  */
 const ENGINE_SIZE_SETTINGS = ['maxRows', 'maxColumns'];
 
@@ -104,30 +112,21 @@ export function getEngineSettingsWithDefaultsAndOverrides(hotSettings: Record<st
   const pluginSettings = hotSettings[PLUGIN_KEY] as Record<string, unknown> | undefined;
 
   const engine = pluginSettings?.engine as Record<string, unknown> | undefined;
-  const userSettings = cleanEngineSettings(
+  const userSettings = dropEngineSizeSettings(cleanEngineSettings(
     engine?.hyperformula ? engine : {}
-  );
+  ));
 
   const overrides = getEngineSettingsOverrides(hotSettings);
 
   return {
     ...DEFAULT_SETTINGS,
     ...userSettings,
-    ...overrides,
-    // The engine created here belongs to this grid alone, so bounding it by the grid's own limits is
-    // safe. `maxColumns` is not a Handsontable option - the option is `maxCols` - so it always resolves
-    // to `undefined`; kept as-is to leave the created engine's configuration exactly as it was.
-    maxColumns: hotSettings.maxColumns,
-    maxRows: hotSettings.maxRows,
+    ...overrides
   };
 }
 
 /**
  * Get engine settings from a Handsontable settings object with overrides.
- *
- * Meant to be used on *every* `updateSettings`, so it must never carry the engine-wide size limits:
- * the engine it updates may be shared with other grids, and shrinking it below what their sheets
- * already hold makes HyperFormula throw `SheetSizeLimitExceededError`. See GH #10672.
  *
  * @param {object} hotSettings Handsontable settings object.
  * @returns {object}
@@ -136,13 +135,13 @@ export function getEngineSettingsWithOverrides(hotSettings: Record<string, unkno
   const pluginSettings = hotSettings[PLUGIN_KEY] as Record<string, unknown> | undefined;
 
   const engine = pluginSettings?.engine as Record<string, unknown> | undefined;
-  const userSettings = cleanEngineSettings(engine?.hyperformula ? engine : {});
+  const userSettings = dropEngineSizeSettings(cleanEngineSettings(engine?.hyperformula ? engine : {}));
   const overrides = getEngineSettingsOverrides(hotSettings);
 
-  return dropEngineSizeSettings({
+  return {
     ...userSettings,
     ...overrides
-  });
+  };
 }
 
 /**

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -98,7 +98,7 @@ function hasValueProperty(candidate: unknown): candidate is { value: unknown } {
 }
 
 export const PLUGIN_KEY = 'formulas';
-// `maxRows` and `maxColumns` are no longer forwarded to the engine (GH #10672), but they stay here:
+// `maxRows` and `maxColumns` no longer reach the engine on update (GH #10672), but they stay here:
 // `updatePlugin` also creates or switches the sheet, and dropping them would skip that.
 export const SETTING_KEYS = ['maxRows', 'maxColumns', 'language'];
 export const PLUGIN_PRIORITY = 260;

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -98,7 +98,7 @@ function hasValueProperty(candidate: unknown): candidate is { value: unknown } {
 }
 
 export const PLUGIN_KEY = 'formulas';
-// `maxRows` and `maxColumns` no longer reach the engine on update (GH #10672), but they stay here:
+// `maxRows` and `maxColumns` no longer reach the engine at all (GH #10672), but they stay here:
 // `updatePlugin` also creates or switches the sheet, and dropping them would skip that.
 export const SETTING_KEYS = ['maxRows', 'maxColumns', 'language'];
 export const PLUGIN_PRIORITY = 260;

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -98,6 +98,8 @@ function hasValueProperty(candidate: unknown): candidate is { value: unknown } {
 }
 
 export const PLUGIN_KEY = 'formulas';
+// `maxRows` and `maxColumns` are no longer forwarded to the engine (GH #10672), but they stay here:
+// `updatePlugin` also creates or switches the sheet, and dropping them would skip that.
 export const SETTING_KEYS = ['maxRows', 'maxColumns', 'language'];
 export const PLUGIN_PRIORITY = 260;
 


### PR DESCRIPTION
### Context

The PR fixes `SheetSizeLimitExceededError: Sheet size limit exceeded`, thrown when grids share one HyperFormula engine and one of them sets `maxRows` lower than another grid's row count. Reported in #10672 against 14.0.0; still reproduces on `develop` (18.0.0 + HyperFormula 3.3.0) with the same stack trace.

The same option name means two different things in the two libraries:

| | Handsontable | HyperFormula |
|---|---|---|
| Scope | per grid instance | per **engine**, shared by every sheet |
| Purpose | how many rows to display | memory ceiling (`Engine` category, default 40000) |

The plugin passed the grid's per-instance display limit into that engine-wide setting, both when it created the engine and on every `updateSettings`. Any engine can end up shared, so the smallest limit among the attached grids became the ceiling for every sheet, and HyperFormula's rebuild threw over a taller one. HyperFormula behaves as documented — this is ours.

**The fix stops passing `maxRows`/`maxColumns` to the engine entirely** — not on update, and not at creation either. Handsontable already enforces `maxRows`/`maxCols` on its own data, so the engine does not need to.

Doing it only on the update path is not enough, because an engine created by one grid is routinely shared with the next: the formulas guide recommends exactly that (`engine: hot1.getPlugin('formulas').engine`). With creation-time bounding still in place, `hot1` with `maxRows: 2` produced an engine that threw as soon as `hot2` loaded five rows into it. That path throws on `develop` too and is now covered by a test.

Two details the merge has to get right:

- The limits must be dropped from **both** sources on the update path. A `maxRows` written inside `formulas.engine` reaches the same merge through the user settings, and on `develop` it was only ever neutralised because the grid's own value spread last.
- `DEFAULT_SETTINGS` now pins `maxRows: Infinity`. Handsontable's `maxRows` defaults to `Infinity` and was always passed on, so an engine the plugin builds has never been bounded; without this it would silently fall back to HyperFormula's 40000 and break large grids.

`maxColumns` is left unset, exactly as before: it was read from a Handsontable option that does not exist (the option is `maxCols`), so it always resolved to `undefined` and HyperFormula fell back to its own default. A `maxRows`/`maxColumns` inside `formulas.engine` stays dead config, as on `develop` — making it live would mean a grid taller than that value starts throwing at construction.

**One user-visible behavior change.** Inserting more rows than `maxRows` allows used to cancel the whole insert, because the engine carried the mirrored limit and `beforeCreateRow` returned `false`. The engine no longer carries it, so `dataMap.createRow` caps the insert at `maxRows` — the same result a grid without the plugin gives. This also fixes the flip side: raising `maxRows` with `updateSettings` now lets rows be added again, where a limit baked into the engine at creation used to block them for good. Both are covered by tests. Not a breaking change under the policy — no default value changed and no API was removed.

No documentation states that these settings reach the engine (checked `docs/content/guides/formulas/` and the plugin JSDoc), so there is nothing to correct there.

### How has this been tested?

Unit tests for the merge contract, written against `develop` first and confirmed to fail on it:

```bash
npm run test:unit --prefix handsontable -- --testPathPattern=formulas/engine
```

E2E specs in `initialization.spec.js` covering all four cases below, plus the updated insert-cap spec in `formulas.spec.js`:

```bash
npm run test:e2e --prefix handsontable -- --testPathPattern=formulas   # 337 specs, 0 failures
npm run test:unit --prefix handsontable                                # 3605 passed
npm run test --prefix wrappers/react-wrapper                           # 75 passed
npm run eslint --prefix handsontable                                   # 0 errors
npm run test:types --prefix handsontable
npm run build --prefix handsontable
```

Verified in headless Chrome against built bundles, before and after:

| Scenario | `develop` | This PR |
|---|---|---|
| Two grids sharing an externally built engine, `maxRows: 2` on the smaller one | throws | OK, engine limit untouched |
| Grid 2 reusing grid 1's engine, the style the guide recommends | throws | OK |
| 100 rows with `engine: { hyperformula, maxRows: 10 }` | OK | OK, formulas compute |
| `maxRows: 2`, raised to 100, then insert 5 rows | 7 rows | 7 rows |

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2588
2. #10672
3. Upstream, same root cause for the column axis: https://github.com/handsontable/hyperformula/issues/1185

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2588

<sub>The commit history shows three passes at this: the first two bounded the engine at creation and were walked back after review found they broke engine reuse and froze the engine's limit at its starting value. Squash-merging, so only the title lands in history.</sub>
