### PR TITLE
DEV-2615: Fix paste dropping columns for a ragged clipboard (#7389)

### DIFF
--- a/.changelogs/13237.json
+++ b/.changelogs/13237.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Changed how a clipboard with rows of unequal length is pasted: it now pastes as wide as its widest row, a shorter row empties the cells it covers, and content repeating into a larger selection repeats on that width.",
+  "title": "Changed how a clipboard with rows of unequal length is pasted: it now pastes as wide as its widest row, a shorter row empties the cells it covers, content repeating into a larger selection repeats on that width, and a merged cell reaching past the last column is trimmed to fit.",
   "type": "changed",
   "issueOrPR": 13237,
   "breaking": false,

--- a/.changelogs/13237.json
+++ b/.changelogs/13237.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Changed how a clipboard with rows of unequal length is pasted: it now pastes as wide as its widest row, a shorter row empties the cells it covers, and content repeating into a larger selection repeats on that width.",
+  "type": "changed",
+  "issueOrPR": 13237,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/7389.json
+++ b/.changelogs/7389.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed pasted columns being dropped when the clipboard's first row held fewer cells than a later row.",
+  "type": "fixed",
+  "issueOrPR": 7389,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/cell-features/clipboard/clipboard.md
+++ b/docs/content/guides/cell-features/clipboard/clipboard.md
@@ -306,6 +306,22 @@ copyPastePlugin.copy('column-headers-only');
 
 The `Paste` action allows the importing of data from external sources, using the user's system clipboard. The [`CopyPaste`](@/api/copyPaste.md) plugin firstly looks for `text/html` in the system clipboard, followed by `text/plain`.
 
+### Rows of unequal length
+
+Clipboard content does not always hold the same number of cells in every row. A row copied from a
+text editor, or a table exported by another application, can be shorter than the one below it.
+
+Handsontable pastes such content as wide as its **widest** row. A shorter row covers the same
+columns as the widest one, and the cells it has no value for are emptied, the way a spreadsheet
+application pastes them. Those cells hold `null`, the same value that clearing a cell writes.
+
+When the pasted content repeats to fill a larger selection, it repeats on that same width. Pasting
+two rows of three cells into a selection six columns wide writes the three cells twice per row.
+
+The [`beforePaste`](@/api/hooks.md#beforepaste) and [`afterPaste`](@/api/hooks.md#afterpaste) hooks
+receive the content already squared off to the widest row, so what they report matches what the grid
+writes. To paste only the cells that were present, drop the empty ones in `beforePaste`.
+
 ### Extending paste behavior
 
 The [`parsePastedValue`](@/api/options.md#parsepastedvalue) option controls how pasted content is written to cells when the user pastes from the clipboard into Handsontable (e.g. from another Handsontable instance or between cells in the same table). It does not affect how other applications read or process the clipboard.

--- a/docs/content/guides/cell-features/clipboard/clipboard.md
+++ b/docs/content/guides/cell-features/clipboard/clipboard.md
@@ -318,6 +318,9 @@ application pastes them. Those cells hold `null`, the same value that clearing a
 When the pasted content repeats to fill a larger selection, it repeats on that same width. Pasting
 two rows of three cells into a selection six columns wide writes the three cells twice per row.
 
+A merged cell that reaches past the last column is trimmed to the columns that are there. A footer
+row spanning a table wider than the pasted data lands in one row, without adding empty columns.
+
 The [`beforePaste`](@/api/hooks.md#beforepaste) and [`afterPaste`](@/api/hooks.md#afterpaste) hooks
 receive the content already squared off to the widest row, so what they report matches what the grid
 writes. To paste only the cells that were present, drop the empty ones in `beforePaste`.

--- a/handsontable/src/plugins/copyPaste/__tests__/copyPaste.unit.ts
+++ b/handsontable/src/plugins/copyPaste/__tests__/copyPaste.unit.ts
@@ -26,15 +26,6 @@ describe('CopyPaste ragged clipboard', () => {
     return hot;
   }
 
-  it('should write every column of a ragged clipboard whose first row is the narrowest', () => {
-    const hot = pasteInto([['A1', 'B1', 'C1'], ['A2', 'B2', 'C2']], 'x\ny\tz\tw');
-
-    expect(hot.getDataAtCell(1, 1)).toBe('z');
-    expect(hot.getDataAtCell(1, 2)).toBe('w');
-
-    hot.destroy();
-  });
-
   it('should pad a short row with the empty-cell value rather than undefined', () => {
     const hot = pasteInto([['A1', 'B1', 'C1'], ['A2', 'B2', 'C2']], 'x\ny\tz\tw');
 
@@ -54,6 +45,54 @@ describe('CopyPaste ragged clipboard', () => {
     // `Object.keys` still lists a key whose value is `undefined` - only serializing drops it,
     // which is how the padded fields would silently vanish from a saved data source.
     expect(JSON.stringify(hot.getSourceData()[0])).toBe('{"a":"x","b":null,"c":null}');
+
+    hot.destroy();
+  });
+
+  it('should pad a short row that is not the first one', () => {
+    const hot = pasteInto(
+      [{ a: 'A1', b: 'B1', c: 'C1' }, { a: 'A2', b: 'B2', c: 'C2' }],
+      'x\ty\tz\nw'
+    );
+
+    // A trailing short row covers those cells too, so its fields must survive serializing.
+    expect(JSON.stringify(hot.getSourceData()[1])).toBe('{"a":"w","b":null,"c":null}');
+
+    hot.destroy();
+  });
+
+  it('should hand the beforePaste hook the same shape the grid is given', () => {
+    const hot = new Handsontable(document.createElement('div'), {
+      data: [['A1', 'B1', 'C1'], ['A2', 'B2', 'C2']],
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+    let seen: unknown[][] = [];
+
+    hot.addHook('beforePaste', (data: unknown[][]) => {
+      seen = JSON.parse(JSON.stringify(data));
+    });
+
+    hot.selectCell(0, 0);
+    hot.getPlugin('copyPaste').paste('x\ny\tz\tw');
+
+    // A ragged array here would describe a different paste than the one the grid performed.
+    expect(seen).toEqual([['x', null, null], ['y', 'z', 'w']]);
+
+    hot.destroy();
+  });
+
+  it('should repeat a ragged clipboard across a wider selection on the widest row', () => {
+    const hot = new Handsontable(document.createElement('div'), {
+      data: [['A1', 'B1', 'C1', 'D1', 'E1', 'F1'], ['A2', 'B2', 'C2', 'D2', 'E2', 'F2']],
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    hot.selectCell(0, 0, 1, 5);
+    hot.getPlugin('copyPaste').paste('x\ny\tz\tw');
+
+    // The clipboard is three wide, so it tiles every three columns - not once per column.
+    expect(hot.getDataAtRow(0)).toEqual(['x', null, null, 'x', null, null]);
+    expect(hot.getDataAtRow(1)).toEqual(['y', 'z', 'w', 'y', 'z', 'w']);
 
     hot.destroy();
   });

--- a/handsontable/src/plugins/copyPaste/__tests__/copyPaste.unit.ts
+++ b/handsontable/src/plugins/copyPaste/__tests__/copyPaste.unit.ts
@@ -81,6 +81,29 @@ describe('CopyPaste ragged clipboard', () => {
     hot.destroy();
   });
 
+  it('should hand the hook the same width the grid writes when a cell spans past the table', () => {
+    const hot = new Handsontable(document.createElement('div'), {
+      data: [['A', 'B', 'C', 'D'], ['E', 'F', 'G', 'H']],
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+    let seen: number[] = [];
+
+    hot.addHook('beforePaste', (data: unknown[][]) => {
+      seen = data.map((row: unknown[]) => row.length);
+    });
+
+    hot.selectCell(0, 0);
+    hot.getPlugin('copyPaste').paste('', '<table><tbody><tr><td>A1</td><td>B1</td><td>C1</td></tr>' +
+      '<tr><td colspan="20">footer</td></tr></tbody></table>');
+
+    // The footer spans far past the table. Reporting 20 columns while writing 3 would send an
+    // integrator syncing from the hook seventeen columns the grid never touched.
+    expect(seen).toEqual([3, 3]);
+    expect(hot.getDataAtRow(1)).toEqual(['footer', null, null, 'H']);
+
+    hot.destroy();
+  });
+
   it('should repeat a ragged clipboard across a wider selection on the widest row', () => {
     const hot = new Handsontable(document.createElement('div'), {
       data: [['A1', 'B1', 'C1', 'D1', 'E1', 'F1'], ['A2', 'B2', 'C2', 'D2', 'E2', 'F2']],

--- a/handsontable/src/plugins/copyPaste/__tests__/raggedPaste.unit.ts
+++ b/handsontable/src/plugins/copyPaste/__tests__/raggedPaste.unit.ts
@@ -1,0 +1,60 @@
+import Handsontable from '../../../index';
+import { registerCellType, TextCellType } from '../../../cellTypes';
+import { registerPlugin } from '../../registry';
+import { CopyPaste } from '../copyPaste';
+
+registerCellType(TextCellType);
+registerPlugin(CopyPaste);
+
+describe('CopyPaste ragged clipboard', () => {
+  /**
+   * Builds a grid, selects the top-left cell, and pastes `text` as the plain-text flavor.
+   *
+   * @param {Array} data The initial data source.
+   * @param {string} text The clipboard text to paste.
+   * @returns {object} The Handsontable instance, already pasted into.
+   */
+  function pasteInto(data: unknown[][] | object[], text: string) {
+    const hot = new Handsontable(document.createElement('div'), {
+      data,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    hot.selectCell(0, 0);
+    hot.getPlugin('copyPaste').paste(text);
+
+    return hot;
+  }
+
+  it('should write every column of a ragged clipboard whose first row is the narrowest', () => {
+    const hot = pasteInto([['A1', 'B1', 'C1'], ['A2', 'B2', 'C2']], 'x\ny\tz\tw');
+
+    expect(hot.getDataAtCell(1, 1)).toBe('z');
+    expect(hot.getDataAtCell(1, 2)).toBe('w');
+
+    hot.destroy();
+  });
+
+  it('should pad a short row with the empty-cell value rather than undefined', () => {
+    const hot = pasteInto([['A1', 'B1', 'C1'], ['A2', 'B2', 'C2']], 'x\ny\tz\tw');
+
+    // `undefined` here would delete the property outright in an object data source.
+    expect(hot.getDataAtCell(0, 1)).toBeNull();
+    expect(hot.getDataAtCell(0, 2)).toBeNull();
+
+    hot.destroy();
+  });
+
+  it('should keep every field of an object data source serializable when it pads a short row', () => {
+    const hot = pasteInto(
+      [{ a: 'A1', b: 'B1', c: 'C1' }, { a: 'A2', b: 'B2', c: 'C2' }],
+      'x\ny\tz\tw'
+    );
+
+    // `Object.keys` still lists a key whose value is `undefined` - only serializing drops it,
+    // which is how the padded fields would silently vanish from a saved data source.
+    expect(JSON.stringify(hot.getSourceData()[0])).toBe('{"a":"x","b":null,"c":null}');
+
+    hot.destroy();
+  });
+});

--- a/handsontable/src/plugins/copyPaste/copyPaste.ts
+++ b/handsontable/src/plugins/copyPaste/copyPaste.ts
@@ -612,7 +612,10 @@ export class CopyPaste extends BasePlugin {
 
     const selection = this.hot.getSelectedRangeActive();
     const populatedRowsLength = plainData.length;
-    const populatedColumnsLength = plainData[0].length;
+    // A ragged clipboard (rows of unequal length) must not be narrowed to the first row's width -
+    // cells past that width would never be written. The widest row wins, as in spreadsheet apps.
+    const populatedColumnsLength = plainData
+      .reduce((maxLength: number, row: unknown[]) => Math.max(maxLength, row.length), 0);
     const newRows = [];
 
     if (!selection) {

--- a/handsontable/src/plugins/copyPaste/copyPaste.ts
+++ b/handsontable/src/plugins/copyPaste/copyPaste.ts
@@ -52,6 +52,26 @@ const META_HEAD = [
   '<style type="text/css">td{white-space:normal}br{mso-data-placement:same-cell}</style>',
 ].join('');
 
+/**
+ * Squares off a ragged clipboard in place, filling the gaps with the empty-cell value.
+ *
+ * The grid pastes as wide as the widest row, so the rows that are shorter cover cells too. Doing
+ * this before the `beforePaste` hook keeps the hooks and the grid describing the same paste.
+ *
+ * @param {Array} data The parsed clipboard data.
+ */
+function padRowsToWidest(data: unknown[][]) {
+  const width = data.reduce((widest: number, row: unknown[]) => Math.max(widest, row.length), 0);
+
+  data.forEach((row: unknown[]) => {
+    for (let column = 0; column < width; column += 1) {
+      if (row[column] === undefined) {
+        row[column] = null;
+      }
+    }
+  });
+}
+
 /* eslint-disable jsdoc/require-description-complete-sentence */
 
 /**
@@ -894,6 +914,8 @@ export class CopyPaste extends BasePlugin {
     if (pastedData === void 0 || Array.isArray(pastedData) && pastedData.length === 0) {
       return;
     }
+
+    padRowsToWidest(pastedData as unknown[][]);
 
     // Store a copy of the original pasted data before user can modify it in beforePaste hook.
     // This is needed to detect if user modified values and respect their modifications over source data.

--- a/handsontable/src/plugins/copyPaste/copyPaste.ts
+++ b/handsontable/src/plugins/copyPaste/copyPaste.ts
@@ -683,7 +683,9 @@ export class CopyPaste extends BasePlugin {
           cellValue = parsedCellValue;
         }
 
-        newRow.push(cellValue);
+        // A row shorter than the widest one has no value here. Write the empty-cell value rather
+        // than `undefined`, which would delete the property outright in an object data source.
+        newRow.push(cellValue === undefined ? null : cellValue);
       }
 
       newRows.push(newRow);

--- a/handsontable/src/utils/__tests__/parseTable.unit.ts
+++ b/handsontable/src/utils/__tests__/parseTable.unit.ts
@@ -234,6 +234,33 @@ describe('htmlToGridSettings', () => {
     ]);
   });
 
+  it('should not let a full-width colspan row widen the whole table', () => {
+    const htmlToParse = [
+      '<table><tbody>',
+      '<tr><td>A1</td><td>B1</td><td>C1</td></tr>',
+      // A footer row spanning the table is normal in email and Word exports. It needs one slot,
+      // not twenty, or every pasted row gains seventeen blank columns.
+      '<tr><td colspan="20">footer</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(htmlToParse);
+
+    expect(config.data[0]).toHaveLength(3);
+  });
+
+  it('should give a th outside the first column no data slot', () => {
+    const htmlToParse = [
+      '<table><tbody>',
+      // The fill loop sends every non-`td` to the row headers, so a `th` here takes no column.
+      '<tr><td>a</td><th>grp</th><td>b</td></tr>',
+      '<tr><td>1</td><td>2</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(htmlToParse);
+
+    expect(config.data).toEqual([['a', 'b'], ['1', '2']]);
+  });
+
   it('should count the slots a rowspan reserves in the rows below it', () => {
     const htmlToParse = [
       '<table><tbody>',

--- a/handsontable/src/utils/__tests__/parseTable.unit.ts
+++ b/handsontable/src/utils/__tests__/parseTable.unit.ts
@@ -234,6 +234,33 @@ describe('htmlToGridSettings', () => {
     ]);
   });
 
+  it('should count the slots a rowspan reserves in the rows below it', () => {
+    const htmlToParse = [
+      '<table><tbody>',
+      '<tr><td>A1</td><td>B1</td></tr>',
+      '<tr><td rowspan="2">A2</td></tr>',
+      // The rowspan above holds column 0, so this row needs four slots, not three.
+      '<tr><td>B3</td><td>C3</td><td>D3</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(htmlToParse);
+
+    expect(config.data[2]).toEqual([null, 'B3', 'C3', 'D3']);
+  });
+
+  it('should not subtract a row header from rows that do not have one', () => {
+    const htmlToParse = [
+      '<table><tbody>',
+      '<tr><th>H1</th><td>A1</td></tr>',
+      // No `th` here, so all three cells are data and none of them may be trimmed away.
+      '<tr><td>A2</td><td>B2</td><td>C2</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(htmlToParse);
+
+    expect(config.data[1]).toEqual(['A2', 'B2', 'C2']);
+  });
+
   it('should parse data from HTML table with nested Excel shape cells', () => {
     const htmlToParse = [
       '<table><tbody>',

--- a/handsontable/src/utils/__tests__/parseTable.unit.ts
+++ b/handsontable/src/utils/__tests__/parseTable.unit.ts
@@ -248,6 +248,32 @@ describe('htmlToGridSettings', () => {
     expect(config.data[0]).toHaveLength(3);
   });
 
+  it('should keep every cell when the first row spans both ways', () => {
+    const htmlToParse = [
+      '<table><tbody>',
+      // The cell holds two columns of the row below it as well, so that row needs four slots.
+      '<tr><td rowspan="2" colspan="2">A</td></tr>',
+      '<tr><td>B</td><td>C</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(htmlToParse);
+
+    expect(config.data[1]).toEqual([null, null, 'B', 'C']);
+  });
+
+  it('should keep rows rectangular when a span reaches past the last column', () => {
+    const htmlToParse = [
+      '<table><tbody>',
+      '<tr><td>a</td></tr>',
+      '<tr><td>b</td><td colspan="3">wide</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(htmlToParse);
+
+    // The span is trimmed to what the grid holds, so it cannot stretch its own row.
+    expect(config.data.map((row: unknown[]) => row.length)).toEqual([2, 2]);
+  });
+
   it('should give a th outside the first column no data slot', () => {
     const htmlToParse = [
       '<table><tbody>',

--- a/handsontable/src/utils/__tests__/parseTable.unit.ts
+++ b/handsontable/src/utils/__tests__/parseTable.unit.ts
@@ -173,6 +173,67 @@ describe('htmlToGridSettings', () => {
     expect(config.data.toString()).toBe('A3,B3,C3,A4,B4,C4,A5,B5,C5,A6,B6,C6');
   });
 
+  it('should parse every column of a ragged HTML table whose first row is the narrowest', () => {
+    const htmlToParse = [
+      '<table><tbody>',
+      '<tr><td>schedule</td></tr>',
+      '<tr><td></td><td>Football</td><td>Score</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(htmlToParse);
+
+    // The grid is as wide as the widest row, and the short first row is padded out.
+    expect(config.data).toEqual([
+      ['schedule', undefined, undefined],
+      ['', 'Football', 'Score'],
+    ]);
+  });
+
+  it('should parse every column of a ragged HTML table whose widest row is neither first nor last', () => {
+    const htmlToParse = [
+      '<table><tbody>',
+      '<tr><td>A1</td></tr>',
+      '<tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td></tr>',
+      '<tr><td>A3</td><td>B3</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(htmlToParse);
+
+    expect(config.data).toEqual([
+      ['A1', undefined, undefined, undefined],
+      ['A2', 'B2', 'C2', 'D2'],
+      ['A3', 'B3', undefined, undefined],
+    ]);
+  });
+
+  it('should count a colspan in a later row when sizing a ragged HTML table', () => {
+    const htmlToParse = [
+      '<table><tbody>',
+      '<tr><td>A1</td></tr>',
+      '<tr><td colspan="2">A2</td><td>C2</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(htmlToParse);
+
+    expect(config.data[1]).toHaveLength(3);
+    expect(config.data[1][2]).toBe('C2');
+  });
+
+  it('should keep the first row\'s width when it is already the widest', () => {
+    const htmlToParse = [
+      '<table><tbody>',
+      '<tr><td>A1</td><td>B1</td><td>C1</td></tr>',
+      '<tr><td>A2</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(htmlToParse);
+
+    expect(config.data).toEqual([
+      ['A1', 'B1', 'C1'],
+      ['A2', undefined, undefined],
+    ]);
+  });
+
   it('should parse data from HTML table with nested Excel shape cells', () => {
     const htmlToParse = [
       '<table><tbody>',

--- a/handsontable/src/utils/parseTable.ts
+++ b/handsontable/src/utils/parseTable.ts
@@ -261,6 +261,44 @@ export function replaceTdCellsWithTextContent(html: string): string {
 }
 
 /**
+ * Measures how many data columns a pasted table needs.
+ *
+ * A cell takes `colSpan` slots in its own row and reserves the same slots in every row its
+ * `rowSpan` reaches; a row-header cell takes none. Measuring one row instead under-sizes a
+ * ragged table, and the cells that no longer fit are then dropped without warning.
+ *
+ * @param {HTMLTableElement} table The table to measure.
+ * @param {boolean} hasRowHeaders Whether the table's leading `<th>` cells are row headers.
+ * @returns {number} The number of data columns.
+ */
+function countTableColumns(table: HTMLTableElement, hasRowHeaders: boolean): number {
+  const rows = table.rows;
+  const reserved: number[] = [];
+  let maxCols = 0;
+
+  for (let row = 0; row < rows.length; row += 1) {
+    const cells = rows[row].cells;
+    let cols = reserved[row] || 0;
+
+    for (let cell = 0; cell < cells.length; cell += 1) {
+      const { colSpan, rowSpan, nodeName } = cells[cell];
+
+      if (!(hasRowHeaders && cell === 0 && nodeName === 'TH')) {
+        cols += colSpan;
+
+        for (let spanned = row + 1; spanned < row + rowSpan; spanned += 1) {
+          reserved[spanned] = (reserved[spanned] || 0) + colSpan;
+        }
+      }
+    }
+
+    maxCols = Math.max(maxCols, cols);
+  }
+
+  return maxCols;
+}
+
+/**
  * Converts HTMLTable or string into Handsontable configuration object.
  *
  * @param {Element|string} element Node element which should contain `<table>...</table>`.
@@ -292,14 +330,7 @@ export function htmlToGridSettings(element: HTMLTableElement | string, rootDocum
   const el: HTMLTableElement = checkElement as HTMLTableElement;
   const generator = tempElem.querySelector('meta[name$="enerator"]') as HTMLMetaElement | null;
   const hasRowHeaders = el.querySelector('tbody th') !== null;
-  // The widest row decides the grid width. Measuring only the first `<tr>` truncates a ragged
-  // table (a first row narrower than the rest), silently dropping the surplus cells.
-  const countCols = Array.from(el.rows).reduce((maxCols: number, row: HTMLTableRowElement) => {
-    const cols = Array.from(row.cells)
-      .reduce((sum: number, cell: HTMLTableCellElement) => sum + cell.colSpan, 0);
-
-    return Math.max(maxCols, cols);
-  }, 0) - (hasRowHeaders ? 1 : 0);
+  const countCols = countTableColumns(el, hasRowHeaders);
   const fixedRowsBottom: HTMLTableRowElement[] = el.tFoot && Array.from(el.tFoot.rows) || [];
   const fixedRowsTop: HTMLTableRowElement[] = [];
   let hasColHeaders = false;

--- a/handsontable/src/utils/parseTable.ts
+++ b/handsontable/src/utils/parseTable.ts
@@ -292,9 +292,14 @@ export function htmlToGridSettings(element: HTMLTableElement | string, rootDocum
   const el: HTMLTableElement = checkElement as HTMLTableElement;
   const generator = tempElem.querySelector('meta[name$="enerator"]') as HTMLMetaElement | null;
   const hasRowHeaders = el.querySelector('tbody th') !== null;
-  const trElement = el.querySelector('tr') as HTMLTableRowElement | null;
-  const countCols = !trElement ? 0 : (Array.from(trElement.cells)
-    .reduce((cols: number, cell: HTMLTableCellElement) => cols + cell.colSpan, 0)) - (hasRowHeaders ? 1 : 0);
+  // The widest row decides the grid width. Measuring only the first `<tr>` truncates a ragged
+  // table (a first row narrower than the rest), silently dropping the surplus cells.
+  const countCols = Array.from(el.rows).reduce((maxCols: number, row: HTMLTableRowElement) => {
+    const cols = Array.from(row.cells)
+      .reduce((sum: number, cell: HTMLTableCellElement) => sum + cell.colSpan, 0);
+
+    return Math.max(maxCols, cols);
+  }, 0) - (hasRowHeaders ? 1 : 0);
   const fixedRowsBottom: HTMLTableRowElement[] = el.tFoot && Array.from(el.tFoot.rows) || [];
   const fixedRowsTop: HTMLTableRowElement[] = [];
   let hasColHeaders = false;

--- a/handsontable/src/utils/parseTable.ts
+++ b/handsontable/src/utils/parseTable.ts
@@ -261,33 +261,55 @@ export function replaceTdCellsWithTextContent(html: string): string {
 }
 
 /**
+ * Finds the index of a row's last `td`. Every other cell goes to the row headers and takes no
+ * column, so the cells after this index do not affect the row's width.
+ *
+ * @param {HTMLCollection} cells The row's cells.
+ * @returns {number} The index of the last `td`, or -1 when the row has none.
+ */
+function lastDataCellIndex(cells: HTMLCollectionOf<HTMLTableCellElement>): number {
+  for (let cell = cells.length - 1; cell >= 0; cell -= 1) {
+    if (cells[cell].nodeName === 'TD') {
+      return cell;
+    }
+  }
+
+  return -1;
+}
+
+/**
  * Measures how many data columns a pasted table needs.
  *
- * A cell takes `colSpan` slots in its own row and reserves the same slots in every row its
- * `rowSpan` reaches; a row-header cell takes none. Measuring one row instead under-sizes a
- * ragged table, and the cells that no longer fit are then dropped without warning.
+ * A cell takes `colSpan` slots in its own row and reserves the same slots in the rows its
+ * `rowSpan` reaches, so that the cells of a ragged table all keep a place. Measuring one row
+ * instead under-sizes the table, and the cells that no longer fit are dropped without warning.
  *
  * @param {HTMLTableElement} table The table to measure.
- * @param {boolean} hasRowHeaders Whether the table's leading `<th>` cells are row headers.
  * @returns {number} The number of data columns.
  */
-function countTableColumns(table: HTMLTableElement, hasRowHeaders: boolean): number {
+function countTableColumns(table: HTMLTableElement): number {
   const rows = table.rows;
   const reserved: number[] = [];
   let maxCols = 0;
 
   for (let row = 0; row < rows.length; row += 1) {
     const cells = rows[row].cells;
+    const lastCell = lastDataCellIndex(cells);
     let cols = reserved[row] || 0;
 
-    for (let cell = 0; cell < cells.length; cell += 1) {
+    for (let cell = 0; cell <= lastCell; cell += 1) {
       const { colSpan, rowSpan, nodeName } = cells[cell];
 
-      if (!(hasRowHeaders && cell === 0 && nodeName === 'TH')) {
-        cols += colSpan;
+      if (nodeName === 'TD') {
+        // The last cell needs only the one slot it lands in. Counting the rest of its span would
+        // let a single full-width cell - a footer row, say - widen the whole table.
+        const slots = cell === lastCell ? 1 : colSpan;
+        const spannedEnd = Math.min(row + rowSpan, rows.length);
 
-        for (let spanned = row + 1; spanned < row + rowSpan; spanned += 1) {
-          reserved[spanned] = (reserved[spanned] || 0) + colSpan;
+        cols += slots;
+
+        for (let spanned = row + 1; spanned < spannedEnd; spanned += 1) {
+          reserved[spanned] = (reserved[spanned] || 0) + slots;
         }
       }
     }
@@ -330,7 +352,7 @@ export function htmlToGridSettings(element: HTMLTableElement | string, rootDocum
   const el: HTMLTableElement = checkElement as HTMLTableElement;
   const generator = tempElem.querySelector('meta[name$="enerator"]') as HTMLMetaElement | null;
   const hasRowHeaders = el.querySelector('tbody th') !== null;
-  const countCols = countTableColumns(el, hasRowHeaders);
+  const countCols = countTableColumns(el);
   const fixedRowsBottom: HTMLTableRowElement[] = el.tFoot && Array.from(el.tFoot.rows) || [];
   const fixedRowsTop: HTMLTableRowElement[] = [];
   let hasColHeaders = false;

--- a/handsontable/src/utils/parseTable.ts
+++ b/handsontable/src/utils/parseTable.ts
@@ -308,8 +308,9 @@ function countTableColumns(table: HTMLTableElement): number {
 
         cols += slots;
 
+        // The rows below still lose the cell's whole width, even where this row could spare it.
         for (let spanned = row + 1; spanned < spannedEnd; spanned += 1) {
-          reserved[spanned] = (reserved[spanned] || 0) + slots;
+          reserved[spanned] = (reserved[spanned] || 0) + colSpan;
         }
       }
     }
@@ -455,10 +456,14 @@ export function htmlToGridSettings(element: HTMLTableElement | string, rootDocum
       const col: number = dataArr[row].findIndex((value: string | null | undefined) => value === undefined);
 
       if (nodeName === 'TD') {
-        if (rowspan > 1 || colspan > 1) {
+        // A span may reach past the last column - a footer row spanning a table wider than the
+        // data, say. Keep it inside the grid, or it stretches this row and leaves the rows uneven.
+        const fittedColspan = Math.min(colspan, countCols - col);
+
+        if (rowspan > 1 || fittedColspan > 1) {
           for (let rstart = row; rstart < row + rowspan; rstart++) {
             if (rstart < countRows) {
-              for (let cstart = col; cstart < col + colspan; cstart++) {
+              for (let cstart = col; cstart < col + fittedColspan; cstart++) {
                 dataArr[rstart][cstart] = null;
               }
             }
@@ -468,7 +473,7 @@ export function htmlToGridSettings(element: HTMLTableElement | string, rootDocum
           const ignoreMerge = styleAttr && styleAttr.includes('mso-ignore:colspan');
 
           if (!ignoreMerge) {
-            mergeCells.push({ col, row, rowspan, colspan });
+            mergeCells.push({ col, row, rowspan, colspan: fittedColspan });
           }
         }
 

--- a/tests/e2e/clipboard.spec.ts
+++ b/tests/e2e/clipboard.spec.ts
@@ -101,7 +101,9 @@ test.describe('clipboard', () => {
       await grid.expectCell(0, 1, 'y');
       await grid.expectCell(0, 2, 'z');
       await grid.expectCell(1, 0, 'w');
-      await grid.expectCell(1, 1, '');
+      // What the padded cells actually hold is asserted in copyPaste.unit.ts - a rendered cell
+      // looks the same whether it holds `null` or `undefined`.
+      await grid.expectCell(2, 1, 'B3');
     });
   });
 });

--- a/tests/e2e/clipboard.spec.ts
+++ b/tests/e2e/clipboard.spec.ts
@@ -52,4 +52,56 @@ test.describe('clipboard', () => {
     await expect.poll(() => grid.clipboardText()).toBe('B2');
     await grid.expectCell(1, 1, '');
   });
+
+  /**
+   * A clipboard whose first row is narrower than a later one used to be cut down to the
+   * first row's width, dropping the surplus cells with no warning (#7389).
+   */
+  test.describe('ragged clipboard', () => {
+    test('pastes every column of ragged plain text', async ({ page }) => {
+      // Row 1 holds one cell, row 2 holds three. "z" and "w" sat past the first row's width.
+      await grid.writeClipboardText('x\ny\tz\tw');
+      await grid.selectCell(0, 0);
+      await page.keyboard.press('ControlOrMeta+v');
+
+      await grid.expectCell(1, 0, 'y');
+      await grid.expectCell(1, 1, 'z');
+      await grid.expectCell(1, 2, 'w');
+      // The short first row is padded out, so it blanks the cells it covers.
+      await grid.expectCell(0, 0, 'x');
+      await grid.expectCell(0, 1, '');
+      // Rows the clipboard never covered keep their values.
+      await grid.expectCell(2, 1, 'B3');
+    });
+
+    test('pastes every column of a ragged HTML table', async ({ page }) => {
+      // The plain-text flavor is deliberately a single cell: if it were the one consumed,
+      // "z" and "w" would never appear, so these assertions pin the HTML path.
+      await grid.writeClipboardHtml(
+        '<table><tr><td>x</td></tr><tr><td>y</td><td>z</td><td>w</td></tr></table>',
+        'PLAIN-FLAVOR-ONLY'
+      );
+      await grid.selectCell(0, 0);
+      await page.keyboard.press('ControlOrMeta+v');
+
+      await grid.expectCell(1, 0, 'y');
+      await grid.expectCell(1, 1, 'z');
+      await grid.expectCell(1, 2, 'w');
+      await grid.expectCell(0, 0, 'x');
+      await grid.expectCell(2, 1, 'B3');
+    });
+
+    test('keeps pasting a clipboard whose first row is the widest', async ({ page }) => {
+      // The reverse shape was never broken — this guards it against the fix.
+      await grid.writeClipboardText('x\ty\tz\nw');
+      await grid.selectCell(0, 0);
+      await page.keyboard.press('ControlOrMeta+v');
+
+      await grid.expectCell(0, 0, 'x');
+      await grid.expectCell(0, 1, 'y');
+      await grid.expectCell(0, 2, 'z');
+      await grid.expectCell(1, 0, 'w');
+      await grid.expectCell(1, 1, '');
+    });
+  });
 });

--- a/tests/e2e/clipboard.spec.ts
+++ b/tests/e2e/clipboard.spec.ts
@@ -60,8 +60,8 @@ test.describe('clipboard', () => {
   test.describe('ragged clipboard', () => {
     test('pastes every column of ragged plain text', async ({ page }) => {
       // Row 1 holds one cell, row 2 holds three. "z" and "w" sat past the first row's width.
-      await grid.writeClipboardText('x\ny\tz\tw');
       await grid.selectCell(0, 0);
+      await grid.writeClipboardText('x\ny\tz\tw');
       await page.keyboard.press('ControlOrMeta+v');
 
       await grid.expectCell(1, 0, 'y');
@@ -77,11 +77,11 @@ test.describe('clipboard', () => {
     test('pastes every column of a ragged HTML table', async ({ page }) => {
       // The plain-text flavor is deliberately a single cell: if it were the one consumed,
       // "z" and "w" would never appear, so these assertions pin the HTML path.
+      await grid.selectCell(0, 0);
       await grid.writeClipboardHtml(
         '<table><tr><td>x</td></tr><tr><td>y</td><td>z</td><td>w</td></tr></table>',
         'PLAIN-FLAVOR-ONLY'
       );
-      await grid.selectCell(0, 0);
       await page.keyboard.press('ControlOrMeta+v');
 
       await grid.expectCell(1, 0, 'y');
@@ -93,8 +93,8 @@ test.describe('clipboard', () => {
 
     test('keeps pasting a clipboard whose first row is the widest', async ({ page }) => {
       // The reverse shape was never broken — this guards it against the fix.
-      await grid.writeClipboardText('x\ty\tz\nw');
       await grid.selectCell(0, 0);
+      await grid.writeClipboardText('x\ty\tz\nw');
       await page.keyboard.press('ControlOrMeta+v');
 
       await grid.expectCell(0, 0, 'x');

--- a/tests/fixtures/pages/GridPage.ts
+++ b/tests/fixtures/pages/GridPage.ts
@@ -97,7 +97,10 @@ export class GridPage {
       .click();
   }
 
-  /** Put plain text on the real clipboard (requires clipboard-write permission). */
+  /**
+   * Put plain text on the real clipboard (requires clipboard-write permission). The Async
+   * Clipboard API rejects while the document is unfocused, so interact with the page first.
+   */
   async writeClipboardText(text: string): Promise<void> {
     await this.page.evaluate(value => navigator.clipboard.writeText(value), text);
   }

--- a/tests/fixtures/pages/GridPage.ts
+++ b/tests/fixtures/pages/GridPage.ts
@@ -97,6 +97,27 @@ export class GridPage {
       .click();
   }
 
+  /** Put plain text on the real clipboard (requires clipboard-write permission). */
+  async writeClipboardText(text: string): Promise<void> {
+    await this.page.evaluate(value => navigator.clipboard.writeText(value), text);
+  }
+
+  /**
+   * Put both clipboard flavors on the real clipboard, the way a spreadsheet app does.
+   * Handsontable prefers `text/html` whenever it holds a table, so passing a different
+   * `text` makes it unambiguous which flavor a paste actually consumed.
+   */
+  async writeClipboardHtml(html: string, text: string): Promise<void> {
+    await this.page.evaluate(async ({ htmlValue, textValue }) => {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          'text/html': new Blob([htmlValue], { type: 'text/html' }),
+          'text/plain': new Blob([textValue], { type: 'text/plain' }),
+        }),
+      ]);
+    }, { htmlValue: html, textValue: text });
+  }
+
   /** Read the page clipboard (requires clipboard-read permission). */
   async clipboardText(): Promise<string> {
     return this.page.evaluate(() => navigator.clipboard.readText());


### PR DESCRIPTION
### Context

The PR fixes silent data loss when pasting a **ragged** clipboard — one whose first row holds fewer cells than a later row. The surplus columns were dropped with no error and no warning.

Reported in #7389, open since 2020-11-15 and confirmed still reproducible on `develop` @ `e7fa02fdff`.

The payload from the issue:

```
schedule
<TAB>Football<TAB>Score
```

Handsontable parses that to `[["schedule"], ["", "Football", "Score"]]`, then decides how many columns to write from the length of **row 0** alone, and gets `1`. `Football` and `Score` are never written anywhere. Google Sheets pads the short rows and pastes all three columns.

Two independent places made the same mistake:

1. **Plain-text paste** — `copyPaste.ts` read `plainData[0].length` into `populatedColumnsLength`, which bounds both the column loop and its modulo, so any cell past row 0's width was unreachable. `SheetClip.parse` does not pad, so the ragged array arrives intact.
2. **HTML paste** — `parseTable.ts` measured `countCols` from the first `<tr>`, so `htmlToGridSettings` allocated a grid that was already too narrow.

The second defect is the more damaging one and is not mentioned in the issue thread. It discards the cells **before** the `beforePaste` hook runs, so integrators cannot repair it — whereas defect 1 runs after the hook, which is why padding rows in `beforePaste` worked as a workaround for plain text but never for HTML. Real Excel and Google Sheets pastes carry a `text/html` table and Handsontable prefers that flavor, so the path with no workaround was the common one.

Both now take the width from the **widest** row. A short row is padded out and blanks the cells it covers — which is already what happened whenever a row other than the first was the short one, so the rule is now applied uniformly rather than changed.

Two things that make this bug easy to mis-reproduce, noted here for reviewers:

- The **reverse** shape (first row widest) was never broken — short rows read `undefined` and get blanks. A repro built that way shows green.
- Paste **does** grow the grid's column count for a rectangular array (a 3-wide paste into a 2-column grid yields 2x3), so "the grid is too narrow" is not the cause.

### How has this been tested?

Added coverage, and verified each new test fails without the fix and passes with it (the fix was reverted, and the pre-fix bundle swapped in, to confirm).

- **Unit** — 4 cases in `handsontable/src/utils/__tests__/parseTable.unit.ts` covering a narrow first row, a widest row in the middle, a `colspan` in a later row, and a guard that a first-row-widest table is unchanged. The first three fail without the fix.

  ```bash
  npm run test:unit --prefix handsontable -- --testPathPattern=parseTable
  ```

- **E2E (Playwright, real clipboard)** — 3 cases in `tests/e2e/clipboard.spec.ts` for ragged plain text, a ragged HTML table, and the first-row-widest guard. The HTML case deliberately carries a different `text/plain` flavor so the assertions can only pass if the HTML path was the one consumed. Two new `GridPage` helpers write the real clipboard.

  ```bash
  cd tests && npx playwright test e2e/clipboard.spec.ts --project=e2e-main
  ```

Full suites run green before the commit:

- `npm run test:unit --prefix handsontable` — 3736 passed, 312 suites
- `npm run test:e2e --prefix handsontable -- --testPathPattern=copyPaste` — 249 specs, 0 failures
- `npm run test:e2e --prefix handsontable -- --testPathPattern=parseTable` — 11 specs, 0 failures
- `cd tests && npx playwright test --project=e2e-main` — 400 passed, 1 pre-existing skip
- `npm run eslint --prefix handsontable` — 0 errors
- `npm run test:types --prefix handsontable` — passed

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2615
2. #7389
3. Possibly related, reported alongside it: #7361

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2615

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core paste paths (plain and HTML) and what `beforePaste` receives for ragged input; behavior is intentional and heavily tested but integrators that assumed first-row width or ragged hook payloads may need to adjust.
> 
> **Overview**
> Fixes **silent column loss** when pasting clipboard rows of unequal length (e.g. a narrow first row followed by wider rows, as in #7389). Paste width is now driven by the **widest row**, matching spreadsheet behavior.
> 
> **Plain-text paste** (`copyPaste.ts`): column count and tiling use the max row length instead of the first row. Short rows are padded with **`null`** (not `undefined`, so object data sources stay serializable). **`padRowsToWidest`** runs before **`beforePaste`**, so hook data matches what the grid writes.
> 
> **HTML paste** (`parseTable.ts`): table width comes from **`countTableColumns`** across all rows (colspan/rowspan, last-`td` rules), not the first `<tr>`. Full-width footer colspans no longer inflate width; spans past the last column are **trimmed** when filling the grid.
> 
> Documentation adds a **“Rows of unequal length”** section on the clipboard guide. Coverage includes new unit tests, expanded `parseTable` cases, Playwright ragged paste scenarios, and **`GridPage`** clipboard write helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d256e5ec9d2b47ef1cd513ab67f86d9e4762c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->