### PR TITLE
DEV-2627: Treat layout-slot UI as grid-internal in foreign-focus detection

### DIFF
--- a/.changelogs/13243.json
+++ b/.changelogs/13243.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue where clicking focusable plugin UI placed in the grid's layout slots (for example, pagination controls) closed the open cell editor and deselected the grid.",
+  "type": "fixed",
+  "issueOrPR": 13243,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/focusManager/__tests__/grid.unit.ts
+++ b/handsontable/src/focusManager/__tests__/grid.unit.ts
@@ -1,0 +1,81 @@
+import { FocusGridManager } from '../grid';
+import type { HotInstance } from '../../core/types';
+
+/**
+ * Builds the DOM shape the grid renders: a root wrapper hosting layout slots and
+ * the grid's root element (which carries the `handsontable` class).
+ *
+ * @returns {{ manager: FocusGridManager, wrapper: HTMLElement, root: HTMLElement, slotEl: HTMLElement }}
+ */
+function makeManager() {
+  const wrapper = document.createElement('div');
+  const slotEl = document.createElement('div');
+  const root = document.createElement('div');
+
+  root.className = 'handsontable';
+  wrapper.append(slotEl, root);
+  document.body.appendChild(wrapper);
+
+  const hot = {
+    rootElement: root,
+    rootWrapperElement: wrapper,
+    rootPortalElement: null,
+    rootDocument: document,
+  } as unknown as HotInstance;
+
+  return { manager: new FocusGridManager(hot), wrapper, root, slotEl };
+}
+
+describe('FocusGridManager.isForeignFocusTarget', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('treats an element inside the root element as internal', () => {
+    const { manager, root } = makeManager();
+    const cell = document.createElement('td');
+
+    root.appendChild(cell);
+
+    expect(manager.isForeignFocusTarget(cell)).toBe(false);
+  });
+
+  it('treats layout-slot UI (inside the wrapper, outside the root element) as internal', () => {
+    const { manager, slotEl } = makeManager();
+    const barInput = document.createElement('textarea');
+
+    slotEl.appendChild(barInput);
+
+    expect(manager.isForeignFocusTarget(barInput)).toBe(false);
+  });
+
+  it('treats an element outside the wrapper as foreign', () => {
+    const { manager } = makeManager();
+    const outside = document.createElement('input');
+
+    document.body.appendChild(outside);
+
+    expect(manager.isForeignFocusTarget(outside)).toBe(true);
+  });
+
+  it('keeps a nested grid inside a cell counting as foreign', () => {
+    const { manager, root } = makeManager();
+    const cell = document.createElement('td');
+    const nestedGridContainer = document.createElement('div');
+    const nestedCell = document.createElement('td');
+
+    nestedGridContainer.className = 'handsontable';
+    nestedGridContainer.appendChild(nestedCell);
+    cell.appendChild(nestedGridContainer);
+    root.appendChild(cell);
+
+    expect(manager.isForeignFocusTarget(nestedCell)).toBe(true);
+  });
+
+  it('never marks the document body or a null element as foreign', () => {
+    const { manager } = makeManager();
+
+    expect(manager.isForeignFocusTarget(null)).toBe(false);
+    expect(manager.isForeignFocusTarget(document.body)).toBe(false);
+  });
+});

--- a/handsontable/src/focusManager/grid.ts
+++ b/handsontable/src/focusManager/grid.ts
@@ -179,13 +179,21 @@ export class FocusGridManager {
    * @returns {boolean}
    */
   isForeignFocusTarget(element: HTMLElement | null): boolean {
-    const { rootElement, rootPortalElement, rootDocument } = this.#hot;
+    const { rootElement, rootWrapperElement, rootPortalElement, rootDocument } = this.#hot;
+    // Grid-owned UI hosted in the root wrapper's layout slots or overlay layer (e.g. a
+    // plugin's formula bar) lives outside `rootElement`, so `isInternalElement` cannot
+    // recognize it. Elements inside `rootElement` are deliberately excluded here: a
+    // nested grid's focus must keep counting as foreign for this instance, exactly as
+    // `isInternalElement` decides.
+    const isWrapperHostedUi = !!rootWrapperElement &&
+      rootWrapperElement.contains(element) && !rootElement.contains(element);
 
     if (
       element === null ||
       element === rootDocument.body ||
       element === rootDocument.documentElement ||
       isInternalElement(element, rootElement) ||
+      isWrapperHostedUi ||
       (rootPortalElement && rootPortalElement.contains(element))
     ) {
       return false;


### PR DESCRIPTION
### Context

The PR fixes a DEV-1619 (#13194) regression in the foreign-focus detection. `FocusGridManager.isForeignFocusTarget()` recognized an element as grid-internal only when it sits inside `rootElement` (or the portal). Plugin UI mounted through the LayoutManager edge slots lives inside `rootWrapperElement` but outside `rootElement`, so its focusable elements were classified as foreign. On every real click, the `mouseup` outside-click path in `tableView` then closed the open editor, deselected the grid, and called `hot.unlisten()`.

Any focusable layout-slot UI is affected — Pagination's controls today, and the FormulaBuilder plugin's formula bar (`feature/HOT-15500-formula-builder-plugin`), where clicking the bar starts an edit that dies within the same click. The originating commit already made `tableView`'s `isPathThroughGridUi` and `FocusGridManager.hasBrowserFocus` wrapper-aware; `isForeignFocusTarget` was the one check that missed the wrapper.

The fix treats elements inside `rootWrapperElement` but outside `rootElement` as grid-internal. Elements inside `rootElement` keep the existing `isInternalElement` semantics, so a nested grid's focus still counts as foreign for the parent instance.

### How has this been tested?

- New unit suite `handsontable/src/focusManager/__tests__/grid.unit.ts`: layout-slot UI counts as internal, outside elements stay foreign, nested-grid focus stays foreign, body/null are never foreign.
  - `npm --prefix handsontable run test:unit -- --testPathPattern=focusManager`
- Full unit suite: 3737 passed.
- Focus-related legacy E2E (181 specs: focus, editorManager, unlisten, outside click) and the selection-interaction suite, green against a fresh build:
  - `npm --prefix handsontable run test:e2e -- --testPathPattern='focus|editorManager|Core_unlisten|outsideClick'`
- Manually verified on the FormulaBuilder feature branch that clicking the formula bar opens and keeps the bar edit (the discovery case); a Playwright test covering that flow lives on the feature branch, since the plugin is not on `develop`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2627

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2627
