### PR TITLE
DEV-2596: Fix the comment tooltip not opening on hover inside Shadow DOM (#8624)

### DIFF
--- a/.changelogs/8624.json
+++ b/.changelogs/8624.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the comment tooltip not opening when you hover a commented cell in a grid rendered inside a shadow root.",
+  "type": "fixed",
+  "issueOrPR": 8624,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/tools-and-building/shadow-dom/shadow-dom.md
+++ b/docs/content/guides/tools-and-building/shadow-dom/shadow-dom.md
@@ -94,7 +94,7 @@ Salesforce Lightning Experience renders Lightning Web Components with its synthe
 
 ## Known limitations
 
-- Handsontable checks the container's root node only when the instance is created. The check controls the `ht-shadow-dom` class and the shadow-root clipboard listeners that copy and paste rely on in sandboxed hosts. If you move a live grid into or out of a shadow root, destroy the instance and create it again.
+- Handsontable checks the container's root node only when the instance is created. The check controls the `ht-shadow-dom` class, the shadow-root clipboard listeners that copy and paste rely on in sandboxed hosts, and the shadow-root mouse listeners that the comment tooltip uses to react to hovering. If you move a live grid into or out of a shadow root, destroy the instance and create it again.
 - The cell editor doesn't leave the grid's stacking context. In a tight layout, an editor that overflows the grid's wrapper can paint under the host page content that creates its own stacking context.
 
 ## Related guides

--- a/docs/content/guides/tools-and-building/shadow-dom/shadow-dom.md
+++ b/docs/content/guides/tools-and-building/shadow-dom/shadow-dom.md
@@ -94,7 +94,7 @@ Salesforce Lightning Experience renders Lightning Web Components with its synthe
 
 ## Known limitations
 
-- Handsontable checks the container's root node only when the instance is created. The check controls the `ht-shadow-dom` class, the shadow-root clipboard listeners that copy and paste rely on in sandboxed hosts, and the shadow-root mouse listeners that the comment tooltip uses to react to hovering. If you move a live grid into or out of a shadow root, destroy the instance and create it again.
+- Handsontable checks the container's root node only when the instance is created. That check controls three things: the `ht-shadow-dom` class, the shadow-root clipboard listeners that copy and paste rely on in sandboxed hosts, and the shadow-root mouse listeners the comment tooltip uses to react to hovering. If you move a live grid into or out of a shadow root, destroy the instance and create it again.
 - The cell editor doesn't leave the grid's stacking context. In a tight layout, an editor that overflows the grid's wrapper can paint under the host page content that creates its own stacking context.
 
 ## Related guides

--- a/handsontable/src/plugins/comments/comments.ts
+++ b/handsontable/src/plugins/comments/comments.ts
@@ -6,7 +6,6 @@ import {
   hasClass,
   hasVerticalScrollbar,
   hasHorizontalScrollbar,
-  isChildOf,
   isShadowRoot,
   outerHeight,
 } from '../../helpers/dom/element';
@@ -532,19 +531,23 @@ export class Comments extends BasePlugin {
   }
 
   /**
-   * Checks whether the element sits in a tree the grid can be rendered into. `isChildOf()`
-   * walks `parentNode` only, so an element inside the grid's shadow tree dead-ends at the
-   * `ShadowRoot` (whose `parentNode` is `null`) and never reaches the document.
+   * Checks whether the element is attached to the document the grid renders into. A
+   * `parentNode` walk cannot answer this: it dead-ends at the first `ShadowRoot` (whose
+   * `parentNode` is `null`), which makes every element inside a shadow tree look detached.
+   * The composed root node crosses shadow boundaries by following host elements, so it
+   * resolves to the document for the grid's own shadow tree, for any other component's
+   * shadow tree on the page, and for the light DOM alike - while a genuinely detached
+   * element still resolves to its own orphaned root.
+   *
+   * Testing only the grid's own shadow root here would leave the tooltip open when the
+   * pointer crosses straight from a commented cell into a *different* shadow tree, which
+   * is an ordinary move on a page built from web components.
    *
    * @param {HTMLElement} element The element to check.
    * @returns {boolean}
    */
   #isInRenderedTree(element: HTMLElement): boolean {
-    if (this.#gridShadowRoot?.contains(element)) {
-      return true;
-    }
-
-    return isChildOf(element, this.hot.rootDocument);
+    return element.getRootNode({ composed: true }) === this.hot.rootDocument;
   }
 
   /**
@@ -552,10 +555,11 @@ export class Comments extends BasePlugin {
    *
    * @private
    * @param {Event} event DOM event.
+   * @param {HTMLElement} [target] The already-resolved event target, to avoid resolving it twice.
    * @returns {boolean}
    */
-  targetIsCellWithComment(event: Event) {
-    const closestCell = closest(this.#resolveEventTarget(event)!, ['TD']);
+  targetIsCellWithComment(event: Event, target = this.#resolveEventTarget(event)) {
+    const closestCell = closest(target!, ['TD']);
 
     return !!(closestCell && hasClass(closestCell, 'htCommentCell') &&
       closest(closestCell, [this.hot.rootElement]));
@@ -566,10 +570,11 @@ export class Comments extends BasePlugin {
    *
    * @private
    * @param {Event} event DOM event.
+   * @param {HTMLElement} [target] The already-resolved event target, to avoid resolving it twice.
    * @returns {boolean}
    */
-  targetIsCommentTextArea(event: Event) {
-    return this.getEditorInputElement() === this.#resolveEventTarget(event);
+  targetIsCommentTextArea(event: Event, target = this.#resolveEventTarget(event)) {
+    return this.getEditorInputElement() === target;
   }
 
   /**
@@ -929,8 +934,10 @@ export class Comments extends BasePlugin {
       return;
     }
 
-    if (!this.#preventEditorAutoSwitch && !this.targetIsCommentTextArea(event)) {
-      const eventCell = closest(this.#resolveEventTarget(event)!, ['TD']);
+    const target = this.#resolveEventTarget(event);
+
+    if (!this.#preventEditorAutoSwitch && !this.targetIsCommentTextArea(event, target)) {
+      const eventCell = closest(target!, ['TD']);
       let coordinates = null;
 
       if (eventCell) {
@@ -973,7 +980,7 @@ export class Comments extends BasePlugin {
     this.#cellBelowCursor = (this.#gridShadowRoot ?? rootDocument).elementFromPoint(
       (event as MouseEvent).clientX, (event as MouseEvent).clientY);
 
-    if (this.targetIsCellWithComment(event)) {
+    if (this.targetIsCellWithComment(event, target)) {
       const coords = this.hot.getCoords(target);
 
       if (coords) {
@@ -982,7 +989,7 @@ export class Comments extends BasePlugin {
         this.#displaySwitch?.show(range);
       }
 
-    } else if (this.#isInRenderedTree(target) && !this.targetIsCommentTextArea(event)) {
+    } else if (this.#isInRenderedTree(target) && !this.targetIsCommentTextArea(event, target)) {
       this.#displaySwitch?.hide();
     }
   };

--- a/handsontable/src/plugins/comments/comments.ts
+++ b/handsontable/src/plugins/comments/comments.ts
@@ -286,6 +286,14 @@ export class Comments extends BasePlugin {
    * @type {ShadowRoot|null}
    */
   #gridShadowRoot: ShadowRoot | null = null;
+  /**
+   * Mouse events already handled for a shadow-hosted grid, so that the document listener
+   * does not process one the shadow-root listener has taken. Only ever populated when the
+   * grid renders inside a shadow root.
+   *
+   * @type {WeakSet}
+   */
+  #processedMouseEvents: WeakSet<object> = new WeakSet();
 
   /**
    * Checks if the plugin is enabled in the handsontable settings. This method is executed in {@link Hooks#beforeInit}
@@ -451,22 +459,40 @@ export class Comments extends BasePlugin {
 
     this.#gridShadowRoot = isShadowRoot(rootNode) ? rootNode : null;
 
-    this.eventManager.addEventListener(rootDocument, 'mouseover', this.#onMouseOver);
-    this.eventManager.addEventListener(rootDocument, 'mousedown', this.#onMouseDown);
-    this.eventManager.addEventListener(rootDocument, 'mouseup', () => this.#onMouseUp());
+    // Claims an event for the first listener that receives it. A shadow-hosted grid binds the
+    // handlers twice, and the two bindings do NOT see the same element under a sandboxed host
+    // (e.g. Salesforce Lightning Web Security): that host collapses `composedPath()` to the
+    // shadow host chain, so only a listener bound inside the grid's own shadow tree gets the
+    // real cell, while the document listener still sees the host. Left undeduped, one hover
+    // would show from the shadow-root listener and then hide from the document listener -
+    // which also clears the display switch's flag, so the debounced show is dropped and the
+    // tooltip never appears. The shadow-root listener runs first (the event reaches the
+    // ShadowRoot before it crosses to the host), so it wins for anything inside the grid and
+    // the document listener keeps handling only what never entered the shadow tree.
+    const dedupe = (handler: (event: Event) => void) => (event: Event) => {
+      if (this.#gridShadowRoot) {
+        if (this.#processedMouseEvents.has(event)) {
+          return;
+        }
 
-    // When the grid lives inside a Shadow DOM tree, the same listeners are attached to the
-    // grid's shadow root as well. The document listeners above stay - they are the ones that
-    // see a click or a hover landing outside the shadow host. Sandboxed hosts (e.g. Salesforce
-    // Lightning Web Security) collapse `composedPath()` to the shadow host chain, so the
-    // document listeners cannot recover the real cell there; listeners bound inside the grid's
-    // own shadow tree still receive a correctly retargeted `target`. No dedupe registry is
-    // needed when both fire for one event: all three handlers resolve the same element and are
-    // idempotent, and showing is debounced by the display switch.
+        this.#processedMouseEvents.add(event);
+      }
+
+      handler(event);
+    };
+
+    const onMouseOver = dedupe(this.#onMouseOver);
+    const onMouseDown = dedupe(this.#onMouseDown);
+    const onMouseUp = dedupe(() => this.#onMouseUp());
+
+    this.eventManager.addEventListener(rootDocument, 'mouseover', onMouseOver);
+    this.eventManager.addEventListener(rootDocument, 'mousedown', onMouseDown);
+    this.eventManager.addEventListener(rootDocument, 'mouseup', onMouseUp);
+
     if (this.#gridShadowRoot) {
-      this.eventManager.addEventListener(this.#gridShadowRoot, 'mouseover', this.#onMouseOver);
-      this.eventManager.addEventListener(this.#gridShadowRoot, 'mousedown', this.#onMouseDown);
-      this.eventManager.addEventListener(this.#gridShadowRoot, 'mouseup', () => this.#onMouseUp());
+      this.eventManager.addEventListener(this.#gridShadowRoot, 'mouseover', onMouseOver);
+      this.eventManager.addEventListener(this.#gridShadowRoot, 'mousedown', onMouseDown);
+      this.eventManager.addEventListener(this.#gridShadowRoot, 'mouseup', onMouseUp);
     }
 
     if (editorElement) {

--- a/handsontable/src/plugins/comments/comments.ts
+++ b/handsontable/src/plugins/comments/comments.ts
@@ -468,11 +468,10 @@ export class Comments extends BasePlugin {
     const isShadowHosted = this.#gridShadowRoot !== null;
 
     // Claims an event for the first listener that receives it. A shadow-hosted grid binds the
-    // handlers twice, and the two bindings do NOT see the same element under a sandboxed host
-    // (e.g. Salesforce Lightning Web Security): that host collapses `composedPath()` to the
-    // shadow host chain, so only a listener bound inside the grid's own shadow tree gets the
-    // real cell, while the document listener still sees the host. Left undeduped, one hover
-    // would show from the shadow-root listener and then hide from the document listener -
+    // handlers twice, and the two bindings never see the same element: a listener inside the
+    // tree gets the real cell, while the document listener gets the retargeted shadow host.
+    // That is intrinsic to retargeting, not specific to a sandboxed host. Left undeduped, one
+    // hover would show from the shadow-root listener and then hide from the document listener -
     // which also clears the display switch's flag, so the debounced show is dropped and the
     // tooltip never appears. The shadow-root listener runs first (the event reaches the
     // ShadowRoot before it crosses to the host), so it wins for anything inside the grid and

--- a/handsontable/src/plugins/comments/comments.ts
+++ b/handsontable/src/plugins/comments/comments.ts
@@ -7,6 +7,7 @@ import {
   hasVerticalScrollbar,
   hasHorizontalScrollbar,
   isChildOf,
+  isShadowRoot,
   outerHeight,
 } from '../../helpers/dom/element';
 import { stopImmediatePropagation } from '../../helpers/dom/event';
@@ -278,6 +279,14 @@ export class Comments extends BasePlugin {
    * @type {string}
    */
   #commentValueBeforeSave = '';
+  /**
+   * The shadow root the grid renders inside, or `null` when it renders in the light DOM.
+   * Listeners bound on the document sit outside that tree, so the browser retargets the
+   * event to the shadow host and the real cell has to be recovered from the composed path.
+   *
+   * @type {ShadowRoot|null}
+   */
+  #gridShadowRoot: ShadowRoot | null = null;
 
   /**
    * Checks if the plugin is enabled in the handsontable settings. This method is executed in {@link Hooks#beforeInit}
@@ -439,10 +448,27 @@ export class Comments extends BasePlugin {
   registerListeners() {
     const { rootDocument } = this.hot;
     const editorElement = this.getEditorInputElement();
+    const rootNode = this.hot.rootElement.getRootNode();
+
+    this.#gridShadowRoot = isShadowRoot(rootNode) ? rootNode : null;
 
     this.eventManager.addEventListener(rootDocument, 'mouseover', this.#onMouseOver);
     this.eventManager.addEventListener(rootDocument, 'mousedown', this.#onMouseDown);
     this.eventManager.addEventListener(rootDocument, 'mouseup', () => this.#onMouseUp());
+
+    // When the grid lives inside a Shadow DOM tree, the same listeners are attached to the
+    // grid's shadow root as well. The document listeners above stay - they are the ones that
+    // see a click or a hover landing outside the shadow host. Sandboxed hosts (e.g. Salesforce
+    // Lightning Web Security) collapse `composedPath()` to the shadow host chain, so the
+    // document listeners cannot recover the real cell there; listeners bound inside the grid's
+    // own shadow tree still receive a correctly retargeted `target`. No dedupe registry is
+    // needed when both fire for one event: all three handlers resolve the same element and are
+    // idempotent, and showing is debounced by the display switch.
+    if (this.#gridShadowRoot) {
+      this.eventManager.addEventListener(this.#gridShadowRoot, 'mouseover', this.#onMouseOver);
+      this.eventManager.addEventListener(this.#gridShadowRoot, 'mousedown', this.#onMouseDown);
+      this.eventManager.addEventListener(this.#gridShadowRoot, 'mouseup', () => this.#onMouseUp());
+    }
 
     if (editorElement) {
       this.eventManager.addEventListener(editorElement, 'focus', () => this.#onEditorFocus());
@@ -478,6 +504,50 @@ export class Comments extends BasePlugin {
   }
 
   /**
+   * Resolves the element the event originated from. A path that crosses a shadow boundary
+   * carries `ShadowRoot` entries and its initial element is the true source - the cell itself,
+   * where `event.target` has been retargeted to the shadow host for a listener bound on the
+   * document. Without such entries there is no shadow tree to pierce, or a sandboxed host
+   * (e.g. Salesforce Lightning Web Security) collapsed the path to the shadow host chain; in
+   * both cases the retargeted `target` is already the deepest reliable reference.
+   *
+   * Grids in the light DOM skip the composed path entirely - `mouseover` fires on every
+   * pointer move, and `composedPath()` allocates an array on each call.
+   *
+   * @param {Event} event DOM event.
+   * @returns {HTMLElement|null} The deepest known source element.
+   */
+  #resolveEventTarget(event: Event): HTMLElement | null {
+    if (this.#gridShadowRoot === null) {
+      return eventTargetEl(event);
+    }
+
+    const eventPath = event.composedPath();
+
+    if (eventPath.some(entry => isShadowRoot(entry))) {
+      return eventPath[0] as HTMLElement;
+    }
+
+    return eventTargetEl(event);
+  }
+
+  /**
+   * Checks whether the element sits in a tree the grid can be rendered into. `isChildOf()`
+   * walks `parentNode` only, so an element inside the grid's shadow tree dead-ends at the
+   * `ShadowRoot` (whose `parentNode` is `null`) and never reaches the document.
+   *
+   * @param {HTMLElement} element The element to check.
+   * @returns {boolean}
+   */
+  #isInRenderedTree(element: HTMLElement): boolean {
+    if (this.#gridShadowRoot?.contains(element)) {
+      return true;
+    }
+
+    return isChildOf(element, this.hot.rootDocument);
+  }
+
+  /**
    * Checks if the event target is a cell containing a comment.
    *
    * @private
@@ -485,7 +555,7 @@ export class Comments extends BasePlugin {
    * @returns {boolean}
    */
   targetIsCellWithComment(event: Event) {
-    const closestCell = closest(eventTargetEl(event)!, ['TD']);
+    const closestCell = closest(this.#resolveEventTarget(event)!, ['TD']);
 
     return !!(closestCell && hasClass(closestCell, 'htCommentCell') &&
       closest(closestCell, [this.hot.rootElement]));
@@ -499,7 +569,7 @@ export class Comments extends BasePlugin {
    * @returns {boolean}
    */
   targetIsCommentTextArea(event: Event) {
-    return this.getEditorInputElement() === event.target;
+    return this.getEditorInputElement() === this.#resolveEventTarget(event);
   }
 
   /**
@@ -860,7 +930,7 @@ export class Comments extends BasePlugin {
     }
 
     if (!this.#preventEditorAutoSwitch && !this.targetIsCommentTextArea(event)) {
-      const eventCell = closest(eventTargetEl(event)!, ['TD']);
+      const eventCell = closest(this.#resolveEventTarget(event)!, ['TD']);
       let coordinates = null;
 
       if (eventCell) {
@@ -891,14 +961,16 @@ export class Comments extends BasePlugin {
   #onMouseOver = (event: Event) => {
     const { rootDocument } = this.hot;
 
-    const target = eventTargetEl(event)!;
+    const target = this.#resolveEventTarget(event)!;
 
     if (this.#preventEditorAutoSwitch || this.#editor?.isFocused() || hasClass(target, 'wtBorder')
         || this.#cellBelowCursor === target || !this.#editor) {
       return;
     }
 
-    this.#cellBelowCursor = rootDocument.elementFromPoint(
+    // `elementFromPoint()` does not pierce shadow boundaries, so on a document it resolves to
+    // the shadow host. The grid's own shadow root resolves the cell actually under the cursor.
+    this.#cellBelowCursor = (this.#gridShadowRoot ?? rootDocument).elementFromPoint(
       (event as MouseEvent).clientX, (event as MouseEvent).clientY);
 
     if (this.targetIsCellWithComment(event)) {
@@ -910,7 +982,7 @@ export class Comments extends BasePlugin {
         this.#displaySwitch?.show(range);
       }
 
-    } else if (isChildOf(target, rootDocument) && !this.targetIsCommentTextArea(event)) {
+    } else if (this.#isInRenderedTree(target) && !this.targetIsCommentTextArea(event)) {
       this.#displaySwitch?.hide();
     }
   };

--- a/handsontable/src/plugins/comments/comments.ts
+++ b/handsontable/src/plugins/comments/comments.ts
@@ -457,7 +457,15 @@ export class Comments extends BasePlugin {
     const editorElement = this.getEditorInputElement();
     const rootNode = this.hot.rootElement.getRootNode();
 
+    // Every shadow-aware path in this plugin hangs off this one gate, and `isShadowRoot()`
+    // recognizes a native shadow root (`DOCUMENT_FRAGMENT_NODE` carrying a `host`). A host
+    // whose synthetic root does not match that shape leaves this `null`, which makes the
+    // second binding, the dedupe and the point reader all inert - the grid then behaves
+    // exactly as it did before this fix. The Playwright fixture mounts a native shadow root,
+    // so the gate is always true there and its false side is not covered.
     this.#gridShadowRoot = isShadowRoot(rootNode) ? rootNode : null;
+
+    const isShadowHosted = this.#gridShadowRoot !== null;
 
     // Claims an event for the first listener that receives it. A shadow-hosted grid binds the
     // handlers twice, and the two bindings do NOT see the same element under a sandboxed host
@@ -470,7 +478,7 @@ export class Comments extends BasePlugin {
     // ShadowRoot before it crosses to the host), so it wins for anything inside the grid and
     // the document listener keeps handling only what never entered the shadow tree.
     const dedupe = (handler: (event: Event) => void) => (event: Event) => {
-      if (this.#gridShadowRoot) {
+      if (isShadowHosted) {
         if (this.#processedMouseEvents.has(event)) {
           return;
         }
@@ -529,34 +537,6 @@ export class Comments extends BasePlugin {
   }
 
   /**
-   * Resolves the element the event originated from. A path that crosses a shadow boundary
-   * carries `ShadowRoot` entries and its initial element is the true source - the cell itself,
-   * where `event.target` has been retargeted to the shadow host for a listener bound on the
-   * document. Without such entries there is no shadow tree to pierce, or a sandboxed host
-   * (e.g. Salesforce Lightning Web Security) collapsed the path to the shadow host chain; in
-   * both cases the retargeted `target` is already the deepest reliable reference.
-   *
-   * Grids in the light DOM skip the composed path entirely - `mouseover` fires on every
-   * pointer move, and `composedPath()` allocates an array on each call.
-   *
-   * @param {Event} event DOM event.
-   * @returns {HTMLElement|null} The deepest known source element.
-   */
-  #resolveEventTarget(event: Event): HTMLElement | null {
-    if (this.#gridShadowRoot === null) {
-      return eventTargetEl(event);
-    }
-
-    const eventPath = event.composedPath();
-
-    if (eventPath.some(entry => isShadowRoot(entry))) {
-      return eventPath[0] as HTMLElement;
-    }
-
-    return eventTargetEl(event);
-  }
-
-  /**
    * Checks whether the element is attached to the document the grid renders into. A
    * `parentNode` walk cannot answer this: it dead-ends at the first `ShadowRoot` (whose
    * `parentNode` is `null`), which makes every element inside a shadow tree look detached.
@@ -581,11 +561,10 @@ export class Comments extends BasePlugin {
    *
    * @private
    * @param {Event} event DOM event.
-   * @param {HTMLElement} [target] The already-resolved event target, to avoid resolving it twice.
    * @returns {boolean}
    */
-  targetIsCellWithComment(event: Event, target = this.#resolveEventTarget(event)) {
-    const closestCell = closest(target!, ['TD']);
+  targetIsCellWithComment(event: Event) {
+    const closestCell = closest(eventTargetEl(event)!, ['TD']);
 
     return !!(closestCell && hasClass(closestCell, 'htCommentCell') &&
       closest(closestCell, [this.hot.rootElement]));
@@ -596,11 +575,10 @@ export class Comments extends BasePlugin {
    *
    * @private
    * @param {Event} event DOM event.
-   * @param {HTMLElement} [target] The already-resolved event target, to avoid resolving it twice.
    * @returns {boolean}
    */
-  targetIsCommentTextArea(event: Event, target = this.#resolveEventTarget(event)) {
-    return this.getEditorInputElement() === target;
+  targetIsCommentTextArea(event: Event) {
+    return this.getEditorInputElement() === eventTargetEl(event);
   }
 
   /**
@@ -960,10 +938,8 @@ export class Comments extends BasePlugin {
       return;
     }
 
-    const target = this.#resolveEventTarget(event);
-
-    if (!this.#preventEditorAutoSwitch && !this.targetIsCommentTextArea(event, target)) {
-      const eventCell = closest(target!, ['TD']);
+    if (!this.#preventEditorAutoSwitch && !this.targetIsCommentTextArea(event)) {
+      const eventCell = closest(eventTargetEl(event)!, ['TD']);
       let coordinates = null;
 
       if (eventCell) {
@@ -994,19 +970,22 @@ export class Comments extends BasePlugin {
   #onMouseOver = (event: Event) => {
     const { rootDocument } = this.hot;
 
-    const target = this.#resolveEventTarget(event)!;
+    const target = eventTargetEl(event)!;
 
     if (this.#preventEditorAutoSwitch || this.#editor?.isFocused() || hasClass(target, 'wtBorder')
         || this.#cellBelowCursor === target || !this.#editor) {
       return;
     }
 
-    // `elementFromPoint()` does not pierce shadow boundaries, so on a document it resolves to
-    // the shadow host. The grid's own shadow root resolves the cell actually under the cursor.
+    // Hygiene, with no behavior visible today: `elementFromPoint()` does not pierce shadow
+    // boundaries, so on a document it resolves to the shadow host. `#cellBelowCursor` feeds
+    // only the `=== target` short circuit above, which a one-`mouseover`-per-cell pointer
+    // move never reaches, so reading it from the wrong root has no observable effect - it
+    // would simply hold an element that can never match.
     this.#cellBelowCursor = (this.#gridShadowRoot ?? rootDocument).elementFromPoint(
       (event as MouseEvent).clientX, (event as MouseEvent).clientY);
 
-    if (this.targetIsCellWithComment(event, target)) {
+    if (this.targetIsCellWithComment(event)) {
       const coords = this.hot.getCoords(target);
 
       if (coords) {
@@ -1015,7 +994,7 @@ export class Comments extends BasePlugin {
         this.#displaySwitch?.show(range);
       }
 
-    } else if (this.#isInRenderedTree(target) && !this.targetIsCommentTextArea(event, target)) {
+    } else if (this.#isInRenderedTree(target) && !this.targetIsCommentTextArea(event)) {
       this.#displaySwitch?.hide();
     }
   };

--- a/tests/e2e/shadow-dom.spec.ts
+++ b/tests/e2e/shadow-dom.spec.ts
@@ -129,6 +129,22 @@ test.describe('grid inside a native shadow root', () => {
     await expect(grid.commentTooltip).toBeHidden();
   });
 
+  /**
+   * Containment cannot be decided from the grid's own shadow root alone. Moving the pointer
+   * straight from a commented cell into a different component's shadow tree never touches the
+   * light DOM, and a `parentNode` walk dead-ends in that other tree too - so a check that only
+   * knows the grid's root leaves the tooltip open. On a page built from web components this is
+   * an ordinary pointer move.
+   */
+  test('hides the comment tooltip when the pointer moves into a different shadow tree', async () => {
+    await grid.cell(3, 1).hover();
+    await expect(grid.commentTooltip).toBeVisible();
+
+    await grid.otherShadowContent.hover();
+
+    await expect(grid.commentTooltip).toBeHidden();
+  });
+
   test('deselects when a light-DOM element outside the shadow host is clicked', async () => {
     await grid.cell(0, 0).click();
     await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);

--- a/tests/e2e/shadow-dom.spec.ts
+++ b/tests/e2e/shadow-dom.spec.ts
@@ -102,6 +102,33 @@ test.describe('grid inside a native shadow root', () => {
     expect(await grid.outsideClickTargets()).toEqual(['focus-mover']);
   });
 
+  /**
+   * Issue #8624. The Comments plugin listens on the document, which sits outside the
+   * shadow tree, so `event.target` arrives retargeted to the shadow host and the hover
+   * never resolved to the cell. `showAtCell()` was unaffected, which is why the tooltip
+   * could be opened programmatically while hovering did nothing.
+   */
+  test('opens the comment tooltip when a commented cell is hovered', async () => {
+    await grid.cell(3, 1).hover();
+
+    await expect(grid.commentTooltip).toBeVisible();
+    await expect(grid.commentTooltipInput).toHaveValue('Comment inside the shadow root');
+  });
+
+  /**
+   * The counterpart to the case above: hiding is driven by a separate branch that tests
+   * containment with a `parentNode` walk, which dead-ends at the `ShadowRoot`. Resolving
+   * the hover target without also fixing that branch turns "never shows" into "never hides".
+   */
+  test('hides the comment tooltip when the pointer moves to a cell without a comment', async () => {
+    await grid.cell(3, 1).hover();
+    await expect(grid.commentTooltip).toBeVisible();
+
+    await grid.cell(3, 0).hover();
+
+    await expect(grid.commentTooltip).toBeHidden();
+  });
+
   test('deselects when a light-DOM element outside the shadow host is clicked', async () => {
     await grid.cell(0, 0).click();
     await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);

--- a/tests/e2e/shadow-dom.spec.ts
+++ b/tests/e2e/shadow-dom.spec.ts
@@ -146,24 +146,6 @@ test.describe('grid inside a native shadow root', () => {
   });
 
   /**
-   * A shadow-hosted grid binds the mouse handlers on both the document and its shadow root.
-   * Under a sandboxed host the two do not agree: `composedPath()` is filtered to the host
-   * chain, so only the shadow-root listener can reach the cell while the document listener
-   * still sees the host. Undeduped, one hover showed from the first and hid from the second,
-   * and the hide cleared the display switch's flag so the queued show was dropped - the
-   * tooltip never appeared. Native embedding cannot catch this: there both listeners resolve
-   * the same cell.
-   */
-  test('opens the comment tooltip on hover when the host filters the composed path', async () => {
-    await grid.simulateSandboxedHost();
-
-    await grid.cell(3, 1).hover();
-
-    await expect(grid.commentTooltip).toBeVisible();
-    await expect(grid.commentTooltipInput).toHaveValue('Comment inside the shadow root');
-  });
-
-  /**
    * The tooltip has to survive the pointer landing on it, or it could never be read or
    * edited. This is the case that exercises `targetIsCommentTextArea()` with the resolved
    * target: the editor is portaled into the light DOM, so the hover crosses out of the

--- a/tests/e2e/shadow-dom.spec.ts
+++ b/tests/e2e/shadow-dom.spec.ts
@@ -145,6 +145,24 @@ test.describe('grid inside a native shadow root', () => {
     await expect(grid.commentTooltip).toBeHidden();
   });
 
+  /**
+   * A shadow-hosted grid binds the mouse handlers on both the document and its shadow root.
+   * Under a sandboxed host the two do not agree: `composedPath()` is filtered to the host
+   * chain, so only the shadow-root listener can reach the cell while the document listener
+   * still sees the host. Undeduped, one hover showed from the first and hid from the second,
+   * and the hide cleared the display switch's flag so the queued show was dropped - the
+   * tooltip never appeared. Native embedding cannot catch this: there both listeners resolve
+   * the same cell.
+   */
+  test('opens the comment tooltip on hover when the host filters the composed path', async () => {
+    await grid.simulateSandboxedHost();
+
+    await grid.cell(3, 1).hover();
+
+    await expect(grid.commentTooltip).toBeVisible();
+    await expect(grid.commentTooltipInput).toHaveValue('Comment inside the shadow root');
+  });
+
   test('deselects when a light-DOM element outside the shadow host is clicked', async () => {
     await grid.cell(0, 0).click();
     await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);

--- a/tests/e2e/shadow-dom.spec.ts
+++ b/tests/e2e/shadow-dom.spec.ts
@@ -163,6 +163,45 @@ test.describe('grid inside a native shadow root', () => {
     await expect(grid.commentTooltipInput).toHaveValue('Comment inside the shadow root');
   });
 
+  /**
+   * The tooltip has to survive the pointer landing on it, or it could never be read or
+   * edited. This is the case that exercises `targetIsCommentTextArea()` with the resolved
+   * target: the editor is portaled into the light DOM, so the hover crosses out of the
+   * shadow tree and back to a document-level listener.
+   */
+  test('keeps the comment tooltip open when the pointer moves onto it', async ({ page }) => {
+    // Hiding runs on a timer, so a bare assertion right after the hover would pass before a
+    // wrongly queued hide could fire. Driving the clock makes the "it stays open" claim real.
+    await page.clock.install();
+
+    await grid.cell(3, 1).hover();
+    await page.clock.runFor(1000);
+    await expect(grid.commentTooltip).toBeVisible();
+
+    await grid.commentTooltipInput.hover();
+    await page.clock.runFor(1000);
+
+    await expect(grid.commentTooltip).toBeVisible();
+  });
+
+  /**
+   * Before the fix a shadow-hosted grid resolved the host here, found no cell above it, and
+   * so hid the tooltip on every mousedown - including one on the very cell the comment
+   * belongs to.
+   */
+  test('keeps the comment tooltip open when its own cell is clicked', async ({ page }) => {
+    await page.clock.install();
+
+    await grid.cell(3, 1).hover();
+    await page.clock.runFor(1000);
+    await expect(grid.commentTooltip).toBeVisible();
+
+    await grid.cell(3, 1).click();
+    await page.clock.runFor(1000);
+
+    await expect(grid.commentTooltip).toBeVisible();
+  });
+
   test('deselects when a light-DOM element outside the shadow host is clicked', async () => {
     await grid.cell(0, 0).click();
     await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);

--- a/tests/fixtures/demo/shadow-dom.html
+++ b/tests/fixtures/demo/shadow-dom.html
@@ -87,6 +87,10 @@
       colHeaders: true,
       rowHeaders: true,
       contextMenu: true,
+      // The comment on B4 backs the hover-tooltip cases (issue #8624). B4 and A4 are
+      // untouched by the other tests, so the comment cannot disturb them.
+      comments: true,
+      cell: [{ row: 3, col: 1, comment: { value: 'Comment inside the shadow root' } }],
       renderer: testIdRenderer,
       licenseKey: 'non-commercial-and-evaluation',
     });

--- a/tests/fixtures/demo/shadow-dom.html
+++ b/tests/fixtures/demo/shadow-dom.html
@@ -134,6 +134,29 @@
         window.__outsideClickTargets = targets;
       },
       outsideClickTargets: () => window.__outsideClickTargets,
+      /**
+       * Makes mouse events look the way a sandboxed host (Salesforce Lightning Web Security)
+       * presents them: `composedPath()` is filtered down to the shadow host chain, so nothing
+       * from inside a shadow tree and no ShadowRoot entry survives. `event.target` is left
+       * alone - the browser already retargets it per listener, which is the whole point: a
+       * listener on the document sees the host while one inside the shadow tree sees the cell.
+       * That split is what the document/shadow-root dedupe has to survive.
+       */
+      simulateSandboxedHost: () => {
+        const nativeComposedPath = Event.prototype.composedPath;
+
+        Event.prototype.composedPath = function() {
+          const path = nativeComposedPath.call(this);
+
+          if (!(this instanceof MouseEvent)) {
+            return path;
+          }
+
+          const firstShadowRoot = path.findIndex(entry => entry instanceof ShadowRoot);
+
+          return firstShadowRoot === -1 ? path : path.slice(firstShadowRoot + 1);
+        };
+      },
     };
   </script>
 </body>

--- a/tests/fixtures/demo/shadow-dom.html
+++ b/tests/fixtures/demo/shadow-dom.html
@@ -23,6 +23,19 @@
     }
   </script>
   <style> body { font-family: sans-serif; margin: 1rem; } #outside-area { margin-top: .8rem; } </style>
+  <!--
+    The grid's stylesheets are linked inside the shadow root below, because document styles
+    do not cross the boundary. They are ALSO linked here, in the light DOM, because the
+    comment editor and the context menu are portaled into `document.body` and so live outside
+    the shadow tree. Without these, `.htComments { position: absolute }` never applies and the
+    tooltip renders in normal page flow - visible, so the show/hide assertions still hold, but
+    positioned nowhere near its cell and impossible to move the pointer onto.
+  -->
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-'
+      + window.htTheme + '.min.css">');
+  </script>
 </head>
 <body>
   <!--
@@ -141,9 +154,20 @@
        * alone - the browser already retargets it per listener, which is the whole point: a
        * listener on the document sees the host while one inside the shadow tree sees the cell.
        * That split is what the document/shadow-root dedupe has to survive.
+       *
+       * Reaches wider than the comment tooltip: the core reads `composedPath()` for
+       * outside-click detection too, and a filtered path makes an in-grid click look like an
+       * outside click. Keep this to hover-only flows, or call `restoreNativeComposedPath()`
+       * before clicking.
        */
       simulateSandboxedHost: () => {
+        if (window.__nativeComposedPath) {
+          return;
+        }
+
         const nativeComposedPath = Event.prototype.composedPath;
+
+        window.__nativeComposedPath = nativeComposedPath;
 
         Event.prototype.composedPath = function() {
           const path = nativeComposedPath.call(this);
@@ -156,6 +180,17 @@
 
           return firstShadowRoot === -1 ? path : path.slice(firstShadowRoot + 1);
         };
+      },
+      /**
+       * Puts the native `composedPath()` back, so a later click is classified normally.
+       */
+      restoreNativeComposedPath: () => {
+        if (!window.__nativeComposedPath) {
+          return;
+        }
+
+        Event.prototype.composedPath = window.__nativeComposedPath;
+        window.__nativeComposedPath = null;
       },
     };
   </script>

--- a/tests/fixtures/demo/shadow-dom.html
+++ b/tests/fixtures/demo/shadow-dom.html
@@ -40,6 +40,13 @@
     <input data-testid="outside-input" type="text">
     <button data-testid="focus-mover" type="button">Move focus to the input</button>
   </div>
+  <!--
+    A SECOND, unrelated shadow root, standing in for any other web component on the host
+    page. Moving the pointer from the grid into this tree never touches the light DOM, so
+    it is the case that catches a containment check which only knows the grid's own shadow
+    root - see the comment-tooltip tests.
+  -->
+  <div id="other-shadow-host" data-testid="other-shadow-host"></div>
 
   <script>
     // The bundle under test, selected above from the sanitized allowlist. The
@@ -70,6 +77,15 @@
     shadowSibling.textContent = 'Non-focusable sibling inside the same shadow root';
     shadowSibling.addEventListener('mousedown', (event) => event.preventDefault());
     shadowRoot.appendChild(shadowSibling);
+
+    const otherShadowRoot = document.querySelector('[data-testid="other-shadow-host"]')
+      .attachShadow({ mode: 'open' });
+    const otherShadowContent = document.createElement('div');
+
+    otherShadowContent.setAttribute('data-testid', 'other-shadow-content');
+    otherShadowContent.style.cssText = 'padding: 16px; margin-top: 8px; background: #dde;';
+    otherShadowContent.textContent = 'Content inside a different shadow root';
+    otherShadowRoot.appendChild(otherShadowContent);
 
     const testIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
       Handsontable.renderers.TextRenderer.apply(this, arguments);

--- a/tests/fixtures/demo/shadow-dom.html
+++ b/tests/fixtures/demo/shadow-dom.html
@@ -147,51 +147,6 @@
         window.__outsideClickTargets = targets;
       },
       outsideClickTargets: () => window.__outsideClickTargets,
-      /**
-       * Makes mouse events look the way a sandboxed host (Salesforce Lightning Web Security)
-       * presents them: `composedPath()` is filtered down to the shadow host chain, so nothing
-       * from inside a shadow tree and no ShadowRoot entry survives. `event.target` is left
-       * alone - the browser already retargets it per listener, which is the whole point: a
-       * listener on the document sees the host while one inside the shadow tree sees the cell.
-       * That split is what the document/shadow-root dedupe has to survive.
-       *
-       * Reaches wider than the comment tooltip: the core reads `composedPath()` for
-       * outside-click detection too, and a filtered path makes an in-grid click look like an
-       * outside click. Keep this to hover-only flows, or call `restoreNativeComposedPath()`
-       * before clicking.
-       */
-      simulateSandboxedHost: () => {
-        if (window.__nativeComposedPath) {
-          return;
-        }
-
-        const nativeComposedPath = Event.prototype.composedPath;
-
-        window.__nativeComposedPath = nativeComposedPath;
-
-        Event.prototype.composedPath = function() {
-          const path = nativeComposedPath.call(this);
-
-          if (!(this instanceof MouseEvent)) {
-            return path;
-          }
-
-          const firstShadowRoot = path.findIndex(entry => entry instanceof ShadowRoot);
-
-          return firstShadowRoot === -1 ? path : path.slice(firstShadowRoot + 1);
-        };
-      },
-      /**
-       * Puts the native `composedPath()` back, so a later click is classified normally.
-       */
-      restoreNativeComposedPath: () => {
-        if (!window.__nativeComposedPath) {
-          return;
-        }
-
-        Event.prototype.composedPath = window.__nativeComposedPath;
-        window.__nativeComposedPath = null;
-      },
     };
   </script>
 </body>

--- a/tests/fixtures/pages/ShadowGridPage.ts
+++ b/tests/fixtures/pages/ShadowGridPage.ts
@@ -101,4 +101,12 @@ export class ShadowGridPage {
   async simulateSandboxedHost(): Promise<void> {
     await this.page.evaluate(() => (window as any).__hotProbe.simulateSandboxedHost());
   }
+
+  /**
+   * Undo `simulateSandboxedHost()`. The patch also reaches the core's outside-click
+   * detection, so restore it before clicking anything (fixture probe).
+   */
+  async restoreNativeComposedPath(): Promise<void> {
+    await this.page.evaluate(() => (window as any).__hotProbe.restoreNativeComposedPath());
+  }
 }

--- a/tests/fixtures/pages/ShadowGridPage.ts
+++ b/tests/fixtures/pages/ShadowGridPage.ts
@@ -19,6 +19,7 @@ export class ShadowGridPage {
   readonly focusMover: Locator;
   readonly commentTooltip: Locator;
   readonly commentTooltipInput: Locator;
+  readonly otherShadowContent: Locator;
 
   constructor(page: Page, theme = 'main', bundle = 'umd') {
     this.page = page;
@@ -33,6 +34,8 @@ export class ShadowGridPage {
     // even though its grid lives inside the shadow root.
     this.commentTooltip = page.locator('.htComments');
     this.commentTooltipInput = page.locator('.htCommentTextArea');
+    // Lives in a second shadow root, unrelated to the grid's own.
+    this.otherShadowContent = page.getByTestId('other-shadow-content');
   }
 
   /**

--- a/tests/fixtures/pages/ShadowGridPage.ts
+++ b/tests/fixtures/pages/ShadowGridPage.ts
@@ -17,6 +17,8 @@ export class ShadowGridPage {
   readonly outsideInput: Locator;
   readonly shadowSibling: Locator;
   readonly focusMover: Locator;
+  readonly commentTooltip: Locator;
+  readonly commentTooltipInput: Locator;
 
   constructor(page: Page, theme = 'main', bundle = 'umd') {
     this.page = page;
@@ -27,6 +29,10 @@ export class ShadowGridPage {
     this.outsideInput = page.getByTestId('outside-input');
     this.shadowSibling = page.getByTestId('shadow-sibling');
     this.focusMover = page.getByTestId('focus-mover');
+    // The comment editor is portaled into `document.body`, so it sits in the light DOM
+    // even though its grid lives inside the shadow root.
+    this.commentTooltip = page.locator('.htComments');
+    this.commentTooltipInput = page.locator('.htCommentTextArea');
   }
 
   /**

--- a/tests/fixtures/pages/ShadowGridPage.ts
+++ b/tests/fixtures/pages/ShadowGridPage.ts
@@ -92,21 +92,4 @@ export class ShadowGridPage {
   async outsideClickTargets(): Promise<string[]> {
     return this.page.evaluate(() => (window as any).__hotProbe.outsideClickTargets());
   }
-
-  /**
-   * Filter `composedPath()` on mouse events down to the shadow host chain, the way Salesforce
-   * Lightning Web Security presents them to sandboxed code (fixture probe). Call before the
-   * interaction under test.
-   */
-  async simulateSandboxedHost(): Promise<void> {
-    await this.page.evaluate(() => (window as any).__hotProbe.simulateSandboxedHost());
-  }
-
-  /**
-   * Undo `simulateSandboxedHost()`. The patch also reaches the core's outside-click
-   * detection, so restore it before clicking anything (fixture probe).
-   */
-  async restoreNativeComposedPath(): Promise<void> {
-    await this.page.evaluate(() => (window as any).__hotProbe.restoreNativeComposedPath());
-  }
 }

--- a/tests/fixtures/pages/ShadowGridPage.ts
+++ b/tests/fixtures/pages/ShadowGridPage.ts
@@ -92,4 +92,13 @@ export class ShadowGridPage {
   async outsideClickTargets(): Promise<string[]> {
     return this.page.evaluate(() => (window as any).__hotProbe.outsideClickTargets());
   }
+
+  /**
+   * Filter `composedPath()` on mouse events down to the shadow host chain, the way Salesforce
+   * Lightning Web Security presents them to sandboxed code (fixture probe). Call before the
+   * interaction under test.
+   */
+  async simulateSandboxedHost(): Promise<void> {
+    await this.page.evaluate(() => (window as any).__hotProbe.simulateSandboxedHost());
+  }
 }


### PR DESCRIPTION
### Context

The PR fixes the comment tooltip not opening when you hover a commented cell in a grid rendered inside a shadow root. Calling `showAtCell()` on the same cell always worked, which is why the report singled hovering out.

Reported in #8624 (2021, Handsontable 9.0.2) and still reproducible on `develop` @ `52e0c9efbd`. The Shadow DOM work in #13194 (DEV-1619) did not cover this path — its only change to the plugin was `isFocused()` in `commentEditor.ts`.

**Cause.** The plugin bound its mouse listeners on the document only. That sits outside the grid's shadow tree, so the browser retargets the event and `event.target` arrives as the shadow host. `targetIsCellWithComment()` then looked for a `TD` above the host, found none, and the tooltip never opened. The `else` branch ran instead and hid it.

Three things were needed, and each is verified below:

1. **Bind the mouse handlers to the grid's shadow root as well.** A listener bound inside the tree receives the real cell as `event.target` — retargeting only affects listeners outside the tree. This is the mechanism that makes hovering work, and it is also what a sandboxed host (Salesforce LWS) needs, because LWS collapses `composedPath()` to the host chain and leaves a document listener with no way to reach the cell.

2. **Dedupe the events across the two bindings.** Both bindings receive the same in-grid event, and they never agree: the listener inside the tree sees the real cell, while the document listener sees the retargeted shadow host. That is intrinsic to retargeting, so it applies to every shadow-hosted grid, not only sandboxed ones. Undeduped, one hover showed from the first and hid from the second — and `DisplaySwitch.hide()` sets `wasLastActionShow = false`, which the queued debounced show re-reads when it fires, so the show was dropped and the tooltip never appeared. The shadow-root listener runs first (the event reaches the `ShadowRoot` before crossing to the host), so it wins for anything inside the grid, and the document listener keeps handling only what never entered the shadow tree.

3. **Make the hide branch's containment test shadow-aware.** It used `isChildOf()`, a plain `parentNode` walk, which dead-ends at the `ShadowRoot` (whose `parentNode` is `null`) and so reports every cell in a shadow tree as detached. It returned `true` before only because it was handed the host. Fixing the target without this turns "never shows" into "never hides". It is now one composed-root-node comparison, which follows host elements across every boundary and still reports a genuinely detached element as detached.

**What is deliberately *not* here.** An earlier revision of this PR also resolved the event target through `composedPath()`. Mutation testing at HEAD showed that layer kills no test: once the handlers are bound to the shadow root, that listener wins every in-grid event and its `event.target` is already the real cell. It was two overlapping mechanisms where one suffices, so it is gone — along with the optional `target` parameter it needed on `targetIsCellWithComment()`/`targetIsCommentTextArea()`, which keeps both at their `develop` signatures. `copyPaste.ts` and `helpers/dom/element.ts` are untouched.

Light-DOM grids are unaffected: the second binding, the dedupe and the point reader all hang off one `isShadowRoot()` gate, and nothing on the hover path changed for them.

### How has this been tested?

Extended the existing DEV-1619 shadow DOM harness rather than adding a fixture. `tests/fixtures/demo/shadow-dom.html` gains a comment on B4, a second unrelated shadow root, and both stylesheets in `<head>` (the comment editor is portaled into `document.body`, so without them it rendered in page flow and the pointer could not reach it). `tests/e2e/shadow-dom.spec.ts` goes from 9 cases to **14**.

```bash
npm run build:umd --prefix handsontable
cd tests && npx playwright test e2e/shadow-dom.spec.ts --project=e2e-main
```

**14 passed**, stable across three consecutive runs. All nine pre-existing cases still pass, the context-menu one included.

Rather than one both-directions run, here is what each mechanism is worth — every row is a mutation applied at HEAD, rebuilt, and run:

| mutation at HEAD | cases killed |
|---|---|
| remove the shadow-root binding | 5 |
| remove the dedupe | 5 |
| containment → `develop`'s `isChildOf` | 1 — `hides… when the pointer moves to a cell without a comment` |
| textarea check → `false` | 1 — `keeps… open when the pointer moves onto it` |
| remove the `composedPath()` resolution | **0** — which is why it is not in the diff |

Two of the new cases drive `page.clock`. Hiding runs on a timer, so asserting straight after the hover passed before a wrongly queued hide could fire — the first version of the hover-onto-tooltip case was hollow and its mutant survived. With the clock both mutants die.

```bash
npx eslint --ext .ts src/plugins/comments/comments.ts   # clean
npm run test:types --prefix handsontable                # clean
```

**One caveat for the reviewer.** Every shadow-aware path hangs off `isShadowRoot()`, and the fixture mounts a *native* shadow root, so that gate's false side is never exercised: a host whose synthetic root fails the predicate makes the whole change inert while the suite stays green. Nothing here is Salesforce-specific any more — the fix is plain retargeting plus a dedupe — so there is no LWS-only path left to simulate, and the probe that used to do it has been removed as inert. The legacy Jasmine comments suite could not run in my worktree (`jasmine is not defined`, a local `node_modules` linking artifact), so CI is the first full run of it, along with the `-min` and horizon/classic legs.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2596
2. #8624

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

The Shadow DOM guide's known limitation about the creation-time root-node check now mentions the comment listeners it also controls.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2596

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Comments plugin mouse handling (show/hide on hover and click). Light-DOM behavior is gated behind `isShadowRoot()`, but dual listeners and event dedupe could still affect tooltip timing if the gate misfires.
> 
> **Overview**
> Fixes **comment tooltips never appearing on hover** when Handsontable is mounted in a shadow root (#8624). Document-only listeners saw the retargeted host, so the cell was never recognized.
> 
> The Comments plugin now also binds `mouseover`/`mousedown`/`mouseup` on the grid’s shadow root, **dedupes** the two listeners so a show is not immediately cancelled by the document handler, and replaces `isChildOf` with a composed-root check so the tooltip still **hides** when the pointer leaves the grid (including into another shadow tree). Light-DOM grids skip the extra path.
> 
> Playwright shadow-DOM e2e coverage is extended for show, hide, other-shadow-tree leave, hover onto the portaled editor, and click on the commented cell. The Shadow DOM guide notes that comment listeners are also tied to the creation-time root-node check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab5f71d047a80b2882ff0723061fa12e9e95b04f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->