### PR TITLE
RELEASE-896: Clear 18.0-era new/updated tags from the documentation sidebar

### DIFF
--- a/docs/content/guides/accessories-and-menus/drag-to-scroll/drag-to-scroll.md
+++ b/docs/content/guides/accessories-and-menus/drag-to-scroll/drag-to-scroll.md
@@ -19,7 +19,7 @@ vue:
   metaTitle: Drag to scroll - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
-menuTag: new
+menuTag: updated
 ---
 
 Drag a selection or one of its interaction handles outside the visible viewport to scroll the grid automatically.

--- a/docs/content/guides/accessories-and-menus/layout-slots/layout-slots.md
+++ b/docs/content/guides/accessories-and-menus/layout-slots/layout-slots.md
@@ -11,7 +11,6 @@ tags:
   - pagination
 searchCategory: Guides
 category: Accessories and menus
-menuTag: new
 ---
 
 Place custom UI in the slots that Handsontable renders around the grid, and control the order of the elements within each slot.

--- a/docs/content/guides/ai-tools/ai-docs-assistant/ai-docs-assistant.md
+++ b/docs/content/guides/ai-tools/ai-docs-assistant/ai-docs-assistant.md
@@ -12,7 +12,6 @@ vue:
   metaTitle: AI Docs Assistant - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: AI Tools
-menuTag: new
 ---
 The AI Docs Assistant is the **Ask AI** button in the docs header. It answers questions about Handsontable and HyperFormula, writes code examples, and links you to the relevant guide or API reference page.
 

--- a/docs/content/guides/ai-tools/ai-theme-builder/ai-theme-builder.md
+++ b/docs/content/guides/ai-tools/ai-theme-builder/ai-theme-builder.md
@@ -12,7 +12,6 @@ vue:
   metaTitle: AI Theme Builder - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: AI Tools
-menuTag: new
 ---
 The <a href="https://handsontable.com/theme-builder" target="_blank" rel="noopener noreferrer">Theme Builder</a> is a free web tool for building Handsontable themes visually, instead of writing code. You can manually adjust over 200 design tokens with UI controls and see the table update in real-time. Then you can export the theme and use it in your own app!
 

--- a/docs/content/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md
+++ b/docs/content/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md
@@ -12,7 +12,6 @@ vue:
   metaTitle: Skills for Claude Code - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: AI Tools
-menuTag: new
 ---
 Skills for Claude Code are bundled instructions that give Claude deep knowledge of Handsontable and HyperFormula. Install them once, then ask Claude to build, configure, or debug -- it pulls from the same product docs you're reading right now, so the code it writes matches current APIs instead of guessing from outdated training data.
 

--- a/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
+++ b/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
@@ -13,7 +13,6 @@ vue:
   metaTitle: Password cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
-menuTag: updated
 ---
 Use the password cell type to mask confidential values by rendering entered characters as symbols.
 

--- a/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
+++ b/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
@@ -13,7 +13,6 @@ vue:
   metaTitle: Time cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
-menuTag: updated
 ---
 Display, format, sort, and filter time values correctly by using the time cell type. Edit times via the cell editor.
 

--- a/docs/content/guides/dialog/notification/notification.md
+++ b/docs/content/guides/dialog/notification/notification.md
@@ -18,7 +18,6 @@ vue:
   metaTitle: Notification - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Dialog
-menuTag: updated
 ---
 
 Show non-blocking toast notifications for save confirmations, errors, and other transient feedback. Toasts are anchored to the Handsontable root, support stacking per corner, and work with the design system themes.

--- a/docs/content/guides/formulas/installation/installation.md
+++ b/docs/content/guides/formulas/installation/installation.md
@@ -18,7 +18,6 @@ vue:
   metaTitle: Install HyperFormula - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Formulas
-menuTag: new
 ---
 
 The [`Formulas`](@/api/formulas.md) plugin runs on [HyperFormula](https://hyperformula.handsontable.com/),

--- a/docs/content/guides/getting-started/custom-id-class-style/custom-id-class-style.md
+++ b/docs/content/guides/getting-started/custom-id-class-style/custom-id-class-style.md
@@ -18,7 +18,6 @@ vue:
   metaTitle: Custom ID, class, and style - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
-menuTag: new
 ---
 
 Apply a custom `id`, `class`, and inline `style` to the Handsontable container, to target the grid with your own CSS or JavaScript selectors.

--- a/docs/content/guides/optimization/bundle-size/bundle-size.md
+++ b/docs/content/guides/optimization/bundle-size/bundle-size.md
@@ -15,7 +15,6 @@ vue:
   metaTitle: Bundle size - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization
-menuTag: updated
 ---
 Reduce the size of your JavaScript bundle by getting rid of redundant Handsontable modules.
 

--- a/docs/content/guides/security/security/security.md
+++ b/docs/content/guides/security/security/security.md
@@ -13,7 +13,6 @@ vue:
   metaTitle: Security - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Security
-menuTag: updated
 ---
 Learn about the security measures we take to make sure you can safely implement Handsontable in your client-side application.
 

--- a/docs/content/guides/tools-and-building/modules/modules.md
+++ b/docs/content/guides/tools-and-building/modules/modules.md
@@ -15,7 +15,6 @@ vue:
   metaTitle: Modules - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building
-menuTag: updated
 ---
 Reduce the size of your JavaScript bundle, by importing only the modules that you need. The base module is mandatory, all other modules are optional.
 

--- a/docs/content/guides/tools-and-building/typescript-types/typescript-types.md
+++ b/docs/content/guides/tools-and-building/typescript-types/typescript-types.md
@@ -18,7 +18,6 @@ vue:
   metaTitle: TypeScript types - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building
-menuTag: new
 ---
 
 Handsontable ships TypeScript declarations for its entire public API. This page lists every type you can import and shows how to use them in common scenarios.

--- a/docs/content/recipes/cell-types/radio/radio.md
+++ b/docs/content/recipes/cell-types/radio/radio.md
@@ -17,7 +17,6 @@ vue:
   metaTitle: Radio Button Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types
-menuTag: new
 ---
 
 This tutorial shows you how to build a custom radio button cell type using a renderer that displays radio inputs directly in cells, with ARIA semantics, roving tabindex, and keyboard navigation.

--- a/docs/content/recipes/data-management/server-side-expressjs/server-side-expressjs.md
+++ b/docs/content/recipes/data-management/server-side-expressjs/server-side-expressjs.md
@@ -19,7 +19,6 @@ vue:
   metaTitle: Server-side Data with Express.js - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
-menuTag: new
 ---
 
 This tutorial shows how to wire Handsontable's `dataProvider` plugin to an Express.js 4 backend. The backend provides paginated, sorted, and filtered server-side data with full CRUD operations using PostgreSQL via TypeORM and Zod for request validation.

--- a/docs/content/recipes/data-management/server-side-supabase/server-side-supabase.md
+++ b/docs/content/recipes/data-management/server-side-supabase/server-side-supabase.md
@@ -17,7 +17,6 @@ react:
   metaTitle: Server-side Data with Supabase - React Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
-menuTag: new
 ---
 
 This tutorial shows how to wire Handsontable's `dataProvider` plugin to a live [Supabase](https://supabase.com) Postgres table. Every page load, sort, filter, and cell edit goes through the database, so the browser never holds the full dataset.

--- a/docs/content/recipes/data-management/server-side-symfony/server-side-symfony.md
+++ b/docs/content/recipes/data-management/server-side-symfony/server-side-symfony.md
@@ -19,7 +19,6 @@ vue:
   metaTitle: Server-side data with Symfony - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
-menuTag: new
 ---
 
 This tutorial shows how to connect Handsontable's `dataProvider` plugin to a Symfony backend. You will build a product inventory grid that loads data with server-side pagination, sorting, and filtering, and that persists row create, update, and delete operations to a Symfony/Doctrine database. The recipe covers two API styles: a **REST API** (Steps 1–8) and an optional **GraphQL** variant using `webonyx/graphql-php` (Step 9).


### PR DESCRIPTION
### Context

The PR clears the `new` and `updated` sidebar badges (`menuTag` frontmatter) that already ran on the live 18.0 documentation, so the 18.1 sidebar highlights 18.1 work only.

The badges are refreshed by hand once per release; the previous pass was #12807, for 18.0. Because that pass never had a follow-up clear-out, `develop` and `release/18.1.0` both carry every tag set since 18.0: **79 tagged pages**, against 11 after #12455 and 19 after #12807.

Two checks decided each page:

1. **Carried over?** `git diff origin/prod-docs/18.0 origin/release/18.1.0 -- docs/content/<page>` — is this page already badged on the live 18.0 docs?
2. **Re-earned?** Since the 18.0.0 merge-base, did any commit touching the page also touch `handsontable/src` or `wrappers/` — that is, does the page document an actual 18.1 product change, the criterion both previous passes used?

**Removed (17 pages)** — badged for 18.0 or an 18.0.x patch, no 18.1 product change:

| Page | Was | Why |
| --- | --- | --- |
| `guides/dialog/notification` | `updated` | file identical to prod-docs/18.0 |
| `guides/formulas/installation` | `new` | file identical to prod-docs/18.0 |
| `guides/getting-started/custom-id-class-style` | `new` | file identical to prod-docs/18.0 |
| `guides/optimization/bundle-size` | `updated` | file identical to prod-docs/18.0 |
| `guides/security/security` | `updated` | file identical to prod-docs/18.0 |
| `recipes/cell-types/radio` | `new` | file identical to prod-docs/18.0 |
| `recipes/data-management/server-side-supabase` | `new` | file identical to prod-docs/18.0 |
| `guides/accessories-and-menus/layout-slots` | `new` | only the `id:` frontmatter removal |
| `guides/ai-tools/ai-docs-assistant` | `new` | only the `id:` frontmatter removal |
| `guides/ai-tools/ai-theme-builder` | `new` | only the `id:` frontmatter removal |
| `guides/ai-tools/skills-for-claude-code` | `new` | only the `id:` frontmatter removal |
| `recipes/data-management/server-side-expressjs` | `new` | only the `id:` frontmatter removal |
| `recipes/data-management/server-side-symfony` | `new` | only the `id:` frontmatter removal |
| `guides/cell-types/password-cell-type` | `updated` | docs-quality only (keyboard-shortcuts section) |
| `guides/cell-types/time-cell-type` | `updated` | docs-quality only (keyboard-shortcuts section) |
| `guides/tools-and-building/modules` | `updated` | docs-quality only |
| `guides/tools-and-building/typescript-types` | `new` | docs-quality only |

**Changed `new` to `updated` (1 page):**

- `guides/accessories-and-menus/drag-to-scroll` — shipped as new in 18.0, so it cannot stay `new`, and 18.1 extends it with the `selectionHandles` and `moveCells` options (#13076).

**Kept** — 18.0-era badges on pages that 18.1 changed again: `context-menu` (`ContextMenu.SEPARATOR`, filter menu items), `date-cell-type` (`intl-datetime` split), `numeric-cell-type` (`preserveNumericLiteral`), `column-groups` (nested headers follow moved columns), `theme-customization` (selection handle tokens), `moment-date` and `pikaday` (custom editor shortcuts fix). Every badge added during the 18.1 cycle is untouched.

Result: **79 tagged pages before, 62 after.**

Follow-up, out of scope here: 62 is still well above the 11-19 of the previous two passes, because most of the 18.1 cycle's badges come from documentation-backlog work rather than product changes. Those badges are correct per the authoring rule in `docs/AGENTS.md`, and the 18.2 pass will clear them the same way this PR clears the 18.0 ones.

This change also has to reach `release/18.1.0` before the stable publish, since that branch becomes `prod-docs/18.1`. `prod-docs/18.0` is deliberately left alone — its 25 badges are correct for the 18.0 documentation.

### How has this been tested?

Frontmatter-only change, no runtime or build behavior involved.

- Verified the diff contains nothing but `menuTag` lines: 12 `-menuTag: new`, 6 `-menuTag: updated`, 1 `+menuTag: updated` — exactly the 17 removals plus the one downgrade.
- Verified every edited file still opens with a terminated YAML frontmatter block and that no `menuTag` key survived where it was meant to be removed.
- Verified all remaining tagged pages are registered in `guides/sidebar.js` or `recipes/sidebar.js`, so every surviving badge renders:

```bash
git grep -c "^menuTag:" -- docs/content   # 62 pages after, 79 before
```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. RELEASE-896

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/RELEASE-896

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation frontmatter only; no runtime, build, or product code changes.
> 
> **Overview**
> Prepares the **18.1** docs sidebar by trimming stale **New** / **Updated** badges that still reflected **18.0** work, so highlights point at **18.1** product changes instead of a backlog of 79 tagged pages.
> 
> Across **18** guide and recipe markdown files, this PR **removes** the `menuTag` frontmatter line from **17** pages that no longer qualify for a badge (unchanged vs live **18.0** docs, docs-only edits, or frontmatter-only cleanup). **One** page keeps a badge but **downgrades** from `new` to `updated`: **Drag to scroll**, because it shipped as new in **18.0** and **18.1** extends it with real product changes.
> 
> No page body content changes—only YAML frontmatter. Tagged page count goes from **79** to **62**; remaining badges are unchanged in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d38293df65f10788a80607461ffaec1053d542a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->