### PR TITLE
DEV-2601: Stop a killed test run from flooding the agent context

### DIFF
--- a/.ai/LOCAL-ENFORCEMENT.md
+++ b/.ai/LOCAL-ENFORCEMENT.md
@@ -26,6 +26,15 @@ Same rules, escalating authority: **agent-time → pre-commit → pre-push → C
 **Changed unit tests** run too — fast (Jest maps to `src`, no build), in both the
 Stop hook and pre-push. A Jest *infra* failure (couldn't start) warns instead of
 blocking (CI is authoritative), the same way the presence gate skips a config gap.
+**A run that was killed is the same case.** A child aborted by Node on buffer
+overflow (`ENOBUFS`) or by a signal produced no verdict — `spawnSync` returns
+`status: null` with a truncated buffer, which is indistinguishable from a real
+failure unless the caller inspects `error`/`signal`. `isSpawnInfraFailure()`
+(`scripts/pre-push.mjs`) classifies it, and it warns instead of blocking. Every
+hook-spawned test run also passes `TEST_RUN_MAX_BUFFER` (64 MB) so the run reaches
+its summary rather than dying on Node's 1 MB default. The trade-off is deliberate:
+a genuinely failing run whose output overflows stops blocking locally, and CI
+catches it.
 **Coverage is a CI floor, not a hook** (it needs a full instrumented run, too slow
 for a hook): the `[CHECK] Coverage floor` job measures the percent of *added*
 executable lines the unit tests cover (`.github/scripts/diff-coverage-gate.mjs`,
@@ -83,6 +92,8 @@ presence gate or the test requirement. Do not use it to dodge writing tests.
 - **Pure + tested.** Put the decision logic in a **pure function** in a lib and **unit-test it** (`scripts/__tests__/`, `.github/scripts/__tests__/`, run with `node --test`). **A hook change ships a test change** — this rule applies to the enforcement machinery too.
 - **Must not false-block.** Skip config/parse gaps (ESLint exit 2), record only **repo-relative, in-repo** paths (never scratchpad/out-of-repo), tolerate a missing base ref. A hook that fires on a false positive gets disabled — that is worse than no hook.
 - **Must stay fast.** No build in the pre-push or agent hooks; run only the **changed scope**. Heavy/full-suite work is CI's job.
+- **Bound what you feed the agent.** An agent hook's failure message is a conversation message, so its cost is re-paid on every later request in the session — never paste a raw run or lint report into it. Pass it through `condenseTestOutput()` (`scripts/pre-push.mjs`): noise stripped, repeats collapsed, the excerpt anchored at the failing test so the diagnosis survives, capped at 120 lines / 8 KB. The caps are structural, not filter-dependent — filter-proof input still condenses. A hook writing to a **terminal** (pre-push) keeps printing in full up to `TERMINAL_OUTPUT_LIMIT`.
+- **Know who reads your stderr.** Claude Code forwards a hook's stderr to the agent only on **exit 2**. A non-blocking leg's note lands in the debug log unless a later leg in the same run blocks, so treat those notes as best-effort and never make the flow depend on the agent reading one.
 - **Floor for everyone.** The git hooks must work without Claude Code; the agent hooks are additive, never the only line of defense.
 
 ## 3. Creating or updating skills — exact rules

--- a/scripts/__tests__/pre-push.test.mjs
+++ b/scripts/__tests__/pre-push.test.mjs
@@ -229,3 +229,100 @@ test('collapses repeated identical lines into a count', () => {
   assert.ok(condensed.includes('jsdom warning    (×50)'));
   assert.ok(condensed.includes('done'));
 });
+
+test('keeps the diagnosis when console noise sits between the FAIL header and the failure block', () => {
+  // The scenario this helper was built for, in Jest's real output order: the
+  // suite header, then the buffered console dump, then the failure details. The
+  // stylesheet ThemeManager emits is many distinct `--ht-*` lines, so it neither
+  // reads as noise nor collapses as a repeat — anchoring on the header hands back
+  // the flood and cuts the `●` block, which tells the agent "failing" with no why.
+  const cssDump = Array.from({ length: 50 }, () => [
+    '  console.error',
+    ...Array.from({ length: 40 }, (_, v) => `      --ht-token-${v}: ${v * 7}px;`),
+  ].join('\n')).join('\n');
+  const condensed = condenseTestOutput([
+    'FAIL handsontable/src/plugins/sheetsBar/__tests__/sheetsBar.unit.js',
+    '  ● Console',
+    cssDump,
+    '  ✕ renames a sheet on double-click (12 ms)',
+    '  ● SheetsBar › renames a sheet on double-click',
+    '    expect(received).toBe(expected)',
+    '    Expected: "Sheet2"',
+    '    Received: "Sheet1"',
+    'Tests:       1 failed, 49 passed, 50 total',
+  ].join('\n'));
+
+  assert.ok(condensed.includes('✕ renames a sheet on double-click'), 'the failing test name must survive');
+  assert.ok(condensed.includes('Expected: "Sheet2"'), 'the expected value must survive');
+  assert.ok(condensed.includes('Received: "Sheet1"'), 'the received value must survive');
+  assert.ok(!condensed.includes('--ht-token-'), 'the console flood must not fill the excerpt');
+  assert.ok(condensed.includes('Tests:       1 failed'), 'the summary must survive');
+});
+
+test('anchors on the FAIL header only when no marker names a failing test', () => {
+  // A suite killed before it reported a single test still has a usable anchor.
+  const condensed = condenseTestOutput([
+    ...Array.from({ length: 200 }, (_, i) => `  ✓ passing case ${i}`),
+    'FAIL handsontable/src/plugins/sheetsBar/__tests__/sheetsBar.unit.js',
+    '  Killed: 9',
+  ].join('\n'), { maxLines: 5 });
+
+  assert.ok(condensed.includes('FAIL handsontable'), 'the header must anchor the excerpt');
+  assert.ok(condensed.includes('Killed: 9'), 'what followed it must survive');
+  assert.ok(!condensed.includes('passing case 0'), 'the passing prologue must be dropped');
+});
+
+test('a Jest config notice never wins the anchor over the real failure', () => {
+  const condensed = condenseTestOutput([
+    '● Validation Warning:',
+    '  Unknown option "foo" with value "bar" was found.',
+    ...Array.from({ length: 200 }, (_, i) => `  ✓ passing case ${i}`),
+    '  ● SheetsBar › renames a sheet',
+    '    expect(received).toBe(expected)',
+  ].join('\n'), { maxLines: 6 });
+
+  assert.ok(condensed.includes('● SheetsBar › renames a sheet'), 'the real failure must anchor the excerpt');
+  assert.ok(!condensed.includes('Unknown option'), 'the config notice must not anchor it');
+});
+
+test('a "test suite failed to run" bullet still anchors the excerpt', () => {
+  const condensed = condenseTestOutput([
+    ...Array.from({ length: 200 }, (_, i) => `  ✓ passing case ${i}`),
+    '  ● Test suite failed to run',
+    '    Cannot find module \'./missing\' from \'sheetsBar.unit.js\'',
+  ].join('\n'), { maxLines: 4 });
+
+  assert.ok(condensed.includes('● Test suite failed to run'), 'an infra bullet is a failure marker too');
+  assert.ok(condensed.includes('Cannot find module'), 'its cause must survive');
+});
+
+test('strips SGR escapes so color in the run output cannot defeat the anchor', () => {
+  // The run inherits the hook environment; a leaked FORCE_COLOR would otherwise
+  // wrap every marker in escape codes and silently break every pattern here.
+  const esc = String.fromCharCode(27);
+  const red = text => `${esc}[31m${text}${esc}[39m`;
+  const condensed = condenseTestOutput([
+    ...Array.from({ length: 200 }, (_, i) => `  ${esc}[32m✓${esc}[39m passing case ${i}`),
+    `  ${red('✕')} renames a sheet (12 ms)`,
+    `  ${red('●')} SheetsBar › renames a sheet`,
+    '    expect(received).toBe(expected)',
+    `${red('Tests:')}       1 failed, 200 passed, 201 total`,
+  ].join('\n'), { maxLines: 6 });
+
+  assert.ok(!condensed.includes(esc), 'escape codes must not reach the excerpt');
+  assert.ok(condensed.includes('✕ renames a sheet'), 'the failure must still anchor the excerpt');
+  assert.ok(condensed.includes('Tests:       1 failed'), 'the summary must still be recognized');
+});
+
+test('counts every dropped line, including the noise filtered before collapsing', () => {
+  // Measuring from the post-`isNoise` list under-reports the flood by exactly the
+  // part that caused it, so the header contradicted the output it described.
+  const condensed = condenseTestOutput([
+    '  ✕ a failing test',
+    ...Array.from({ length: 100 }, (_, i) => `    at frame${i} (/repo/a.js:${i}:1)`),
+    'Tests:       1 failed, 0 passed, 1 total',
+  ].join('\n'));
+  const dropped = Number(/(\d+) noise\/duplicate lines dropped/.exec(condensed)?.[1]);
+
+  assert.equal(dropped, 100, 'the 100 stack frames must be counted as dropped');
+});

--- a/scripts/__tests__/pre-push.test.mjs
+++ b/scripts/__tests__/pre-push.test.mjs
@@ -5,6 +5,9 @@ import {
   changedUnitTests,
   unitTestPattern,
   isJestInfraFailure,
+  isSpawnInfraFailure,
+  condenseTestOutput,
+  TEST_RUN_MAX_BUFFER,
 } from '../pre-push.mjs';
 
 test('selects changed Playwright specs and maps them relative to tests/', () => {
@@ -62,4 +65,167 @@ test('treats a jest config/module-resolution failure as infra (non-blocking), no
   assert.equal(isJestInfraFailure('No tests found, exiting with code 1'), true);
   // A real run that reports failures is NOT infra — it must block.
   assert.equal(isJestInfraFailure('Tests:       1 failed, 4 passed, 5 total'), false);
+});
+
+test('a child killed before it could report (ENOBUFS, signal) is infra, not a test failure', () => {
+  const overflow = Object.assign(new Error('stdout maxBuffer exceeded'), { code: 'ENOBUFS' });
+
+  assert.equal(isSpawnInfraFailure({ error: overflow, status: null }), true);
+  assert.equal(isSpawnInfraFailure({ status: null, signal: 'SIGTERM' }), true);
+  assert.equal(isSpawnInfraFailure({ status: 1, signal: null }), false);
+  assert.equal(isSpawnInfraFailure({ status: 0, signal: null }), false);
+});
+
+test('the run buffer is far above the 1 MB Node default that killed jsdom-noisy runs', () => {
+  assert.ok(TEST_RUN_MAX_BUFFER >= 32 * 1024 * 1024);
+});
+
+test('condenses a jsdom-flooded run to a bounded excerpt', () => {
+  const noise = Array.from({ length: 400 }, () => [
+    '  console.error',
+    '    Error: Could not parse CSS stylesheet',
+    '        at exports.createStylesheet (/repo/node_modules/jsdom/lib/stylesheets.js:34:21)',
+    `    .ht-cell::before { -webkit-mask-image: url("data:image/svg+xml,${'%3Csvg'.repeat(60)}"); }`,
+  ].join('\n')).join('\n');
+  const output = `${noise}\nTests:       50 passed, 50 total\n`;
+  const condensed = condenseTestOutput(output);
+
+  assert.ok(condensed.length < 8200, `expected a bounded excerpt, got ${condensed.length} chars`);
+  assert.ok(!condensed.includes('data:image/svg+xml'), 'inlined CSS must be dropped');
+  assert.ok(!condensed.includes('    at exports.createStylesheet'), 'stack frames must be dropped');
+  assert.ok(condensed.includes('Tests:       50 passed, 50 total'), 'the summary must survive');
+  assert.ok(condensed.startsWith('[output condensed'), 'truncation must be announced');
+});
+
+test('anchors the excerpt at the first failure so the diagnosis survives a long run', () => {
+  const output = [
+    ...Array.from({ length: 300 }, (_, i) => `  ✓ passing case ${i}`),
+    '  ✕ renames a sheet on double-click (12 ms)',
+    '  ● SheetsBar › renames a sheet on double-click',
+    '    expect(received).toBe(expected)',
+    'Tests:       1 failed, 300 passed, 301 total',
+  ].join('\n');
+  const condensed = condenseTestOutput(output, { maxLines: 10 });
+
+  assert.ok(condensed.includes('✕ renames a sheet on double-click'), 'the failing test name must survive');
+  assert.ok(condensed.includes('expect(received).toBe(expected)'), 'the assertion must survive');
+  assert.ok(!condensed.includes('passing case 5'), 'the passing tail must be dropped');
+});
+
+test('keeps the first failure even when the failure block is longer than the caps', () => {
+  // The anchor exists to preserve the diagnosis, so it must survive precisely when
+  // the failure block is big enough to need trimming — trimming from the end would
+  // drop the anchor and hand back the middle of the failure list instead.
+  const output = [
+    ...Array.from({ length: 40 }, (_, i) => `  ✓ passing case ${i}`),
+    '  ✕ the first failing test (12 ms)',
+    '  ● SheetsBar › the first failing test',
+    '    expect(received).toBe(expected)',
+    ...Array.from({ length: 200 }, (_, i) => `  ✕ later failing test ${i} (3 ms)`),
+    'Tests:       201 failed, 40 passed, 241 total',
+  ].join('\n');
+  const condensed = condenseTestOutput(output);
+
+  assert.ok(condensed.includes('✕ the first failing test'), 'the first failure must survive');
+  assert.ok(condensed.includes('expect(received).toBe(expected)'), 'its assertion must survive');
+  assert.ok(condensed.includes('Tests:       201 failed'), 'the summary must survive');
+  assert.ok(!condensed.includes('passing case 3'), 'the passing prologue must be dropped');
+  assert.ok(condensed.split('\n').length <= 121, 'the excerpt must stay bounded');
+});
+
+test('keeps the tail when there is no failure to anchor on', () => {
+  // A crash or an infra error prints nothing matching a failure marker; there the
+  // end of the run is the informative part.
+  const condensed = condenseTestOutput([
+    ...Array.from({ length: 300 }, (_, i) => `  ✓ passing case ${i}`),
+    'Cannot find module jest-jasmine2',
+  ].join('\n'), { maxLines: 5 });
+
+  assert.ok(condensed.includes('Cannot find module jest-jasmine2'));
+  assert.ok(!condensed.includes('passing case 0'));
+});
+
+test('keeps the assertion values, truncating long lines instead of dropping them', () => {
+  // Jest prints each of `Expected:`/`Received:` on one line, and those lines run
+  // long precisely when the values are interesting. Dropping them by length hands
+  // back "a test failed" with no way to tell why.
+  const long = 'x'.repeat(230);
+  const condensed = condenseTestOutput([
+    '  ✕ renames a sheet (12 ms)',
+    '  ● SheetsBar › renames a sheet',
+    '    expect(received).toBe(expected)',
+    `    Expected: "${long}"`,
+    `    Received: "${long.replace(/x/g, 'y')}"`,
+    'Tests:       1 failed, 49 passed, 50 total',
+  ].join('\n'));
+
+  assert.ok(condensed.includes('Expected: "xxx'), 'the expected value must survive');
+  assert.ok(condensed.includes('Received: "yyy'), 'the received value must survive');
+  condensed.split('\n').forEach((line) => {
+    assert.ok(line.length <= 202, `every line stays bounded, got ${line.length}`);
+  });
+});
+
+test('drops data-URI CSS dumps regardless of length', () => {
+  const condensed = condenseTestOutput([
+    '  ✕ a failing test',
+    `    .ht-cell::before { -webkit-mask-image: url("data:image/svg+xml,${'%3Csvg'.repeat(60)}"); }`,
+    'Tests:       1 failed, 0 passed, 1 total',
+  ].join('\n'));
+
+  assert.ok(!condensed.includes('data:image'), 'the CSS dump is noise and must go');
+  assert.ok(condensed.includes('✕ a failing test'), 'the failure must stay');
+});
+
+test('still truncates when the summary alone fills the character budget', () => {
+  // charBudget hits 0 here. A negative-offset tail slice would read as slice(-0),
+  // i.e. slice(0), and hand back the whole run instead of nothing.
+  const condensed = condenseTestOutput(
+    `${Array.from({ length: 50 }, (_, i) => `  ✓ passing case ${i}`).join('\n')
+    }\nTests:       50 passed, 50 total`,
+    { maxChars: 20 },
+  );
+
+  assert.ok(!condensed.includes('passing case 0'), 'the body must be cut, not returned whole');
+  assert.ok(condensed.includes('Tests:       50 passed'), 'the summary is always kept');
+});
+
+test('anchors a Playwright failure too, not just a Jest one', () => {
+  // The Stop hook runs both suites through this helper; Playwright's reporter
+  // numbers its failures instead of using Jest's markers.
+  const condensed = condenseTestOutput([
+    ...Array.from({ length: 50 }, (_, i) => `  ✓ spec ${i}`),
+    '  1) grid.spec.ts:12:3 › renames a sheet',
+    '    Error: expect(locator).toBeVisible() failed',
+    ...Array.from({ length: 200 }, (_, i) => `  noise ${i}`),
+  ].join('\n'));
+
+  assert.ok(condensed.includes('renames a sheet'), 'the failing spec must survive');
+  assert.ok(condensed.includes('toBeVisible'), 'its error must survive');
+});
+
+test('returns nothing when nothing survives condensing', () => {
+  // A header describing an empty excerpt is worse than silence.
+  assert.equal(condenseTestOutput('\n\n\n').trim(), '');
+  assert.equal(condenseTestOutput('    at foo (/a/b.js:1:1)\n    at bar (/a/b.js:2:2)').trim(), '');
+});
+
+test('never stamps a repeat count on a blank line', () => {
+  const condensed = condenseTestOutput('a\n\n\n\nb');
+
+  assert.ok(!/\(×\d+\)\s*$/m.test(condensed), 'a count on emptiness reads as missing content');
+  assert.ok(condensed.split('\n').filter(line => line.trim() === '').length <= 1, 'blanks still collapse');
+});
+
+test('leaves a short, clean output untouched', () => {
+  const output = 'Test Suites: 1 passed, 1 total\nTests:       3 passed, 3 total\n';
+
+  assert.equal(condenseTestOutput(output), 'Test Suites: 1 passed, 1 total\nTests:       3 passed, 3 total');
+});
+
+test('collapses repeated identical lines into a count', () => {
+  const condensed = condenseTestOutput(`${Array.from({ length: 50 }, () => 'jsdom warning').join('\n')}\ndone`);
+
+  assert.ok(condensed.includes('jsdom warning    (×50)'));
+  assert.ok(condensed.includes('done'));
 });

--- a/scripts/claude/post-tool-use.mjs
+++ b/scripts/claude/post-tool-use.mjs
@@ -13,6 +13,7 @@ import { spawnSync } from 'node:child_process';
 import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { repoRoot, sessionEditsFile, toRepoRelative } from './session.mjs';
+import { TEST_RUN_MAX_BUFFER, condenseTestOutput } from '../pre-push.mjs';
 
 // npx is a .cmd shim on Windows; spawnSync needs a shell there or it ENOENTs.
 const WIN = process.platform === 'win32';
@@ -64,8 +65,13 @@ try {
 // Lint edited specs only — running the full typed ESLint on every core .ts edit
 // is too slow for the edit loop.
 if (/\.(spec|unit)\.[jt]sx?$/.test(rel)) {
+  // Same buffer-and-flood hazard as the test runs in stop.mjs: on Node's 1 MB
+  // default a lint report large enough to overflow kills the child mid-run, and
+  // pasting the report back whole floods the agent's context on every edit. A
+  // buffer overflow cannot false-block here (`status` would be null, not 1), but
+  // the flood can happen at any size.
   const res = spawnSync('npx', ['eslint', '--fix', file], {
-    stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8', shell: WIN,
+    stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8', shell: WIN, maxBuffer: TEST_RUN_MAX_BUFFER,
   });
   const output = `${res.stdout || ''}${res.stderr || ''}`;
   // Only block on genuine rule violations. A parsing error or eslint's own error
@@ -77,7 +83,7 @@ if (/\.(spec|unit)\.[jt]sx?$/.test(rel)) {
   const configGap = res.status === 2 || /Parsing error/i.test(output);
 
   if (res.status === 1 && !configGap) {
-    process.stderr.write(`Lint errors in ${file}:\n${output}`);
+    process.stderr.write(`Lint errors in ${file}:\n${condenseTestOutput(output)}\n`);
     process.exit(2);
   }
 }

--- a/scripts/claude/stop.mjs
+++ b/scripts/claude/stop.mjs
@@ -15,7 +15,15 @@ import { readFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
 import { isNewJasmineSpec } from '../../.github/scripts/lib/presence-gate.mjs';
 import { repoRoot, sessionEditsFile, stopVerdict, toRepoRelative } from './session.mjs';
-import { changedPlaywrightSpecs, changedUnitTests, unitTestPattern, isJestInfraFailure } from '../pre-push.mjs';
+import {
+  changedPlaywrightSpecs,
+  changedUnitTests,
+  unitTestPattern,
+  isJestInfraFailure,
+  isSpawnInfraFailure,
+  condenseTestOutput,
+  TEST_RUN_MAX_BUFFER,
+} from '../pre-push.mjs';
 import { filterCached, recordGreen } from '../e2e-run-cache.mjs';
 
 // npx/npm are .cmd shims on Windows; spawnSync needs a shell there or it ENOENTs.
@@ -128,16 +136,29 @@ if (toRun.length > 0) {
   // theme matrix (main/horizon/classic). See the run-scope note in the
   // handsontable-playwright-e2e skill.
   const pw = spawnSync('npx', ['playwright', 'test', '--project=e2e-main', ...toRun], {
-    cwd: path.join(root, 'tests'), stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8', shell: WIN,
+    cwd: path.join(root, 'tests'),
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
+    shell: WIN,
+    maxBuffer: TEST_RUN_MAX_BUFFER,
   });
 
-  if (pw.status !== 0) {
+  if (pw.status !== 0 && isSpawnInfraFailure(pw)) {
+    // No verdict, so nothing to block on — but the unit checks below are
+    // independent and must still run. Do NOT exit here.
     process.stderr.write(
-      `Playwright specs you touched are failing — fix them before finishing:\n${pw.stdout || ''}${pw.stderr || ''}`,
+      `Note: the Playwright run for ${toRun.join(', ')} could not complete (${
+        pw.error?.code || pw.signal}). Not treated as a test failure — verify it yourself.\n`,
+    );
+  } else if (pw.status !== 0) {
+    process.stderr.write(
+      `Playwright specs you touched are failing — fix them before finishing:\n${
+        condenseTestOutput(`${pw.stdout || ''}${pw.stderr || ''}`)}\n`,
     );
     process.exit(2);
+  } else {
+    recordGreen(root, toRun);
   }
-  recordGreen(root, toRun);
 }
 
 // Run any changed Jest unit test the session touched — fast (jest maps to src,
@@ -150,15 +171,32 @@ for (const file of unitFiles) {
   const jest = spawnSync(
     'npm',
     ['run', 'test:unit', '--', `--testPathPattern=${unitTestPattern(file)}`],
-    { cwd: path.join(root, 'handsontable'), encoding: 'utf8', shell: WIN },
+    {
+      cwd: path.join(root, 'handsontable'),
+      encoding: 'utf8',
+      shell: WIN,
+      maxBuffer: TEST_RUN_MAX_BUFFER,
+    },
   );
 
   if (jest.status !== 0) {
-    if (isJestInfraFailure(`${jest.stdout || ''}${jest.stderr || ''}`)) {
+    const output = `${jest.stdout || ''}${jest.stderr || ''}`;
+
+    if (isSpawnInfraFailure(jest)) {
+      // This one file produced no verdict; the others are independent runs, so
+      // keep checking them rather than abandoning the loop.
+      process.stderr.write(
+        `Note: the unit run for ${file} could not complete (${
+          jest.error?.code || jest.signal}). Not treated as a test failure — verify it yourself.\n`,
+      );
+      continue;
+    }
+
+    if (isJestInfraFailure(output)) {
       break;
     }
     process.stderr.write(
-      `Unit tests you touched are failing — fix them before finishing:\n${jest.stdout || ''}${jest.stderr || ''}`,
+      `Unit tests you touched are failing — fix them before finishing:\n${condenseTestOutput(output)}\n`,
     );
     process.exit(2);
   }

--- a/scripts/claude/stop.mjs
+++ b/scripts/claude/stop.mjs
@@ -146,6 +146,12 @@ if (toRun.length > 0) {
   if (pw.status !== 0 && isSpawnInfraFailure(pw)) {
     // No verdict, so nothing to block on — but the unit checks below are
     // independent and must still run. Do NOT exit here.
+    //
+    // Audience caveat: Claude Code forwards a hook's stderr to the agent only on
+    // exit 2. This leg does not exit, so the note reaches the agent only if a
+    // later leg blocks in the same run (stderr accumulates) — otherwise it lands
+    // in the debug log. Best-effort by design: nothing may depend on the agent
+    // reading it. The same holds for the unit-loop note below.
     process.stderr.write(
       `Note: the Playwright run for ${toRun.join(', ')} could not complete (${
         pw.error?.code || pw.signal}). Not treated as a test failure — verify it yourself.\n`,
@@ -184,7 +190,8 @@ for (const file of unitFiles) {
 
     if (isSpawnInfraFailure(jest)) {
       // This one file produced no verdict; the others are independent runs, so
-      // keep checking them rather than abandoning the loop.
+      // keep checking them rather than abandoning the loop. As above, this note
+      // only reaches the agent if a later leg exits 2 — do not rely on it.
       process.stderr.write(
         `Note: the unit run for ${file} could not complete (${
           jest.error?.code || jest.signal}). Not treated as a test failure — verify it yourself.\n`,

--- a/scripts/pre-push.mjs
+++ b/scripts/pre-push.mjs
@@ -113,6 +113,17 @@ export const TEST_RUN_MAX_BUFFER = 64 * 1024 * 1024;
 const MAX_LINE_LENGTH = 200;
 
 /**
+ * SGR (color) escape sequences, stripped before anything is matched. A test run
+ * inherits the hook's environment, so a leaked `FORCE_COLOR` would wrap every
+ * failure marker in escape codes and silently defeat the anchor and summary
+ * patterns — the excerpt would stay bounded but stop pointing at the diagnosis.
+ *
+ * @type {RegExp}
+ */
+// eslint-disable-next-line no-control-regex -- ESC is exactly what this matches.
+const ANSI_SGR = /\u001b\[[0-9;]*m/g;
+
+/**
  * Output size past which the pre-push gate condenses a run rather than printing
  * it whole. A terminal tolerates far more than a condensed excerpt, but not the
  * tens of megabytes `TEST_RUN_MAX_BUFFER` allows a run to produce.
@@ -163,7 +174,8 @@ export function condenseTestOutput(output, { maxLines = 120, maxChars = 8000 } =
   const isNoise = line => /^\s+at\s/.test(line)
     || /Could not parse CSS stylesheet/.test(line)
     || /url\(["']?data:/.test(line);
-  const lines = (output || '').replace(/\r\n/g, '\n').split('\n')
+  const raw = (output || '').replace(ANSI_SGR, '').replace(/\r\n/g, '\n').replace(/\n+$/, '').split('\n');
+  const lines = raw
     .filter(line => !isNoise(line))
     .map(line => (line.length > MAX_LINE_LENGTH ? `${line.slice(0, MAX_LINE_LENGTH)} …` : line));
 
@@ -186,16 +198,33 @@ export function condenseTestOutput(output, { maxLines = 120, maxChars = 8000 } =
     .filter((line, index, all) => line.trim() !== '' || (all[index - 1] || '').trim() !== '');
 
   const summary = rendered.filter(isSummary);
-  // Jest marks failures with FAIL/●/✕; Playwright's list reporter uses ✘ and
-  // numbers each failure (`1) spec.ts:3:1 › …`). Both run through this helper.
-  // The numbered form also requires Playwright's `›`, so an ordinary numbered
-  // line in someone's output cannot anchor the excerpt by accident.
-  const firstFailure = rendered.findIndex(line => /^\s*(FAIL\b|●|✕|✘)/.test(line)
-    || /^\s*\d+\)\s.*›/.test(line));
+  // `FAIL` is a fallback anchor, never a first-choice one. Jest prints a suite's
+  // buffered console output between the `FAIL` header and the failure details, so
+  // anchoring on the first marker of any kind returns the console flood and cuts
+  // the block the diagnosis lives in — exactly the case this helper exists for.
+  // Anchor on the earliest marker that names a failing test instead, and fall
+  // back to the bare suite header only when the run printed no such marker at all
+  // (a suite killed before it could report one).
+  //
+  // Two `●` headers are not failures and must not anchor: `● Console` opens the
+  // console dump itself, and `● Validation Warning:` / `● Deprecation Warning:`
+  // are config notices Jest prints before any test runs. `● Test suite failed to
+  // run` IS a failure and is deliberately still matched.
+  //
+  // Playwright's numbered form requires its `›`, so an ordinary numbered line in
+  // someone's output cannot anchor the excerpt by accident.
+  const isNonFailureBullet = line => /^\s*●\s*(Console\b|(Validation|Deprecation)\s+Warning:)/.test(line);
+  const namesAFailure = line => (/^\s*(●|✕|✘)/.test(line) && !isNonFailureBullet(line))
+    || /^\s*\d+\)\s.*›/.test(line);
+  const namedFailure = rendered.findIndex(namesAFailure);
+  const firstFailure = namedFailure === -1 ? rendered.findIndex(line => /^\s*FAIL\b/.test(line)) : namedFailure;
   const anchored = (firstFailure === -1 ? rendered : rendered.slice(firstFailure)).filter(l => !isSummary(l));
   const lineBudget = Math.max(1, maxLines - summary.length);
   const kept = firstFailure === -1 ? anchored.slice(-lineBudget) : anchored.slice(0, lineBudget);
-  const dropped = (rendered.length - kept.length - summary.length) + (lines.length - collapsed.length);
+  // Count against the RAW line total, not the post-`isNoise` one: noise-filtered
+  // lines are gone from `lines` before this point, so measuring from there
+  // under-reports the flood by exactly the part that caused it.
+  const dropped = raw.length - kept.length - summary.length;
   const charBudget = Math.max(0, maxChars - summary.join('\n').length);
   let excerpt = kept.join('\n').trimEnd();
   const cutByChars = excerpt.length > charBudget;

--- a/scripts/pre-push.mjs
+++ b/scripts/pre-push.mjs
@@ -93,6 +93,139 @@ export function isJestInfraFailure(output) {
   return infra && !ran;
 }
 
+/**
+ * Buffer cap for a hook-spawned test run. A suite can print far more than Node's
+ * 1 MB default, and overflowing the buffer kills the child mid-run: the result
+ * then carries a nonzero status and no summary, which reads exactly like failing
+ * tests unless the caller inspects `result.error`.
+ *
+ * @type {number}
+ */
+export const TEST_RUN_MAX_BUFFER = 64 * 1024 * 1024;
+
+/**
+ * Longest line kept verbatim in a condensed excerpt. Longer ones are truncated
+ * rather than dropped, so a long `Expected:`/`Received:` value still shows its
+ * head instead of vanishing.
+ *
+ * @type {number}
+ */
+const MAX_LINE_LENGTH = 200;
+
+/**
+ * Output size past which the pre-push gate condenses a run rather than printing
+ * it whole. A terminal tolerates far more than a condensed excerpt, but not the
+ * tens of megabytes `TEST_RUN_MAX_BUFFER` allows a run to produce.
+ *
+ * @type {number}
+ */
+const TERMINAL_OUTPUT_LIMIT = 256 * 1024;
+
+/**
+ * Did the child process itself fail to run to completion — killed by a signal,
+ * or aborted by Node (ENOBUFS on buffer overflow) — rather than finish and
+ * report failing tests? Such a result carries no verdict and must not block.
+ *
+ * @param {{error?: Error, signal?: string|null, status?: number|null}} result A `spawnSync` result.
+ * @returns {boolean} True when the process never produced a verdict.
+ */
+export function isSpawnInfraFailure(result) {
+  return Boolean(result?.error) || Boolean(result?.signal) || result?.status === null;
+}
+
+/**
+ * Condense a test run's output down to a bounded excerpt.
+ * Three problems at once: stack frames and injected-stylesheet dumps are pure
+ * noise, single lines repeat hundreds of times, and the result must stay inside a
+ * fixed size budget no matter how much the run printed.
+ *
+ * Noise is identified by what a line IS, never by how long it is: an over-long
+ * line is truncated, not dropped, because Jest puts each of the
+ * `Expected:`/`Received:` values on a single line and those run long exactly
+ * when they matter.
+ *
+ * Once a failure marker is found the excerpt keeps the lines that FOLLOW it, not
+ * the tail of the run: the diagnosis sits at the anchor, so trimming from the end
+ * would discard it exactly when the failure block is long enough to need trimming.
+ * With no failure to anchor on (a crash, an infra error) the tail is the
+ * informative part and is kept instead. The summary lines are pulled out and
+ * always appended, so the counts survive either way.
+ *
+ * @param {string} output Combined stdout + stderr of the run.
+ * @param {{maxLines?: number, maxChars?: number}} [options] Excerpt caps.
+ * @returns {string} A bounded excerpt, prefixed with a note when truncated.
+ */
+export function condenseTestOutput(output, { maxLines = 120, maxChars = 8000 } = {}) {
+  const isSummary = line => /^\s*(Tests|Test Suites|Snapshots):\s/.test(line);
+  // Only these three are pure noise. Length alone is NOT a noise signal: Jest
+  // prints the `Expected:`/`Received:` values on one line each, and dropping
+  // those by length removes exactly the values needed to read the failure.
+  const isNoise = line => /^\s+at\s/.test(line)
+    || /Could not parse CSS stylesheet/.test(line)
+    || /url\(["']?data:/.test(line);
+  const lines = (output || '').replace(/\r\n/g, '\n').split('\n')
+    .filter(line => !isNoise(line))
+    .map(line => (line.length > MAX_LINE_LENGTH ? `${line.slice(0, MAX_LINE_LENGTH)} …` : line));
+
+  const collapsed = [];
+
+  for (const line of lines) {
+    const previous = collapsed[collapsed.length - 1];
+
+    if (previous && previous.line === line) {
+      previous.count += 1;
+    } else {
+      collapsed.push({ line, count: 1 });
+    }
+  }
+
+  // Blank lines separate Jest's blocks, so they collapse to one but never carry a
+  // repeat count — `(×4)` stamped on emptiness reads as content that is not there.
+  const rendered = collapsed
+    .map(({ line, count }) => (count > 1 && line.trim() !== '' ? `${line}    (×${count})` : line))
+    .filter((line, index, all) => line.trim() !== '' || (all[index - 1] || '').trim() !== '');
+
+  const summary = rendered.filter(isSummary);
+  // Jest marks failures with FAIL/●/✕; Playwright's list reporter uses ✘ and
+  // numbers each failure (`1) spec.ts:3:1 › …`). Both run through this helper.
+  // The numbered form also requires Playwright's `›`, so an ordinary numbered
+  // line in someone's output cannot anchor the excerpt by accident.
+  const firstFailure = rendered.findIndex(line => /^\s*(FAIL\b|●|✕|✘)/.test(line)
+    || /^\s*\d+\)\s.*›/.test(line));
+  const anchored = (firstFailure === -1 ? rendered : rendered.slice(firstFailure)).filter(l => !isSummary(l));
+  const lineBudget = Math.max(1, maxLines - summary.length);
+  const kept = firstFailure === -1 ? anchored.slice(-lineBudget) : anchored.slice(0, lineBudget);
+  const dropped = (rendered.length - kept.length - summary.length) + (lines.length - collapsed.length);
+  const charBudget = Math.max(0, maxChars - summary.join('\n').length);
+  let excerpt = kept.join('\n').trimEnd();
+  const cutByChars = excerpt.length > charBudget;
+
+  if (cutByChars) {
+    // Tail slices index from the front rather than passing a negative offset:
+    // `slice(-0)` is `slice(0)`, which returns the whole string and silently
+    // bypasses the cap when the summary alone fills the budget.
+    excerpt = firstFailure === -1
+      ? `…\n${excerpt.slice(excerpt.length - charBudget)}`
+      : `${excerpt.slice(0, charBudget)}\n…`;
+  }
+
+  const body = [excerpt, ...summary].filter(part => part !== '').join('\n');
+
+  // Nothing survived (blank or noise-only output) — a lone header describing an
+  // empty excerpt is worse than saying nothing.
+  if (body.trim() === '' || (dropped === 0 && !cutByChars)) {
+    return body;
+  }
+
+  // Say when the excerpt was cut on size alone, or the header would read "0 lines
+  // dropped" over an excerpt that was in fact truncated.
+  const note = dropped > 0
+    ? `${dropped} noise/duplicate lines dropped${cutByChars ? ', excerpt truncated' : ''}`
+    : 'excerpt truncated';
+
+  return `[output condensed — ${note}]\n${body}`;
+}
+
 // Exit early when imported by a test. pathToFileURL handles the cases a naive
 // `file://${argv[1]}` template misses (Windows drive letters, URL-escaped chars).
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
@@ -182,13 +315,34 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       const jest = spawnSync(
         'npm',
         ['run', 'test:unit', '--', `--testPathPattern=${unitTestPattern(file)}`],
-        { cwd: path.join(root, 'handsontable'), encoding: 'utf8', shell: WIN, env },
+        {
+          cwd: path.join(root, 'handsontable'),
+          encoding: 'utf8',
+          shell: WIN,
+          env,
+          maxBuffer: TEST_RUN_MAX_BUFFER,
+        },
       );
 
-      process.stdout.write(jest.stdout || '');
-      process.stderr.write(jest.stderr || '');
+      const runOutput = `${jest.stdout || ''}${jest.stderr || ''}`;
+
+      if (runOutput.length > TERMINAL_OUTPUT_LIMIT) {
+        process.stdout.write(`${condenseTestOutput(runOutput, { maxLines: 400, maxChars: 40000 })}\n`);
+        process.stdout.write(`pre-push: ${Math.round(runOutput.length / 1024)} KB of output condensed — `
+          + `run \`npm run test:unit --prefix handsontable -- --testPathPattern=${unitTestPattern(file)}\` `
+          + 'to see all of it.\n');
+      } else {
+        process.stdout.write(jest.stdout || '');
+        process.stderr.write(jest.stderr || '');
+      }
 
       if (jest.status !== 0) {
+        if (isSpawnInfraFailure(jest)) {
+          // Only this file lost its verdict; the remaining runs are independent.
+          console.log(`pre-push: the unit run for ${file} could not complete (${
+            jest.error?.code || jest.signal}) — skipping; CI runs it.`);
+          continue;
+        }
         if (isJestInfraFailure(`${jest.stdout || ''}${jest.stderr || ''}`)) {
           console.log('pre-push: could not run unit tests locally (jest infra) — skipping; CI runs them.');
           break;


### PR DESCRIPTION
### Context

The PR fixes a Stop hook that reported passing tests as failing and pasted a megabyte of test output into the agent's context.

`scripts/claude/stop.mjs` re-runs the unit tests a session touched, through `spawnSync`, whose default output cap is 1 MB. A grid-instantiating Jest suite prints far more than that (jsdom logs the whole injected stylesheet on every CSS parse failure — 4.86 MB from one 50-test suite), so the buffer overflowed, Node killed Jest mid-run, and the result came back with a non-zero status and no test summary. That is indistinguishable from a real failure unless the caller inspects `error`. The hook reported "Unit tests you touched are failing" on a suite that was 50/50 green, and pasted the whole truncated buffer back to the agent: ~386k tokens, injected once per turn end until the session was interrupted. Hook feedback lands as a conversation message, so the cost is re-paid on every later request in that session rather than being a one-off spike.

Three independent fixes, any one of which breaks the chain:

- `TEST_RUN_MAX_BUFFER` (64 MB) on every hook-spawned test run, so the run completes and prints the summary the classifiers depend on.
- `isSpawnInfraFailure()` — a child killed by ENOBUFS or a signal produced no verdict and must not block, the same way a Jest that could not start already did not. Trade-off: a genuinely failing run whose output overflows no longer blocks at the hook. Acceptable — pre-push and CI still catch it, and CI is authoritative.
- `condenseTestOutput()` — hook feedback is never worth a megabyte; the diagnosis is a dozen lines. Stack frames and CSS dumps are stripped, repeats collapsed to `(xN)`, the excerpt anchored at the first failure so the diagnosis survives, and capped at 120 lines / 8 KB. Worst case a Stop block can inject drops from 1 MB to 8 KB.

`scripts/pre-push.mjs` gets the buffer and the spawn-failure guard too. It prints to a terminal, so it keeps writing full output.

**Scope note.** The 4.86 MB of jsdom noise that overflowed the buffer has its own root cause — `ThemeManager` emits the runtime theme stylesheet using CSS nesting, which jsdom cannot parse and which is above the declared browser floor. That is deliberately **not** fixed here; it is tracked separately. This PR makes the hook immune to noisy output regardless of where the noise comes from.

This PR touches `scripts/` only, so the path-aware changelog gate passes automatically and no changelog entry is included.

### How has this been tested?

- New unit coverage in `scripts/__tests__/pre-push.test.mjs` for the three helpers — spawn-infra classification, the buffer floor, and condensing (bounded excerpt, noise stripped, summary preserved, failure-anchored, repeats collapsed). Verified red before the fix.

- Review fixes are covered too (`8d1f884`): the excerpt anchor now takes the earliest marker that *names* a failing test, so a console flood between the `FAIL` header and the `●` block no longer costs the diagnosis; `dropped` counts from the raw line total; SGR escapes are stripped before matching. Each verified red before its fix. The ESLint spawn in `post-tool-use.mjs` got the same buffer and condensing treatment, and `.ai/LOCAL-ENFORCEMENT.md` documents the killed-child infra case, the condensing contract, and the stderr audience.

  ```bash
  node --test "scripts/__tests__/*.test.mjs"    # 38 passing
  ```

- Reproduced the original overflow against a real suite: the run produces 4.86 MB, exceeding the 1 MB default and returning `status != 0` with no summary. With `TEST_RUN_MAX_BUFFER` the same run returns `status 0` and prints `Tests: 50 passed, 50 total`, so the false alarm never forms.

- Repo lint and the full core suite were run on the branch while the (now separated) theme fix was present: `npm run eslint --prefix handsontable` (0 errors), `npm run stylelint --prefix handsontable`, `npm run test:unit --prefix handsontable` (3734 passing, 312 suites), `npm run test:types --prefix handsontable`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2601

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Repository tooling only — no shipped package is affected.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86cb9a3k0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes local enforcement hook behavior (spawn overflow no longer blocks; very noisy failing runs may slip past hooks), but scope is tooling only and CI remains authoritative.
> 
> **Overview**
> Fixes the Stop hook falsely reporting green unit tests as failing and dumping megabytes of output into the agent session when Jest’s console noise exceeds Node’s default **1 MB** `spawnSync` buffer.
> 
> **`scripts/pre-push.mjs`** adds **`TEST_RUN_MAX_BUFFER` (64 MB)** on hook-spawned runs, **`isSpawnInfraFailure()`** so ENOBUFS/signals/`status: null` warn/skip instead of blocking, and **`condenseTestOutput()`** to strip stack/CSS noise, collapse repeats, anchor on the first real failure (Jest or Playwright), and cap excerpts (~120 lines / 8 KB for agent hooks). Pre-push still prints full output up to **`TERMINAL_OUTPUT_LIMIT`**, then condenses for the terminal.
> 
> **`scripts/claude/stop.mjs`** and **`post-tool-use.mjs`** use the same buffer and condensing for Playwright/Jest failures and ESLint reports. **`LOCAL-ENFORCEMENT.md`** documents killed-run handling and agent output bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1f884afb06c60a667a99c63f62659989ecaec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
