### PR TITLE
DEV-2595: Document the sentence-case heading convention

### DIFF
--- a/.ai/DOC-STANDARDS.md
+++ b/.ai/DOC-STANDARDS.md
@@ -32,6 +32,7 @@ Apply to all documentation text — guides, JSDoc comments, changelog entries, m
 11. **Clause separators.** Use en dashes (–) in non-site text (JSDoc, changelog, migration guides). The docs *site* uses hyphens or double hyphens instead — see `docs/AGENTS.md` 2.2.
 12. **Consistent 3rd-party naming.** Use official capitalization: `Node.js`, `webpack`, `GitLab`, `TypeScript`.
 13. **PR descriptions**: Use plain, concise language. Avoid literary wording — developers need to parse it quickly.
+14. **Sentence case headings.** Capitalize only the first word, plus proper nouns, product names, API identifiers, and acronyms. ("Definition of done (local enforcement)", not "Definition of Done (Local Enforcement)".) Applies to Markdown headings at every level and to the docs frontmatter `title:` field. Terms with fixed capitalization keep it: `Node.js`, `HyperFormula`, `HotTable`, `UndoRedo`, `Content Security Policy (CSP)`. Sentence case composes with the Diátaxis title patterns in `docs/AGENTS.md` 2.1 (verb phrase, "How to …", "Understanding …") rather than replacing them. **Not covered:** `README.md`, which is marketing-facing and uses Title Case with emoji headings by design, and agent instruction files (`AGENTS.md`, `.claude/skills/**`), whose heading style is currently mixed and out of scope for this rule.
 
 ## Migration guide requirements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ High-level principles. Core-internal detail lives in `handsontable/.ai/ARCHITECT
 These standards apply to **all** documentation across the monorepo — guides, the API reference (JSDoc/Typedoc inside `handsontable/src`), code comments, changelog entries, release notes, migration guides, and READMEs. An agent editing core JSDoc applies them without opening `docs/AGENTS.md`. **Full reference: `.ai/DOC-STANDARDS.md`** (the complete 13 writing-style rules, migration-guide spec, trademark rules, and docs branch conventions). The docs *site* has additional mechanics (frontmatter, sidebar, example embedding, voice overrides) in `docs/AGENTS.md`.
 
 - **When docs are required:** any public-API change updates JSDoc/Typedoc + guides; any user-facing behavior change is documented; any breaking change adds a migration guide step.
-- **Writing style (most-violated):** short sentences, active voice, American English (`behavior` not `behaviour`), "you" not "we", Oxford comma, no evaluative adjectives ("easy"/"simple"/"obvious"), en dashes (–) in non-site text. Full list in `.ai/DOC-STANDARDS.md`.
+- **Writing style (most-violated):** short sentences, active voice, American English (`behavior` not `behaviour`), "you" not "we", Oxford comma, no evaluative adjectives ("easy"/"simple"/"obvious"), en dashes (–) in non-site text, sentence case headings (`Definition of done`, not `Definition of Done`; `README.md` and `AGENTS.md`/skill files are out of scope). Full list in `.ai/DOC-STANDARDS.md`.
 - **Trademarks:** pages mentioning "Excel" (and "Google Sheets") need the trademark disclaimer — see `.ai/DOC-STANDARDS.md`.
 - **JSDoc format:** always use the multiline block style — never the single-line form. Every JSDoc comment must be written as:
   ```js

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -92,6 +92,7 @@ This is the docs-**site** voice — it overrides the monorepo-wide documentation
 ### Formatting conventions
 
 - Hyphens (`-`) or double hyphens (`--`) to separate clauses. No en dashes or em dashes.
+- Sentence case for every heading and for the frontmatter `title:`. Capitalize only the first word, plus proper nouns, product names, API identifiers, and acronyms: `Use a cell renderer`, not `Use a Cell Renderer`. Composes with the Diátaxis title patterns in 2.1.
 - Straight quotes (`"` and `'`) only. No curly/smart quotes.
 - Bold for UI elements: **Save**, **Add column**.
 - Inline code for API names: `columnSorting`, `readOnly`.
@@ -494,6 +495,7 @@ Copy and complete this checklist in your PR description:
 - [ ] No `var` in code examples; uses `const` / `let`
 - [ ] All examples include `licenseKey: 'non-commercial-and-evaluation'`
 - [ ] Heading hierarchy is correct (no skipped levels, e.g., H2 → H4)
+- [ ] Headings and the frontmatter `title:` use sentence case
 - [ ] Active voice and second person ("you") used throughout
 - [ ] No banned words: simply, just, easy, straightforward, note that, please
 - [ ] Tutorials and how-tos have a Prerequisites section


### PR DESCRIPTION
### Context

The PR writes down the sentence case heading convention, which the repo follows everywhere in its documentation but states nowhere.

External PR #13118 changed five `CONTRIBUTING.md` section headings from sentence case to Title Case, on the stated grounds that it matched "Title Case conventions". No such convention exists. That PR was closed, but the contributor was not unreasonable to guess: neither `.ai/DOC-STANDARDS.md`, the root `AGENTS.md`, nor `docs/AGENTS.md` says anything about heading capitalization.

What the evidence showed while reviewing #13118:

- `CONTRIBUTING.md` had no genuine Title Case `##` headings. `Prerequisites` is a single word, and `Contributor License Agreement` is a proper-noun legal term. The other five were sentence case.
- Root `AGENTS.md` is 14/14 sentence case. `.changelogs/README.md` is 3/3.
- `docs/content/guides` holds roughly 565 sentence case `##` headings against at most 40 Title Case ones, concentrated in a handful of pages. Counting every level (`##` through `######`) plus the frontmatter `title:` field raises the deviation total to 175, which is what #13226 fixes -- the two numbers measure different scopes, not different findings.
- `README.md` is Title Case, but it is marketing-facing and uses emoji headings by design.

This PR is prose only. It states the rule in the three places an agent or a contributor would look. The existing deviations in `docs/content/guides` are fixed separately in #13226 so that the rule and the cleanup can be reviewed independently. The two PRs are deliberately **not stacked**: both branch from `develop` and can be reviewed and merged in either order.

### Scope boundary

The rule covers documentation: the guides, JSDoc, changelog entries, migration guides, and contributor-facing repo docs. It explicitly does not cover `README.md`, or the agent instruction files (`AGENTS.md`, `.claude/skills/**`).

That exclusion is deliberate and evidence-based. Heading style in the agent files is genuinely mixed: root `AGENTS.md` and `tests/AGENTS.md` are fully sentence case, while `docs/AGENTS.md` has 14 Title Case `##` headings, the package `AGENTS.md` files have 2 to 6 each, and `.claude/skills/**` has around 97. Declaring either style the rule there would either balloon this PR by roughly 130 edits or assert a convention the data does not support, which is how #13118 happened in the first place. Those files are left out of scope and can be settled on their own.

Two clauses were considered and dropped for the same reason:

- Changelog entry titles. Sampling `.changelogs/*.json` shows the titles are full sentences, not headings, so the rule would be vacuous there.
- Heading hyphenation (`Long term support` to `Long-term support`, `Server side rendering` to `Server-side rendering`). Real style issues, but not capitalization, and not this PR.

### Changes

- `.ai/DOC-STANDARDS.md` -- new rule 14 in the "Writing style rules" list, with the proper-noun carve-outs and the two exclusions.
- `AGENTS.md` -- "Writing style (most-violated)" digest bullet now mentions sentence case headings.
- `docs/AGENTS.md` -- the rule restated in section 2.2 "Formatting conventions", and a new item in the pre-submit page checklist.

`CONTRIBUTING.md` needs no change; it is already compliant on `develop`.

### How has this been tested?

No automated test applies. Documentation-only, nothing under `handsontable/src/**` or `wrappers/**`, so the test presence gate passes on path and no changelog entry is required.

Verification was the evidence gathering described above:

```bash
# heading style across the guides
grep -rhE "^## [A-Za-z]" docs/content/guides | sed 's/^## //' \
  | grep -cE "^[A-Z][a-z]+ +[a-z]"     # 565 sentence case
grep -rhE "^## [A-Za-z]" docs/content/guides | sed 's/^## //' \
  | grep -cE "^[A-Z][a-z]+ +[A-Z][a-z]" # <=40 Title Case, upper bound

# sibling process docs
grep -E "^## " AGENTS.md .changelogs/README.md

# why the agent files are out of scope
grep -rhE "^#{2,4} " .claude/skills | grep -cE "[a-z]+ +[A-Z][a-z]"  # ~97
```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2595
2. Companion cleanup PR: #13226
3. Closed PR that prompted this: #13118

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) -- one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2595
