### PR TITLE
DEV-2597: Give each table its own portal container for component renderers (#9063)

### DIFF
--- a/.changelogs/9063.json
+++ b/.changelogs/9063.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed a bug where a component-based renderer used in a frozen column rendered its content into only one of the two tables the grid draws that column in, so the cell looked empty in the other one and the frozen columns stopped lining up with the rest of the rows.",
+  "title": "Fixed a bug where a component-based renderer in a frozen row or column left the cell empty in one of the two tables the grid draws it in, which made the frozen area stop lining up with the rest of the rows.",
   "type": "fixed",
   "issueOrPR": 9063,
   "breaking": false,

--- a/.changelogs/9063.json
+++ b/.changelogs/9063.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a bug where a component-based renderer used in a frozen column rendered its content into only one of the two tables the grid draws that column in, so the cell looked empty in the other one and the frozen columns stopped lining up with the rest of the rows.",
+  "type": "fixed",
+  "issueOrPR": 9063,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react-wrapper/src/hotTableContext.tsx
+++ b/wrappers/react-wrapper/src/hotTableContext.tsx
@@ -110,6 +110,37 @@ const HotTableContextProvider: FC<PropsWithChildren> = ({ children }) => {
   }, []);
   const getPortalContainerCacheSize = useCallback(() => portalContainerCache.current.size, []);
 
+  // Stable id per table element the grid draws into. Handsontable renders the
+  // same cell once per table it appears in — the master table plus an overlay
+  // table for every fixed row/column edge — and each draw gets its own TD.
+  const tableIds = useRef<WeakMap<Element, number>>(new WeakMap());
+  const nextTableId = useRef(0);
+
+  /**
+   * Identify the table a rendered cell belongs to, so the master table and the
+   * overlay tables get separate portal containers for the same cell.
+   *
+   * @param {HTMLTableCellElement} TD The cell being rendered.
+   * @returns {Number} The id of the table the cell belongs to.
+   */
+  const getTableId = useCallback((TD: HTMLTableCellElement): number => {
+    // Overlay tables are built once and never hand their cells to another
+    // table, so the TABLE element is a stable identity for the draw.
+    const table: Element = TD.closest('table') ?? TD;
+    const cachedId = tableIds.current.get(table);
+
+    if (cachedId !== undefined) {
+      return cachedId;
+    }
+
+    const id = nextTableId.current;
+
+    nextTableId.current += 1;
+    tableIds.current.set(table, id);
+
+    return id;
+  }, []);
+
   const getRendererWrapper = useCallback((Renderer: ComponentType<HotRendererProps>): typeof Handsontable.renderers.BaseRenderer => {
     return function __internalRenderer(instance, TD, row, col, prop, value, cellProperties) {
       const key = `${row}-${col}`;
@@ -117,10 +148,16 @@ const HotTableContextProvider: FC<PropsWithChildren> = ({ children }) => {
       // Handsontable.Core type is missing guid
       const instanceGuid = (instance as unknown as { guid: string }).guid;
 
-      const portalContainerKey = `${instanceGuid}-${key}`;
-      const portalKey = `${key}-${instanceGuid}`;
-
       if (TD && !TD.getAttribute('ghost-table')) {
+        // The table has to be part of the key. A cell that sits in a fixed
+        // column is drawn both in the master table and in the inline-start
+        // overlay; keyed by coordinates alone, both draws share one container,
+        // which then moves into whichever table rendered last and leaves the
+        // other cell empty. The two tables then size their rows from different
+        // content and stop lining up (see issue #9063).
+        const tableId = getTableId(TD);
+        const portalContainerKey = `${instanceGuid}-${tableId}-${key}`;
+        const portalKey = `${key}-${tableId}-${instanceGuid}`;
         const cachedPortalContainer = portalContainerCache.current.get(portalContainerKey);
         // When the cached portal container is still attached to the same
         // TD as the previous render, the DOM is already correct and must
@@ -158,7 +195,7 @@ const HotTableContextProvider: FC<PropsWithChildren> = ({ children }) => {
       renderedCellCache.current.set(key, TD);
       return TD;
     };
-  }, []);
+  }, [getTableId]);
 
   const renderersPortalManager = useRef<RenderersPortalManagerRef>(() => undefined);
 

--- a/wrappers/react-wrapper/src/hotTableContext.tsx
+++ b/wrappers/react-wrapper/src/hotTableContext.tsx
@@ -124,10 +124,13 @@ const HotTableContextProvider: FC<PropsWithChildren> = ({ children }) => {
    * @returns {Number} The id of the table the cell belongs to.
    */
   const getTableId = useCallback((TD: HTMLTableCellElement): number => {
-    // Overlay tables are built once and never hand their cells to another
-    // table, so the TABLE element is a stable identity for the draw.
-    const table: Element = TD.closest('table') ?? TD;
-    const cachedId = tableIds.current.get(table);
+    // TD -> TR -> TBODY. The section belongs to exactly one table, and the
+    // overlay tables are built once and never hand their cells to another
+    // table, so it is a stable identity for the draw. Two property hops rather
+    // than a selector walk, because this runs for every component-rendered
+    // cell on every render.
+    const tableSection: Element = TD.parentElement?.parentElement ?? TD;
+    const cachedId = tableIds.current.get(tableSection);
 
     if (cachedId !== undefined) {
       return cachedId;
@@ -136,7 +139,7 @@ const HotTableContextProvider: FC<PropsWithChildren> = ({ children }) => {
     const id = nextTableId.current;
 
     nextTableId.current += 1;
-    tableIds.current.set(table, id);
+    tableIds.current.set(tableSection, id);
 
     return id;
   }, []);

--- a/wrappers/react-wrapper/test/fixedColumnsPortals.spec.tsx
+++ b/wrappers/react-wrapper/test/fixedColumnsPortals.spec.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { HotTable } from '../src/hotTable';
+import {
+  createSpreadsheetData,
+  mockElementDimensions,
+  mountComponentWithRef,
+  sleep,
+} from './_helpers';
+import { HotRendererProps, HotTableRef } from '../src/types';
+
+// Regression tests for issue #9063: Handsontable draws a cell of a fixed column
+// twice — once in the master table and once in the inline-start overlay — and
+// each draw gets its own TD. The wrapper cached one portal container per
+// (row, col), so both draws shared a container, it moved into whichever table
+// rendered last, and the other table's cell was left empty. The two tables then
+// sized their rows from different content and stopped lining up.
+describe('Component-based renderers in fixed columns', () => {
+  const CELL_TEXT = 'rendered-by-component';
+
+  function Cell(props: HotRendererProps) {
+    return <span className="cell-marker">{`${CELL_TEXT}:${props.row}-${props.col}`}</span>;
+  }
+
+  /**
+   * Read the cell of the first column out of one of the rendered tables.
+   *
+   * @param {String} tableSelector Selector of the table holder to read from.
+   * @param {Number} row Row index of the cell to read.
+   * @returns {HTMLTableCellElement} The cell element.
+   */
+  function firstColumnCell(tableSelector: string, row: number): HTMLTableCellElement {
+    const rows = document.querySelectorAll(`${tableSelector} tbody tr`);
+
+    return rows[row].querySelectorAll('td')[0] as HTMLTableCellElement;
+  }
+
+  it('should render the component into both the master table and the inline-start overlay', async () => {
+    mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(5, 4)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                fixedColumnsStart={1}
+                autoRowSize={false}
+                autoColumnSize={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}
+                renderer={(props) => <Cell {...props} />}
+      />
+    ), false);
+
+    await sleep(100);
+
+    const masterCell = firstColumnCell('.ht_master', 0);
+    const overlayCell = firstColumnCell('.ht_clone_inline_start', 0);
+
+    // Both tables must hold their own copy of the rendered content. Before the
+    // fix one of them was empty, which is what made the rows drift apart.
+    expect(masterCell.textContent).toBe(`${CELL_TEXT}:0-0`);
+    expect(overlayCell.textContent).toBe(`${CELL_TEXT}:0-0`);
+
+    // Separate containers, not one container shared between the two tables.
+    expect(masterCell.firstElementChild).not.toBe(overlayCell.firstElementChild);
+  });
+
+  it('should keep both copies of a fixed cell after a re-render', async () => {
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(5, 4)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                fixedColumnsStart={1}
+                autoRowSize={false}
+                autoColumnSize={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}
+                renderer={(props) => <Cell {...props} />}
+      />
+    ), false).hotInstance!;
+
+    await sleep(100);
+
+    hotInstance.render();
+
+    await sleep(100);
+
+    // A re-render must not hand one table's container to the other one.
+    expect(firstColumnCell('.ht_master', 1).textContent).toBe(`${CELL_TEXT}:1-0`);
+    expect(firstColumnCell('.ht_clone_inline_start', 1).textContent).toBe(`${CELL_TEXT}:1-0`);
+  });
+});

--- a/wrappers/react-wrapper/test/fixedColumnsPortals.spec.tsx
+++ b/wrappers/react-wrapper/test/fixedColumnsPortals.spec.tsx
@@ -67,6 +67,33 @@ describe('Component-based renderers in fixed columns', () => {
     expect(masterCell.firstElementChild).not.toBe(overlayCell.firstElementChild);
   });
 
+  it('should render the component into both the master table and the top overlay', async () => {
+    mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(5, 4)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                fixedRowsTop={1}
+                autoRowSize={false}
+                autoColumnSize={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}
+                renderer={(props) => <Cell {...props} />}
+      />
+    ), false);
+
+    await sleep(100);
+
+    // A frozen row splits the same cell across two tables just like a frozen
+    // column does, so it needs its own container too.
+    expect(firstColumnCell('.ht_master', 0).textContent).toBe(`${CELL_TEXT}:0-0`);
+    expect(firstColumnCell('.ht_clone_top', 0).textContent).toBe(`${CELL_TEXT}:0-0`);
+  });
+
   it('should keep both copies of a fixed cell after a re-render', async () => {
     const hotInstance = mountComponentWithRef<HotTableRef>((
       <HotTable licenseKey="non-commercial-and-evaluation"


### PR DESCRIPTION
### Context

The PR fixes [#9063](https://github.com/handsontable/handsontable/issues/9063): with a component-based renderer whose cell height depends on its content, the rows of a frozen column stop lining up with the rest of the grid.

Handsontable draws a cell of a frozen column twice — once in the master table and once in the inline-start overlay — and each draw gets its own `TD`. The React wrapper cached one portal container per cell, keyed by `<instance guid>-<row>-<col>` in `hotTableContext.tsx` (`getRendererWrapper`). Nothing in that key said which of the two tables the cell belonged to, so both draws shared one container `DIV`, and whichever table rendered last physically took it. The other table's cell was left **empty**, so the two tables sized their rows from different content and drifted apart.

Measured on `develop` before the fix (12 rows, a renderer drawing 1–3 lines per row, `fixedColumnsStart: 2`, `autoRowSize: false`): master rows all 29 px, overlay rows 32/53/75 px, worst row-top drift **242 px**, unchanged after scrolling. The master's cell for row 2 had `innerHTML === ""` while the overlay's held the three rendered lines. A control run with an equivalent plain function renderer gave pixel-identical heights in both tables and **0 px** drift, which ruled out the core and the theme.

The fix puts the table into the portal-container cache key and into the React portal key, so every table gets its own container. The in-place container reuse added for #10800 (renderer components must not remount on every grid render) and the viewport-bounded eviction in `pushCellPortalsIntoPortalManager` are unchanged.

**Behavior note:** for a cell in a frozen column, the renderer component now mounts once per table rather than once in total. That matches what function renderers already do — the renderer is called once per draw — but a component with side effects in its body or in an effect will now run them for each table the cell appears in.

**What this PR does not fix.** When the tall component column is *not* in the frozen area, the overlay still misaligns (measured: same 242 px). That is a different mechanism and it is the long-standing async-measurement problem described in [this comment](https://github.com/handsontable/handsontable/issues/9063#issuecomment-1352739965) and tracked as [#7544](https://github.com/handsontable/handsontable/issues/7544): portals are flushed in `afterViewRender` through a React state setter, so Handsontable's row measurement runs while the React cells are still empty. The same control run shows the core side is fine — a function renderer in a scrollable column aligns the row headers exactly — so the remaining work is to re-measure after the portals mount. That needs `flushSync` plus a guarded extra render pass on every draw that mounts new rows, which is a render-path performance decision for every React user, so it is deliberately left out of this bug fix.

The Vue 3 wrapper has its own renderer mechanism and was not tested; it needs a separate check.

### How has this been tested?

New jsdom regression spec, `wrappers/react-wrapper/test/fixedColumnsPortals.spec.tsx`, asserting that the master table and the inline-start overlay each hold their own copy of the rendered content for the same frozen cell, and that a re-render does not hand one table's container to the other. Both cases were confirmed to **fail** before the fix (`Expected: "rendered-by-component:0-0"`, `Received: ""` — the empty cell), and pass after it.

```bash
npm run build --prefix handsontable
npm run test --prefix wrappers/react-wrapper                                  # 16 suites, 77 tests pass
npm run test --prefix wrappers/react-wrapper -- --testPathPattern=fixedColumnsPortals
npm run eslint --prefix handsontable
```

The two existing portal-cache eviction specs pass unchanged — worth noting because this key change adds a second cache entry per frozen cell, and those specs pin the cache to a viewport-sized bound.

Real-browser alignment was verified manually, since there is no React wrapper harness in the Playwright suite yet (all `tests/e2e` page objects load the core UMD bundles). With the built wrapper in Chromium, per-row heights and row-top drift were read from the DOM: `fixedColumnsStart: 2` with the renderer in a frozen column went from 242 px drift to **0 px**, and stayed at 0 px after scrolling down and back up.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2597
2. #9063
3. Related, not fixed here: #7544

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2597

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the React wrapper’s cell-portal cache, which can remount renderers extra times in frozen areas. Logic is localized and covered by regression tests; no auth or data-handling changes.
> 
> **Overview**
> Fixes frozen-row/column misalignment when using React component renderers: Handsontable draws the same cell in the master table and overlay tables, but portal containers were keyed only by instance + coordinates, so one table stole the container and left the other cell empty.
> 
> Portal cache keys now include a stable per-table id (from the cell’s `TBODY`), so each overlay gets its own container. In-place reuse and viewport eviction are unchanged. Frozen cells now mount the renderer once per table (matching function renderers).
> 
> Adds a regression spec covering fixed columns, fixed rows, and re-render. Does not address overlay misalignment for tall components outside the frozen area (#7544).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fbb949443f37cc8f8dac67cbba6b9f3ecfd4c1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->