### PR TITLE
PRO-1051: Render HYPERLINK formulas as links

### DIFF
--- a/.changelogs/13223.json
+++ b/.changelogs/13223.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added the `formulas.hyperlinks` option, which renders cells holding a `HYPERLINK` formula as clickable links.",
+  "type": "added",
+  "issueOrPR": 13223,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -651,6 +651,52 @@ The plugin inherits all calculation capabilities from HyperFormula. The complete
 in the
 [HyperFormula built-in functions docs](https://handsontable.github.io/hyperformula/guide/built-in-functions.html).
 
+## Render `HYPERLINK` formulas as links
+
+By default, a cell that holds a `HYPERLINK` formula displays the link label as plain text. To render
+it as a clickable link, set the `hyperlinks` property of the [`formulas`](@/api/options.md#formulas)
+option to `true`:
+
+```js
+formulas: {
+  engine: HyperFormula,
+  hyperlinks: true,
+},
+```
+
+With `hyperlinks` enabled, `=HYPERLINK("https://handsontable.com", "Handsontable")` renders
+`Handsontable` as a link that points to `https://handsontable.com`. When you omit the second
+argument, the URL becomes the label.
+
+The cell keeps its own renderer. Handsontable wraps whatever the renderer produced in a link element,
+so a custom renderer, a [cell type](@/guides/cell-types/cell-type/cell-type.md), and the cell's
+configuration all keep working.
+
+Only a cell whose root expression is `HYPERLINK` becomes a link. A nested call such as
+`=CONCATENATE("see ", HYPERLINK("https://handsontable.com"))` evaluates to text, so the cell renders
+as text.
+
+### Allowed URL schemes
+
+Handsontable creates a link only for the `http`, `https`, `mailto`, and `tel` schemes. Any other
+scheme, including `javascript:`, renders the label as plain text and logs a warning. This applies to
+the URL that the formula produces, so a URL that comes from cell data is checked the same way.
+
+### Keyboard access
+
+A link inside a cell stays out of the tab order, so tabbing still moves between cells. To open the
+link of the selected cell, press <kbd>**Alt**</kbd>+<kbd>**Enter**</kbd>. Links open in a new browser
+tab.
+
+### Styling
+
+Each link element gets the `ht-hyperlink` class, and takes its color from the `--ht-link-color` and
+`--ht-link-hover-color` [theme variables](@/guides/styling/themes/themes.md).
+
+To render links in cells that hold plain URLs rather than formulas, write a
+[custom renderer](@/guides/cell-functions/cell-renderer/cell-renderer.md#render-hyperlinks-in-cells)
+instead.
+
 ## [`afterFormulasValuesUpdate`](@/api/hooks.md#afterformulasvaluesupdate) hook
 
 This hook fires whenever the calculation engine recomputes cell values - including cells that

--- a/handsontable/src/core/settings.ts
+++ b/handsontable/src/core/settings.ts
@@ -183,7 +183,7 @@ export interface GridSettings {
   dropdownMenu?: boolean | object | string[];
   emptyDataState?: boolean | object;
   filters?: boolean | object;
-  formulas?: boolean | { engine: unknown; sheetName?: string; [key: string]: unknown };
+  formulas?: boolean | { engine: unknown; sheetName?: string; hyperlinks?: boolean; [key: string]: unknown };
   hiddenColumns?: boolean | object;
   hiddenRows?: boolean | object;
   loading?: boolean | object;

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -3081,6 +3081,16 @@ export default (): Record<string, unknown> => {
      * | `sheetId`   | A number                                                                                                                                                                                                               |
      * | `sheetName` | A string                                                                                                                                                                                                               |
      * | `language`  | A [HyperFormula language pack](https://handsontable.github.io/hyperformula/guide/localizing-functions.html), imported from `hyperformula/es/i18n/languages`                                                          |
+     * | `hyperlinks` | `true` \|<br>`false` (default)                                                                                                                                                                                        |
+     *
+     * Set `hyperlinks` to `true` to render a cell whose formula is `HYPERLINK()` as a link. The cell
+     * keeps its own renderer, and the link label is the value the formula returns. Only a cell whose
+     * root expression is `HYPERLINK()` becomes a link, so a nested call such as
+     * `=CONCATENATE("see ", HYPERLINK("https://example.com"))` renders as plain text.
+     *
+     * A link is created only for the `http`, `https`, `mailto` and `tel` schemes. Any other scheme,
+     * `javascript:` included, renders the label as plain text instead. Press
+     * <kbd>**Alt**</kbd>+<kbd>**Enter**</kbd> to open the link of the selected cell.
      *
      * Read more:
      * - [Plugins: `Formulas`](@/api/formulas.md)
@@ -3104,6 +3114,12 @@ export default (): Record<string, unknown> => {
      *   engine: HyperFormula,
      *   sheetId: 1,
      *   sheetName: 'Sheet 1'
+     * }
+     *
+     * // or, render `HYPERLINK()` formulas as links
+     * formulas: {
+     *   engine: HyperFormula,
+     *   hyperlinks: true
      * }
      *
      * // or, add a HyperFormula instance

--- a/handsontable/src/plugins/formulas/__tests__/formulas.types.ts
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.types.ts
@@ -39,6 +39,12 @@ new Handsontable(document.createElement('div'), {
     ],
   },
 });
+new Handsontable(document.createElement('div'), {
+  formulas: {
+    engine: Hyperformula,
+    hyperlinks: true,
+  },
+});
 const hot = new Handsontable(document.createElement('div'), {});
 const formulas = hot.getPlugin('formulas');
 

--- a/handsontable/src/plugins/formulas/__tests__/hyperlinkUrl.unit.ts
+++ b/handsontable/src/plugins/formulas/__tests__/hyperlinkUrl.unit.ts
@@ -1,0 +1,101 @@
+/* eslint-disable no-script-url -- the script URLs below are the subject of these tests: the guard
+   must be exercised with the literal payloads it is meant to refuse. */
+import { resolveHyperlinkUrl } from '../hyperlinkUrl';
+
+const BASE = 'https://example.com/dir/page.html';
+
+describe('resolveHyperlinkUrl', () => {
+  describe('allowed protocols', () => {
+    it('should accept an `http` URL', () => {
+      expect(resolveHyperlinkUrl('http://a.com/x', BASE)).toBe('http://a.com/x');
+    });
+
+    it('should accept an `https` URL', () => {
+      expect(resolveHyperlinkUrl('https://a.com/x?q=1#f', BASE)).toBe('https://a.com/x?q=1#f');
+    });
+
+    it('should accept a `mailto` URL', () => {
+      expect(resolveHyperlinkUrl('mailto:someone@example.com', BASE)).toBe('mailto:someone@example.com');
+    });
+
+    it('should accept a `tel` URL', () => {
+      expect(resolveHyperlinkUrl('tel:+48123456789', BASE)).toBe('tel:+48123456789');
+    });
+  });
+
+  describe('rejected protocols', () => {
+    it('should reject a `javascript` URL', () => {
+      expect(resolveHyperlinkUrl('javascript:alert(1)', BASE)).toBe(null);
+    });
+
+    it('should reject a `javascript` URL written in mixed case', () => {
+      expect(resolveHyperlinkUrl('JaVaScRiPt:alert(1)', BASE)).toBe(null);
+    });
+
+    it('should reject a `javascript` URL obfuscated with a tab', () => {
+      expect(resolveHyperlinkUrl('java\tscript:alert(1)', BASE)).toBe(null);
+    });
+
+    it('should reject a `javascript` URL obfuscated with a newline', () => {
+      expect(resolveHyperlinkUrl('java\nscript:alert(1)', BASE)).toBe(null);
+    });
+
+    it('should reject a `javascript` URL padded with leading whitespace', () => {
+      expect(resolveHyperlinkUrl('   javascript:alert(1)', BASE)).toBe(null);
+    });
+
+    it('should reject a `data` URL', () => {
+      expect(resolveHyperlinkUrl('data:text/html,<script>alert(1)</script>', BASE)).toBe(null);
+    });
+
+    it('should reject a `vbscript` URL', () => {
+      expect(resolveHyperlinkUrl('vbscript:msgbox(1)', BASE)).toBe(null);
+    });
+
+    it('should reject a `file` URL', () => {
+      expect(resolveHyperlinkUrl('file:///etc/passwd', BASE)).toBe(null);
+    });
+  });
+
+  describe('resolution against the base URL', () => {
+    it('should resolve a root-relative URL', () => {
+      expect(resolveHyperlinkUrl('/a/b', BASE)).toBe('https://example.com/a/b');
+    });
+
+    it('should resolve a path-relative URL', () => {
+      expect(resolveHyperlinkUrl('sub/page', BASE)).toBe('https://example.com/dir/sub/page');
+    });
+
+    it('should resolve a protocol-relative URL', () => {
+      expect(resolveHyperlinkUrl('//example.org/p', BASE)).toBe('https://example.org/p');
+    });
+
+    it('should reject a protocol-relative URL when the base itself is not allowlisted', () => {
+      expect(resolveHyperlinkUrl('//example.org/p', 'file:///tmp/page.html')).toBe(null);
+    });
+  });
+
+  describe('unusable input', () => {
+    it('should reject an empty string', () => {
+      expect(resolveHyperlinkUrl('', BASE)).toBe(null);
+    });
+
+    it('should reject a whitespace-only string', () => {
+      expect(resolveHyperlinkUrl('   \t ', BASE)).toBe(null);
+    });
+
+    it('should reject an unparseable URL', () => {
+      expect(resolveHyperlinkUrl('http://', BASE)).toBe(null);
+    });
+
+    it('should reject a non-string value', () => {
+      expect(resolveHyperlinkUrl(undefined as unknown as string, BASE)).toBe(null);
+      expect(resolveHyperlinkUrl(null as unknown as string, BASE)).toBe(null);
+      expect(resolveHyperlinkUrl(42 as unknown as string, BASE)).toBe(null);
+    });
+
+    it('should reject any URL when the base URL is unusable', () => {
+      expect(resolveHyperlinkUrl('https://a.com', '')).toBe(null);
+    });
+  });
+});

--- a/handsontable/src/plugins/formulas/engine/types.ts
+++ b/handsontable/src/plugins/formulas/engine/types.ts
@@ -13,6 +13,7 @@ export interface HyperFormulaEngine {
   getCellType(address: { sheet: number | null; row: number; col: number }): unknown;
   doesCellHaveFormula(address: { sheet: number | null; row: number; col: number }): boolean;
   getCellValue(address: { sheet: number | null; row: number; col: number }): unknown;
+  getCellHyperlink(address: { sheet: number | null; row: number; col: number }): string | undefined;
   getCellSerialized(address: { sheet: number | null; row: number; col: number }): unknown;
   isItPossibleToSetCellContents(address: object): boolean;
   setCellContents(address: { sheet: number | null; row: number; col: number }, value: unknown): unknown[];

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -909,8 +909,16 @@ export class Formulas extends BasePlugin {
    */
   #refreshHyperlinksSetting() {
     const pluginSettings = this.hot.getSettings()[PLUGIN_KEY];
+    const wasEnabled = this.#hyperlinksEnabled;
 
     this.#hyperlinksEnabled = isFormulasSettingsObject(pluginSettings) && pluginSettings.hyperlinks === true;
+
+    // Turning the option off is the moment to clean up, not every subsequent draw: a renderer that
+    // leaves its previous DOM in place would keep an anchor that no later render pass rewrites.
+    // Doing it here keeps the per-cell path free for the default, disabled case.
+    if (wasEnabled && !this.#hyperlinksEnabled) {
+      this.#unwrapRenderedHyperlinks();
+    }
   }
 
   /**
@@ -923,15 +931,27 @@ export class Formulas extends BasePlugin {
   #unwrapRenderedHyperlinks() {
     this.hot.rootElement
       ?.querySelectorAll<HTMLElement>(`a.${HYPERLINK_CLASS_NAME}`)
-      .forEach((link) => {
-        const { parentNode } = link;
+      .forEach(link => this.#unwrapLink(link));
+  }
 
-        while (link.firstChild) {
-          parentNode?.insertBefore(link.firstChild, link);
-        }
+  /**
+   * Moves an anchor's content up into the anchor's own parent and drops the anchor.
+   *
+   * The insertion goes through `link.parentNode` rather than the cell: a renderer that leaves the
+   * previous DOM in place can wrap an existing anchor, leaving it as `TD > div > a` instead of a
+   * direct child. Inserting relative to the cell would then throw `NotFoundError` and, because this
+   * runs inside `afterRenderer`, take the whole draw down with it.
+   *
+   * @param {Element} link The anchor to unwrap.
+   */
+  #unwrapLink(link: Element) {
+    const { parentNode } = link;
 
-        link.remove();
-      });
+    while (link.firstChild) {
+      parentNode?.insertBefore(link.firstChild, link);
+    }
+
+    link.remove();
   }
 
   /**
@@ -950,11 +970,7 @@ export class Formulas extends BasePlugin {
     let link = TD.querySelector(`a.${HYPERLINK_CLASS_NAME}`);
 
     while (link !== null) {
-      while (link.firstChild) {
-        TD.insertBefore(link.firstChild, link);
-      }
-
-      link.remove();
+      this.#unwrapLink(link);
       link = TD.querySelector(`a.${HYPERLINK_CLASS_NAME}`);
     }
   }
@@ -1625,16 +1641,16 @@ export class Formulas extends BasePlugin {
    * @param {number} column Visual column index.
    */
   #onAfterRenderer = (TD: HTMLTableCellElement, row: number, column: number) => {
-    // Walkontable recycles TD elements, and a renderer is free to leave its previous DOM in place.
-    // Unwrapping first, unconditionally, keeps this idempotent by construction: no anchor nests
-    // inside another one across render passes, and the `href` is always rebuilt from the current
-    // formula instead of inherited from whatever the previous pass resolved. It also runs BEFORE the
-    // checks below, so turning the option off drops an anchor that such a renderer would keep.
-    this.#unwrapHyperlink(TD);
-
     if (!this.#hyperlinksEnabled || this.#internalOperationPending) {
       return;
     }
+
+    // Walkontable recycles TD elements, and a renderer is free to leave its previous DOM in place.
+    // Unwrapping first keeps this idempotent by construction: no anchor nests inside another one
+    // across render passes, and the `href` is always rebuilt from the current formula instead of
+    // inherited from whatever the previous pass resolved. Cleanup for the option being turned off
+    // happens once, in `#refreshHyperlinksSetting`, so this path never runs for a disabled grid.
+    this.#unwrapHyperlink(TD);
 
     const href = this.#getHyperlinkHref(row, column);
 

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -875,8 +875,19 @@ export class Formulas extends BasePlugin {
           }
         },
         stopPropagation: true,
-        runOnlyIf: (): boolean => this.#hyperlinksEnabled &&
-          !!this.hot.getSelectedRangeActive()?.highlight.isCell(),
+        // The shortcut prevents the default action and stops propagation whenever `runOnlyIf`
+        // passes, so it must claim the chord only for a cell that actually resolves to a link.
+        // Testing just `isCell()` would swallow `Alt`+`Enter` grid-wide and break a host
+        // application's own handler for it.
+        runOnlyIf: (): boolean => {
+          const highlight = this.hot.getSelectedRangeActive()?.highlight;
+
+          return this.#hyperlinksEnabled &&
+            !!highlight?.isCell() &&
+            highlight.row !== null &&
+            highlight.col !== null &&
+            this.#getHyperlinkHref(highlight.row, highlight.col) !== null;
+        },
         group: SHORTCUTS_GROUP,
       });
   }
@@ -899,6 +910,25 @@ export class Formulas extends BasePlugin {
     const pluginSettings = this.hot.getSettings()[PLUGIN_KEY];
 
     this.#hyperlinksEnabled = isFormulasSettingsObject(pluginSettings) && pluginSettings.hyperlinks === true;
+  }
+
+  /**
+   * Moves the content of a cell's `HYPERLINK` anchor back into the cell and drops the anchor. Loops
+   * so that anchors nested by an older render pass are unwrapped as well.
+   *
+   * @param {HTMLTableCellElement} TD The rendered cell element.
+   */
+  #unwrapHyperlink(TD: HTMLTableCellElement) {
+    let link = TD.querySelector(`a.${HYPERLINK_CLASS_NAME}`);
+
+    while (link !== null) {
+      while (link.firstChild) {
+        TD.insertBefore(link.firstChild, link);
+      }
+
+      link.remove();
+      link = TD.querySelector(`a.${HYPERLINK_CLASS_NAME}`);
+    }
   }
 
   /**
@@ -1571,11 +1601,11 @@ export class Formulas extends BasePlugin {
       return;
     }
 
-    // Walkontable recycles TD elements. A renderer that leaves its previous DOM in place would
-    // otherwise collect one nested anchor per render pass.
-    if (TD.childElementCount === 1 && TD.firstElementChild?.classList.contains(HYPERLINK_CLASS_NAME)) {
-      return;
-    }
+    // Walkontable recycles TD elements, and a renderer is free to leave its previous DOM in place.
+    // Unwrapping first, unconditionally, keeps this idempotent by construction: no anchor nests
+    // inside another one across render passes, and the `href` is always rebuilt from the current
+    // formula instead of inherited from whatever the previous pass resolved.
+    this.#unwrapHyperlink(TD);
 
     const href = this.#getHyperlinkHref(row, column);
 

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -1,6 +1,6 @@
 import { BasePlugin } from '../base';
 import { staticRegister } from '../../utils/staticRegister';
-import { error, warn } from '../../helpers/console';
+import { error, warn, warnOnce } from '../../helpers/console';
 import { isNumeric } from '../../helpers/number';
 import { isObject } from '../../helpers/object';
 import { isDefined, isUndefined } from '../../helpers/mixed';
@@ -17,6 +17,7 @@ import {
   normalizeValueForFormulaEngine,
   unescapeFormulaExpression,
 } from './utils';
+import { resolveHyperlinkUrl } from './hyperlinkUrl';
 import { getEngineSettingsWithOverrides, haveEngineSettingsChanged } from './engine/settings';
 import { isArrayOfArrays } from '../../helpers/data';
 import { toUpperCaseFirst } from '../../helpers/string';
@@ -75,6 +76,7 @@ interface MoveCellsRect {
 interface FormulasPluginSettings {
   sheetName?: string;
   engine: unknown;
+  hyperlinks?: boolean;
 }
 
 /**
@@ -119,6 +121,17 @@ const isBlockedSource = (source: unknown) =>
 // `removeRows`/`removeColumns` call. An unbounded argument spread could overflow the call stack.
 const REMOVAL_SPANS_CHUNK_SIZE = 1000;
 
+// Group under which the plugin's grid shortcuts are registered, so `disablePlugin` can drop them all.
+const SHORTCUTS_GROUP = PLUGIN_KEY;
+
+// Class name of the anchor that wraps the content of a `HYPERLINK` cell. It is also the marker that
+// keeps the wrapping idempotent when a renderer leaves the previous DOM in place.
+const HYPERLINK_CLASS_NAME = 'ht-hyperlink';
+
+// `warnOnce` key for a `HYPERLINK` URL refused by the protocol allowlist. Warning per cell would
+// flood the console on every render pass.
+const HYPERLINK_WARN_KEY = 'formulas-hyperlink-refused';
+
 /**
  * This plugin allows you to perform Excel-like calculations in your business applications. It does it by an
  * integration with our other product, [HyperFormula](https://github.com/handsontable/hyperformula/), which is a
@@ -161,6 +174,12 @@ export class Formulas extends BasePlugin {
    * @type {boolean}
    */
   #internalOperationPending = false;
+
+  /**
+   * Whether `HYPERLINK` cells are rendered as links. Mirrors the `hyperlinks` plugin setting, cached
+   * because it is read once per rendered cell.
+   */
+  #hyperlinksEnabled = false;
 
   /**
    * Flag needed to mark if Handsontable was initialized with no data.
@@ -622,7 +641,12 @@ export class Formulas extends BasePlugin {
     this.addHook('beforeMoveCells', this.#onBeforeMoveCells);
     this.addHook('afterMoveCells', this.#onAfterMoveCells);
 
+    this.addHook('afterRenderer', this.#onAfterRenderer);
+
     this.#engineListeners?.forEach(([eventName, listener]) => this.engine!.on(eventName, listener));
+
+    this.#refreshHyperlinksSetting();
+    this.registerShortcuts();
 
     super.enablePlugin();
   }
@@ -631,6 +655,7 @@ export class Formulas extends BasePlugin {
    * Disables the plugin functionality for this Handsontable instance.
    */
   disablePlugin() {
+    this.unregisterShortcuts();
     this.#engineListeners?.forEach(([eventName, listener]) => this.engine?.off(eventName, listener));
 
     if (this.engine) {
@@ -686,6 +711,8 @@ export class Formulas extends BasePlugin {
         }
       }
     }
+
+    this.#refreshHyperlinksSetting();
 
     super.updatePlugin(newSettings);
   }
@@ -821,6 +848,99 @@ export class Formulas extends BasePlugin {
       row: this.rowAxisSyncer!.getHfIndexFromVisualIndex(row),
       col: this.columnAxisSyncer!.getHfIndexFromVisualIndex(column),
     });
+  }
+
+  /**
+   * Registers the shortcut that opens the link of the selected `HYPERLINK` cell. The anchor is kept
+   * out of the tab order, so this is the only keyboard path to the link.
+   *
+   * @private
+   */
+  registerShortcuts() {
+    this.hot.getShortcutManager()
+      .getContext('grid')
+      ?.addShortcut({
+        keys: [['Alt', 'Enter']],
+        callback: () => {
+          const highlight = this.hot.getSelectedRangeActive()?.highlight;
+
+          if (!highlight || highlight.row === null || highlight.col === null) {
+            return;
+          }
+
+          const href = this.#getHyperlinkHref(highlight.row, highlight.col);
+
+          if (href !== null) {
+            this.hot.rootWindow.open(href, '_blank', 'noopener,noreferrer');
+          }
+        },
+        stopPropagation: true,
+        runOnlyIf: (): boolean => this.#hyperlinksEnabled &&
+          !!this.hot.getSelectedRangeActive()?.highlight.isCell(),
+        group: SHORTCUTS_GROUP,
+      });
+  }
+
+  /**
+   * Removes the shortcuts registered by the plugin.
+   *
+   * @private
+   */
+  unregisterShortcuts() {
+    this.hot.getShortcutManager()
+      .getContext('grid')
+      ?.removeShortcutsByGroup(SHORTCUTS_GROUP);
+  }
+
+  /**
+   * Reads the `hyperlinks` plugin setting into the cached flag.
+   */
+  #refreshHyperlinksSetting() {
+    const pluginSettings = this.hot.getSettings()[PLUGIN_KEY];
+
+    this.#hyperlinksEnabled = isFormulasSettingsObject(pluginSettings) && pluginSettings.hyperlinks === true;
+  }
+
+  /**
+   * Returns the URL that a cell should link to, or `null` when the cell must not become a link.
+   *
+   * The engine reports a hyperlink only for a cell whose root expression is `HYPERLINK()`, so a
+   * nested call such as `=CONCATENATE("see ", HYPERLINK(...))` resolves to `null` here.
+   *
+   * @param {number} row Visual row index.
+   * @param {number} column Visual column index.
+   * @returns {string|null} The resolved absolute URL, or `null`.
+   */
+  #getHyperlinkHref(row: number, column: number): string | null {
+    if (
+      this.sheetName === null ||
+      !this.engine?.doesSheetExist(this.sheetName) ||
+      !this.rowAxisSyncer ||
+      !this.columnAxisSyncer ||
+      !this.isFormulaCellType(row, column)
+    ) {
+      return null;
+    }
+
+    const url = this.engine.getCellHyperlink({
+      sheet: this.sheetId,
+      row: this.rowAxisSyncer.getHfIndexFromVisualIndex(row),
+      col: this.columnAxisSyncer.getHfIndexFromVisualIndex(column),
+    });
+
+    if (url === undefined) {
+      return null;
+    }
+
+    const href = resolveHyperlinkUrl(url, this.hot.rootDocument.baseURI);
+
+    if (href === null) {
+      warnOnce(this, HYPERLINK_WARN_KEY,
+        `A "HYPERLINK" formula points at a URL that Handsontable refuses to link to ("${url}"). ` +
+        'Only the "http", "https", "mailto" and "tel" schemes can be linked.');
+    }
+
+    return href;
   }
 
   /**
@@ -1435,6 +1555,49 @@ export class Formulas extends BasePlugin {
 
     // If `cellValue` is an object it is expected to be an error
     valueHolder.value = hasValueProperty(cellValue) ? cellValue.value : cellValue;
+  };
+
+  /**
+   * `afterRenderer` hook callback. Wraps the already rendered content of a `HYPERLINK` cell in an
+   * anchor. The cell keeps its own renderer and its cell meta is left untouched, so disabling the
+   * plugin or clearing the formula needs no cleanup.
+   *
+   * @param {HTMLTableCellElement} TD The rendered cell element.
+   * @param {number} row Visual row index.
+   * @param {number} column Visual column index.
+   */
+  #onAfterRenderer = (TD: HTMLTableCellElement, row: number, column: number) => {
+    if (!this.#hyperlinksEnabled || this.#internalOperationPending) {
+      return;
+    }
+
+    // Walkontable recycles TD elements. A renderer that leaves its previous DOM in place would
+    // otherwise collect one nested anchor per render pass.
+    if (TD.childElementCount === 1 && TD.firstElementChild?.classList.contains(HYPERLINK_CLASS_NAME)) {
+      return;
+    }
+
+    const href = this.#getHyperlinkHref(row, column);
+
+    if (href === null) {
+      return;
+    }
+
+    const link = this.hot.rootDocument.createElement('a');
+
+    link.className = HYPERLINK_CLASS_NAME;
+    link.href = href;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    // Cell content stays out of the grid's tab order; `Alt`+`Enter` is the keyboard path instead.
+    link.tabIndex = -1;
+
+    // The nodes are moved, never re-serialized, so a label containing markup stays text.
+    while (TD.firstChild) {
+      link.appendChild(TD.firstChild);
+    }
+
+    TD.appendChild(link);
   };
 
   /**

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -655,6 +655,7 @@ export class Formulas extends BasePlugin {
    * Disables the plugin functionality for this Handsontable instance.
    */
   disablePlugin() {
+    this.#unwrapRenderedHyperlinks();
     this.unregisterShortcuts();
     this.#engineListeners?.forEach(([eventName, listener]) => this.engine?.off(eventName, listener));
 
@@ -913,12 +914,39 @@ export class Formulas extends BasePlugin {
   }
 
   /**
+   * Unwraps every `HYPERLINK` anchor currently in the grid, including the overlay clones.
+   *
+   * Disabling the plugin removes the `afterRenderer` hook, so a renderer that leaves its previous
+   * DOM in place would keep its cells clickable with nothing left to clean them up. The anchors are
+   * matched by the plugin's own class, so no knowledge of the rendering internals is needed.
+   */
+  #unwrapRenderedHyperlinks() {
+    this.hot.rootElement
+      ?.querySelectorAll<HTMLElement>(`a.${HYPERLINK_CLASS_NAME}`)
+      .forEach((link) => {
+        const { parentNode } = link;
+
+        while (link.firstChild) {
+          parentNode?.insertBefore(link.firstChild, link);
+        }
+
+        link.remove();
+      });
+  }
+
+  /**
    * Moves the content of a cell's `HYPERLINK` anchor back into the cell and drops the anchor. Loops
    * so that anchors nested by an older render pass are unwrapped as well.
    *
    * @param {HTMLTableCellElement} TD The rendered cell element.
    */
   #unwrapHyperlink(TD: HTMLTableCellElement) {
+    // A cell rendered as plain text has no element children at all, which is the overwhelmingly
+    // common case and the one that must not pay for a selector query on every render pass.
+    if (TD.firstElementChild === null) {
+      return;
+    }
+
     let link = TD.querySelector(`a.${HYPERLINK_CLASS_NAME}`);
 
     while (link !== null) {
@@ -1597,15 +1625,16 @@ export class Formulas extends BasePlugin {
    * @param {number} column Visual column index.
    */
   #onAfterRenderer = (TD: HTMLTableCellElement, row: number, column: number) => {
-    if (!this.#hyperlinksEnabled || this.#internalOperationPending) {
-      return;
-    }
-
     // Walkontable recycles TD elements, and a renderer is free to leave its previous DOM in place.
     // Unwrapping first, unconditionally, keeps this idempotent by construction: no anchor nests
     // inside another one across render passes, and the `href` is always rebuilt from the current
-    // formula instead of inherited from whatever the previous pass resolved.
+    // formula instead of inherited from whatever the previous pass resolved. It also runs BEFORE the
+    // checks below, so turning the option off drops an anchor that such a renderer would keep.
     this.#unwrapHyperlink(TD);
+
+    if (!this.#hyperlinksEnabled || this.#internalOperationPending) {
+      return;
+    }
 
     const href = this.#getHyperlinkHref(row, column);
 

--- a/handsontable/src/plugins/formulas/hyperlinkUrl.ts
+++ b/handsontable/src/plugins/formulas/hyperlinkUrl.ts
@@ -1,0 +1,33 @@
+/**
+ * URL schemes a `HYPERLINK` cell may link to. Everything outside this list is refused, which is what
+ * keeps `javascript:`, `data:` and `vbscript:` payloads out of the anchor's `href`. Default
+ * sanitization is a pass-through in this codebase, so the guard cannot be delegated to a sanitizer.
+ */
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+
+/**
+ * Resolves the URL of a `HYPERLINK` cell against the host document, and refuses anything that is not
+ * a navigable link.
+ *
+ * The URL is parsed instead of pattern-matched, so obfuscations that survive a string comparison
+ * (`JaVaScRiPt:`, `java\tscript:`, leading whitespace) are normalized before the protocol is read.
+ *
+ * @param {string} rawUrl The URL as reported by the formula engine.
+ * @param {string} baseUrl The document URL that relative URLs are resolved against.
+ * @returns {string|null} The resolved absolute URL, or `null` when the cell must not become a link.
+ */
+export function resolveHyperlinkUrl(rawUrl: string, baseUrl: string): string | null {
+  if (typeof rawUrl !== 'string' || rawUrl.trim() === '') {
+    return null;
+  }
+
+  let url: URL;
+
+  try {
+    url = new URL(rawUrl, baseUrl);
+  } catch (error) {
+    return null;
+  }
+
+  return ALLOWED_PROTOCOLS.has(url.protocol) ? url.href : null;
+}

--- a/handsontable/src/styles/components/_index.scss
+++ b/handsontable/src/styles/components/_index.scss
@@ -13,6 +13,7 @@
 @use "./plugins/hidden-rows";
 @use "./plugins/dropdown-menu";
 @use "./plugins/filters";
+@use "./plugins/formulas";
 @use "./plugins/comments";
 @use "./plugins/custom-borders";
 @use "./plugins/column-sorting";
@@ -80,6 +81,7 @@
   @include hidden-rows.output();
   @include dropdown-menu.output();
   @include filters.output();
+  @include formulas.output();
   @include comments.output();
   @include custom-borders.output();
   @include column-sorting.output();

--- a/handsontable/src/styles/components/plugins/_formulas.scss
+++ b/handsontable/src/styles/components/plugins/_formulas.scss
@@ -1,0 +1,17 @@
+// Handsontable Formulas
+
+@mixin output {
+  .handsontable {
+    // The anchor of a `HYPERLINK` cell is rendered by the grid, so it is grid chrome and gets the
+    // link color. The base rule cannot cover it: it deliberately skips every `<a>` inside a data
+    // cell, because such an anchor is normally user content that keeps its own color (#4363).
+    td a.ht-hyperlink {
+      color: var(--ht-link-color);
+      text-decoration: underline;
+
+      &:hover {
+        color: var(--ht-link-hover-color);
+      }
+    }
+  }
+}

--- a/tests/e2e/formulas-hyperlink.spec.ts
+++ b/tests/e2e/formulas-hyperlink.spec.ts
@@ -190,6 +190,46 @@ test.describe('formulas: HYPERLINK rendering', () => {
     await expect(grid.openedUrls()).resolves.toEqual(['https://example.com/one']);
   });
 
+  test('leaves Alt+Enter to the host application on a cell with no link', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.recordHostAltEnter();
+
+    // A cell holding no link must not have the chord taken from it: the event has to reach the
+    // document undefeated, or a host application's own Alt+Enter handler stops firing grid-wide.
+    await grid.selectCell(6, 0);
+    await grid.pressOpenLinkShortcut();
+
+    await expect(grid.hostAltEnterEvents()).resolves.toEqual([false]);
+
+    // On a link cell the plugin claims the chord, so the event is stopped before the document.
+    await grid.selectCell(0, 0);
+    await grid.pressOpenLinkShortcut();
+
+    await expect(grid.hostAltEnterEvents()).resolves.toEqual([false]);
+  });
+
+  test('rebuilds a stale href when only the URL behind the formula changes',
+    async({ page, theme, bundle }) => {
+      const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+      await grid.goto();
+
+      // Column E holds `=HYPERLINK(E2,"Steady")` and renders through a memoizing renderer that
+      // leaves the cell's DOM alone when the value is unchanged. Changing E2 changes the URL while
+      // the label stays "Steady", so nothing about the cell's content signals the change.
+      await expect(grid.link(0, 4)).toHaveText('Steady');
+      await expect(grid.link(0, 4)).toHaveAttribute('href', 'https://example.com/first');
+
+      await grid.setCellValue(1, 4, 'https://example.com/second');
+
+      await expect(grid.link(0, 4)).toHaveText('Steady');
+      await expect(grid.link(0, 4)).toHaveAttribute('href', 'https://example.com/second');
+      // Exactly one anchor: unwrapping before wrapping must not nest or duplicate.
+      await expect(grid.link(0, 4)).toHaveCount(1);
+    });
+
   test('does nothing on Alt+Enter when the selected cell holds no link', async({ page, theme, bundle }) => {
     const grid = new FormulasHyperlinkPage(page, theme, bundle);
 

--- a/tests/e2e/formulas-hyperlink.spec.ts
+++ b/tests/e2e/formulas-hyperlink.spec.ts
@@ -152,6 +152,33 @@ test.describe('formulas: HYPERLINK rendering', () => {
     await expect(grid.link(0, 0)).toHaveCount(1);
   });
 
+  test('drops a memoizing renderer\'s anchor when the option is turned off', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+    await expect(grid.link(0, 4)).toHaveCount(1);
+
+    // Column E renders through a memoizing renderer, so nothing else would remove the anchor: the
+    // cell would stay clickable after the feature was switched off.
+    await grid.setHyperlinks(false);
+
+    await expect(grid.link(0, 4)).toHaveCount(0);
+    await expect(grid.cell(0, 4)).toHaveText('Steady');
+  });
+
+  test('drops a memoizing renderer\'s anchor when the plugin is disabled', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+    await expect(grid.link(0, 4)).toHaveCount(1);
+
+    // Disabling the plugin removes the `afterRenderer` hook, and without a redraw there is no
+    // render pass left to rewrite the cell, so the cleanup has to happen on disable itself.
+    await grid.disableFormulasPluginWithoutRender();
+
+    await expect(grid.link(0, 4)).toHaveCount(0);
+  });
+
   test('follows a link on click and still selects the cell', async({ page, theme, bundle }) => {
     const grid = new FormulasHyperlinkPage(page, theme, bundle);
 

--- a/tests/e2e/formulas-hyperlink.spec.ts
+++ b/tests/e2e/formulas-hyperlink.spec.ts
@@ -179,6 +179,28 @@ test.describe('formulas: HYPERLINK rendering', () => {
     await expect(grid.link(0, 4)).toHaveCount(0);
   });
 
+  test('survives a renderer that wraps the anchor it produced', async({ page, theme, bundle }) => {
+    const pageErrors: string[] = [];
+
+    page.on('pageerror', error => pageErrors.push(error.message));
+
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    // Column F's renderer boxes whatever the cell already holds, so from the second draw on the
+    // anchor is `TD > div.wrap-box > a` rather than a direct child. Unwrapping relative to the cell
+    // would throw NotFoundError inside `afterRenderer` and take the whole draw down.
+    await grid.render(2);
+
+    await expect(grid.link(0, 5)).toHaveCount(1);
+    await expect(grid.link(0, 5)).toHaveAttribute('href', 'https://example.com/boxed');
+    await expect(grid.cell(0, 5)).toHaveText('Boxed');
+    // A draw killed mid-flight leaves later cells unrendered, so check one that comes after it.
+    await expect(grid.cell(6, 0)).toHaveText('plain');
+    expect(pageErrors).toEqual([]);
+  });
+
   test('follows a link on click and still selects the cell', async({ page, theme, bundle }) => {
     const grid = new FormulasHyperlinkPage(page, theme, bundle);
 

--- a/tests/e2e/formulas-hyperlink.spec.ts
+++ b/tests/e2e/formulas-hyperlink.spec.ts
@@ -1,0 +1,204 @@
+import { test, expect } from '../fixtures/test';
+import { FormulasHyperlinkPage } from '../fixtures/pages/FormulasHyperlinkPage';
+
+/**
+ * `formulas.hyperlinks`: a cell whose root expression is `HYPERLINK()` renders
+ * its value inside an anchor (PRO-1051). The feature decorates the cell after
+ * its own renderer has run and never writes cell meta, so the cases below also
+ * pin the two regressions that sank the original proposal (#10314): a swapped
+ * renderer and an unsanitized `href`.
+ */
+test.describe('formulas: HYPERLINK rendering', () => {
+  test('renders an anchor with the label as text and the URL as href', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await expect(grid.link(0, 0)).toHaveText('Example one');
+    await expect(grid.link(0, 0)).toHaveAttribute('href', 'https://example.com/one');
+    await expect(grid.link(0, 0)).toHaveAttribute('rel', 'noopener noreferrer');
+    await expect(grid.link(0, 0)).toHaveAttribute('target', '_blank');
+  });
+
+  test('uses the URL as the label when the second argument is omitted', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await expect(grid.link(1, 0)).toHaveText('https://example.com/two');
+    await expect(grid.link(1, 0)).toHaveAttribute('href', 'https://example.com/two');
+  });
+
+  test('renders no anchor when HYPERLINK is not the root expression', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await expect(grid.cell(2, 0)).toHaveText('see three');
+    await expect(grid.link(2, 0)).toHaveCount(0);
+  });
+
+  test('renders no anchor for a plain, non-formula value', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await expect(grid.cell(6, 0)).toHaveText('plain');
+    await expect(grid.link(6, 0)).toHaveCount(0);
+  });
+
+  test('refuses a `javascript:` URL, keeps the label as text, and warns once', async({ page, theme, bundle }) => {
+    const warnings: string[] = [];
+
+    page.on('console', (message) => {
+      if (message.type() === 'warning') {
+        warnings.push(message.text());
+      }
+    });
+
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await expect(grid.cell(3, 0)).toHaveText('Danger');
+    await expect(grid.link(3, 0)).toHaveCount(0);
+
+    const refusals = warnings.filter(text => text.includes('refuses to link to'));
+
+    expect(refusals).toHaveLength(1);
+  });
+
+  test('renders a label containing markup as text', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await expect(grid.link(4, 0)).toHaveText('<img src=x onerror=\'window.__xss = true\'>');
+    await expect(grid.cell(4, 0).locator('img')).toHaveCount(0);
+    await expect(page.evaluate(() => (window as any).__xss)).resolves.toBeUndefined();
+  });
+
+  test('keeps a column\'s custom renderer and wraps its output', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    // The custom renderer's element still exists, and it sits inside the anchor.
+    await expect(grid.customMark(0)).toHaveText('B one');
+    await expect(grid.link(0, 1).locator('span.custom-mark')).toHaveCount(1);
+    // A non-hyperlink cell in the same column keeps the renderer and gains no anchor.
+    await expect(grid.customMark(1)).toHaveText('b2');
+    await expect(grid.link(1, 1)).toHaveCount(0);
+  });
+
+  test('leaves a `checkbox` cell type untouched', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await expect(grid.cell(0, 2).locator('input[type="checkbox"]')).toHaveCount(1);
+    await expect(grid.link(0, 2)).toHaveCount(0);
+  });
+
+  test('keeps a cell type\'s renderer on a hyperlink cell', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    // The `password` renderer masks the label, and the mask is what the anchor
+    // wraps. A swapped renderer would leak the plain label instead.
+    await expect(grid.link(0, 3)).toHaveText('******');
+    await expect(grid.link(0, 3)).toHaveAttribute('href', 'https://example.com/pw');
+    // A non-hyperlink cell in the same column is still masked and gains no anchor.
+    await expect(grid.cell(1, 3)).toHaveText('***********');
+    await expect(grid.link(1, 3)).toHaveCount(0);
+  });
+
+  test('drops the anchor when the formula is replaced by a plain value', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+    await expect(grid.link(0, 1)).toHaveCount(1);
+
+    await grid.setCellValue(0, 1, 'no longer a formula');
+
+    await expect(grid.link(0, 1)).toHaveCount(0);
+    // The column's own renderer survived the change.
+    await expect(grid.customMark(0)).toHaveText('no longer a formula');
+  });
+
+  test('drops the anchor when the plugin is disabled, keeping the renderer', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+    await expect(grid.link(0, 1)).toHaveCount(1);
+
+    await grid.disableFormulasPlugin();
+
+    await expect(grid.link(0, 1)).toHaveCount(0);
+    await expect(grid.customMark(0)).toHaveCount(1);
+  });
+
+  test('renders no anchor while the option is off, and again once it is on', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await grid.setHyperlinks(false);
+    await expect(grid.link(0, 0)).toHaveCount(0);
+    await expect(grid.cell(0, 0)).toHaveText('Example one');
+
+    await grid.setHyperlinks(true);
+    await expect(grid.link(0, 0)).toHaveCount(1);
+  });
+
+  test('follows a link on click and still selects the cell', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    const [popup] = await Promise.all([
+      page.waitForEvent('popup'),
+      grid.link(5, 0).click(),
+    ]);
+
+    await expect(popup).toHaveURL(/\/tests\/fixtures\/demo\/grid\.html$/);
+    await popup.close();
+
+    await expect(grid.selectedCoords()).resolves.toEqual([5, 0]);
+  });
+
+  test('opens the editor with the raw formula on double click', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+
+    await grid.cell(0, 0).dblclick({ position: { x: 2, y: 2 } });
+
+    await expect(grid.editorValue()).resolves.toBe('=HYPERLINK("https://example.com/one","Example one")');
+  });
+
+  test('opens the selected cell\'s link with Alt+Enter', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.recordWindowOpen();
+
+    await grid.selectCell(0, 0);
+    await grid.pressOpenLinkShortcut();
+
+    await expect(grid.openedUrls()).resolves.toEqual(['https://example.com/one']);
+  });
+
+  test('does nothing on Alt+Enter when the selected cell holds no link', async({ page, theme, bundle }) => {
+    const grid = new FormulasHyperlinkPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.recordWindowOpen();
+
+    await grid.selectCell(6, 0);
+    await grid.pressOpenLinkShortcut();
+
+    await expect(grid.openedUrls()).resolves.toEqual([]);
+  });
+});

--- a/tests/fixtures/demo/formulas-hyperlink.html
+++ b/tests/fixtures/demo/formulas-hyperlink.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Formulas HYPERLINK e2e fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back — a
+    // typo in the project config must be one red leg, never a silently
+    // mislabeled green one (nothing else asserts which file actually loaded).
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    // Written into <head> so the themed stylesheet is present before first render.
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    // 1:1 with the Puppeteer legs (umd = handsontable.js, full-min =
+    // handsontable.full.min.js, the exact file `test:production` loads).
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } </style>
+</head>
+<body>
+  <!--
+    HyperFormula-backed grid for the `formulas.hyperlinks` option: a cell whose
+    root expression is HYPERLINK() renders its value inside an anchor, while the
+    cell keeps its own renderer and its cell meta is never touched (PRO-1051).
+    Column B carries a custom renderer, column C a `checkbox` cell type and
+    column D a `password` cell type, so a spec can prove none of them is
+    displaced. Every leg runs exactly ONE engine: the
+    `umd` legs load HyperFormula as an external script (the base bundle ships
+    none — the DEV-2190 wiring); the `full-min` legs use the baked-in engine.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    // HyperFormula comes from THIS package's own node_modules (declared in
+    // tests/package.json, pinned to the exact version the handsontable
+    // package locks): CI installs only the filtered handsontable-tests
+    // workspace, so a path into another package's node_modules would 404
+    // there. Loaded ONLY on the base-bundle legs — handsontable.full.min.js
+    // sets window.HyperFormula itself as it loads and would overwrite this
+    // global anyway; gating gives every leg exactly one engine.
+    if (window.htBundle === 'handsontable.js') {
+      document.write('<scr' + 'ipt src="/tests/node_modules/hyperformula/dist/hyperformula.full.min.js"></scr' + 'ipt>');
+    }
+  </script>
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The
+    // closing tag is split so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    // A renderer that writes its own element into the cell. If the feature ever
+    // goes back to swapping the `renderer` cell meta, this marker disappears.
+    function markerRenderer(instance, td, row, col, prop, value) {
+      td.textContent = '';
+
+      const mark = document.createElement('span');
+
+      mark.className = 'custom-mark';
+      mark.textContent = value === null || value === undefined ? '' : String(value);
+      td.appendChild(mark);
+    }
+
+    window.hot = new Handsontable(container, {
+      data: [
+        // A plain link, label given explicitly.
+        ['=HYPERLINK("https://example.com/one","Example one")', '=HYPERLINK("https://example.com/b1","B one")', true, '=HYPERLINK("https://example.com/pw","secret")'],
+        // The label defaults to the URL when the second argument is omitted.
+        ['=HYPERLINK("https://example.com/two")', 'b2', false, 'plainsecret'],
+        // HYPERLINK is not the root expression, so the engine reports no link.
+        ['=CONCATENATE("see ", HYPERLINK("https://example.com/three","three"))', 'b3', true, 'x'],
+        // Refused by the protocol allowlist.
+        ['=HYPERLINK("javascript:alert(1)","Danger")', 'b4', false, 'x'],
+        // The label must stay text, never markup.
+        ['=HYPERLINK("https://example.com/five","<img src=x onerror=\'window.__xss = true\'>")', 'b5', true, 'x'],
+        // A relative URL resolves against the document, which keeps a real
+        // click navigation local and offline-safe.
+        ['=HYPERLINK("/tests/fixtures/demo/grid.html","Local page")', 'b6', false, 'x'],
+        // Not a formula at all.
+        ['plain', 'b7', true, 'x'],
+      ],
+      formulas: {
+        engine: HyperFormula,
+        sheetName: 'Sheet1',
+        hyperlinks: true,
+      },
+      columns: [
+        {},
+        { renderer: markerRenderer },
+        { type: 'checkbox' },
+        // A cell type whose renderer transforms the value: the masked output has
+        // to survive inside the anchor, which only holds if the type's renderer
+        // still runs (finding #6 of the review of #10314).
+        { type: 'password' },
+      ],
+      width: 600,
+      height: 300,
+      rowHeaders: true,
+      colHeaders: true,
+      // Stamp test ids without displacing the per-column renderers.
+      afterRenderer(td, row, col) {
+        td.setAttribute('data-testid', `cell-${row}-${col}`);
+      },
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/formulas-hyperlink.html
+++ b/tests/fixtures/demo/formulas-hyperlink.html
@@ -91,23 +91,46 @@
       td.textContent = next;
     }
 
+    // A renderer that wraps whatever the cell already holds in a box, without clearing it. On the
+    // second pass that box swallows the anchor, so the anchor is no longer a direct child of the TD
+    // — the shape that makes an unwrap relative to the cell throw NotFoundError.
+    function wrappingRenderer(instance, td, row, col, prop, value) {
+      if (td.firstElementChild === null) {
+        td.textContent = value === null || value === undefined ? '' : String(value);
+      }
+
+      if (td.firstElementChild && td.firstElementChild.className === 'wrap-box') {
+        return;
+      }
+
+      const box = document.createElement('div');
+
+      box.className = 'wrap-box';
+
+      while (td.firstChild) {
+        box.appendChild(td.firstChild);
+      }
+
+      td.appendChild(box);
+    }
+
     window.hot = new Handsontable(container, {
       data: [
         // A plain link, label given explicitly.
-        ['=HYPERLINK("https://example.com/one","Example one")', '=HYPERLINK("https://example.com/b1","B one")', true, '=HYPERLINK("https://example.com/pw","secret")', '=HYPERLINK(E2,"Steady")'],
+        ['=HYPERLINK("https://example.com/one","Example one")', '=HYPERLINK("https://example.com/b1","B one")', true, '=HYPERLINK("https://example.com/pw","secret")', '=HYPERLINK(E2,"Steady")', '=HYPERLINK("https://example.com/boxed","Boxed")'],
         // The label defaults to the URL when the second argument is omitted.
-        ['=HYPERLINK("https://example.com/two")', 'b2', false, 'plainsecret', 'https://example.com/first'],
+        ['=HYPERLINK("https://example.com/two")', 'b2', false, 'plainsecret', 'https://example.com/first', 'f2'],
         // HYPERLINK is not the root expression, so the engine reports no link.
-        ['=CONCATENATE("see ", HYPERLINK("https://example.com/three","three"))', 'b3', true, 'x', 'x'],
+        ['=CONCATENATE("see ", HYPERLINK("https://example.com/three","three"))', 'b3', true, 'x', 'x', 'x'],
         // Refused by the protocol allowlist.
-        ['=HYPERLINK("javascript:alert(1)","Danger")', 'b4', false, 'x', 'x'],
+        ['=HYPERLINK("javascript:alert(1)","Danger")', 'b4', false, 'x', 'x', 'x'],
         // The label must stay text, never markup.
-        ['=HYPERLINK("https://example.com/five","<img src=x onerror=\'window.__xss = true\'>")', 'b5', true, 'x', 'x'],
+        ['=HYPERLINK("https://example.com/five","<img src=x onerror=\'window.__xss = true\'>")', 'b5', true, 'x', 'x', 'x'],
         // A relative URL resolves against the document, which keeps a real
         // click navigation local and offline-safe.
-        ['=HYPERLINK("/tests/fixtures/demo/grid.html","Local page")', 'b6', false, 'x', 'x'],
+        ['=HYPERLINK("/tests/fixtures/demo/grid.html","Local page")', 'b6', false, 'x', 'x', 'x'],
         // Not a formula at all.
-        ['plain', 'b7', true, 'x', 'x'],
+        ['plain', 'b7', true, 'x', 'x', 'x'],
       ],
       formulas: {
         engine: HyperFormula,
@@ -123,6 +146,7 @@
         // still runs (finding #6 of the review of #10314).
         { type: 'password' },
         { renderer: memoRenderer },
+        { renderer: wrappingRenderer },
       ],
       width: 600,
       height: 300,

--- a/tests/fixtures/demo/formulas-hyperlink.html
+++ b/tests/fixtures/demo/formulas-hyperlink.html
@@ -35,8 +35,9 @@
     root expression is HYPERLINK() renders its value inside an anchor, while the
     cell keeps its own renderer and its cell meta is never touched (PRO-1051).
     Column B carries a custom renderer, column C a `checkbox` cell type and
-    column D a `password` cell type, so a spec can prove none of them is
-    displaced. Every leg runs exactly ONE engine: the
+    column D a `password` cell type and column E a memoizing renderer, so a spec
+    can prove none of them is displaced and that a stale `href` cannot survive a
+    render pass. Every leg runs exactly ONE engine: the
     `umd` legs load HyperFormula as an external script (the base bundle ships
     none — the DEV-2190 wiring); the `full-min` legs use the baked-in engine.
   -->
@@ -76,23 +77,37 @@
       td.appendChild(mark);
     }
 
+    // A renderer that leaves the cell's DOM untouched when the rendered value has not changed.
+    // This is the shape that made the old shape-based idempotency guard keep a stale `href`.
+    function memoRenderer(instance, td, row, col, prop, value) {
+      const next = value === null || value === undefined ? '' : String(value);
+      const key = `${row}:${col}:${next}`;
+
+      if (td.dataset.memo === key) {
+        return;
+      }
+
+      td.dataset.memo = key;
+      td.textContent = next;
+    }
+
     window.hot = new Handsontable(container, {
       data: [
         // A plain link, label given explicitly.
-        ['=HYPERLINK("https://example.com/one","Example one")', '=HYPERLINK("https://example.com/b1","B one")', true, '=HYPERLINK("https://example.com/pw","secret")'],
+        ['=HYPERLINK("https://example.com/one","Example one")', '=HYPERLINK("https://example.com/b1","B one")', true, '=HYPERLINK("https://example.com/pw","secret")', '=HYPERLINK(E2,"Steady")'],
         // The label defaults to the URL when the second argument is omitted.
-        ['=HYPERLINK("https://example.com/two")', 'b2', false, 'plainsecret'],
+        ['=HYPERLINK("https://example.com/two")', 'b2', false, 'plainsecret', 'https://example.com/first'],
         // HYPERLINK is not the root expression, so the engine reports no link.
-        ['=CONCATENATE("see ", HYPERLINK("https://example.com/three","three"))', 'b3', true, 'x'],
+        ['=CONCATENATE("see ", HYPERLINK("https://example.com/three","three"))', 'b3', true, 'x', 'x'],
         // Refused by the protocol allowlist.
-        ['=HYPERLINK("javascript:alert(1)","Danger")', 'b4', false, 'x'],
+        ['=HYPERLINK("javascript:alert(1)","Danger")', 'b4', false, 'x', 'x'],
         // The label must stay text, never markup.
-        ['=HYPERLINK("https://example.com/five","<img src=x onerror=\'window.__xss = true\'>")', 'b5', true, 'x'],
+        ['=HYPERLINK("https://example.com/five","<img src=x onerror=\'window.__xss = true\'>")', 'b5', true, 'x', 'x'],
         // A relative URL resolves against the document, which keeps a real
         // click navigation local and offline-safe.
-        ['=HYPERLINK("/tests/fixtures/demo/grid.html","Local page")', 'b6', false, 'x'],
+        ['=HYPERLINK("/tests/fixtures/demo/grid.html","Local page")', 'b6', false, 'x', 'x'],
         // Not a formula at all.
-        ['plain', 'b7', true, 'x'],
+        ['plain', 'b7', true, 'x', 'x'],
       ],
       formulas: {
         engine: HyperFormula,
@@ -107,6 +122,7 @@
         // to survive inside the anchor, which only holds if the type's renderer
         // still runs (finding #6 of the review of #10314).
         { type: 'password' },
+        { renderer: memoRenderer },
       ],
       width: 600,
       height: 300,

--- a/tests/fixtures/pages/FormulasHyperlinkPage.ts
+++ b/tests/fixtures/pages/FormulasHyperlinkPage.ts
@@ -107,6 +107,15 @@ export class FormulasHyperlinkPage {
     return this.page.evaluate(() => (window as any).__opened as string[]);
   }
 
+  /** Force N extra draws, so TD reuse and re-decoration are actually exercised. */
+  async render(times = 1): Promise<void> {
+    await this.page.evaluate((count) => {
+      for (let i = 0; i < count; i++) {
+        (window as any).hot.render();
+      }
+    }, times);
+  }
+
   /** Click a cell so it becomes the selected one, without hitting its anchor. */
   async selectCell(row: number, col: number): Promise<void> {
     const box = await this.cell(row, col).boundingBox();

--- a/tests/fixtures/pages/FormulasHyperlinkPage.ts
+++ b/tests/fixtures/pages/FormulasHyperlinkPage.ts
@@ -1,0 +1,136 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the `formulas.hyperlinks` fixture. Encapsulates reading the
+ * anchor a `HYPERLINK` cell renders, flipping the option at runtime, and the
+ * `Alt`+`Enter` keyboard path (the anchor is deliberately kept out of the tab
+ * order, so the shortcut is the only keyboard way to follow a link).
+ */
+export class FormulasHyperlinkPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly grid: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.grid = page.getByTestId('grid');
+  }
+
+  /**
+   * Navigate and wait until the engine has evaluated the formulas: the first
+   * cell showing its label instead of the raw expression proves both the grid
+   * and the engine are up.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(
+      `/tests/fixtures/demo/formulas-hyperlink.html?theme=${this.theme}&bundle=${this.bundle}`);
+    await expect(this.cell(0, 0)).toHaveText('Example one');
+  }
+
+  /** A single data cell, by visual row/column, via its stable test id. */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /** The anchor a `HYPERLINK` cell renders, if any. */
+  link(row: number, col: number): Locator {
+    return this.cell(row, col).locator('a.ht-hyperlink');
+  }
+
+  /** The element the fixture's custom renderer writes into column B. */
+  customMark(row: number): Locator {
+    return this.cell(row, 1).locator('span.custom-mark');
+  }
+
+  /** Turn the `hyperlinks` sub-option on or off through `updateSettings`. */
+  async setHyperlinks(enabled: boolean): Promise<void> {
+    await this.page.evaluate((hyperlinks) => {
+      const hot = (window as any).hot;
+
+      hot.updateSettings({
+        formulas: {
+          engine: (window as any).HyperFormula,
+          sheetName: 'Sheet1',
+          hyperlinks,
+        },
+      });
+    }, enabled);
+  }
+
+  /** Write a raw value into a cell, replacing whatever formula it held. */
+  async setCellValue(row: number, col: number, value: string): Promise<void> {
+    await this.page.evaluate(([r, c, v]) => {
+      (window as any).hot.setDataAtCell(r, c, v);
+    }, [row, col, value] as [number, number, string]);
+  }
+
+  /** Disable the Formulas plugin at runtime and force a redraw. */
+  async disableFormulasPlugin(): Promise<void> {
+    await this.page.evaluate(() => {
+      const hot = (window as any).hot;
+
+      hot.getPlugin('formulas').disablePlugin();
+      hot.render();
+    });
+  }
+
+  /**
+   * Replace `window.open` with a recorder. The plugin opens links through it,
+   * so this keeps the keyboard assertion deterministic and offline.
+   */
+  async recordWindowOpen(): Promise<void> {
+    await this.page.evaluate(() => {
+      (window as any).__opened = [];
+      window.open = (url?: string | URL) => {
+        (window as any).__opened.push(String(url));
+
+        return null;
+      };
+    });
+  }
+
+  /** The URLs passed to `window.open` since `recordWindowOpen()` was called. */
+  async openedUrls(): Promise<string[]> {
+    return this.page.evaluate(() => (window as any).__opened as string[]);
+  }
+
+  /** Click a cell so it becomes the selected one, without hitting its anchor. */
+  async selectCell(row: number, col: number): Promise<void> {
+    const box = await this.cell(row, col).boundingBox();
+
+    if (!box) {
+      throw new Error(`cell ${row},${col} is not rendered`);
+    }
+
+    // Click near the right edge, past the label, so the pointer lands on the
+    // cell itself rather than on the anchor.
+    await this.page.mouse.click(box.x + box.width - 4, box.y + box.height / 2);
+    await expect(this.selectedCoords()).resolves.toEqual([row, col]);
+  }
+
+  /** The coordinates of the currently highlighted cell. */
+  async selectedCoords(): Promise<[number, number] | null> {
+    return this.page.evaluate(() => {
+      const highlight = (window as any).hot.getSelectedRangeActive()?.highlight;
+
+      return highlight ? [highlight.row, highlight.col] : null;
+    });
+  }
+
+  /** Press the shortcut that opens the link of the selected cell. */
+  async pressOpenLinkShortcut(): Promise<void> {
+    await this.page.keyboard.press('Alt+Enter');
+  }
+
+  /** Whether an editor is open, and what it holds. */
+  async editorValue(): Promise<string | null> {
+    return this.page.evaluate(() => {
+      const editor = (window as any).hot.getActiveEditor();
+
+      return editor?.isOpened() ? editor.getValue() : null;
+    });
+  }
+}

--- a/tests/fixtures/pages/FormulasHyperlinkPage.ts
+++ b/tests/fixtures/pages/FormulasHyperlinkPage.ts
@@ -120,6 +120,27 @@ export class FormulasHyperlinkPage {
     });
   }
 
+  /**
+   * Record the `Alt`+`Enter` keydown events that reach the document, and whether their default was
+   * prevented. A shortcut that claims the chord stops propagation, so a swallowed event never
+   * arrives here at all — which is exactly what a host application's own handler would see.
+   */
+  async recordHostAltEnter(): Promise<void> {
+    await this.page.evaluate(() => {
+      (window as any).__altEnter = [];
+      document.addEventListener('keydown', (event) => {
+        if (event.altKey && event.key === 'Enter') {
+          (window as any).__altEnter.push(event.defaultPrevented);
+        }
+      });
+    });
+  }
+
+  /** The `Alt`+`Enter` events that reached the document since `recordHostAltEnter()`. */
+  async hostAltEnterEvents(): Promise<boolean[]> {
+    return this.page.evaluate(() => (window as any).__altEnter as boolean[]);
+  }
+
   /** Press the shortcut that opens the link of the selected cell. */
   async pressOpenLinkShortcut(): Promise<void> {
     await this.page.keyboard.press('Alt+Enter');

--- a/tests/fixtures/pages/FormulasHyperlinkPage.ts
+++ b/tests/fixtures/pages/FormulasHyperlinkPage.ts
@@ -78,6 +78,16 @@ export class FormulasHyperlinkPage {
   }
 
   /**
+   * Disable the Formulas plugin WITHOUT forcing a redraw, which is what a caller that simply turns
+   * the plugin off does. No render means no `afterRenderer` pass, so nothing rewrites the cells.
+   */
+  async disableFormulasPluginWithoutRender(): Promise<void> {
+    await this.page.evaluate(() => {
+      (window as any).hot.getPlugin('formulas').disablePlugin();
+    });
+  }
+
+  /**
    * Replace `window.open` with a recorder. The plugin opens links through it,
    * so this keeps the keyboard assertion deterministic and offline.
    */


### PR DESCRIPTION
### Context

The PR adds an opt-in `formulas.hyperlinks` option that renders a cell whose root expression is `HYPERLINK()` as a clickable link.

HyperFormula has exposed everything needed since v2.5.0 (`HyperlinkPlugin`, `getCellHyperlink()`), and we depend on `^3.0.0`, so the missing half was purely Handsontable-side rendering. Until now such a cell evaluated correctly but displayed its label as dead plain text.

This replaces #10314, which proposed the same feature in 2023 and was closed instead of rebased. Its review objections shape this implementation:

- **No new public renderer and no new cell type.** The `Formulas` plugin decorates the already rendered cell from the `afterRenderer` hook, so nothing is added to the renderer registry.
- **No cell meta is written.** #10314 restored `textRenderer` into cell meta for every non-hyperlink cell, which destroyed user-defined renderers and built-in cell types. Here the cell keeps its own renderer and there is nothing to undo when a formula is removed or the plugin is disabled.
- **The URL is parsed, not pattern-matched.** `resolveHyperlinkUrl()` resolves through `new URL()` and allowlists `http`, `https`, `mailto` and `tel`. Everything else, `javascript:` included, renders the label as plain text and warns once. Obfuscations that survive a string check (`JaVaScRiPt:`, `java\tscript:`, leading whitespace) normalize before the protocol is read.
- **No `innerHTML`.** The anchor is built with DOM APIs and the cell's existing child nodes are moved into it, so a label containing markup stays text whatever the `sanitizer` option is set to. This matters because `sanitize()` is a documented pass-through and `sanitizer` defaults to `undefined`.

Two behavioral details worth reviewing:

- **Default is `false`.** Enabling it by default would change rendering for existing grids that already hold `HYPERLINK` formulas, so it stays opt-in. Flipping the default is a separate major-release decision.
- **Keyboard access is <kbd>Alt</kbd>+<kbd>Enter</kbd>**, matching Google Sheets. The anchor carries `tabindex="-1"` so cell content stays out of the grid's tab order. `Alt`+`Enter` was free: `grid.ts` binds `Enter`, `Shift`+`Enter` and `Control/Meta`+`Enter`, and no core context binds any `Alt` combination.

Also of note: `htmlRenderer` has the same unsanitized-`href` gap that #10314 was flagged for. It is out of scope here and should be tracked separately.

### How has this been tested?

Unit, type, and Playwright E2E, all from the repo root:

```bash
npm --prefix handsontable run eslint
npm --prefix handsontable run stylelint
npm --prefix handsontable run test:unit
npm --prefix handsontable run test:types
npm --prefix handsontable run build
npm --prefix tests run test:e2e -- e2e/formulas-hyperlink.spec.ts
```

- **Unit** (`handsontable/src/plugins/formulas/__tests__/hyperlinkUrl.unit.ts`, 21 cases): every allowed scheme accepted; `javascript:`, `data:`, `vbscript:` and `file:` refused, including mixed-case, tab-obfuscated and whitespace-padded variants; relative and protocol-relative URLs resolved against the base; empty, non-string and unparseable input refused. Full suite: 308 suites / 3669 tests green.
- **E2E** (`tests/e2e/formulas-hyperlink.spec.ts`, 16 cases): anchor attributes; the one-argument form; no anchor for a nested `HYPERLINK` call or a plain value; the refused-scheme path with exactly one warning; a markup label staying text; a column's custom renderer surviving and being wrapped; a `checkbox` cell type untouched; a `password` cell type's masked output surviving inside the anchor; the anchor disappearing when the formula is replaced or the plugin is disabled; the option toggled off and back on; click navigation plus cell selection; double click opening the editor with the raw formula; `Alt`+`Enter` on a link cell and on a non-link cell. 16/16 green on `e2e-main`.
- **Mutation-checked**: forcing the cached option flag to `false` turns six of those E2E cases red, so the spec binds to real behavior rather than merely executing it.
- **Render cost measured** on the worst case, 504 rendered cells all holding `HYPERLINK` formulas, median of 25 renders: 9.4 ms with the option off, 13.0 ms with it on, so roughly 7 µs per link cell including anchor creation. With the option off the per-cell cost is a single boolean read.
- **Legacy Jasmine/Puppeteer suite** (`npm --prefix handsontable run test:e2e`): 9669 specs, 0 failures, 8 pending. This is the closest existing coverage to the three lifecycle methods the PR touches (`enablePlugin`, `disablePlugin`, `updatePlugin`), including the missing-engine path in `initialization.spec.js` and `memoryLeak.spec.js`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. PRO-1051
2. Replaces #10314

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86c8j1xwa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches formula rendering and URL handling (XSS-sensitive hrefs). Mitigated by an allowlist, DOM-only wrapping, and opt-in default, but still security-relevant.
> 
> **Overview**
> Adds an opt-in `formulas.hyperlinks` setting so a cell whose **root** formula is `HYPERLINK()` renders as a clickable link, without changing cell types or cell meta.
> 
> The Formulas plugin wraps the cell’s existing renderer output in an `a.ht-hyperlink` after render. URLs are parsed with `new URL()` and only `http`, `https`, `mailto`, and `tel` become links; other schemes (including `javascript:`) stay plain text. Nested `HYPERLINK` calls stay text. Links open in a new tab (`noopener,noreferrer`); keyboard access is **Alt+Enter** (anchors are out of tab order). Default remains off so existing grids are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c05c74786691b79bf8ca31fc77c430ed545bbbab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->