### PR TITLE
DEV-2594: Fix nestedRows invalid state after updateData changes the children count

### DIFF
--- a/.changelogs/10239.json
+++ b/.changelogs/10239.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the `nestedRows` plugin hiding parent rows and showing orphaned child rows when `updateData()` was called with a different number of children while some parents were collapsed.",
+  "type": "fixed",
+  "issueOrPR": 10239,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13224.json
+++ b/.changelogs/13224.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Changed how the `nestedRows` plugin treats collapsed rows when the data is replaced: `updateData()` now keeps the collapsed parents, matching them by their position in the tree, while `loadData()` drops them, so `getCollapsedParents()` no longer reports parents from the previous dataset.",
+  "type": "changed",
+  "issueOrPR": 13224,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/rows/row-parent-child/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child/row-parent-child.md
@@ -359,10 +359,27 @@ const configurationOptions = {
 };
 ```
 
+One case fires no hooks: when [`updateData()`](@/api/core.md#updatedata) collapses the same parents
+again on the new data. That is not a new action, only the state the user already chose, so it stays
+silent. If you mirror the collapsed state somewhere, read it back with
+[`getCollapsedParents()`](@/api/nestedRows.md#getcollapsedparents) after `updateData()` instead of
+counting on a hook.
+
 ### Save and restore the collapsed rows
 
-The hooks carry physical indexes, which is what you want to store. To restore the state after
-replacing the data, collapse the deepest parents first: collapsing a parent hides its children, so a
+The two data methods treat the collapsed rows differently, and the difference decides whether you
+have to restore anything at all:
+
+- [`updateData()`](@/api/core.md#updatedata) **keeps** the collapsed parents. It matches them by
+  their position in the tree, so they stay collapsed even when the number of children changes. Do
+  not restore them yourself here. A saved list holds physical row indexes, and those move as soon as
+  a parent gains or loses a child, so replaying it collapses the wrong rows.
+- [`loadData()`](@/api/core.md#loaddata) **drops** them, along with every other row state.
+  [`getCollapsedParents()`](@/api/nestedRows.md#getcollapsedparents) returns an empty array
+  afterwards. Restore the state yourself if you want it back.
+
+The example below covers the `loadData()` case. The hooks carry physical indexes, which is what you
+want to store. Collapse the deepest parents first: collapsing a parent hides its children, so a
 nested parent has to be collapsed while it is still visible.
 
 ```js

--- a/handsontable/src/plugins/nestedRows/AGENTS.md
+++ b/handsontable/src/plugins/nestedRows/AGENTS.md
@@ -121,8 +121,9 @@ They are written in different places and can drift. Keep this in mind:
   and `BasePlugin#onUpdateSettings` always fires. Anything you keep outside the settings object is
   lost there unless it is explicitly preserved. This regressed once before — see `CHANGELOG.md` for
   "using `updateSettings()` caused the state of nested rows to reset".
-- **Neither collapse store survives a data replacement, because both are keyed by physical row
-  index.** `loadData()` resets the index maps for you (`initIndexMappers()`), but `updateData()` only
+- **No collapse store survives a data replacement, because all of them are keyed by physical row
+  index** — `collapsedRows`, `collapsedRowsMap`, and `lastCollapsedRows` (the stash, see below).
+  `loadData()` resets the index maps for you (`initIndexMappers()`), but `updateData()` only
   resizes them (`rowIndexMapper.fitToLength()`), so stale trimmed indexes stay behind and land on
   whatever row now sits there — including parent rows, which then vanish while their children stay on
   screen (#10239). The plugin therefore splits the two data hooks: `beforeLoadData` drops the
@@ -134,7 +135,11 @@ They are written in different places and can drift. Keep this in mind:
   reordering or removing siblings moves it, which is the best that is possible when the new dataset
   carries no identity; and the map must only be cleared when a parent really is collapsed, because
   clearing it rebuilds the row index cache and a data load runs on every grid init
-  (`core.unit.js` asserts exactly one cache reset).
+  (`core.unit.js` asserts exactly one cache reset). The stash needs the same treatment for a
+  different reason: during a stash window `collapsedRows` is already **empty** (the stash expanded
+  the grid), so the main capture sees nothing and only `lastCollapsedRows` still holds the user's
+  state — an app that replaces the data from inside an add-child, detach-child, remove-row or
+  row-move hook would otherwise get `applyStash()` replayed onto the old row numbers.
 - **`collapsedRowsStash.stash()` temporarily expands everything.** Any operation wrapped in
   stash/applyStash briefly un-trims all rows. It is used around add child, detach child, row move,
   and filtering.

--- a/handsontable/src/plugins/nestedRows/AGENTS.md
+++ b/handsontable/src/plugins/nestedRows/AGENTS.md
@@ -130,7 +130,13 @@ They are written in different places and can drift. Keep this in mind:
   collapsed state (`loadData` resets row states by contract), while `beforeUpdateData` records the
   collapsed parents as **tree paths** (`dataManager.getRowTreePath()`), clears both stores, and
   `afterUpdateData` re-collapses whatever those paths still resolve to
-  (`dataManager.getRowIndexByTreePath()`). Replay shallowest-first and with `shouldRunHooks = false`.
+  (`dataManager.getRowIndexByTreePath()`). Replay with `shouldRunHooks = false` and
+  `forceRender = false` — `replaceData` renders the moment the hook returns, so a render there is a
+  second full one, which Angular pays on every `data` input change. Replay order does **not** matter
+  (collapsing changes trimming, not physical indexes), unlike the expand path. The replay must end
+  with `hot.selection.refresh()`: the Core clamps the selection before `afterUpdateData`, while the
+  grid is still fully expanded, and a trimming change never re-clamps it — `selection.commit()`
+  follows `hiddenIndexesChanged` only (`core.ts`).
   Two things to keep: a tree path is **positional**, so it follows the slot rather than the object —
   reordering or removing siblings moves it, which is the best that is possible when the new dataset
   carries no identity; and the map must only be cleared when a parent really is collapsed, because

--- a/handsontable/src/plugins/nestedRows/AGENTS.md
+++ b/handsontable/src/plugins/nestedRows/AGENTS.md
@@ -121,6 +121,20 @@ They are written in different places and can drift. Keep this in mind:
   and `BasePlugin#onUpdateSettings` always fires. Anything you keep outside the settings object is
   lost there unless it is explicitly preserved. This regressed once before — see `CHANGELOG.md` for
   "using `updateSettings()` caused the state of nested rows to reset".
+- **Neither collapse store survives a data replacement, because both are keyed by physical row
+  index.** `loadData()` resets the index maps for you (`initIndexMappers()`), but `updateData()` only
+  resizes them (`rowIndexMapper.fitToLength()`), so stale trimmed indexes stay behind and land on
+  whatever row now sits there — including parent rows, which then vanish while their children stay on
+  screen (#10239). The plugin therefore splits the two data hooks: `beforeLoadData` drops the
+  collapsed state (`loadData` resets row states by contract), while `beforeUpdateData` records the
+  collapsed parents as **tree paths** (`dataManager.getRowTreePath()`), clears both stores, and
+  `afterUpdateData` re-collapses whatever those paths still resolve to
+  (`dataManager.getRowIndexByTreePath()`). Replay shallowest-first and with `shouldRunHooks = false`.
+  Two things to keep: a tree path is **positional**, so it follows the slot rather than the object —
+  reordering or removing siblings moves it, which is the best that is possible when the new dataset
+  carries no identity; and the map must only be cleared when a parent really is collapsed, because
+  clearing it rebuilds the row index cache and a data load runs on every grid init
+  (`core.unit.js` asserts exactly one cache reset).
 - **`collapsedRowsStash.stash()` temporarily expands everything.** Any operation wrapped in
   stash/applyStash briefly un-trims all rows. It is used around add child, detach child, row move,
   and filtering.
@@ -159,7 +173,9 @@ They are written in different places and can drift. Keep this in mind:
 | `__tests__/keyboardShortcuts.spec.js` | <kbd>Enter</kbd> on a row header |
 | `__tests__/integration/manualRowMove.spec.js` | The richest file — moves into and around collapsed parents |
 | `__tests__/nestedRows.types.ts` | Type coverage for the public surface |
+| `__tests__/data/dataManager.unit.js` | The tree-path helpers, including the round trip across a data swap |
 | `tests/e2e/nested-rows-api.spec.ts` | Playwright: hooks, cancelling, and post-`loadData` safety |
+| `tests/e2e/nested-rows-update-data.spec.ts` | Playwright: collapsed parents across `updateData` / `loadData` |
 
 Physical layouts of the shared fixtures, which the specs depend on:
 

--- a/handsontable/src/plugins/nestedRows/__tests__/data/dataManager.unit.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/data/dataManager.unit.js
@@ -1,0 +1,112 @@
+import DataManager from '../../data/dataManager';
+
+/**
+ * Builds a DataManager over the given tree.
+ *
+ * The tree path helpers read the structure cache only, so the plugin and the Handsontable
+ * instance are never touched and can stay out of the way.
+ *
+ * @param {object[]} data The nested data.
+ * @returns {DataManager}
+ */
+function dataManagerWith(data) {
+  const dataManager = new DataManager(null, null);
+
+  dataManager.updateWithData(data);
+
+  return dataManager;
+}
+
+/**
+ * Physical row indexes of this tree:
+ *   0 A / 1 A-1 / 2 A-2 / 3 A-2-a / 4 A-2-b / 5 B / 6 B-1.
+ *
+ * @returns {object[]}
+ */
+function sampleTree() {
+  return [
+    {
+      id: 'A',
+      __children: [
+        { id: 'A-1' },
+        { id: 'A-2', __children: [{ id: 'A-2-a' }, { id: 'A-2-b' }] },
+      ],
+    },
+    {
+      id: 'B',
+      __children: [{ id: 'B-1' }],
+    },
+  ];
+}
+
+describe('NestedRows DataManager', () => {
+  describe('getRowTreePath', () => {
+    it('should return a single-element path for a top-level row', () => {
+      const dataManager = dataManagerWith(sampleTree());
+
+      expect(dataManager.getRowTreePath(0)).toEqual([0]);
+      expect(dataManager.getRowTreePath(5)).toEqual([1]);
+    });
+
+    it('should return the chain of child indexes for a nested row', () => {
+      const dataManager = dataManagerWith(sampleTree());
+
+      expect(dataManager.getRowTreePath(1)).toEqual([0, 0]);
+      expect(dataManager.getRowTreePath(2)).toEqual([0, 1]);
+      expect(dataManager.getRowTreePath(3)).toEqual([0, 1, 0]);
+      expect(dataManager.getRowTreePath(4)).toEqual([0, 1, 1]);
+      expect(dataManager.getRowTreePath(6)).toEqual([1, 0]);
+    });
+
+    it('should return `null` for a row that is not part of the structure', () => {
+      const dataManager = dataManagerWith(sampleTree());
+
+      expect(dataManager.getRowTreePath(7)).toBe(null);
+      expect(dataManager.getRowTreePath(-1)).toBe(null);
+    });
+  });
+
+  describe('getRowIndexByTreePath', () => {
+    it('should find the physical row index the path points at', () => {
+      const dataManager = dataManagerWith(sampleTree());
+
+      expect(dataManager.getRowIndexByTreePath([0])).toBe(0);
+      expect(dataManager.getRowIndexByTreePath([0, 1])).toBe(2);
+      expect(dataManager.getRowIndexByTreePath([0, 1, 1])).toBe(4);
+      expect(dataManager.getRowIndexByTreePath([1, 0])).toBe(6);
+    });
+
+    it('should return `null` for a path that leads outside the structure', () => {
+      const dataManager = dataManagerWith(sampleTree());
+
+      expect(dataManager.getRowIndexByTreePath([2])).toBe(null);
+      expect(dataManager.getRowIndexByTreePath([0, 0, 0])).toBe(null);
+      expect(dataManager.getRowIndexByTreePath([])).toBe(null);
+      expect(dataManager.getRowIndexByTreePath(null)).toBe(null);
+    });
+
+    it('should round-trip every row of the tree', () => {
+      const dataManager = dataManagerWith(sampleTree());
+
+      for (let row = 0; row < 7; row++) {
+        expect(dataManager.getRowIndexByTreePath(dataManager.getRowTreePath(row))).toBe(row);
+      }
+    });
+
+    it('should point at the same node after the children counts change', () => {
+      const dataManager = dataManagerWith(sampleTree());
+      // `A-2` sits at physical row 2, `B` at physical row 5.
+      const pathToA2 = dataManager.getRowTreePath(2);
+      const pathToB = dataManager.getRowTreePath(5);
+      const grownTree = sampleTree();
+
+      grownTree[0].__children[1].__children.push({ id: 'A-2-c' });
+      dataManager.updateWithData(grownTree);
+
+      // The extra child pushed `B` down by one, but neither path had to change.
+      expect(dataManager.getRowIndexByTreePath(pathToA2)).toBe(2);
+      expect(dataManager.getRowIndexByTreePath(pathToB)).toBe(6);
+      expect(dataManager.getDataObject(6).id).toBe('B');
+    });
+  });
+});

--- a/handsontable/src/plugins/nestedRows/data/dataManager.ts
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.ts
@@ -317,6 +317,11 @@ class DataManager {
    * A physical row index shifts as soon as any other node gains or loses children. A tree path does
    * not, so it can be used to find the same node again after the data is replaced.
    *
+   * Assumes each row object appears in the tree once. The path is built with `indexOf`, on object
+   * identity, while `getRowIndexByTreePath()` finishes through the `cache.nodeInfo` WeakMap, which
+   * keeps only a node's last occurrence - so the same object placed at two spots makes the two
+   * disagree.
+   *
    * @param {number} row Physical row index.
    * @returns {number[]|null} The path, or `null` when the row is not part of the current structure.
    */
@@ -346,10 +351,12 @@ class DataManager {
   /**
    * Find the physical row index of the node that the provided tree path points at.
    *
-   * @param {number[]} path Chain of child indexes, as returned by {@link DataManager#getRowTreePath}.
+   * @param {number[]|null} path Chain of child indexes, as returned by
+   * {@link DataManager#getRowTreePath} - which returns `null` for a row it does not know, so the
+   * `null` is accepted here rather than filtered at every call site.
    * @returns {number|null} Physical row index, or `null` when the path leads outside the structure.
    */
-  getRowIndexByTreePath(path: number[]): number | null {
+  getRowIndexByTreePath(path: number[] | null): number | null {
     if (!Array.isArray(path) || path.length === 0) {
       return null;
     }

--- a/handsontable/src/plugins/nestedRows/data/dataManager.ts
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.ts
@@ -311,6 +311,66 @@ class DataManager {
   }
 
   /**
+   * Get the position of a row within the nested structure, expressed as the chain of child indexes
+   * that leads from the top level down to that row.
+   *
+   * A physical row index shifts as soon as any other node gains or loses children. A tree path does
+   * not, so it can be used to find the same node again after the data is replaced.
+   *
+   * @param {number} row Physical row index.
+   * @returns {number[]|null} The path, or `null` when the row is not part of the current structure.
+   */
+  getRowTreePath(row: number): number[] | null {
+    let rowObject: RowObject | null | undefined = this.getDataObject(row);
+
+    if (!rowObject) {
+      return null;
+    }
+
+    const path: number[] = [];
+
+    while (rowObject) {
+      const indexWithinParent = this.getRowIndexWithinParent(rowObject);
+
+      if (indexWithinParent === -1) {
+        return null;
+      }
+
+      path.unshift(indexWithinParent);
+      rowObject = this.getRowObjectParent(rowObject);
+    }
+
+    return path;
+  }
+
+  /**
+   * Find the physical row index of the node that the provided tree path points at.
+   *
+   * @param {number[]} path Chain of child indexes, as returned by {@link DataManager#getRowTreePath}.
+   * @returns {number|null} Physical row index, or `null` when the path leads outside the structure.
+   */
+  getRowIndexByTreePath(path: number[]): number | null {
+    if (!Array.isArray(path) || path.length === 0) {
+      return null;
+    }
+
+    let siblings: RowObject[] | null | undefined = this.data;
+    let node: RowObject | null = null;
+
+    for (let i = 0; i < path.length; i++) {
+      node = siblings?.[path[i]] ?? null;
+
+      if (node === null) {
+        return null;
+      }
+
+      siblings = node.__children;
+    }
+
+    return this.getRowIndex(node);
+  }
+
+  /**
    * Count all rows (including all parents and children).
    *
    * @returns {number}

--- a/handsontable/src/plugins/nestedRows/nestedRows.ts
+++ b/handsontable/src/plugins/nestedRows/nestedRows.ts
@@ -112,6 +112,14 @@ export class NestedRows extends BasePlugin {
   #collapsedParentPaths: number[][] = [];
 
   /**
+   * Tree paths held by a stash that an outer operation left open when `updateData()` started.
+   * `null` means there was no open stash.
+   *
+   * @type {number[][]|null}
+   */
+  #stashedParentPaths: number[][] | null = null;
+
+  /**
    * Checks if the plugin is enabled in the handsontable settings. This method is executed in {@link Hooks#beforeInit}
    * hook and if it returns `true` then the {@link NestedRows#enablePlugin} method is called.
    *
@@ -953,19 +961,58 @@ export class NestedRows extends BasePlugin {
   /**
    * Forgets which parents are collapsed, and untrims the rows that collapse had hidden.
    *
-   * Both stores are keyed by physical row index, and neither of those indexes means anything once
-   * the data is replaced.
+   * All three stores are keyed by physical row index, and none of those indexes means anything once
+   * the data is replaced: the collapsed-parents list, the trimming map, and the stash an outer
+   * operation left open.
    *
-   * There is nothing to do when no parent is collapsed, and skipping the map matters there:
+   * There is nothing to trim when no parent is collapsed, and skipping the map matters there:
    * clearing it rebuilds the row index cache, and a data load runs on every grid init.
    */
   #clearCollapsedState() {
-    if (!this.collapsingUI || this.collapsingUI.collapsedRows.length === 0) {
+    if (!this.collapsingUI) {
+      return;
+    }
+
+    if (this.collapsingUI.lastCollapsedRows) {
+      this.collapsingUI.lastCollapsedRows = [];
+    }
+
+    if (this.collapsingUI.collapsedRows.length === 0) {
       return;
     }
 
     this.collapsingUI.collapsedRows.length = 0;
     this.collapsedRowsMap?.clear();
+  }
+
+  /**
+   * Translates physical row indexes into tree paths, dropping the rows the current cache does not
+   * know about.
+   *
+   * @param {number[]} rows Physical row indexes.
+   * @returns {number[][]}
+   */
+  #toTreePaths(rows: number[]): number[][] {
+    return rows
+      .map(row => this.dataManager!.getRowTreePath(row))
+      .filter((path): path is number[] => path !== null);
+  }
+
+  /**
+   * Translates tree paths back into physical row indexes, keeping only the rows that still exist and
+   * still have children.
+   *
+   * Sorted shallowest first, so an ancestor is always handled before its own descendants.
+   *
+   * @param {number[][]} paths Tree paths.
+   * @returns {number[]} Physical row indexes.
+   */
+  #toCollapsibleRows(paths: number[][]): number[] {
+    return paths
+      .slice()
+      .sort((pathA, pathB) => pathA.length - pathB.length)
+      .map(path => this.dataManager!.getRowIndexByTreePath(path))
+      .filter((row): row is number => row !== null && this.dataManager!.hasChildren(row));
   }
 
   /**
@@ -1002,9 +1049,13 @@ export class NestedRows extends BasePlugin {
       return;
     }
 
-    this.#collapsedParentPaths = (this.collapsingUI?.getCollapsedParents() ?? [])
-      .map(parentRow => this.dataManager!.getRowTreePath(parentRow))
-      .filter((path): path is number[] => path !== null);
+    const openStash = this.collapsingUI?.lastCollapsedRows;
+
+    this.#collapsedParentPaths = this.#toTreePaths(this.collapsingUI?.getCollapsedParents() ?? []);
+    // An outer operation - add child, detach child, remove row, row move - may hold the collapsed
+    // state in an open stash instead, having expanded the grid for the duration. That copy has to
+    // be re-pointed as well, or `applyStash()` collapses whatever now sits at the old indexes.
+    this.#stashedParentPaths = openStash ? this.#toTreePaths(openStash) : null;
 
     this.#clearCollapsedState();
 
@@ -1016,23 +1067,25 @@ export class NestedRows extends BasePlugin {
    * `afterUpdateData` hook callback.
    *
    * Collapses the parents that were collapsed before the update and are still parents in the new
-   * data. A parent that the new data dropped, or that no longer has children, is simply forgotten.
+   * data, and re-points an open stash at the same rows. A parent that the new data dropped, or that
+   * no longer has children, is simply forgotten.
    */
   #onAfterUpdateData = () => {
     const paths = this.#collapsedParentPaths;
+    const stashedPaths = this.#stashedParentPaths;
 
     this.#collapsedParentPaths = [];
+    this.#stashedParentPaths = null;
 
-    if (paths.length === 0 || !this.collapsingUI || !this.dataManager) {
+    if (!this.collapsingUI || !this.dataManager) {
       return;
     }
 
-    const parentsToCollapse = paths
-      // Shallowest first, so an ancestor is always collapsed before its own descendants.
-      .slice()
-      .sort((pathA, pathB) => pathA.length - pathB.length)
-      .map(path => this.dataManager!.getRowIndexByTreePath(path))
-      .filter((row): row is number => row !== null && this.dataManager!.hasChildren(row));
+    if (stashedPaths !== null) {
+      this.collapsingUI.lastCollapsedRows = this.#toCollapsibleRows(stashedPaths);
+    }
+
+    const parentsToCollapse = this.#toCollapsibleRows(paths);
 
     if (parentsToCollapse.length > 0) {
       // Replaying a state the user already chose is not a new action, so the hooks stay silent.

--- a/handsontable/src/plugins/nestedRows/nestedRows.ts
+++ b/handsontable/src/plugins/nestedRows/nestedRows.ts
@@ -104,6 +104,14 @@ export class NestedRows extends BasePlugin {
   #isFirstRender = true;
 
   /**
+   * Tree paths of the parents that were collapsed when `updateData()` started, kept only until the
+   * new structure is cached and they can be collapsed again.
+   *
+   * @type {number[][]}
+   */
+  #collapsedParentPaths: number[][] = [];
+
+  /**
    * Checks if the plugin is enabled in the handsontable settings. This method is executed in {@link Hooks#beforeInit}
    * hook and if it returns `true` then the {@link NestedRows#enablePlugin} method is called.
    *
@@ -151,7 +159,8 @@ export class NestedRows extends BasePlugin {
     this.addHook('afterCreateRow', this.#onAfterCreateRow);
     this.addHook('beforeRowMove', this.#onBeforeRowMove);
     this.addHook('beforeLoadData', this.#onBeforeLoadData);
-    this.addHook('beforeUpdateData', this.#onBeforeLoadData);
+    this.addHook('beforeUpdateData', this.#onBeforeUpdateData);
+    this.addHook('afterUpdateData', this.#onAfterUpdateData);
 
     this.registerShortcuts();
     super.enablePlugin();
@@ -923,22 +932,112 @@ export class NestedRows extends BasePlugin {
   };
 
   /**
+   * Checks the incoming data and turns the plugin off when it cannot work with it.
+   *
+   * @param {Array} data The source data.
+   * @returns {boolean} `true` when the plugin accepts the data.
+   */
+  #acceptsData(data: unknown[]): boolean {
+    if (isValidDataSource(data)) {
+      return true;
+    }
+
+    error(WRONG_DATA_TYPE_ERROR);
+
+    this.hot.getSettings()[PLUGIN_KEY] = false;
+    this.disablePlugin();
+
+    return false;
+  }
+
+  /**
+   * Forgets which parents are collapsed, and untrims the rows that collapse had hidden.
+   *
+   * Both stores are keyed by physical row index, and neither of those indexes means anything once
+   * the data is replaced.
+   *
+   * There is nothing to do when no parent is collapsed, and skipping the map matters there:
+   * clearing it rebuilds the row index cache, and a data load runs on every grid init.
+   */
+  #clearCollapsedState() {
+    if (!this.collapsingUI || this.collapsingUI.collapsedRows.length === 0) {
+      return;
+    }
+
+    this.collapsingUI.collapsedRows.length = 0;
+    this.collapsedRowsMap?.clear();
+  }
+
+  /**
    * `beforeLoadData` hook callback.
+   *
+   * `loadData()` resets the rows' states, so the collapsed parents are dropped along with them.
    *
    * @param {Array} data The source data.
    */
   #onBeforeLoadData = (data: unknown[]) => {
-    if (!isValidDataSource(data)) {
-      error(WRONG_DATA_TYPE_ERROR);
-
-      this.hot.getSettings()[PLUGIN_KEY] = false;
-      this.disablePlugin();
-
+    if (!this.#acceptsData(data)) {
       return;
     }
 
+    this.#clearCollapsedState();
+
     this.dataManager!.setData(data as RowObject[]);
     this.dataManager!.rewriteCache();
+  };
+
+  /**
+   * `beforeUpdateData` hook callback.
+   *
+   * `updateData()` keeps the rows' states, so the collapsed parents have to survive the swap. They
+   * cannot be carried over as physical row indexes: those shift as soon as any parent gains or
+   * loses a child, and the stale indexes then hide the wrong rows - parent rows included. The
+   * parents are remembered as tree paths instead, and collapsed again in `afterUpdateData`, once
+   * the index maps have been resized to the new data.
+   *
+   * @param {Array} data The source data.
+   */
+  #onBeforeUpdateData = (data: unknown[]) => {
+    if (!this.#acceptsData(data)) {
+      return;
+    }
+
+    this.#collapsedParentPaths = (this.collapsingUI?.getCollapsedParents() ?? [])
+      .map(parentRow => this.dataManager!.getRowTreePath(parentRow))
+      .filter((path): path is number[] => path !== null);
+
+    this.#clearCollapsedState();
+
+    this.dataManager!.setData(data as RowObject[]);
+    this.dataManager!.rewriteCache();
+  };
+
+  /**
+   * `afterUpdateData` hook callback.
+   *
+   * Collapses the parents that were collapsed before the update and are still parents in the new
+   * data. A parent that the new data dropped, or that no longer has children, is simply forgotten.
+   */
+  #onAfterUpdateData = () => {
+    const paths = this.#collapsedParentPaths;
+
+    this.#collapsedParentPaths = [];
+
+    if (paths.length === 0 || !this.collapsingUI || !this.dataManager) {
+      return;
+    }
+
+    const parentsToCollapse = paths
+      // Shallowest first, so an ancestor is always collapsed before its own descendants.
+      .slice()
+      .sort((pathA, pathB) => pathA.length - pathB.length)
+      .map(path => this.dataManager!.getRowIndexByTreePath(path))
+      .filter((row): row is number => row !== null && this.dataManager!.hasChildren(row));
+
+    if (parentsToCollapse.length > 0) {
+      // Replaying a state the user already chose is not a new action, so the hooks stay silent.
+      this.collapsingUI.toggleCollapsedRows(parentsToCollapse, 'collapse', false);
+    }
   };
 
   /**

--- a/handsontable/src/plugins/nestedRows/nestedRows.ts
+++ b/handsontable/src/plugins/nestedRows/nestedRows.ts
@@ -965,10 +965,11 @@ export class NestedRows extends BasePlugin {
    * the data is replaced: the collapsed-parents list, the trimming map, and the stash an outer
    * operation left open.
    *
-   * There is nothing to trim when no parent is collapsed, and skipping the map matters there:
-   * clearing it rebuilds the row index cache, and a data load runs on every grid init.
+   * @param {boolean} untrimRows `true` also clears the trimming map. `loadData()` passes `false`,
+   * because `initIndexMappers()` resets every map moments later and doing it twice costs a second
+   * row index cache rebuild.
    */
-  #clearCollapsedState() {
+  #clearCollapsedState(untrimRows: boolean) {
     if (!this.collapsingUI) {
       return;
     }
@@ -977,12 +978,18 @@ export class NestedRows extends BasePlugin {
       this.collapsingUI.lastCollapsedRows = [];
     }
 
+    // Nothing is trimmed when no parent is collapsed, and the early return is load-bearing:
+    // `core.unit.js` asserts exactly one `cacheUpdated` on init with `nestedRows: true`, and a data
+    // load runs on every grid init.
     if (this.collapsingUI.collapsedRows.length === 0) {
       return;
     }
 
     this.collapsingUI.collapsedRows.length = 0;
-    this.collapsedRowsMap?.clear();
+
+    if (untrimRows) {
+      this.collapsedRowsMap?.clear();
+    }
   }
 
   /**
@@ -1002,15 +1009,14 @@ export class NestedRows extends BasePlugin {
    * Translates tree paths back into physical row indexes, keeping only the rows that still exist and
    * still have children.
    *
-   * Sorted shallowest first, so an ancestor is always handled before its own descendants.
+   * Order is left alone. Collapsing changes which rows are trimmed, not their physical indexes, so
+   * an ancestor and its descendant can be collapsed in either order for the same result.
    *
    * @param {number[][]} paths Tree paths.
    * @returns {number[]} Physical row indexes.
    */
   #toCollapsibleRows(paths: number[][]): number[] {
     return paths
-      .slice()
-      .sort((pathA, pathB) => pathA.length - pathB.length)
       .map(path => this.dataManager!.getRowIndexByTreePath(path))
       .filter((row): row is number => row !== null && this.dataManager!.hasChildren(row));
   }
@@ -1027,7 +1033,7 @@ export class NestedRows extends BasePlugin {
       return;
     }
 
-    this.#clearCollapsedState();
+    this.#clearCollapsedState(false);
 
     this.dataManager!.setData(data as RowObject[]);
     this.dataManager!.rewriteCache();
@@ -1057,7 +1063,7 @@ export class NestedRows extends BasePlugin {
     // be re-pointed as well, or `applyStash()` collapses whatever now sits at the old indexes.
     this.#stashedParentPaths = openStash ? this.#toTreePaths(openStash) : null;
 
-    this.#clearCollapsedState();
+    this.#clearCollapsedState(true);
 
     this.dataManager!.setData(data as RowObject[]);
     this.dataManager!.rewriteCache();
@@ -1087,10 +1093,18 @@ export class NestedRows extends BasePlugin {
 
     const parentsToCollapse = this.#toCollapsibleRows(paths);
 
-    if (parentsToCollapse.length > 0) {
-      // Replaying a state the user already chose is not a new action, so the hooks stay silent.
-      this.collapsingUI.toggleCollapsedRows(parentsToCollapse, 'collapse', false);
+    if (parentsToCollapse.length === 0) {
+      return;
     }
+
+    // Replaying a state the user already chose is not a new action, so the hooks stay silent, and
+    // `replaceData` renders as soon as this hook returns - a render here would be the second one.
+    this.collapsingUI.toggleCollapsedRows(parentsToCollapse, 'collapse', false, false);
+
+    // The Core clamped the selection before this hook ran, against a grid that was still fully
+    // expanded. Trimming does not re-clamp it - `selection.commit()` only follows hidden indexes -
+    // so without this the highlight can sit past the last row.
+    this.hot.selection.refresh();
   };
 
   /**

--- a/handsontable/src/plugins/nestedRows/ui/collapsing.ts
+++ b/handsontable/src/plugins/nestedRows/ui/collapsing.ts
@@ -407,14 +407,21 @@ class CollapsingUI extends BaseUI {
    * @param {string} action Either `'collapse'` or `'expand'`.
    * @param {boolean} [shouldRunHooks=true] `false` skips both hooks - used when replaying state that the
    * user already chose, such as restoring after an `updateSettings` call.
+   * @param {boolean} [forceRender=true] `false` leaves the render to the caller, for the cases where one
+   * runs right afterwards anyway.
    * @returns {boolean} `true` if the collapsed state actually changed.
    * @fires Hooks#beforeRowCollapse
    * @fires Hooks#afterRowCollapse
    * @fires Hooks#beforeRowExpand
    * @fires Hooks#afterRowExpand
    */
-  toggleCollapsedRows(parents: number[], action: 'collapse' | 'expand', shouldRunHooks = true): boolean {
-    return this.applyCollapsedRowsChange(parents, action, shouldRunHooks).performed;
+  toggleCollapsedRows(
+    parents: number[],
+    action: 'collapse' | 'expand',
+    shouldRunHooks = true,
+    forceRender = true
+  ): boolean {
+    return this.applyCollapsedRowsChange(parents, action, shouldRunHooks, forceRender).performed;
   }
 
   /**
@@ -427,6 +434,7 @@ class CollapsingUI extends BaseUI {
    * @param {number[]} parents Physical row indexes of the parents to act on.
    * @param {string} action Either `'collapse'` or `'expand'`.
    * @param {boolean} [shouldRunHooks=true] `false` skips both hooks.
+   * @param {boolean} [forceRender=true] `false` leaves the render to the caller.
    * @returns {{performed: boolean, vetoed: boolean}} `performed` says the collapsed state changed,
    * `vetoed` says a `before*` hook returned `false`.
    * @fires Hooks#beforeRowCollapse
@@ -437,7 +445,8 @@ class CollapsingUI extends BaseUI {
   applyCollapsedRowsChange(
     parents: number[],
     action: 'collapse' | 'expand',
-    shouldRunHooks = true
+    shouldRunHooks = true,
+    forceRender = true
   ): { performed: boolean, vetoed: boolean } {
     const actionTranslator = actionDictionary.get(action);
 
@@ -479,7 +488,7 @@ class CollapsingUI extends BaseUI {
 
     const isActionPerformed = !this.#isSameCollapsedState(currentCollapsedRows);
 
-    if (isActionPerformed) {
+    if (isActionPerformed && forceRender) {
       this.renderAndAdjust();
     }
 

--- a/tests/e2e/nested-rows-update-data.spec.ts
+++ b/tests/e2e/nested-rows-update-data.spec.ts
@@ -159,6 +159,55 @@ test.describe('NestedRows collapsed parents across a data replacement', () => {
     expect(await nestedRows.visibleNames()).toEqual(['Root A', 'A-1', 'A-2', 'A-3', 'Root B']);
   });
 
+  test('forgets a collapsed parent that updateData() removed from the data', async({ page, theme }) => {
+    const nestedRows = new NestedRowsPage(page, theme);
+
+    await nestedRows.goto();
+
+    await nestedRows.callPlugin('collapseParent', 6); // Root B
+    await nestedRows.callPlugin('collapseParent', 2); // A-2
+
+    // Root B is gone from the new data, so its path leads nowhere and it is simply dropped.
+    await nestedRows.updateData([tree(['A-2-a'], [])[0]]);
+
+    expect(await nestedRows.collapsedParents()).toEqual([2]);
+    expect(await nestedRows.visibleNames()).toEqual(['Root A', 'A-1', 'A-2', 'A-3']);
+  });
+
+  test('leaves the selection inside the grid after the replay trims rows', async({ page, theme }) => {
+    const nestedRows = new NestedRowsPage(page, theme);
+
+    await nestedRows.goto();
+
+    await nestedRows.callPlugin('collapseParent', 2); // A-2, leaves 7 rows
+    await page.evaluate(() => window.hot.selectCell(6, 0));
+
+    // The Core clamps the selection while the grid is still fully expanded, and trimming does not
+    // re-clamp it, so the highlight could end up past the last row.
+    await nestedRows.updateData(tree(['A-2-a'], ['B-1']));
+
+    const highlightedRow = await nestedRows.highlightedRow();
+
+    expect(highlightedRow).not.toBeNull();
+    expect(highlightedRow).toBeLessThan(await nestedRows.countRows());
+    expect(await page.evaluate(row => window.hot.toPhysicalRow(row as number), highlightedRow)).not.toBeNull();
+  });
+
+  test('keeps the collapsed parents when the data is replaced from inside an add-child', async({ page, theme }) => {
+    const nestedRows = new NestedRowsPage(page, theme);
+
+    await nestedRows.goto();
+
+    await nestedRows.callPlugin('collapseParent', 6); // Root B
+    await nestedRows.callPlugin('collapseParent', 2); // A-2
+
+    // A real operation opens the stash, not the spec: `beforeAddChild` stashes, `afterAddChild`
+    // restores, and the data is replaced in between.
+    await nestedRows.replaceDataWhileAddingChild(tree(['A-2-a'], ['B-1']), 6);
+
+    expect(await nestedRows.collapsedParents()).toEqual([2, 5]);
+  });
+
   test('loadData() drops the collapsed parents, as it resets every other row state', async({ page, theme }) => {
     const nestedRows = new NestedRowsPage(page, theme);
 

--- a/tests/e2e/nested-rows-update-data.spec.ts
+++ b/tests/e2e/nested-rows-update-data.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect } from '../fixtures/test';
+import { NestedRowsPage } from '../fixtures/pages/NestedRowsPage';
+
+/**
+ * `updateData()` is documented to keep the rows' states, and a collapsed parent is one of
+ * those states. The plugin used to keep it as raw physical row indexes, which stop pointing
+ * at the same rows as soon as any parent gains or loses a child. The stale indexes then hid
+ * whatever row happened to sit there - parent rows included, which made them vanish while
+ * their children stayed on screen (GitHub #10239, DEV-2594).
+ *
+ * The fixture tree, by physical row index:
+ *   0 Root A / 1 A-1 / 2 A-2 / 3 A-2-a / 4 A-2-b / 5 A-3 / 6 Root B / 7 B-1 / 8 B-2
+ *
+ * Every dataset below keeps the parents where they are in the tree and only changes how many
+ * children they hold - which is what the issue reports, and what used to break.
+ */
+
+interface TreeRow {
+  name: string;
+  __children?: TreeRow[];
+}
+
+const ALL_ROWS = ['Root A', 'A-1', 'A-2', 'A-2-a', 'A-2-b', 'A-3', 'Root B', 'B-1', 'B-2'];
+
+const leaves = (...names: string[]): TreeRow[] => names.map(name => ({ name }));
+
+/**
+ * Builds the fixture tree with the parts a test varies.
+ *
+ * @param {string[]} a2 Names of A-2's children. An empty list leaves A-2 without children.
+ * @param {string[]} rootB Names of Root B's children.
+ * @param {string[]} [extraRootA] Names of extra leaves appended to Root A, after A-3.
+ * @returns {TreeRow[]}
+ */
+function tree(a2: string[], rootB: string[], extraRootA: string[] = []): TreeRow[] {
+  const a2Node: TreeRow = a2.length > 0 ? { name: 'A-2', __children: leaves(...a2) } : { name: 'A-2' };
+
+  return [
+    {
+      name: 'Root A',
+      __children: [{ name: 'A-1' }, a2Node, { name: 'A-3' }, ...leaves(...extraRootA)],
+    },
+    {
+      name: 'Root B',
+      __children: leaves(...rootB),
+    },
+  ];
+}
+
+/** The same shape the fixture seeds the grid with. */
+const baseTree = () => tree(['A-2-a', 'A-2-b'], ['B-1', 'B-2']);
+
+test.describe('NestedRows collapsed parents across a data replacement', () => {
+  test('keeps the same parents collapsed when updateData() shrinks their children', async({ page, theme }) => {
+    const nestedRows = new NestedRowsPage(page, theme);
+
+    await nestedRows.goto();
+
+    // `collapseParent` takes a visual index, so the deeper parent goes last - collapsing A-2
+    // first would pull Root B up out of visual row 6.
+    await nestedRows.callPlugin('collapseParent', 6); // Root B
+    await nestedRows.callPlugin('collapseParent', 2); // A-2
+
+    expect(await nestedRows.visibleNames()).toEqual(['Root A', 'A-1', 'A-2', 'A-3', 'Root B']);
+
+    // A-2 and Root B each drop a child, so every physical index after A-2 shifts.
+    await nestedRows.updateData(tree(['A-2-a'], ['B-1']));
+
+    // A-2 is still physical 2, but Root B moved from 6 to 5.
+    expect(await nestedRows.collapsedParents()).toEqual([2, 5]);
+    expect(await nestedRows.visibleNames()).toEqual(['Root A', 'A-1', 'A-2', 'A-3', 'Root B']);
+  });
+
+  test('keeps the same parents collapsed when updateData() grows their children', async({ page, theme }) => {
+    const nestedRows = new NestedRowsPage(page, theme);
+
+    await nestedRows.goto();
+
+    await nestedRows.callPlugin('collapseParent', 6); // Root B
+
+    expect(await nestedRows.visibleNames()).toEqual(['Root A', 'A-1', 'A-2', 'A-2-a', 'A-2-b', 'A-3', 'Root B']);
+
+    // Root A gains a fourth child, which pushes Root B one row down.
+    await nestedRows.updateData(tree(['A-2-a', 'A-2-b'], ['B-1', 'B-2'], ['A-4']));
+
+    expect(await nestedRows.collapsedParents()).toEqual([7]);
+    expect(await nestedRows.visibleNames())
+      .toEqual(['Root A', 'A-1', 'A-2', 'A-2-a', 'A-2-b', 'A-3', 'A-4', 'Root B']);
+  });
+
+  test('keeps a parent collapsed inside another collapsed parent', async({ page, theme }) => {
+    const nestedRows = new NestedRowsPage(page, theme);
+
+    await nestedRows.goto();
+
+    // Visual indexes again: Root B while it is still at row 6, then A-2, then Root A.
+    await nestedRows.callPlugin('collapseParent', 6); // Root B
+    await nestedRows.callPlugin('collapseParent', 2); // A-2, nested inside Root A
+    await nestedRows.callPlugin('collapseParent', 0); // Root A
+
+    expect(await nestedRows.collapsedParents()).toEqual([0, 2, 6]);
+    expect(await nestedRows.visibleNames()).toEqual(['Root A', 'Root B']);
+
+    // A-2 gains a third child, which pushes Root B one row down.
+    await nestedRows.updateData(tree(['A-2-a', 'A-2-b', 'A-2-c'], ['B-1', 'B-2']));
+
+    expect(await nestedRows.collapsedParents()).toEqual([0, 2, 7]);
+    expect(await nestedRows.visibleNames()).toEqual(['Root A', 'Root B']);
+  });
+
+  test('forgets a collapsed parent that updateData() left without children', async({ page, theme }) => {
+    const nestedRows = new NestedRowsPage(page, theme);
+
+    await nestedRows.goto();
+
+    await nestedRows.callPlugin('collapseParent', 2); // A-2
+
+    await nestedRows.updateData(tree([], ['B-1', 'B-2']));
+
+    expect(await nestedRows.collapsedParents()).toEqual([]);
+    expect(await nestedRows.visibleNames())
+      .toEqual(['Root A', 'A-1', 'A-2', 'A-3', 'Root B', 'B-1', 'B-2']);
+  });
+
+  test('replaying the collapsed parents does not fire the collapse hooks', async({ page, theme }) => {
+    const nestedRows = new NestedRowsPage(page, theme);
+
+    await nestedRows.goto();
+
+    await nestedRows.callPlugin('collapseParent', 6); // Root B
+    await nestedRows.resetHookLog();
+
+    await nestedRows.updateData(tree(['A-2-a'], ['B-1', 'B-2']));
+
+    // The user already chose this state, so restoring it is not a new collapse.
+    expect(await nestedRows.hookNames()).toEqual([]);
+    expect(await nestedRows.collapsedParents()).toEqual([5]);
+  });
+
+  test('loadData() drops the collapsed parents, as it resets every other row state', async({ page, theme }) => {
+    const nestedRows = new NestedRowsPage(page, theme);
+
+    await nestedRows.goto();
+
+    await nestedRows.callPlugin('collapseParent', 6); // Root B
+    await nestedRows.callPlugin('collapseParent', 2); // A-2
+
+    await nestedRows.loadData(baseTree());
+
+    // Nothing may be left pointing at the old rows. The reported state and the internal one
+    // both have to be empty, otherwise the next collapse acts on a parent the user never
+    // collapsed.
+    expect(await nestedRows.collapsedParents()).toEqual([]);
+    expect(await nestedRows.visibleNames()).toEqual(ALL_ROWS);
+
+    await nestedRows.callPlugin('collapseParent', 0);
+
+    expect(await nestedRows.collapsedParents()).toEqual([0]);
+    expect(await nestedRows.visibleNames()).toEqual(['Root A', 'Root B', 'B-1', 'B-2']);
+  });
+});

--- a/tests/e2e/nested-rows-update-data.spec.ts
+++ b/tests/e2e/nested-rows-update-data.spec.ts
@@ -137,6 +137,28 @@ test.describe('NestedRows collapsed parents across a data replacement', () => {
     expect(await nestedRows.collapsedParents()).toEqual([5]);
   });
 
+  test('re-points a stash that another operation left open', async({ page, theme }) => {
+    const nestedRows = new NestedRowsPage(page, theme);
+
+    await nestedRows.goto();
+
+    await nestedRows.callPlugin('collapseParent', 6); // Root B
+    await nestedRows.callPlugin('collapseParent', 2); // A-2
+
+    // Add child, detach child, remove row and row move each expand the grid and park the collapsed
+    // parents in a stash until they finish. An app that replaces the data from inside one of those
+    // windows must not get the stash restored onto the old row numbers.
+    await nestedRows.stashCollapsedState();
+    expect(await nestedRows.visibleNames()).toEqual(ALL_ROWS);
+
+    await nestedRows.updateData(tree(['A-2-a'], ['B-1']));
+
+    await nestedRows.applyCollapsedStash();
+
+    expect(await nestedRows.collapsedParents()).toEqual([2, 5]);
+    expect(await nestedRows.visibleNames()).toEqual(['Root A', 'A-1', 'A-2', 'A-3', 'Root B']);
+  });
+
   test('loadData() drops the collapsed parents, as it resets every other row state', async({ page, theme }) => {
     const nestedRows = new NestedRowsPage(page, theme);
 

--- a/tests/fixtures/pages/NestedRowsPage.ts
+++ b/tests/fixtures/pages/NestedRowsPage.ts
@@ -77,6 +77,16 @@ export class NestedRowsPage {
     return this.page.evaluate(() => window.hot.getPlugin('nestedRows').getCollapsedParents());
   }
 
+  /** Replace the data with `updateData()`, which is documented to keep the rows' states. */
+  async updateData(data: unknown[]): Promise<void> {
+    await this.page.evaluate(rows => window.hot.updateData(rows), data);
+  }
+
+  /** Replace the data with `loadData()`, which is documented to reset the rows' states. */
+  async loadData(data: unknown[]): Promise<void> {
+    await this.page.evaluate(rows => window.hot.loadData(rows), data);
+  }
+
   /** Every collapse/expand hook call the fixture has recorded, in order. */
   hookLog(): Promise<NestedRowsHookCall[]> {
     return this.page.evaluate(() => window.hookLog);

--- a/tests/fixtures/pages/NestedRowsPage.ts
+++ b/tests/fixtures/pages/NestedRowsPage.ts
@@ -87,6 +87,25 @@ export class NestedRowsPage {
     await this.page.evaluate(rows => window.hot.loadData(rows), data);
   }
 
+  /**
+   * Opens the collapse stash, the way add child, detach child, remove row and row move all do:
+   * the grid is expanded and the collapsed parents are parked until `applyCollapsedStash()`.
+   *
+   * No public API opens that window, so the spec drives the plugin internals directly.
+   */
+  async stashCollapsedState(): Promise<void> {
+    await this.page.evaluate(() => {
+      window.hot.getPlugin('nestedRows').collapsingUI.collapsedRowsStash.stash();
+    });
+  }
+
+  /** Closes the stash window, restoring the parked parents. */
+  async applyCollapsedStash(): Promise<void> {
+    await this.page.evaluate(() => {
+      window.hot.getPlugin('nestedRows').collapsingUI.collapsedRowsStash.applyStash();
+    });
+  }
+
   /** Every collapse/expand hook call the fixture has recorded, in order. */
   hookLog(): Promise<NestedRowsHookCall[]> {
     return this.page.evaluate(() => window.hookLog);

--- a/tests/fixtures/pages/NestedRowsPage.ts
+++ b/tests/fixtures/pages/NestedRowsPage.ts
@@ -106,6 +106,38 @@ export class NestedRowsPage {
     });
   }
 
+  /**
+   * Replaces the data from inside a real `beforeAddChild` window, the way an app that refetches on
+   * every structural change does. The plugin has the stash open for the whole call, so this drives
+   * the data hooks through an operation rather than opening the stash by hand.
+   *
+   * @param data The new source data.
+   * @param parentRow Physical row index of the parent to add a child to.
+   */
+  async replaceDataWhileAddingChild(data: unknown[], parentRow: number): Promise<void> {
+    await this.page.evaluate(({ rows, parent }) => {
+      window.hot.addHook('beforeAddChild', () => {
+        window.hot.updateData(rows as unknown[]);
+      });
+
+      const { dataManager } = window.hot.getPlugin('nestedRows');
+      const parentObject = dataManager.getDataObject(parent as number);
+
+      if (parentObject) {
+        dataManager.addChild(parentObject);
+      }
+    }, { rows: data, parent: parentRow });
+  }
+
+  /** The visual row the selection highlight sits on, or `null` when nothing is selected. */
+  highlightedRow(): Promise<number | null> {
+    return this.page.evaluate(() => {
+      const last = window.hot.getSelectedLast();
+
+      return last ? last[0] : null;
+    });
+  }
+
   /** Every collapse/expand hook call the fixture has recorded, in order. */
   hookLog(): Promise<NestedRowsHookCall[]> {
     return this.page.evaluate(() => window.hookLog);

--- a/tests/fixtures/pages/windowTypes.ts
+++ b/tests/fixtures/pages/windowTypes.ts
@@ -66,6 +66,10 @@ export interface FixtureHotInstance {
         applyStash(): void,
       },
     },
+    dataManager: {
+      getDataObject(row: number): object | null,
+      addChild(parent: object): void,
+    },
   };
   getPlugin(name: 'selectionHandles'): {
     isDragActive(): boolean,

--- a/tests/fixtures/pages/windowTypes.ts
+++ b/tests/fixtures/pages/windowTypes.ts
@@ -58,6 +58,14 @@ export interface FixtureHotInstance {
     countChildren(row: number, recursive?: boolean): number,
     expandToRow(row: number): boolean,
     expandToLevel(level: number): void,
+    // Private, but a spec needs it: there is no public API for the stash window that add child,
+    // detach child, remove row and row move open around themselves.
+    collapsingUI: {
+      collapsedRowsStash: {
+        stash(): void,
+        applyStash(): void,
+      },
+    },
   };
   getPlugin(name: 'selectionHandles'): {
     isDragActive(): boolean,

--- a/tests/fixtures/pages/windowTypes.ts
+++ b/tests/fixtures/pages/windowTypes.ts
@@ -88,6 +88,7 @@ export interface FixtureHotInstance {
   toPhysicalRow(row: number): number | null;
   selectCell(row: number, col: number): boolean;
   loadData(data: unknown[]): void;
+  updateData(data: unknown[]): void;
   updateSettings(settings: Record<string, unknown>): void;
   countCols(): number;
   _createCellCoords(row: number, col: number): unknown;


### PR DESCRIPTION
### Context

The PR fixes an invalid grid state that appears when `nestedRows` is on, some parents are collapsed, and `updateData()` is called with a different number of `__children` (GitHub #10239, reported against 12.3.1 and still reproducing on 18.0.0).

The collapsed state is kept in two places, and both are keyed by the **physical** row index:

1. `collapsedRowsMap` — the `trimming` index map registered in `nestedRows.ts`.
2. `CollapsingUI.collapsedRows` — a plain array of collapsed parents.

`loadData()` resets the index maps through `initIndexMappers()`, but `updateData()` only resizes them with `rowIndexMapper.fitToLength()`. The plugin's own `beforeLoadData` / `beforeUpdateData` handler rebuilt the data-manager cache and touched neither store. So as soon as a parent gained or lost a child, every physical index after it shifted and the kept trimmed indexes landed on different rows — parent rows included, which then disappeared while their children stayed on screen.

Reproduced on `develop` @ `b5ab75f8`: three parents with three children each, parents 1 and 2 collapsed, then `updateData()` with two children each leaves three rows on screen — `P1`, `P2-C1`, `P3-C2`. `getData()` and the DOM agree; both are wrong.

**The fix.** The two data hooks now do different things, matching what each method promises:

- `beforeLoadData` drops the collapsed state. `loadData()` resets the rows' states by contract, and this also clears a latent inconsistency where `collapsedRows` kept listing parents from the previous dataset.
- `beforeUpdateData` records the collapsed parents as **tree paths** (the chain of child indexes from the top level down), clears the stores, and `afterUpdateData` collapses again whatever those paths still resolve to. The replay runs shallowest-first and with the hooks silenced, because it repeats a choice the user already made.

Two new `DataManager` helpers back this: `getRowTreePath()` and `getRowIndexByTreePath()`. A tree path is positional, so it follows the slot rather than the object — that is the best available match when the new dataset carries no identity, and it covers the reported case, where parents keep their place in the tree and only the children counts change.

**A third store, found in review.** `collapsingUI.lastCollapsedRows` — the stash that `beforeAddChild`, `beforeDetachChild`, `beforeRemoveRow` and a row move keep open around themselves — is keyed by physical row index as well. It matters because during a stash window `collapsedRows` is already **empty**: the stash expanded the grid and parked the state. So an app that replaces the data from inside one of those hooks captures nothing on the main path, and `applyStash()` later replays the old row numbers onto the new data. Verified against a real grid before fixing: with parents 1 and 2 collapsed, a stash open, and `updateData()` shrinking the children, `applyStash()` restored only parent 1 and silently dropped parent 2 — with a different shape it would collapse the wrong parent instead. The stash is now re-pointed through the same tree paths in `afterUpdateData`, and zeroed on `loadData()`.

The trimming map is cleared only when a parent really is collapsed. Clearing it rebuilds the row index cache, and a data load runs on every grid init — `core.unit.js` asserts exactly one cache reset there.

### How has this been tested?

The reported scenario was reproduced in a real browser before the change and re-checked after it. The new specs were confirmed to fail on the unfixed build and pass on the fixed one — the first six with the main fix reverted (all 6 red), and the stash test with only the stash handling removed (1 red, the other 6 still green).

- New Playwright E2E — `tests/e2e/nested-rows-update-data.spec.ts`, 7 tests: fewer children, more children, a parent collapsed inside another collapsed parent, a collapsed parent left without children, no hooks fired on replay, a stash left open by another operation, and `loadData()` dropping the state.
- New unit tests — `handsontable/src/plugins/nestedRows/__tests__/data/dataManager.unit.js`, 7 tests for the tree-path helpers, including a round trip across a data swap.

```bash
# unit (whole core suite: 3673 passed)
npm run test:unit --prefix handsontable

# types
npm run test:types --prefix handsontable

# legacy E2E (whole suite: 9669 specs, 0 failures)
npm run test:e2e --prefix handsontable

# Playwright functional E2E (e2e-main leg: 356 passed, 1 skipped)
npm --prefix tests run test:e2e

# lint
npm run eslint --prefix handsontable    # 0 errors
npm run stylelint --prefix handsontable
npm --prefix tests run lint
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2594
2. #10239

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2594

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches nestedRows collapse/trim state and data-replacement hooks, which can hide the wrong rows or leave selection past the last row if the remapping is wrong. Behavior of loadData vs updateData is now explicitly different.
> 
> **Overview**
> Fixes **#10239**: collapsed nested parents no longer vanish (or hide the wrong rows) when `updateData()` changes child counts. Collapse stores were keyed by physical indexes, which shift as soon as a parent gains or loses children.
> 
> **`updateData()`** now snapshots collapsed parents (and any open collapse stash) as **tree paths**, clears the old indexes, then re-collapses whatever those paths still resolve to. Replay is silent (no collapse hooks) and skips an extra render; selection is refreshed so the highlight cannot sit past the last visible row. Parents that disappear or lose all children are dropped.
> 
> **`loadData()`** now clears collapsed state, matching its “reset row state” contract, so `getCollapsedParents()` no longer reports the previous dataset.
> 
> Adds `getRowTreePath()` / `getRowIndexByTreePath()` on `DataManager`, documents the load vs update difference, and covers the cases with unit and Playwright tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6180d48bfa0423fa8ab32929bfe24c9d00a5638. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->