### PR TITLE
DEV-2628: Fix the gutter between the docs sidebar and content column

### DIFF
--- a/docs/src/styles/base/scrollbars.css
+++ b/docs/src/styles/base/scrollbars.css
@@ -53,3 +53,20 @@
 .handsontable *::-webkit-scrollbar-thumb:hover {
   background-color: revert;
 }
+
+/* Chrome 121+ / Safari 18.2+ give a non-`auto` `scrollbar-width` precedence over
+ * the `::-webkit-scrollbar` rules above, so the 4px intent never reached the
+ * sidebar -- it rendered a 12px bar hard against the content divider (DEV-2628).
+ * Resetting both standard properties to `auto` re-enables the pseudo-elements.
+ * Firefox has no `::-webkit-scrollbar`, so the `@supports` guard leaves it on
+ * `scrollbar-width: thin`.  Scoped to >= 50rem because the same element is the
+ * mobile nav drawer below that breakpoint.
+ */
+@supports selector(::-webkit-scrollbar) {
+  @media (min-width: 50rem) {
+    .sidebar-pane {
+      scrollbar-width: auto;
+      scrollbar-color: auto;
+    }
+  }
+}

--- a/docs/src/styles/layout/page.css
+++ b/docs/src/styles/layout/page.css
@@ -120,7 +120,7 @@ starlight-theme-select :is(:hover, :focus-visible) :is(.moon, .sun) {
 /* Align fixed sidebar with the constrained page */
 @media (min-width: 50rem) {
   .sidebar-pane {
-    inset-inline-start: max(0px, calc(50vw - 750px)) !important;
+    inset-inline-start: max(0px, calc(50% - 750px)) !important;
   }
 }
 
@@ -302,6 +302,15 @@ starlight-toc {
 @media (max-width: 71.99rem) {
   .content-panel {
     padding-inline: 1rem !important;
+  }
+}
+
+/* ...and on the three-column desktop layout, where the content column otherwise
+   starts flush against the sidebar divider until the viewport is wide enough for
+   the 45rem column to center itself (DEV-2628). */
+@media (min-width: 72rem) {
+  .content-panel {
+    padding-inline: var(--sl-content-pad-x) !important;
   }
 }
 


### PR DESCRIPTION
### Context

The PR fixes the gutter between the left Guides sidebar and the content column on the docs site. DEV-2628 reported a grey vertical scrollbar floating in that gutter, "unattached to either column", at a specific window width.

Reproducing the reported screenshot 1:1 against production (its DPR works out to 2, so the reporter's viewport was ~1268 CSS px) turned up three separate defects that all converge on that strip. The dominant one is not the scrollbar.

**1. The content column has no inline padding between 1152px and ~1390px.** `docs/src/styles/layout/page.css` zeroes `.content-panel` padding unconditionally and then restores it only under `@media (max-width: 71.99rem)`. Above 72rem the padding is simply gone, and nothing rescues it until the viewport is wide enough for the 45rem column to start centering itself inside `.main-pane` via `--sl-content-margin-inline: auto 0`. Measured gap from the divider to the `<h1>`, breadcrumb, and body text:

| viewport | padding-inline | gap to divider |
|---|---|---|
| 1000, 1140 | 16px | 16px |
| **1152 (72rem)** | **0px** | **0** |
| **1200, 1268, 1300** | **0px** | **0** |
| 1400 | 0px | 34.5 (incidental) |
| 1600, 1920 | 0px | 84.5 (incidental) |

72rem is exactly the breakpoint the ticket describes -- it is where the third column turns on. The same rule cost the right-hand side too: `.sl-container`'s right edge equalled `.right-sidebar-container`'s left edge at every width above 1152, so text ran flush into the TOC column as well.

**2. The sidebar scrollbar is 12px, not the 4px the site intends.** `docs/src/styles/base/scrollbars.css` sets `* { scrollbar-width: thin }` and then tries for a 4px bar with `*::-webkit-scrollbar { width: 4px }`. In Chrome 121+ and Safari 18.2+ a non-`auto` `scrollbar-width` / `scrollbar-color` takes precedence over the `::-webkit-scrollbar` pseudo-elements, so that 4px rule has been dead code. Measured track on `.sidebar-pane`: 12px. The right "On this page" column hides its scrollbar entirely (`scrollbar-width: none`, upstream `TwoColumnContent.astro`); the left one had no counterpart, which is why the bar read as unattached.

One correction to the ticket: the bar's presence is driven by viewport **height**, not width. At 1268x835 the pane overflows and shows it; at 1268x1400 it does not.

**3. The fixed sidebar is misaligned above 1500px.** `page.css` positioned the pane with `max(0px, calc(50vw - 750px))` while `.page` centers with `max-width: 1500px; margin-inline: auto`. `50vw` includes a classic, space-taking scrollbar; the layout centering does not. On Windows, and on macOS with "Always show scrollbars" (which the reporter has, per the screenshot), the pane was pushed right by half the scrollbar width at every viewport above 1500px, so its divider and scrollbar overlapped the content column. Measured on production in Chromium with an 11px scrollbar:

| viewport | `.page` left | `.sidebar-pane` left | `sidebarRight - mainPaneLeft` |
|---|---|---|---|
| 1400, 1500 | 0 | 0 | 0 |
| 1520 | 4.5 | 10 | **+5.5** |
| 1600 | 44.5 | 50 | **+5.5** |
| 1920 | 204.5 | 210 | **+5.5** |

On macOS classic scrollbars (15px) the offset is 7.5px.

### The changes

All three are CSS-only, confined to `docs/src/styles/`, which keeps the `prod-docs/18.0` and `release/18.1.0` cherry-picks clean.

1. `layout/page.css` -- add the missing counterpart to the existing `max-width: 71.99rem` rule:

   ```css
   @media (min-width: 72rem) {
     .content-panel {
       padding-inline: var(--sl-content-pad-x) !important;
     }
   }
   ```

   `--sl-content-pad-x` is `1.5rem` above 72rem, matching Starlight's own `ContentPanel.astro` default.

2. `layout/page.css` -- `calc(50vw - 750px)` becomes `calc(50% - 750px)`. For a `position: fixed` element a percentage inset resolves against the initial containing block, which excludes the classic scrollbar -- exactly the basis `.page` centers on.

3. `base/scrollbars.css` -- hand `.sidebar-pane` back to the `::-webkit-scrollbar` rules already in that file:

   ```css
   @supports selector(::-webkit-scrollbar) {
     @media (min-width: 50rem) {
       .sidebar-pane {
         scrollbar-width: auto;
         scrollbar-color: auto;
       }
     }
   }
   ```

   Both properties have to be reset: `scrollbar-width: auto` alone measures 16px because `scrollbar-color` is still non-`auto` and the standard path keeps winning; `auto` + `auto` measures 5px (4px track plus the pane's 1px border). Firefox has no `::-webkit-scrollbar`, so the `@supports` guard leaves it on `scrollbar-width: thin`. The `min-width: 50rem` scope matters -- the same element is the mobile nav drawer below that breakpoint.

### Blast radius

Below 1500px both inset expressions clamp to 0, so nothing changes in the 50-71.99rem tablet regime and the rules that position off `var(--sl-sidebar-width)` (`layout/subbar.css`, `layout/toc-panel.css`) are untouched. Above 1440px the 45rem content column keeps its width and shifts 24px left, gaining a matching 24px away from the TOC column that it did not have before.

### How has this been tested?

No automated test is added. The test-presence gate covers `handsontable/src/**` and `wrappers/**` only, and the docs site has no CSS regression suite. Verified by measurement against a local `develop` build of the docs site rather than by eye:

```bash
cd docs && npx astro dev --port 4330
```

Then, per viewport, in the console:

```js
const pane = document.querySelector('.sidebar-pane');
const pr   = pane.getBoundingClientRect();
const pg   = document.querySelector('.page').getBoundingClientRect();
const mp   = document.querySelector('.main-pane').getBoundingClientRect();
const h1   = document.querySelector('main h1').getBoundingClientRect();
({
  gapToDivider: h1.left - pr.right,                  // >= 24 at every width >= 1152
  aligned:      Math.abs(pr.left - pg.left) < 0.02,  // true
  overlap:      pr.right - mp.left,                  // 0
  track:        pane.offsetWidth - pane.clientWidth, // 5, was 12
});
```

Results across 12 viewports (1920x1080, 1600x900, 1440x900, 1400x900, 1300x900, 1268x835, 1268x1400, 1200x900, 1152x900, 1140x900, 1000x900, 780x900):

- Gap to divider goes 0 -> 24px across the 1152-1400 dead band; 16px at and below 1140 is untouched; the TOC side gains 24px where it had 0.
- Sidebar track is 5px on desktop and still 12px in the mobile drawer at 780px, confirming the rule is correctly scoped out.
- `.sidebar-pane` left equals `.page` left at every width, and `sidebarRight - mainPaneLeft` is 0 (was +5.5 above 1500px).
- `document.documentElement.scrollWidth === clientWidth` everywhere -- no page-level horizontal scrolling.

Also checked on four page types (Introduction, Rows sorting with wide code blocks and tables, the API index, Changes between versions) and in both light and dark mode.

**One consequence worth a reviewer's eye:** on pages with wide code blocks the narrower column pushes already-scrolling `<pre>` elements further. On Rows sorting at 1268px the worst inner overflow goes from 114px to 162px and one additional block crosses into scrolling. It stays contained inside `overflow-x: auto`, produces no page-level scroll, and is unchanged at 1600px.

**Pre-existing dead code, deliberately left alone:** `.content-panel:first-child { padding-top: 0.8rem }` in `page.css` is overridden by the `padding: 0 !important` two rules below it (computed `padding-top` measures 0px at every width). Reviving it would shift vertical rhythm on every page, which is outside this ticket.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2628

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Docs site only (`docs/src/styles/`). No package source is touched.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2628

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped docs-site CSS only; no package or auth/data changes. Wide code blocks may scroll slightly more in narrow desktop widths.
> 
> **Overview**
> Fixes the **docs layout gutter** between the Guides sidebar and main content (DEV-2628) with three CSS-only updates in `docs/src/styles/`.
> 
> On **desktop (≥72rem)**, `.content-panel` gets horizontal padding via `var(--sl-content-pad-x)` so text no longer sits flush against the sidebar and TOC dividers in the ~1152–1390px band where padding had been zeroed out.
> 
> The **fixed sidebar** horizontal inset switches from `calc(50vw - 750px)` to `calc(50% - 750px)` so alignment matches the centered `.page` when classic scrollbars consume viewport width above ~1500px.
> 
> For **`.sidebar-pane` on ≥50rem** in WebKit-based browsers, `scrollbar-width` and `scrollbar-color` are reset to `auto` inside `@supports selector(::-webkit-scrollbar)` so the existing 4px `::-webkit-scrollbar` rules apply instead of a ~12px standard scrollbar in the gutter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edf887c287148ce87a4b6754e4e5989bb9b6654c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->