### PR TITLE
DEV-2590: Stop the fill handle painting over the frozen panes

### DIFF
--- a/.changelogs/13220.json
+++ b/.changelogs/13220.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the autofill fill handle being cut in half at the bottom freeze line.",
+  "type": "fixed",
+  "issueOrPR": 13220,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -29,6 +29,32 @@ Self-contained rendering engine for viewport calculation, DOM rendering, scroll 
 
 `Border` in `src/selection/border/border.ts` has TWO distinct handle systems: `selectionHandles` (mobile touch handles, created by `createMultipleSelectorHandles()`, CSS classes `topSelectionHandle`/`bottomSelectionHandle`) and `adjustHandles` (desktop drag-to-resize handles added in 18.0.0, CSS class `.wtSelectionHandle`, controlled by the `selectionHandles` grid option). Do not conflate them.
 
+## Selection affordances must stay under the overlay clones (z-index < 120)
+
+`.ht_master` is `position: relative` with no z-index, so it opens **no stacking context** and every
+element inside it competes directly with the overlay clone divs (`inline_start` 120, `bottom` 130,
+`bottom_inline_start_corner` 150, `top` 160, `top_inline_start_corner` 180). An affordance drawn
+inside the master at 120 or above therefore paints on top of a frozen pane once its cell scrolls
+under one, and wins hit-testing there — the crosshair and the drag are stolen from the frozen cells.
+
+The window 101–119 is reserved for these: the `moveCells` bands (100, inlined by `createMoveZone`),
+the autofill fill handle (`.wtBorder.corner`, 110) and the desktop resize handles
+(`.wtSelectionHandle`, 115). Do not raise any of them to clear something else — every frozen overlay
+draws its own copy of each affordance, so none of them needs to outrank a clone to appear inside a
+pane. `.ht_clone_master: 100` in the z-index map does **not** apply to the master overlay; that class
+is stamped on the editor container by `src/editors/factory.ts`.
+
+Two related mechanisms that look like counter-examples and are not: the mobile selection handles take
+an inline `zIndex = '9999'` when a selection edge lands on a freeze line (`border.ts`, legacy #9850),
+and the fill handle is *repositioned* rather than re-layered at the `fixedRowsBottom` line
+(`isCornerLiftedAtBlockEnd`). Handles drawn by a frozen overlay itself need no such treatment: they
+already land flush against the `.wtHolder` edge that clips them, which `border.spec.js` pins to the
+pixel on both axes. Note `.wtHolder` is the clipping box (`overflow: hidden`), while the clone element
+is `overflow: visible` and ends a few pixels earlier — measure the holder, not the clone.
+
+The declarations live in `src/styles/base/_z-index-map.scss`, `css/walkontable.scss` (clone values,
+duplicated — keep in sync) and `src/styles/components/core/_selection.scss` (the affordances).
+
 ## Naming gotcha: `moveCells` grid option vs. HyperFormula engine method
 
 The Handsontable `moveCells` grid option (added 18.0.0) enables drag-to-move for selections. HyperFormula exposes an identically named `engine.moveCells()` method that the `Formulas` plugin calls internally to relocate formula references. They are unrelated -- do not confuse the user-facing option with the HyperFormula engine API.

--- a/handsontable/src/3rdparty/walkontable/css/walkontable.scss
+++ b/handsontable/src/3rdparty/walkontable/css/walkontable.scss
@@ -190,6 +190,12 @@ innerBorderBottom - Property controlled by bottom overlay
   cursor: crosshair;
 }
 
+/*
+ * Overlay clone layers. Declared twice — here and in `src/styles/base/_z-index-map.scss`, which also
+ * documents the 101–119 window reserved for selection affordances drawn inside an overlay. Keep the
+ * two lists in sync, and keep every affordance below 120: `.ht_master` opens no stacking context, so
+ * anything at or above that value paints over a frozen pane its cell has scrolled under.
+ */
 .ht_clone_master {
   z-index: 100;
 }

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -1249,6 +1249,12 @@ class Border {
   /**
    * Show border around one or many cells.
    *
+   * The fill handle is normally centered on the selection's bottom-end corner, so half of it hangs
+   * past that corner. Two rows cannot afford that overhang and lift the handle by half its height
+   * instead (the `wtCornerBlockEndEdge` class pulls its hit area up to match): the grid's last row,
+   * where the overhang would spill out of the trimming container, and the `fixedRowsBottom` seam
+   * row, where the bottom overlay paints above the master and would cut the handle in half.
+   *
    * @param {Array} corners The corner coordinates.
    */
   appear(corners: number[]) {
@@ -1552,11 +1558,15 @@ class Border {
         removeClass(this.corner!, 'wtCornerInlineEndEdge');
       }
 
-      if (toRow === (this.wot.getSetting('totalRows') as number) - 1) {
+      const isBlockEndRow = toRow === (this.wot.getSetting('totalRows') as number) - 1;
+      const isBottomFreezeSeamRow = this.isFrozenBottomBoundaryEdge(toRow);
+
+      if (isBlockEndRow || isBottomFreezeSeamRow) {
         const { top: toTdOffsetTop } = fillHandleAnchor;
         const cornerHalfHeight = parseInt(String(this.cornerDefaultStyle.height), 10) / 2;
         const cornerBottomEdge = toTdOffsetTop + geometryReader.outerHeight(toTDEl) + cornerHalfHeight;
-        const cornerOverlappingContainer = cornerBottomEdge >= geometryReader.innerHeight(trimmingContainer);
+        const cornerOverlappingContainer = isBottomFreezeSeamRow ||
+          cornerBottomEdge >= geometryReader.innerHeight(trimmingContainer);
 
         if (cornerOverlappingContainer) {
           const cornerTopPosition = Math.floor(

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -479,7 +479,7 @@ class Border {
    * one selection edge. Hovering a band shows a `grab` cursor; a `mousedown` on a band calls the
    * `onSelectionEdgeMouseDown` Walkontable setting so the core can initiate a move drag.
    *
-   * Bands sit at z-index 100 — below the resize pills (z-index 200) and below the autofill fill
+   * Bands sit at z-index 100 — below the resize pills (z-index 115) and below the autofill fill
    * handle (`.wtBorder.corner`, z-index 110), so both keep winning their own pixels in the corner
    * regions where the bands overlap them. All four bands are created hidden; `positionMoveZone`
    * + `appear` control their visibility.
@@ -1247,13 +1247,86 @@ class Border {
   }
 
   /**
+   * Tells whether the fill handle must be pulled back inside the selection's inline-end edge instead
+   * of straddling it. Only the grid's last column needs that, where the overhang would spill out of
+   * the trimming container and force a scrollbar. A selection ending on the last frozen-start column
+   * does not: the frozen overlay draws that handle itself and already lands it flush against its own
+   * edge, which `border.spec.js` pins to the pixel — lifting it there moves it off that line.
+   *
+   * @private
+   * @param {number} toColumn The selection's inline-end column index.
+   * @param {number} anchorInlineStart The fill handle anchor's inline-start offset.
+   * @param {HTMLElement} TD The cell that carries the fill handle.
+   * @param {HTMLElement | Window} trimmingContainer The container that clips the grid.
+   * @param {boolean} isRtl Whether the grid renders right-to-left.
+   * @returns {boolean}
+   */
+  isCornerLiftedAtInlineEnd(
+    toColumn: number,
+    anchorInlineStart: number,
+    TD: HTMLElement,
+    trimmingContainer: HTMLElement | Window,
+    isRtl: boolean,
+  ): boolean {
+    if (toColumn !== (this.wot.getSetting('totalColumns') as number) - 1) {
+      return false;
+    }
+
+    const { geometryReader } = this.wot.domBindings;
+    const cornerHalfWidth = parseInt(String(this.cornerDefaultStyle.width), 10) / 2;
+
+    if (isRtl) {
+      return anchorInlineStart - cornerHalfWidth < 0;
+    }
+
+    return anchorInlineStart + geometryReader.outerWidth(TD) + cornerHalfWidth
+      >= geometryReader.innerWidth(trimmingContainer);
+  }
+
+  /**
+   * Block-axis mirror of {@link Border#isCornerLiftedAtInlineEnd}. Two rows pull the fill handle back
+   * inside the selection's bottom edge: the grid's last row, where the overhang would spill out of
+   * the trimming container, and the last scrollable row above the `fixedRowsBottom` line, where the
+   * bottom overlay is painted above the master and would cover the overhang. The last frozen-top row
+   * is not one of them — like the frozen-start column, that handle is drawn by the overlay itself and
+   * already sits flush against its edge.
+   *
+   * @private
+   * @param {number} toRow The selection's bottom row index.
+   * @param {number} anchorTop The fill handle anchor's top offset.
+   * @param {HTMLElement} TD The cell that carries the fill handle.
+   * @param {HTMLElement | Window} trimmingContainer The container that clips the grid.
+   * @returns {boolean}
+   */
+  isCornerLiftedAtBlockEnd(
+    toRow: number,
+    anchorTop: number,
+    TD: HTMLElement,
+    trimmingContainer: HTMLElement | Window,
+  ): boolean {
+    if (this.isFrozenBottomBoundaryEdge(toRow)) {
+      return true;
+    }
+
+    if (toRow !== (this.wot.getSetting('totalRows') as number) - 1) {
+      return false;
+    }
+
+    const { geometryReader } = this.wot.domBindings;
+    const cornerHalfHeight = parseInt(String(this.cornerDefaultStyle.height), 10) / 2;
+
+    return anchorTop + geometryReader.outerHeight(TD) + cornerHalfHeight
+      >= geometryReader.innerHeight(trimmingContainer);
+  }
+
+  /**
    * Show border around one or many cells.
    *
    * The fill handle is normally centered on the selection's bottom-end corner, so half of it hangs
-   * past that corner. Two rows cannot afford that overhang and lift the handle by half its height
-   * instead (the `wtCornerBlockEndEdge` class pulls its hit area up to match): the grid's last row,
-   * where the overhang would spill out of the trimming container, and the `fixedRowsBottom` seam
-   * row, where the bottom overlay paints above the master and would cut the handle in half.
+   * past that corner. Where that overhang cannot survive — a container edge, or a frozen pane that
+   * clips or covers it — the handle is pulled back inside instead, and `wtCornerInlineEndEdge` /
+   * `wtCornerBlockEndEdge` pull its hit area along. See {@link Border#isCornerLiftedAtInlineEnd} and
+   * {@link Border#isCornerLiftedAtBlockEnd} for which edges those are.
    *
    * @param {Array} corners The corner coordinates.
    */
@@ -1530,53 +1603,34 @@ class Border {
       const cornerHalfHeight = Math.ceil(parseInt(String(this.cornerDefaultStyle.height), 10) / 2);
       const fillHandleAnchor = this.getFillHandleAnchor(toTDEl, toOffset, trimToWindow);
 
-      if (toColumn === (this.wot.getSetting('totalColumns') as number) - 1) {
-        const { left: toTdOffsetLeft } = fillHandleAnchor;
-        let cornerOverlappingContainer = false;
-        let cornerEdge = 0;
+      const liftsAtInlineEnd = this.isCornerLiftedAtInlineEnd(
+        toColumn, fillHandleAnchor.left, toTDEl, trimmingContainer, isRtl
+      );
 
-        if (isRtl) {
-          cornerEdge = toTdOffsetLeft - (parseInt(String(this.cornerDefaultStyle.width), 10) / 2);
-          cornerOverlappingContainer = cornerEdge < 0;
+      if (liftsAtInlineEnd) {
+        const inlineStartPosition = Math.floor(
+          inlineStartPos + width + this.cornerCenterPointOffset - cornerHalfWidth - cornerBorderCompensation
+        );
 
-        } else {
-          cornerEdge = toTdOffsetLeft + geometryReader.outerWidth(toTDEl)
-            + (parseInt(String(this.cornerDefaultStyle.width), 10) / 2);
-          cornerOverlappingContainer = cornerEdge >= geometryReader.innerWidth(trimmingContainer);
-        }
+        addClass(this.corner!, 'wtCornerInlineEndEdge');
 
-        if (cornerOverlappingContainer) {
-          const inlineStartPosition = Math.floor(
-            inlineStartPos + width + this.cornerCenterPointOffset - cornerHalfWidth - cornerBorderCompensation
-          );
-
-          addClass(this.corner!, 'wtCornerInlineEndEdge');
-
-          this.cornerStyle![inlinePosProperty] = `${inlineStartPosition - 1}px`;
-        }
+        this.cornerStyle![inlinePosProperty] = `${inlineStartPosition - 1}px`;
       } else {
         removeClass(this.corner!, 'wtCornerInlineEndEdge');
       }
 
-      const isBlockEndRow = toRow === (this.wot.getSetting('totalRows') as number) - 1;
-      const isBottomFreezeSeamRow = this.isFrozenBottomBoundaryEdge(toRow);
+      const liftsAtBlockEnd = this.isCornerLiftedAtBlockEnd(
+        toRow, fillHandleAnchor.top, toTDEl, trimmingContainer
+      );
 
-      if (isBlockEndRow || isBottomFreezeSeamRow) {
-        const { top: toTdOffsetTop } = fillHandleAnchor;
-        const cornerHalfHeight = parseInt(String(this.cornerDefaultStyle.height), 10) / 2;
-        const cornerBottomEdge = toTdOffsetTop + geometryReader.outerHeight(toTDEl) + cornerHalfHeight;
-        const cornerOverlappingContainer = isBottomFreezeSeamRow ||
-          cornerBottomEdge >= geometryReader.innerHeight(trimmingContainer);
+      if (liftsAtBlockEnd) {
+        const cornerTopPosition = Math.floor(
+          top + height + this.cornerCenterPointOffset - cornerHalfHeight - cornerBorderCompensation
+        );
 
-        if (cornerOverlappingContainer) {
-          const cornerTopPosition = Math.floor(
-            top + height + this.cornerCenterPointOffset - cornerHalfHeight - cornerBorderCompensation
-          );
+        addClass(this.corner!, 'wtCornerBlockEndEdge');
 
-          addClass(this.corner!, 'wtCornerBlockEndEdge');
-
-          this.cornerStyle!.top = `${cornerTopPosition - 1}px`;
-        }
+        this.cornerStyle!.top = `${cornerTopPosition - 1}px`;
       } else {
         removeClass(this.corner!, 'wtCornerBlockEndEdge');
       }

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -480,7 +480,7 @@ class Border {
    * `onSelectionEdgeMouseDown` Walkontable setting so the core can initiate a move drag.
    *
    * Bands sit at z-index 100 — below the resize pills (z-index 200) and below the autofill fill
-   * handle (`.wtBorder.corner`, z-index 150), so both keep winning their own pixels in the corner
+   * handle (`.wtBorder.corner`, z-index 110), so both keep winning their own pixels in the corner
    * regions where the bands overlap them. All four bands are created hidden; `positionMoveZone`
    * + `appear` control their visibility.
    *

--- a/handsontable/src/styles/base/_z-index-map.scss
+++ b/handsontable/src/styles/base/_z-index-map.scss
@@ -1,6 +1,16 @@
 @use "sass:map";
 
-// Z-index map
+// Z-index map.
+// 101–119 is reserved for selection affordances drawn inside an overlay: the moveCells bands (100,
+// inlined by `border.ts`), the autofill fill handle (110) and the selection resize handles (115),
+// all in `components/core/_selection.scss`.
+// Nothing in that group may reach 120. `.ht_master` declares no z-index, so it opens no stacking
+// context and its children compete directly with the clone values below — an affordance at 120 or
+// above paints over a frozen pane its cell has scrolled under, and wins hit-testing there. The
+// frozen overlays draw their own copy of every affordance, so none of them needs to outrank a clone
+// to be visible inside a pane.
+// The clone values are declared twice: here, and in
+// `handsontable/src/3rdparty/walkontable/css/walkontable.scss`. Keep both in sync.
 
 $z-indexes: (
   "ht_clone_master": 100,

--- a/handsontable/src/styles/components/core/_selection.scss
+++ b/handsontable/src/styles/components/core/_selection.scss
@@ -43,7 +43,10 @@
     .wtSelectionHandle {
       position: absolute;
       box-sizing: border-box;
-      z-index: 200;
+      // Above the fill handle (110) and the moveCells bands (100), below the overlay clones
+      // (inline_start 120) — `.ht_master` opens no stacking context, so a pill above the clones
+      // paints over a frozen pane the selection has scrolled under and takes the click there.
+      z-index: 115;
       background: var(--ht-cell-selection-handle-background-color);
       border: var(--ht-cell-selection-handle-border-width) solid var(--ht-cell-selection-handle-border-color);
       border-radius: var(--ht-cell-selection-handle-border-radius);
@@ -211,7 +214,7 @@
         font-size: 0;
         cursor: crosshair;
         // Above the moveCells bands (z-index 100, inline) — they span the SE corner, and the fill
-        // handle must keep winning its own pixels there — but below the resize pills (z-index 200).
+        // handle must keep winning its own pixels there — but below the resize pills (z-index 115).
         // The ceiling is tighter than 200 though: `.ht_master` sets no z-index, so it opens no
         // stacking context and every border inside it competes directly with the overlay clones
         // (inline_start 120, bottom 130 — see base/_z-index-map.scss). Anything at 120 or above

--- a/handsontable/src/styles/components/core/_selection.scss
+++ b/handsontable/src/styles/components/core/_selection.scss
@@ -212,7 +212,12 @@
         cursor: crosshair;
         // Above the moveCells bands (z-index 100, inline) — they span the SE corner, and the fill
         // handle must keep winning its own pixels there — but below the resize pills (z-index 200).
-        z-index: 150;
+        // The ceiling is tighter than 200 though: `.ht_master` sets no z-index, so it opens no
+        // stacking context and every border inside it competes directly with the overlay clones
+        // (inline_start 120, bottom 130 — see base/_z-index-map.scss). Anything at 120 or above
+        // paints the handle over a frozen pane the selection has scrolled under, and lets it win
+        // hit-testing there too.
+        z-index: 110;
 
         &::after {
           content: '';

--- a/tests/e2e/fill-handle-frozen-panes.spec.ts
+++ b/tests/e2e/fill-handle-frozen-panes.spec.ts
@@ -42,7 +42,9 @@ test.describe('fill handle and frozen panes', () => {
     await expect(grid.fillHandle()).toBeVisible();
     await grid.scrollCellBehindFrozenPane(5, 3, 'columns');
 
-    await expect.poll(() => grid.elementAtFillHandleCenter()).not.toContain('wtBorder');
+    // The frozen pane owns those pixels now — asserting on the overlay too, so a handle that simply
+    // moved somewhere else cannot pass this as "occluded".
+    await expect.poll(() => grid.elementAtFillHandleCenter()).toBe('ht_clone_inline_start/');
   });
 
   test('hides the fill handle behind the bottom frozen rows when the cell scrolls under them', async () => {
@@ -52,6 +54,6 @@ test.describe('fill handle and frozen panes', () => {
     await expect(grid.fillHandle()).toBeVisible();
     await grid.scrollCellBehindFrozenPane(3, 1, 'rows');
 
-    await expect.poll(() => grid.elementAtFillHandleCenter()).not.toContain('wtBorder');
+    await expect.poll(() => grid.elementAtFillHandleCenter()).toBe('ht_clone_bottom/');
   });
 });

--- a/tests/e2e/fill-handle-frozen-panes.spec.ts
+++ b/tests/e2e/fill-handle-frozen-panes.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '../fixtures/test';
+import { SelectionFeaturesPage } from '../fixtures/pages/SelectionFeaturesPage';
+
+/**
+ * The autofill fill handle (`.wtBorder.corner`) against the frozen panes. `.ht_master` declares no
+ * z-index, so it opens no stacking context and every border inside it competes directly with the
+ * overlay clones. A handle whose z-index reaches the clone range paints over a frozen pane the
+ * selection has scrolled under, and wins hit-testing there.
+ */
+test.describe('fill handle and frozen panes', () => {
+  let grid: SelectionFeaturesPage;
+
+  test.beforeEach(async ({ page, theme }) => {
+    grid = new SelectionFeaturesPage(page, theme);
+    await grid.goto();
+  });
+
+  test('keeps the fill handle between the move bands and the frozen panes in the stack', async () => {
+    await grid.initGrid({ fixedColumnsStart: 2 });
+    await grid.selectCells(4, 3, 6, 5);
+    await grid.hoverCell(5, 4);
+
+    // Both the bands and the resize pills are created lazily on the first draw that enables them,
+    // so the stack can only be read once they are on the page.
+    await expect(grid.visibleHandles()).toHaveCount(4);
+    await expect(grid.visibleMoveZones()).toHaveCount(4);
+
+    const stack = await grid.selectionStackOrder();
+
+    // Above the bands, or pressing the handle in the SE corner starts a move drag instead of
+    // autofill; below the resize pills, which own the edge midpoints.
+    expect(stack.moveZone).toBeLessThan(stack.fillHandle);
+    expect(stack.fillHandle).toBeLessThan(stack.resizeHandle);
+    // Below the frozen panes, or the handle outranks a clone that is supposed to occlude it.
+    expect(stack.fillHandle).toBeLessThan(stack.frozenColumnsPane);
+  });
+
+  test('hides the fill handle behind the frozen columns when the cell scrolls under them', async () => {
+    await grid.initGrid({ fixedColumnsStart: 2 });
+    await grid.selectCells(5, 3, 5, 3);
+
+    await expect(grid.fillHandle()).toBeVisible();
+    await grid.scrollCellBehindFrozenPane(5, 3, 'columns');
+
+    await expect.poll(() => grid.elementAtFillHandleCenter()).not.toContain('wtBorder');
+  });
+
+  test('hides the fill handle behind the bottom frozen rows when the cell scrolls under them', async () => {
+    await grid.initGrid({ fixedRowsBottom: 2, height: 150 });
+    await grid.selectCells(3, 1, 3, 1);
+
+    await expect(grid.fillHandle()).toBeVisible();
+    await grid.scrollCellBehindFrozenPane(3, 1, 'rows');
+
+    await expect.poll(() => grid.elementAtFillHandleCenter()).not.toContain('wtBorder');
+  });
+});

--- a/tests/e2e/fill-handle-frozen-panes.spec.ts
+++ b/tests/e2e/fill-handle-frozen-panes.spec.ts
@@ -10,6 +10,9 @@ import { SelectionFeaturesPage } from '../fixtures/pages/SelectionFeaturesPage';
 test.describe('fill handle and frozen panes', () => {
   let grid: SelectionFeaturesPage;
 
+  const WIDE_DATA = Array.from({ length: 10 }, (_, row) =>
+    Array.from({ length: 40 }, (_, col) => `R${row + 1}C${col + 1}`));
+
   test.beforeEach(async ({ page, theme }) => {
     grid = new SelectionFeaturesPage(page, theme);
     await grid.goto();
@@ -36,7 +39,9 @@ test.describe('fill handle and frozen panes', () => {
   });
 
   test('hides the fill handle behind the frozen columns when the cell scrolls under them', async () => {
-    await grid.initGrid({ fixedColumnsStart: 2 });
+    // The fixture's 10 columns leave a theme like horizon barely any horizontal scroll room, and a
+    // scroll that clamps short never pushes the cell under the pane. WIDE_DATA guarantees the room.
+    await grid.initGrid({ data: WIDE_DATA, fixedColumnsStart: 2 });
     await grid.selectCells(5, 3, 5, 3);
 
     await expect(grid.fillHandle()).toBeVisible();
@@ -44,7 +49,7 @@ test.describe('fill handle and frozen panes', () => {
 
     // The frozen pane owns those pixels now — asserting on the overlay too, so a handle that simply
     // moved somewhere else cannot pass this as "occluded".
-    await expect.poll(() => grid.elementAtFillHandleCenter()).toBe('ht_clone_inline_start/');
+    await expect.poll(() => grid.elementAtFillHandleCenter()).toMatch(/^ht_clone_inline_start\//);
   });
 
   test('lifts the fill handle above the bottom freeze seam so it stays whole', async () => {
@@ -55,7 +60,7 @@ test.describe('fill handle and frozen panes', () => {
     await grid.selectCells(7, 1, 7, 1);
 
     await expect(grid.fillHandle()).toHaveClass(/wtCornerBlockEndEdge/);
-    await expect.poll(() => grid.elementAtFillHandleCenter()).toContain('corner');
+    await expect.poll(() => grid.elementAtFillHandleCenter()).toMatch(/^ht_master\/.*corner/);
   });
 
   test('hides the fill handle behind the bottom frozen rows when the cell scrolls under them', async () => {
@@ -65,6 +70,6 @@ test.describe('fill handle and frozen panes', () => {
     await expect(grid.fillHandle()).toBeVisible();
     await grid.scrollCellBehindFrozenPane(3, 1, 'rows');
 
-    await expect.poll(() => grid.elementAtFillHandleCenter()).toBe('ht_clone_bottom/');
+    await expect.poll(() => grid.elementAtFillHandleCenter()).toMatch(/^ht_clone_bottom\//);
   });
 });

--- a/tests/e2e/fill-handle-frozen-panes.spec.ts
+++ b/tests/e2e/fill-handle-frozen-panes.spec.ts
@@ -63,6 +63,36 @@ test.describe('fill handle and frozen panes', () => {
     await expect.poll(() => grid.elementAtFillHandleCenter()).toMatch(/^ht_master\/.*corner/);
   });
 
+  test('leaves the frozen-column handle flush with the pane edge instead of lifting it', async () => {
+    // The frozen overlay draws this handle itself and already lands it on its own edge, so it needs
+    // no lift — walkontable's border.spec.js pins that alignment to the pixel.
+    await grid.initGrid({ data: WIDE_DATA, fixedColumnsStart: 2 });
+    await grid.selectCells(5, 1, 5, 1);
+
+    await expect(grid.frozenColumnsFillHandle()).not.toHaveClass(/wtCornerInlineEndEdge/);
+    expect(await grid.frozenFillHandleOverflow('columns')).toBeLessThanOrEqual(1);
+  });
+
+  test('leaves the frozen-top-row handle flush with the pane edge instead of lifting it', async () => {
+    await grid.initGrid({ fixedRowsTop: 2 });
+    await grid.selectCells(1, 1, 1, 1);
+
+    await expect(grid.frozenTopFillHandle()).not.toHaveClass(/wtCornerBlockEndEdge/);
+    expect(await grid.frozenFillHandleOverflow('rows')).toBeLessThanOrEqual(1);
+  });
+
+  test('keeps the resize pills under the frozen panes in the stack', async () => {
+    await grid.initGrid({ data: WIDE_DATA, fixedColumnsStart: 2 });
+    await grid.selectCells(4, 3, 6, 5);
+    await grid.hoverCell(5, 4);
+
+    await expect(grid.visibleHandles()).toHaveCount(4);
+
+    const stack = await grid.selectionStackOrder();
+
+    expect(stack.resizeHandle).toBeLessThan(stack.frozenColumnsPane);
+  });
+
   test('hides the fill handle behind the bottom frozen rows when the cell scrolls under them', async () => {
     await grid.initGrid({ fixedRowsBottom: 2, height: 150 });
     await grid.selectCells(3, 1, 3, 1);

--- a/tests/e2e/fill-handle-frozen-panes.spec.ts
+++ b/tests/e2e/fill-handle-frozen-panes.spec.ts
@@ -47,6 +47,17 @@ test.describe('fill handle and frozen panes', () => {
     await expect.poll(() => grid.elementAtFillHandleCenter()).toBe('ht_clone_inline_start/');
   });
 
+  test('lifts the fill handle above the bottom freeze seam so it stays whole', async () => {
+    // 10 rows, fixedRowsBottom: 2 → row 7 is the last scrollable row and its bottom edge is the
+    // seam. A handle centered there would be cut in half by the bottom overlay, so it is lifted by
+    // half its height, exactly like the handle on the grid's own last row.
+    await grid.initGrid({ fixedRowsBottom: 2, height: 150 });
+    await grid.selectCells(7, 1, 7, 1);
+
+    await expect(grid.fillHandle()).toHaveClass(/wtCornerBlockEndEdge/);
+    await expect.poll(() => grid.elementAtFillHandleCenter()).toContain('corner');
+  });
+
   test('hides the fill handle behind the bottom frozen rows when the cell scrolls under them', async () => {
     await grid.initGrid({ fixedRowsBottom: 2, height: 150 });
     await grid.selectCells(3, 1, 3, 1);

--- a/tests/e2e/move-zone.spec.ts
+++ b/tests/e2e/move-zone.spec.ts
@@ -405,7 +405,7 @@ test.describe('moveCells edge move bands', () => {
 
   test('keeps the autofill fill handle clickable above the move bands', async ({ page }) => {
     // The bottom/end bands span the SE corner where the fill handle sits. The handle must win
-    // that overlap (z-index 150 vs the bands' 100) — otherwise pressing it starts a move drag
+    // that overlap (z-index 110 vs the bands' 100) — otherwise pressing it starts a move drag
     // instead of autofill.
     await grid.selectCells(2, 2, 2, 2);
 

--- a/tests/e2e/move-zone.spec.ts
+++ b/tests/e2e/move-zone.spec.ts
@@ -23,7 +23,7 @@ test.describe('moveCells edge move bands', () => {
 
     for (let index = 0; index < 4; index++) {
       // The grab cursor is the move affordance; z-index 100 keeps the bands
-      // below the resize pills (z-index 200) where they overlap in corners.
+      // below the resize pills (z-index 115) where they overlap in corners.
       await expect(bands.nth(index)).toHaveCSS('cursor', 'grab');
       await expect(bands.nth(index)).toHaveCSS('z-index', '100');
     }

--- a/tests/fixtures/pages/SelectionFeaturesPage.ts
+++ b/tests/fixtures/pages/SelectionFeaturesPage.ts
@@ -752,12 +752,16 @@ export class SelectionFeaturesPage {
   }
 
   /**
-   * Scroll the master viewport until the given cell slides behind a frozen pane, stopping with the
-   * cell's trailing edge at the middle of that pane. The cell stays rendered, so its border (and
-   * fill handle) keep their positions — the frozen pane is simply expected to occlude them.
+   * Scroll the master viewport until the given cell's trailing edge sits just inside a frozen pane,
+   * which is where its fill handle is drawn. Stopping a fixed few pixels past the pane's edge rather
+   * than at its middle keeps the cell inside the rendered range in every theme, whatever its column
+   * widths and row heights are — a cell scrolled clean out of that range drops its handle entirely
+   * and leaves nothing to assert on.
    */
   async scrollCellBehindFrozenPane(row: number, col: number, pane: 'columns' | 'rows'): Promise<void> {
-    await this.page.evaluate(({ targetRow, targetCol, targetPane }) => {
+    const paneInset = 8;
+
+    await this.page.evaluate(({ targetRow, targetCol, targetPane, inset }) => {
       const holder = document.querySelector('.ht_master .wtHolder');
       const cell = document.querySelector(`.ht_master [data-testid="cell-${targetRow}-${targetCol}"]`);
       const paneElement = document.querySelector(
@@ -772,18 +776,18 @@ export class SelectionFeaturesPage {
       const paneRect = paneElement.getBoundingClientRect();
 
       if (targetPane === 'columns') {
-        holder.scrollLeft += cellRect.right - (paneRect.left + (paneRect.width / 2));
+        holder.scrollLeft += cellRect.right - (paneRect.right - inset);
       } else {
-        holder.scrollTop += cellRect.bottom - (paneRect.top + (paneRect.height / 2));
+        holder.scrollTop += cellRect.bottom - (paneRect.top + inset);
       }
-    }, { targetRow: row, targetCol: col, targetPane: pane });
+    }, { targetRow: row, targetCol: col, targetPane: pane, inset: paneInset });
   }
 
   /**
    * What the browser hit-tests at the center of the fill handle, as `<overlay>/<class name>`. A
-   * frozen pane that occludes the handle owns those pixels, so the topmost element there is one of
-   * that pane's cells rather than the handle. The overlay half of the reading matters: a hit on a
-   * master cell would mean the handle simply is not where the test assumed, not that the pane won.
+   * frozen pane that occludes the handle owns those pixels, so the topmost element there belongs to
+   * that pane rather than to the master. Match on the overlay and treat the class name as detail:
+   * which of the pane's elements is topmost at that point depends on the theme's cell metrics.
    */
   async elementAtFillHandleCenter(): Promise<string> {
     const handleBox = await this.fillHandle().boundingBox();

--- a/tests/fixtures/pages/SelectionFeaturesPage.ts
+++ b/tests/fixtures/pages/SelectionFeaturesPage.ts
@@ -724,6 +724,44 @@ export class SelectionFeaturesPage {
   }
 
   /**
+   * The fill handle drawn by the frozen-columns overlay — a selection ending inside that pane is
+   * rendered by the clone, not by the master.
+   */
+  frozenColumnsFillHandle(): Locator {
+    return this.page.locator('.ht_clone_inline_start .wtBorder.current.corner:visible');
+  }
+
+  /** The fill handle drawn by the frozen top-rows overlay. */
+  frozenTopFillHandle(): Locator {
+    return this.page.locator('.ht_clone_top .wtBorder.current.corner:visible');
+  }
+
+  /**
+   * How far a frozen overlay's own fill handle sticks out past the edge that clips it, in pixels.
+   * The clipping box is the overlay's `.wtHolder` (`overflow: hidden`), not the clone element, which
+   * is `overflow: visible` and ends a few pixels earlier — measuring the clone reports an overhang
+   * that is not actually cut off.
+   */
+  async frozenFillHandleOverflow(pane: 'columns' | 'rows'): Promise<number> {
+    return this.page.evaluate((targetPane) => {
+      const overlaySelector = targetPane === 'columns' ? '.ht_clone_inline_start' : '.ht_clone_top';
+      const clippingBox = document.querySelector(`${overlaySelector} .wtHolder`);
+      const handle = document.querySelector(`${overlaySelector} .wtBorder.current.corner`);
+
+      if (!clippingBox || !handle) {
+        throw new Error(`No fill handle is rendered by "${overlaySelector}".`);
+      }
+
+      const clippingRect = clippingBox.getBoundingClientRect();
+      const handleRect = handle.getBoundingClientRect();
+
+      return targetPane === 'columns'
+        ? handleRect.right - clippingRect.right
+        : handleRect.bottom - clippingRect.bottom;
+    }, pane);
+  }
+
+  /**
    * The stacking order the selection affordances resolve to. `.ht_master` declares no z-index, so
    * it opens no stacking context and its borders compete directly with the overlay clones — which
    * is why the frozen pane's own z-index belongs in the same reading.

--- a/tests/fixtures/pages/SelectionFeaturesPage.ts
+++ b/tests/fixtures/pages/SelectionFeaturesPage.ts
@@ -780,9 +780,10 @@ export class SelectionFeaturesPage {
   }
 
   /**
-   * The class name of whatever the browser hit-tests at the center of the fill handle. A frozen
-   * pane that occludes the handle owns those pixels, so the topmost element there is one of its
-   * cells rather than the handle itself.
+   * What the browser hit-tests at the center of the fill handle, as `<overlay>/<class name>`. A
+   * frozen pane that occludes the handle owns those pixels, so the topmost element there is one of
+   * that pane's cells rather than the handle. The overlay half of the reading matters: a hit on a
+   * master cell would mean the handle simply is not where the test assumed, not that the pane won.
    */
   async elementAtFillHandleCenter(): Promise<string> {
     const handleBox = await this.fillHandle().boundingBox();
@@ -794,7 +795,15 @@ export class SelectionFeaturesPage {
     return this.page.evaluate(({ x, y }) => {
       const element = document.elementFromPoint(x, y);
 
-      return element ? element.className : '';
+      if (!element) {
+        return 'none/none';
+      }
+
+      const overlay = element.closest('[class*="ht_clone_"], .ht_master');
+      const overlayName = overlay
+        ? Array.from(overlay.classList).find(name => name.startsWith('ht_')) : 'none';
+
+      return `${overlayName}/${element.className}`;
     }, { x: handleBox.x + (handleBox.width / 2), y: handleBox.y + (handleBox.height / 2) });
   }
 

--- a/tests/fixtures/pages/SelectionFeaturesPage.ts
+++ b/tests/fixtures/pages/SelectionFeaturesPage.ts
@@ -718,6 +718,86 @@ export class SelectionFeaturesPage {
     return this.page.locator('.ht_master .wtMoveZone:visible');
   }
 
+  /** The autofill fill handle of the focus selection, scoped to the master overlay. */
+  fillHandle(): Locator {
+    return this.page.locator('.ht_master .wtBorder.current.corner:visible');
+  }
+
+  /**
+   * The stacking order the selection affordances resolve to. `.ht_master` declares no z-index, so
+   * it opens no stacking context and its borders compete directly with the overlay clones — which
+   * is why the frozen pane's own z-index belongs in the same reading.
+   */
+  async selectionStackOrder(): Promise<{
+    moveZone: number, fillHandle: number, resizeHandle: number, frozenColumnsPane: number,
+  }> {
+    return this.page.evaluate(() => {
+      const zIndexOf = (selector: string) => {
+        const element = document.querySelector(selector);
+
+        if (!element) {
+          throw new Error(`No element matched "${selector}".`);
+        }
+
+        return parseInt(window.getComputedStyle(element).zIndex, 10);
+      };
+
+      return {
+        moveZone: zIndexOf('.ht_master .wtMoveZone'),
+        fillHandle: zIndexOf('.ht_master .wtBorder.current.corner'),
+        resizeHandle: zIndexOf('.ht_master .wtSelectionHandle'),
+        frozenColumnsPane: zIndexOf('.ht_clone_inline_start'),
+      };
+    });
+  }
+
+  /**
+   * Scroll the master viewport until the given cell slides behind a frozen pane, stopping with the
+   * cell's trailing edge at the middle of that pane. The cell stays rendered, so its border (and
+   * fill handle) keep their positions — the frozen pane is simply expected to occlude them.
+   */
+  async scrollCellBehindFrozenPane(row: number, col: number, pane: 'columns' | 'rows'): Promise<void> {
+    await this.page.evaluate(({ targetRow, targetCol, targetPane }) => {
+      const holder = document.querySelector('.ht_master .wtHolder');
+      const cell = document.querySelector(`.ht_master [data-testid="cell-${targetRow}-${targetCol}"]`);
+      const paneElement = document.querySelector(
+        targetPane === 'columns' ? '.ht_clone_inline_start' : '.ht_clone_bottom'
+      );
+
+      if (!holder || !cell || !paneElement) {
+        throw new Error('The master viewport, the target cell or the frozen pane is not rendered.');
+      }
+
+      const cellRect = cell.getBoundingClientRect();
+      const paneRect = paneElement.getBoundingClientRect();
+
+      if (targetPane === 'columns') {
+        holder.scrollLeft += cellRect.right - (paneRect.left + (paneRect.width / 2));
+      } else {
+        holder.scrollTop += cellRect.bottom - (paneRect.top + (paneRect.height / 2));
+      }
+    }, { targetRow: row, targetCol: col, targetPane: pane });
+  }
+
+  /**
+   * The class name of whatever the browser hit-tests at the center of the fill handle. A frozen
+   * pane that occludes the handle owns those pixels, so the topmost element there is one of its
+   * cells rather than the handle itself.
+   */
+  async elementAtFillHandleCenter(): Promise<string> {
+    const handleBox = await this.fillHandle().boundingBox();
+
+    if (!handleBox) {
+      throw new Error('The fill handle is not rendered.');
+    }
+
+    return this.page.evaluate(({ x, y }) => {
+      const element = document.elementFromPoint(x, y);
+
+      return element ? element.className : '';
+    }, { x: handleBox.x + (handleBox.width / 2), y: handleBox.y + (handleBox.height / 2) });
+  }
+
   /**
    * The grid's root wrapper carrying the `ht__moving` drag-state class. The
    * class lands on the wrapper Handsontable creates inside the container, not


### PR DESCRIPTION
### Context

The PR fixes the autofill fill handle painting on top of a frozen pane, and winning hit-testing there, once the selected cell scrolls under that pane.

Repro on `develop`: a grid with `fixedColumnsStart: 2`, select C9, scroll horizontally until C9 slides behind the frozen columns. The rest of the selection border clips correctly, but the handle dot stays visible over the frozen cells — and `document.elementFromPoint` over that area returns `wtBorder current corner` instead of the frozen `TD`, so the dot steals the crosshair and the drag from those cells. The `fixedRowsBottom` mirror behaves the same way.

Root cause: `.ht_master` declares no z-index, so it opens no stacking context, and every `.wtBorder` inside it competes directly with the overlay clone divs — which take their z-index from `handsontable/src/styles/base/_z-index-map.scss` (`inline_start: 120`, `bottom: 130`, `top: 160`). The `ht_clone_master: 100` entry in that map does not apply to the master overlay: that class is stamped on the editor container by `handsontable/src/editors/factory.ts`, while the overlay div is `ht_master`.

#13076 raised `.wtBorder.corner` from `z-index: 10` to `150` so the handle would stay above the `moveCells` bands (`wtMoveZone`, inline `z-index: 100`). 150 also clears `inline_start` (120) and `bottom` (130), which is the regression.

**The z-index change.** `.wtBorder.corner` drops to `110`, keeping the constraint #13076 introduced — above the bands (100), so pressing the handle starts autofill rather than a move drag — while the frozen panes get their occlusion back.

**The resize handles move too.** `.wtSelectionHandle` (the desktop `selectionHandles` pills) sat at `200`, also from #13076, which is above every clone. A pill whose cell scrolled under a pane painted over it and took the click there — the same bug in the same family, so it is fixed here rather than left for a follow-up. They drop to `115`: above the fill handle and the bands, below `inline_start` (120). Their only frozen-pane handling today is the `display: none` that fires when an edge lands exactly on a freeze line, which does not cover the scrolled-under case; the `zIndex = '9999'` escape hatch in `border.ts` belongs to the mobile handles, not these.

Containing `.ht_master` in its own stacking context would be the structural fix, but `border.ts` deliberately bumps those mobile selection handles to `z-index: 9999` when a selection edge lands on a freeze boundary (legacy, from #9850). Containment would break that on purpose-built behavior, so the targeted z-values are the right scope here.

**The rule is now written down.** The ceiling both values obey — selection affordances inside `.ht_master` stay under 120 — is recorded in `_z-index-map.scss`, in the duplicated clone list in `walkontable.scss`, and in the walkontable `AGENTS.md`. Nothing recorded it before, which is how #13076 came to pick 150 and 200.

**The seam follow-on.** Lowering the handle exposes one case that needs geometry, not stacking. With `fixedRowsBottom` set, a selection ending on the last scrollable row puts the handle exactly on the seam — centered on the cell's bottom-end corner, so half of it hangs into the frozen strip. Below the pane's 130 that half is covered, and the dot renders cut in half with only its top half clickable. No z-value fixes this: the handle has to stay under 120 for the frozen columns, and the bottom pane is at 130.

`appear()` already solves the identical problem on the grid's own last row — it lifts the handle by half its height and adds `wtCornerBlockEndEdge`, which pulls the hit area up to match. This PR extends that branch to the seam row through the existing `isFrozenBottomBoundaryEdge()` predicate. The last row still lifts only when the handle would spill out of the trimming container; the seam always lifts, because the bottom overlay is always painted above the master there.

Measured on a 60-row grid with `fixedRowsBottom: 2`, selection ending on row 57: the handle spans 482–490 with the pane starting at 489, carries `wtCornerBlockEndEdge`, and hit tests at 25%, 50% and 75% of its height all return the handle. Before the lift, everything below its midpoint returned a frozen cell.

The column axis and the top pane need no equivalent, and a first attempt to give them one was wrong: their handles are drawn by the overlay that owns them and already land flush against the `.wtHolder` edge that clips them, which `border.spec.js` pins to the pixel on both axes. Lifting them there moved them 3px off that line and broke three walkontable specs. (Watch the measurement: `.wtHolder` is the clipping box, while the clone element is `overflow: visible` and ends a few pixels earlier, so measuring the clone reports an overhang that is not actually cut.)

### How has this been tested?

New Playwright spec `tests/e2e/fill-handle-frozen-panes.spec.ts` (7 tests):

1. pins the whole stacking window — bands < handle < resize pills, and handle < frozen columns pane;
2. scrolls the selected cell under the frozen columns and asserts the hit test at the handle's center lands on `ht_clone_inline_start`;
3. the same under the bottom frozen rows, landing on `ht_clone_bottom`;
4. pins the seam lift — the handle on the last scrollable row carries `wtCornerBlockEndEdge` and still hit-tests as itself;
5. and 6. pin the opposite for the frozen-column and frozen-top-row handles — no lift class, and no overhang past the `.wtHolder` edge that clips them;
7. pins the resize pills below the frozen columns pane.

Tests 2 and 3 assert the *occluding overlay* by name, not just "something other than the handle", so a handle that merely moved elsewhere cannot pass them as occluded.

Negative control: with the handle reverted to `150` in the served bundle, the occlusion tests fail; with the fix, they pass.

Regression runs, all green:

```bash
npm --prefix handsontable run build

# Playwright — 465 passed, 0 failed (all three themes, not just e2e-main:
# the first round of this spec passed locally and failed on classic and horizon)
cd tests && npx playwright test \
  e2e/move-zone.spec.ts e2e/selection-handles.spec.ts \
  e2e/fill-handle-frozen-panes.spec.ts e2e/move-cells-api.spec.ts \
  e2e/move-cells-undo.spec.ts e2e/mobile-selection-handles.spec.ts \
  e2e/customBorders.spec.ts \
  --project=e2e-main --project=e2e-classic --project=e2e-horizon

# Walkontable — 816 specs, 0 failures
npm --prefix handsontable run test:walkontable

# Legacy Jasmine — 1445 specs, 0 failures, 1 pending
npm --prefix handsontable run test:e2e -- --testPathPattern="autofill|fillHandle|selection"
```

Lint:

```bash
npm --prefix handsontable run eslint
npm --prefix handsontable run stylelint
cd tests && npx eslint e2e/fill-handle-frozen-panes.spec.ts fixtures/pages/SelectionFeaturesPage.ts
```

Also checked by hand in a local demo with `fixedRowsTop`, `fixedRowsBottom` and `fixedColumnsStart` set: the handle is occluded by both panes when its cell scrolls under them, sits whole above the seam when the selection ends there, and `elementFromPoint` agrees with what is on screen in every case.

No visual test covers a selection scrolled under a frozen pane, so Argos should be unchanged. A diff there would mean a stray dot disappearing.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2590
2. Regression from #13076

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2590
