### PR TITLE
DEV-2605: Fix cell meta not shifting on NestedRows row insert

### DIFF
--- a/.changelogs/7727.json
+++ b/.changelogs/7727.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a bug where inserting a row through the `nestedRows` context menu left cell meta behind: comments, cell classes, and any other stored meta stayed on their old rows instead of moving down with the data. Affected `Insert row above`, `Insert row below`, and `Insert child row`.",
+  "type": "fixed",
+  "issueOrPR": 7727,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/7727.json
+++ b/.changelogs/7727.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed a bug where inserting a row through the `nestedRows` context menu left cell meta behind: comments, cell classes, and any other stored meta stayed on their old rows instead of moving down with the data. Affected `Insert row above`, `Insert row below`, and `Insert child row`.",
+  "title": "Fixed a bug where inserting a row next to a nested child row through the `nestedRows` context menu left cell meta behind: comments, cell classes, and any other stored meta stayed on their old rows instead of moving down with the data. Affected `Insert row above`, `Insert row below`, and `Insert child row`.",
   "type": "fixed",
   "issueOrPR": 7727,
   "breaking": false,

--- a/handsontable/src/plugins/nestedRows/__tests__/alter.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/alter.spec.js
@@ -134,18 +134,32 @@ describe('NestedRows', () => {
      * Inserts a row through the context menu, the way the issue reporter did.
      *
      * @param {number} row Visual row index to open the context menu on.
-     * @param {number} itemIndex Index of the non-separator context menu item to click.
+     * @param {string} optionName Label of the context menu item to click.
      */
-    async function insertRowViaContextMenu(row, itemIndex) {
+    async function insertRowViaContextMenu(row, optionName) {
       await selectCell(row, 0);
       await contextMenu();
+      await selectContextMenuOption(optionName);
+    }
 
-      $('.htContextMenu .ht_master .htCore')
-        .find('tbody td')
-        .not('.htSeparator')
-        .eq(itemIndex)
-        .simulate('mousedown')
-        .simulate('mouseup');
+    /**
+     * Marks one cell above the insertion point and one below it, so an assertion can tell a correct
+     * shift from a shift at the wrong index. Splicing the meta too high moves the row above too.
+     *
+     * @param {number} aboveRow Visual row above the insertion point.
+     * @param {number} belowRow Visual row below the insertion point.
+     * @param {number} column Visual column to mark.
+     * @returns {object} The values held by both marked cells before the insert.
+     */
+    async function markCells(aboveRow, belowRow, column) {
+      await setCellMeta(aboveRow, column, 'className', 'above-cell');
+      await setCellMeta(belowRow, column, 'className', 'below-cell');
+      await setCellMeta(belowRow, column, 'comment', { value: 'below-comment' });
+
+      return {
+        aboveValue: getDataAtCell(aboveRow, column),
+        belowValue: getDataAtCell(belowRow, column),
+      };
     }
 
     it('nestedRows ON, context menu "Insert row below" (the exact issue repro)', async() => {
@@ -157,20 +171,19 @@ describe('NestedRows', () => {
         rowHeaders: true,
       });
 
-      await setCellMeta(3, 2, 'className', 'marked-cell');
-      await setCellMeta(3, 2, 'comment', { value: 'marked-comment' });
+      // Rows 1-5 are the children of the first parent. Insert below row 2.
+      const { aboveValue, belowValue } = await markCells(1, 3, 2);
 
-      const markedValueBefore = getDataAtCell(3, 2);
+      await insertRowViaContextMenu(2, 'Insert row below');
 
-      // Non-separator items with nestedRows: 0=add_child, 1=detach_from_parent, 2=row_above, 3=row_below.
-      await insertRowViaContextMenu(1, 3);
+      // The row above the insertion point must not move, and neither must its meta.
+      expect(getDataAtCell(1, 2)).toBe(aboveValue);
+      expect(getCellMeta(1, 2).className).toBe('above-cell');
 
-      // Sanity: the marked row really moved from visual 3 to visual 4.
-      expect(getDataAtCell(4, 2)).toBe(markedValueBefore);
-
-      // The meta must have followed the row.
-      expect(getCellMeta(4, 2).className).toBe('marked-cell');
-      expect(getCellMeta(4, 2).comment).toEqual({ value: 'marked-comment' });
+      // The row below moved down by one, so its meta must follow.
+      expect(getDataAtCell(4, 2)).toBe(belowValue);
+      expect(getCellMeta(4, 2).className).toBe('below-cell');
+      expect(getCellMeta(4, 2).comment).toEqual({ value: 'below-comment' });
       expect(getCellMeta(3, 2).className).toBeUndefined();
       expect(getCellMeta(3, 2).comment).toBeUndefined();
     });
@@ -184,18 +197,92 @@ describe('NestedRows', () => {
         rowHeaders: true,
       });
 
-      await setCellMeta(3, 2, 'className', 'marked-cell');
-      await setCellMeta(3, 2, 'comment', { value: 'marked-comment' });
+      const { aboveValue, belowValue } = await markCells(1, 3, 2);
 
-      const markedValueBefore = getDataAtCell(3, 2);
+      await insertRowViaContextMenu(3, 'Insert row above');
 
-      await insertRowViaContextMenu(3, 2);
+      expect(getDataAtCell(1, 2)).toBe(aboveValue);
+      expect(getCellMeta(1, 2).className).toBe('above-cell');
 
-      expect(getDataAtCell(4, 2)).toBe(markedValueBefore);
-      expect(getCellMeta(4, 2).className).toBe('marked-cell');
-      expect(getCellMeta(4, 2).comment).toEqual({ value: 'marked-comment' });
+      expect(getDataAtCell(4, 2)).toBe(belowValue);
+      expect(getCellMeta(4, 2).className).toBe('below-cell');
+      expect(getCellMeta(4, 2).comment).toEqual({ value: 'below-comment' });
       expect(getCellMeta(3, 2).className).toBeUndefined();
-      expect(getCellMeta(3, 2).comment).toBeUndefined();
+    });
+
+    it('nestedRows ON, context menu "Insert child row"', async() => {
+      handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        comments: true,
+        contextMenu: true,
+        rowHeaders: true,
+      });
+
+      // "Insert child row" on the first parent appends a child at row 6, so rows 1-5 stay put.
+      const { aboveValue, belowValue } = await markCells(3, 7, 2);
+
+      await insertRowViaContextMenu(0, 'Insert child row');
+
+      expect(getDataAtCell(3, 2)).toBe(aboveValue);
+      expect(getCellMeta(3, 2).className).toBe('above-cell');
+
+      expect(getDataAtCell(8, 2)).toBe(belowValue);
+      expect(getCellMeta(8, 2).className).toBe('below-cell');
+      expect(getCellMeta(8, 2).comment).toEqual({ value: 'below-comment' });
+      expect(getCellMeta(7, 2).className).toBeUndefined();
+    });
+
+    it('nestedRows ON, sibling with descendants sits between the row and the insertion point', async() => {
+      handsontable({
+        data: getMoreComplexNestedData(),
+        nestedRows: true,
+        comments: true,
+        contextMenu: true,
+        rowHeaders: true,
+      });
+
+      // Flattened: 0 a0, 1 a0-a0, 2 a0-a1, 3 a0-a2, 4 a0-a2-a0, 5 a0-a2-a0-a0, 6 a0-a3.
+      // `a0-a2` is the third child of `a0` but owns rows 3-5, so a sibling inserted below it lands
+      // at row 6 - not at `parentIndex + indexWithinParent + 1`, which would be row 4.
+      const { aboveValue, belowValue } = await markCells(4, 6, 0);
+
+      await insertRowViaContextMenu(3, 'Insert row below');
+
+      // Rows 4 and 5 are inside `a0-a2`'s own subtree, so they must not move.
+      expect(getDataAtCell(4, 0)).toBe(aboveValue);
+      expect(getCellMeta(4, 0).className).toBe('above-cell');
+
+      expect(getDataAtCell(7, 0)).toBe(belowValue);
+      expect(getCellMeta(7, 0).className).toBe('below-cell');
+      expect(getCellMeta(7, 0).comment).toEqual({ value: 'below-comment' });
+      expect(getCellMeta(6, 0).className).toBeUndefined();
+    });
+
+    it('nestedRows ON, another plugin trims a row above the insertion point', async() => {
+      handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        comments: true,
+        contextMenu: true,
+        rowHeaders: true,
+        // The nestedRows stash only untrims its own collapsed rows, so this row stays trimmed and
+        // visual indexes no longer match physical ones.
+        trimRows: [1],
+      });
+
+      // Physical rows 1-5 are the first parent's children; with physical 1 trimmed, the visual rows
+      // are 0 a0, 1 physical 2, 2 physical 3, 3 physical 4, 4 physical 5.
+      const { aboveValue, belowValue } = await markCells(1, 3, 2);
+
+      await insertRowViaContextMenu(2, 'Insert row below');
+
+      expect(getDataAtCell(1, 2)).toBe(aboveValue);
+      expect(getCellMeta(1, 2).className).toBe('above-cell');
+
+      expect(getDataAtCell(4, 2)).toBe(belowValue);
+      expect(getCellMeta(4, 2).className).toBe('below-cell');
+      expect(getCellMeta(3, 2).className).toBeUndefined();
     });
 
     // Control: this path goes through `DataMap#createRow`, which always shifted the meta. It guards
@@ -208,45 +295,19 @@ describe('NestedRows', () => {
         rowHeaders: true,
       });
 
-      await setCellMeta(3, 2, 'className', 'marked-cell');
-      await setCellMeta(3, 2, 'comment', { value: 'marked-comment' });
+      const { aboveValue, belowValue } = await markCells(1, 3, 2);
 
-      const markedValueBefore = getDataAtCell(3, 2);
+      await alter('insert_row_below', 2, 1);
 
-      await alter('insert_row_below', 1, 1);
+      expect(getDataAtCell(1, 2)).toBe(aboveValue);
+      expect(getCellMeta(1, 2).className).toBe('above-cell');
 
-      expect(getDataAtCell(4, 2)).toBe(markedValueBefore);
-      expect(getCellMeta(4, 2).className).toBe('marked-cell');
-      expect(getCellMeta(4, 2).comment).toEqual({ value: 'marked-comment' });
+      expect(getDataAtCell(4, 2)).toBe(belowValue);
+      expect(getCellMeta(4, 2).className).toBe('below-cell');
       expect(getCellMeta(3, 2).className).toBeUndefined();
-      expect(getCellMeta(3, 2).comment).toBeUndefined();
     });
 
-    it('nestedRows ON, context menu "Insert child row"', async() => {
-      handsontable({
-        data: getSimplerNestedData(),
-        nestedRows: true,
-        comments: true,
-        contextMenu: true,
-        rowHeaders: true,
-      });
-
-      // Parents hold no `title`, so mark row 7 - the first child of the second parent.
-      await setCellMeta(7, 2, 'className', 'marked-cell');
-      await setCellMeta(7, 2, 'comment', { value: 'marked-comment' });
-
-      const markedValueBefore = getDataAtCell(7, 2);
-
-      // "Insert child row" appends a child to the first parent, so everything below shifts by one.
-      await insertRowViaContextMenu(0, 0);
-
-      expect(getDataAtCell(8, 2)).toBe(markedValueBefore);
-      expect(getCellMeta(8, 2).className).toBe('marked-cell');
-      expect(getCellMeta(8, 2).comment).toEqual({ value: 'marked-comment' });
-      expect(getCellMeta(7, 2).className).toBeUndefined();
-      expect(getCellMeta(7, 2).comment).toBeUndefined();
-    });
-
+    // Control: the same menu item without the plugin, proving the shift is the plugin's job.
     it('control: nestedRows OFF, context menu "Insert row below"', async() => {
       handsontable({
         data: createSpreadsheetData(10, 4),
@@ -255,19 +316,16 @@ describe('NestedRows', () => {
         rowHeaders: true,
       });
 
-      await setCellMeta(3, 2, 'className', 'marked-cell');
-      await setCellMeta(3, 2, 'comment', { value: 'marked-comment' });
+      const { aboveValue, belowValue } = await markCells(1, 3, 2);
 
-      const markedValueBefore = getDataAtCell(3, 2);
+      await insertRowViaContextMenu(2, 'Insert row below');
 
-      // Non-separator items without nestedRows: 0=row_above, 1=row_below.
-      await insertRowViaContextMenu(1, 1);
+      expect(getDataAtCell(1, 2)).toBe(aboveValue);
+      expect(getCellMeta(1, 2).className).toBe('above-cell');
 
-      expect(getDataAtCell(4, 2)).toBe(markedValueBefore);
-      expect(getCellMeta(4, 2).className).toBe('marked-cell');
-      expect(getCellMeta(4, 2).comment).toEqual({ value: 'marked-comment' });
+      expect(getDataAtCell(4, 2)).toBe(belowValue);
+      expect(getCellMeta(4, 2).className).toBe('below-cell');
       expect(getCellMeta(3, 2).className).toBeUndefined();
-      expect(getCellMeta(3, 2).comment).toBeUndefined();
     });
   });
 });

--- a/handsontable/src/plugins/nestedRows/__tests__/alter.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/alter.spec.js
@@ -127,4 +127,122 @@ describe('NestedRows', () => {
       expect(getData()).toEqual([[null, null, null, null], ...dataAtStart]);
     });
   });
+
+  // Repro for https://github.com/handsontable/handsontable/issues/7727
+  describe('cell meta shifting when a row is inserted (#7727)', () => {
+    /**
+     * Inserts a row through the context menu, the way the issue reporter did.
+     *
+     * @param {number} row Visual row index to open the context menu on.
+     * @param {number} itemIndex Index of the non-separator context menu item to click.
+     */
+    async function insertRowViaContextMenu(row, itemIndex) {
+      await selectCell(row, 0);
+      await contextMenu();
+
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(itemIndex)
+        .simulate('mousedown')
+        .simulate('mouseup');
+    }
+
+    it('nestedRows ON, context menu "Insert row below" (the exact issue repro)', async() => {
+      handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        comments: true,
+        contextMenu: true,
+        rowHeaders: true,
+      });
+
+      await setCellMeta(3, 2, 'className', 'marked-cell');
+      await setCellMeta(3, 2, 'comment', { value: 'marked-comment' });
+
+      const markedValueBefore = getDataAtCell(3, 2);
+
+      // Non-separator items with nestedRows: 0=add_child, 1=detach_from_parent, 2=row_above, 3=row_below.
+      await insertRowViaContextMenu(1, 3);
+
+      // Sanity: the marked row really moved from visual 3 to visual 4.
+      expect(getDataAtCell(4, 2)).toBe(markedValueBefore);
+
+      // The meta must have followed the row.
+      expect(getCellMeta(4, 2).className).toBe('marked-cell');
+      expect(getCellMeta(4, 2).comment).toEqual({ value: 'marked-comment' });
+      expect(getCellMeta(3, 2).className).toBeUndefined();
+      expect(getCellMeta(3, 2).comment).toBeUndefined();
+    });
+
+    it('nestedRows ON, `alter("insert_row_below")` API', async() => {
+      handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        comments: true,
+        rowHeaders: true,
+      });
+
+      await setCellMeta(3, 2, 'className', 'marked-cell');
+      await setCellMeta(3, 2, 'comment', { value: 'marked-comment' });
+
+      const markedValueBefore = getDataAtCell(3, 2);
+
+      await alter('insert_row_below', 1, 1);
+
+      expect(getDataAtCell(4, 2)).toBe(markedValueBefore);
+      expect(getCellMeta(4, 2).className).toBe('marked-cell');
+      expect(getCellMeta(4, 2).comment).toEqual({ value: 'marked-comment' });
+      expect(getCellMeta(3, 2).className).toBeUndefined();
+      expect(getCellMeta(3, 2).comment).toBeUndefined();
+    });
+
+    it('nestedRows ON, context menu "Insert child row"', async() => {
+      handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        comments: true,
+        contextMenu: true,
+        rowHeaders: true,
+      });
+
+      // Parents hold no `title`, so mark row 7 - the first child of the second parent.
+      await setCellMeta(7, 2, 'className', 'marked-cell');
+      await setCellMeta(7, 2, 'comment', { value: 'marked-comment' });
+
+      const markedValueBefore = getDataAtCell(7, 2);
+
+      // "Insert child row" appends a child to the first parent, so everything below shifts by one.
+      await insertRowViaContextMenu(0, 0);
+
+      expect(getDataAtCell(8, 2)).toBe(markedValueBefore);
+      expect(getCellMeta(8, 2).className).toBe('marked-cell');
+      expect(getCellMeta(8, 2).comment).toEqual({ value: 'marked-comment' });
+      expect(getCellMeta(7, 2).className).toBeUndefined();
+      expect(getCellMeta(7, 2).comment).toBeUndefined();
+    });
+
+    it('control: nestedRows OFF, context menu "Insert row below"', async() => {
+      handsontable({
+        data: createSpreadsheetData(10, 4),
+        comments: true,
+        contextMenu: true,
+        rowHeaders: true,
+      });
+
+      await setCellMeta(3, 2, 'className', 'marked-cell');
+      await setCellMeta(3, 2, 'comment', { value: 'marked-comment' });
+
+      const markedValueBefore = getDataAtCell(3, 2);
+
+      // Non-separator items without nestedRows: 0=row_above, 1=row_below.
+      await insertRowViaContextMenu(1, 1);
+
+      expect(getDataAtCell(4, 2)).toBe(markedValueBefore);
+      expect(getCellMeta(4, 2).className).toBe('marked-cell');
+      expect(getCellMeta(4, 2).comment).toEqual({ value: 'marked-comment' });
+      expect(getCellMeta(3, 2).className).toBeUndefined();
+      expect(getCellMeta(3, 2).comment).toBeUndefined();
+    });
+  });
 });

--- a/handsontable/src/plugins/nestedRows/__tests__/alter.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/alter.spec.js
@@ -175,7 +175,32 @@ describe('NestedRows', () => {
       expect(getCellMeta(3, 2).comment).toBeUndefined();
     });
 
-    it('nestedRows ON, `alter("insert_row_below")` API', async() => {
+    it('nestedRows ON, context menu "Insert row above"', async() => {
+      handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        comments: true,
+        contextMenu: true,
+        rowHeaders: true,
+      });
+
+      await setCellMeta(3, 2, 'className', 'marked-cell');
+      await setCellMeta(3, 2, 'comment', { value: 'marked-comment' });
+
+      const markedValueBefore = getDataAtCell(3, 2);
+
+      await insertRowViaContextMenu(3, 2);
+
+      expect(getDataAtCell(4, 2)).toBe(markedValueBefore);
+      expect(getCellMeta(4, 2).className).toBe('marked-cell');
+      expect(getCellMeta(4, 2).comment).toEqual({ value: 'marked-comment' });
+      expect(getCellMeta(3, 2).className).toBeUndefined();
+      expect(getCellMeta(3, 2).comment).toBeUndefined();
+    });
+
+    // Control: this path goes through `DataMap#createRow`, which always shifted the meta. It guards
+    // against the fix breaking the API path, not against the bug itself.
+    it('control: nestedRows ON, `alter("insert_row_below")` API', async() => {
       handsontable({
         data: getSimplerNestedData(),
         nestedRows: true,

--- a/handsontable/src/plugins/nestedRows/data/dataManager.ts
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.ts
@@ -575,15 +575,33 @@ class DataManager {
 
     this.rewriteCache();
 
-    const newRowIndex = this.getRowIndex(childElement) ?? 0;
+    const newPhysicalIndex = this.getRowIndex(childElement);
+    const newRowIndex = newPhysicalIndex ?? 0;
 
     this.hot.rowIndexMapper.insertIndexes(newRowIndex, 1);
 
-    // Shift the cell meta like `DataMap#createRow` does, or it stays on the rows that moved down (#7727).
-    this.hot.spliceCellsMeta(newRowIndex, 0, []);
+    this.shiftCellsMeta(newPhysicalIndex);
 
     this.hot.runHooks('afterCreateRow', newRowIndex, 1);
     this.hot.runHooks('afterAddChild', parent, childElement);
+  }
+
+  /**
+   * Inserts one empty cell meta row, so meta stored below the new row moves down with its data.
+   *
+   * The methods that build a row by hand have to do this themselves - only `DataMap#createRow`
+   * does it on the regular insert path, and it is never reached from here (#7727). `MetaManager`
+   * takes a physical index, which is what `getRowIndex()` returns, and it does not render.
+   *
+   * @param {number|null} physicalRow Physical index of the new row. `null` skips the shift, so an
+   * unknown row object cannot move every meta row from index 0 down.
+   */
+  shiftCellsMeta(physicalRow: number | null) {
+    if (physicalRow === null) {
+      return;
+    }
+
+    this.hot._getMetaManager().createRow(physicalRow, 1);
   }
 
   /**
@@ -626,10 +644,9 @@ class DataManager {
 
       this.plugin.enableCoreAPIModifiers();
 
-      // Shift the cell meta like `DataMap#createRow` does, or it stays on the rows that moved
-      // down (#7727). Keep it after `enableCoreAPIModifiers()` - `spliceCellsMeta` renders, and
-      // a render with the modifiers off reads the raw, un-flattened source.
-      this.hot.spliceCellsMeta(finalChildIndex, 0, []);
+      // Read the real index instead of reusing `finalChildIndex`: that one assumes every preceding
+      // sibling is a leaf, so a sibling with descendants would splice the meta above the new row.
+      this.shiftCellsMeta(this.getRowIndex(childElement));
 
       this.hot.runHooks('afterCreateRow', finalChildIndex, 1);
 

--- a/handsontable/src/plugins/nestedRows/data/dataManager.ts
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.ts
@@ -579,6 +579,9 @@ class DataManager {
 
     this.hot.rowIndexMapper.insertIndexes(newRowIndex, 1);
 
+    // Shift the cell meta like `DataMap#createRow` does, or it stays on the rows that moved down (#7727).
+    this.hot.spliceCellsMeta(newRowIndex, 0, []);
+
     this.hot.runHooks('afterCreateRow', newRowIndex, 1);
     this.hot.runHooks('afterAddChild', parent, childElement);
   }
@@ -622,6 +625,11 @@ class DataManager {
       this.hot.rowIndexMapper.insertIndexes(finalChildIndex, 1);
 
       this.plugin.enableCoreAPIModifiers();
+
+      // Shift the cell meta like `DataMap#createRow` does, or it stays on the rows that moved
+      // down (#7727). Keep it after `enableCoreAPIModifiers()` - `spliceCellsMeta` renders, and
+      // a render with the modifiers off reads the raw, un-flattened source.
+      this.hot.spliceCellsMeta(finalChildIndex, 0, []);
 
       this.hot.runHooks('afterCreateRow', finalChildIndex, 1);
 


### PR DESCRIPTION
### Context

The PR fixes cell meta not shifting when the NestedRows plugin inserts a row.

In a grid with `nestedRows`, right-clicking a child row and choosing **Insert row above** / **Insert row below** shifted the data down by one row, but comments, `className` and every other stored cell meta stayed on their old rows — so they ended up attached to the wrong cells. The same happened with **Insert child row**. Reported in #7727 (open since 2021), reproduced on `develop`.

NestedRows **replaces** the context menu `row_above` / `row_below` callbacks with its own (`ui/contextMenu.ts`), so clicking the menu never reaches `hot.alter()`. The replacement goes through `DataManager#addSibling()` → `addChildAtIndex()`, and **Insert child row** goes through `DataManager#addChild()`. Both of those insert the row by hand: they splice `__children`, call `rowIndexMapper.insertIndexes()` and fire `beforeCreateRow` / `afterCreateRow` — but neither shifts the cell meta. The regular insert path does, in `DataMap#createRow`, which is why `alter('insert_row_below')` was never affected.

The fix adds the missing shift to both methods, using the public `spliceCellsMeta()` that this plugin's `rowMoveController` already uses for the same purpose. `finalChildIndex` / `newRowIndex` are passed straight through, so the meta shift uses the same index the index mapper was given.

One placement detail worth noting for review: in `addChildAtIndex()` the call sits **after** `enableCoreAPIModifiers()`. `spliceCellsMeta()` ends with a render, and a render taken while the core API modifiers are disabled reads the raw, un-flattened source data.

### How has this been tested?

Four E2E cases added to `handsontable/src/plugins/nestedRows/__tests__/alter.spec.js`. Each one marks a cell with a `className` and a comment, inserts a row above it, then asserts both that the row moved (data check) and that the meta moved with it. Both new failing cases were confirmed red before the fix and green after.

| Case | Before | After |
|---|---|---|
| `nestedRows` ON, context menu "Insert row below" | fails | passes |
| `nestedRows` ON, context menu "Insert child row" | fails | passes |
| `nestedRows` ON, `alter('insert_row_below')` API (control) | passes | passes |
| `nestedRows` OFF, context menu "Insert row below" (control) | passes | passes |

```bash
npm --prefix handsontable run build

# The changed area
npm --prefix handsontable run test:e2e -- --testPathPattern=nestedRows          # 167 specs, 0 failures

# Broader sweep - `addChildAtIndex` / `addChild` have other consumers
npm --prefix handsontable run test:e2e -- --testPathPattern='(nestedRows|columnSummary|contextMenu|comments)'
                                                                                # 909 specs, 0 failures
npm --prefix handsontable run test:unit                                         # 3732 tests, 0 failures
npm run test:types --prefix handsontable                                        # passes
npm run eslint --prefix handsontable                                            # 0 errors
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #7727
2. DEV-2605

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2605

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches nested row insert hooks and render timing around `spliceCellsMeta`, but the change mirrors `DataMap#createRow` and is covered by new E2E tests.
> 
> **Overview**
> Fixes **#7727**: with `nestedRows`, context-menu **Insert row above/below** and **Insert child row** moved row data but left comments, `className`, and other cell meta on the old visual rows.
> 
> NestedRows inserts through `DataManager#addChild` and `#addChildAtIndex` without going through `DataMap#createRow`, so meta was never shifted. The PR calls `hot.spliceCellsMeta(index, 0, [])` at the same flattened index used for `rowIndexMapper.insertIndexes`, matching the normal create-row path. In `addChildAtIndex`, that call runs **after** `enableCoreAPIModifiers()` so a render triggered by `spliceCellsMeta` does not read un-flattened source data.
> 
> E2E coverage in `alter.spec.js` exercises the failing context-menu paths plus controls for `alter('insert_row_below')` and nestedRows-off inserts. Changelog entry **7727.json** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce32ece9c70bd51cec1ec61ebf87cb3c8f7487e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->