### PR TITLE
Update the deprecation plan for 18.1

### DIFF
--- a/.ai/BREAKING-CHANGES.md
+++ b/.ai/BREAKING-CHANGES.md
@@ -11,7 +11,7 @@ The lean rule lives in the root `AGENTS.md` "Breaking changes policy" section (a
 | Renaming a CSS class produced by Handsontable | Breaks custom stylesheets | Keep the legacy class name in the DOM. Add tests verifying the old name still works. |
 | Renaming APIs (methods, configuration options, hooks) | Breaks customer integrations | Keep the legacy API working and translate it to the new API internally. Legacy APIs do not produce console warnings. |
 | Changing API signatures or behavior | Breaks customer integrations | Keep the deprecated API working until the next major release. Deprecated APIs produce a console warning (fired only once). |
-| Removing hooks or configuration options | May go undetected by customers | Add the hook to `REMOVED_HOOKS` in `handsontable/src/core/hooks/constants.ts`, or the option to `REMOVED_OPTIONS` in `handsontable/src/core.ts`, so a one-time warning shows when someone uses it in configuration. The warning names the removing version and carries no `Deprecated:` prefix (`removedWarnOnce`, not `deprecatedWarnOnce`). |
+| Removing hooks or configuration options | May go undetected by customers | Add the hook to `REMOVED_HOOKS` in `handsontable/src/core/hooks/constants.ts`, or the option to `REMOVED_OPTIONS` in `handsontable/src/core.ts`, so a warning shows when someone uses it in configuration. Both warnings name the removing version and carry no `Deprecated:` prefix. The option warning is one-time (`removedWarnOnce`, not `deprecatedWarnOnce`); the hook warning goes through plain `warn()` on every `add()` and links to the release notes (see `handsontable/.ai/HOOKS.md`). |
 | Changing a default setting value | 🚫 **Strictly forbidden** — a "really bad" breaking change. | Never change defaults. |
 
 ## Legacy vs deprecated

--- a/.ai/BREAKING-CHANGES.md
+++ b/.ai/BREAKING-CHANGES.md
@@ -19,6 +19,17 @@ The lean rule lives in the root `AGENTS.md` "Breaking changes policy" section (a
 - **Legacy**: Old API kept working forever alongside the new API. No console warnings. The legacy feature set may be frozen. Tests must verify the old name keeps working.
 - **Deprecated**: Old API works until the next stable release, then is removed. Produces a one-time console warning. Tests must verify the old name keeps working until removal.
 
+## Deprecation checklist
+
+When you deprecate a public API, do all of the following in the same PR:
+
+1. JSDoc: `@deprecated Since X.Y.Z. <reason>. It will be removed in <next major>. Use <replacement> instead.` – never a bare `@deprecated` (the API docs render the text as a warning box).
+2. Runtime (methods, options, helpers): call `deprecatedWarnOnce('<Owner>.<name>', '<message>')` from `handsontable/src/helpers/console.ts`. Types cannot warn; the JSDoc tag is enough.
+3. Tests: keep a test proving the old API still works, and one proving the warning prints once. The once-state is module-global, so put the warning test first in its `describe`.
+4. Docs: add a row to `docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md` ("List of current deprecations") and a step in the current migration guide.
+5. Changelog: `.changelogs/<PR>.json` with `"type": "deprecated"`.
+6. Removal happens only in the next major release, at least 3 months later: delete the code, move the docs row to "Removed in version N.0", add a `"type": "removed", "breaking": true` changelog entry, and add a migration step.
+
 ## What is NOT considered breaking
 
 Changes to JavaScript APIs not listed in the public API reference (e.g., internal Walkontable code that does not affect the DOM or CSS). Note such changes in release notes.

--- a/.ai/BREAKING-CHANGES.md
+++ b/.ai/BREAKING-CHANGES.md
@@ -25,7 +25,7 @@ When you deprecate a public API, do all of the following in the same PR:
 
 1. JSDoc: `@deprecated Since X.Y.Z. <reason>. It will be removed in <next major>. Use <replacement> instead.` – never a bare `@deprecated` (the API docs render the text as a warning box).
 2. Runtime (methods, options, helpers): call `deprecatedWarnOnce('<Owner>.<name>', '<message>')` from `handsontable/src/helpers/console.ts`. Types cannot warn; the JSDoc tag is enough.
-3. Tests: keep a test proving the old API still works, and one proving the warning prints once. The once-state is module-global, so put the warning test first in its `describe`.
+3. Tests: keep a test proving the old API still works, and one proving the warning prints once. The once-state is module-global, so call `_resetDeprecationWarnings()` (from `handsontable/src/helpers/console.ts`) in `beforeEach` – otherwise the assertion silently passes whenever another spec printed that warning first.
 4. Docs: add a row to `docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md` ("List of current deprecations") and a step in the current migration guide.
 5. Changelog: `.changelogs/<PR>.json` with `"type": "deprecated"`.
 6. Removal happens only in the next major release, at least 3 months later: delete the code, move the docs row to "Removed in version N.0", add a `"type": "removed", "breaking": true` changelog entry, and add a migration step.

--- a/.ai/BREAKING-CHANGES.md
+++ b/.ai/BREAKING-CHANGES.md
@@ -10,14 +10,14 @@ The lean rule lives in the root `AGENTS.md` "Breaking changes policy" section (a
 |---|---|---|
 | Renaming a CSS class produced by Handsontable | Breaks custom stylesheets | Keep the legacy class name in the DOM. Add tests verifying the old name still works. |
 | Renaming APIs (methods, configuration options, hooks) | Breaks customer integrations | Keep the legacy API working and translate it to the new API internally. Legacy APIs do not produce console warnings. |
-| Changing API signatures or behavior | Breaks customer integrations | Keep the deprecated API working until the next stable release. Deprecated APIs produce a console warning (fired only once). |
-| Removing hooks or configuration options | May go undetected by customers | Add the hook or option to the list of removed hooks so an error shows when someone uses it in configuration. |
+| Changing API signatures or behavior | Breaks customer integrations | Keep the deprecated API working until the next major release. Deprecated APIs produce a console warning (fired only once). |
+| Removing hooks or configuration options | May go undetected by customers | Add the hook to `REMOVED_HOOKS` in `handsontable/src/core/hooks/constants.ts`, or the option to `REMOVED_OPTIONS` in `handsontable/src/core.ts`, so a one-time warning shows when someone uses it in configuration. The warning names the removing version and carries no `Deprecated:` prefix (`removedWarnOnce`, not `deprecatedWarnOnce`). |
 | Changing a default setting value | 🚫 **Strictly forbidden** — a "really bad" breaking change. | Never change defaults. |
 
 ## Legacy vs deprecated
 
 - **Legacy**: Old API kept working forever alongside the new API. No console warnings. The legacy feature set may be frozen. Tests must verify the old name keeps working.
-- **Deprecated**: Old API works until the next stable release, then is removed. Produces a one-time console warning. Tests must verify the old name keeps working until removal.
+- **Deprecated**: Old API works until the next major release, then is removed. Produces a one-time console warning. Tests must verify the old name keeps working until removal.
 
 ## Deprecation checklist
 
@@ -26,7 +26,7 @@ When you deprecate a public API, do all of the following in the same PR:
 1. JSDoc: `@deprecated Since X.Y.Z. <reason>. It will be removed in <next major>. Use <replacement> instead.` – never a bare `@deprecated` (the API docs render the text as a warning box).
 2. Runtime (methods, options, helpers): call `deprecatedWarnOnce('<Owner>.<name>', '<message>')` from `handsontable/src/helpers/console.ts`. Types cannot warn; the JSDoc tag is enough.
 3. Tests: keep a test proving the old API still works, and one proving the warning prints once. The once-state is module-global, so call `_resetDeprecationWarnings()` (from `handsontable/src/helpers/console.ts`) in `beforeEach` – otherwise the assertion silently passes whenever another spec printed that warning first.
-4. Docs: add a row to `docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md` ("List of current deprecations") and a step in the current migration guide.
+4. Docs: add a row to `docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md` ("List of current deprecations") and, when the release has a migration guide (minor releases usually do not), a step in it.
 5. Changelog: `.changelogs/<PR>.json` with `"type": "deprecated"`.
 6. Removal happens only in the next major release, at least 3 months later: delete the code, move the docs row to "Removed in version N.0", add a `"type": "removed", "breaking": true` changelog entry, and add a migration step.
 

--- a/.changelogs/13249.json
+++ b/.changelogs/13249.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Deprecated the `columnHeaders` option of the `exportFile` plugin (use `colHeaders`), the `Handsontable.helper.sanitize()` helper, and the `Settings` and `DataProviderOptions` type aliases. Deprecated APIs now print a one-time console warning that names 19.0.0 as the removal version.",
+  "type": "deprecated",
+  "issueOrPR": 13249,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13249.json
+++ b/.changelogs/13249.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Deprecated the `columnHeaders` option of the `exportFile` plugin (use `colHeaders`), the `Handsontable.helper.sanitize()` helper, and the `Settings` and `DataProviderOptions` type aliases. Deprecated APIs now print a one-time console warning that names 19.0.0 as the removal version.",
-  "type": "deprecated",
-  "issueOrPR": 13249,
-  "breaking": false,
-  "framework": "none"
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 - **Breaking change**: Removed the numbro, moment.js, DOMPurify, and @handsontable/pikaday dependencies. [#12689](https://github.com/handsontable/handsontable/issues/12689)
-- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. [#12727](https://github.com/handsontable/handsontable/pull/12727)
+- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. Removed from the source tree; the published 17.0 release already shipped without it (see [#12015](https://github.com/handsontable/handsontable/pull/12015)). [#12727](https://github.com/handsontable/handsontable/pull/12727)
 - **Breaking change**: Removed the deprecated Core-level undo/redo methods (`hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, `hot.undoRedo`). Use `hot.getPlugin('undoRedo')` instead. [#12728](https://github.com/handsontable/handsontable/issues/12728)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 - **Breaking change**: Removed the numbro, moment.js, DOMPurify, and @handsontable/pikaday dependencies. [#12689](https://github.com/handsontable/handsontable/issues/12689)
-- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. [#0](https://github.com/handsontable/handsontable/pull/0)
+- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. [#12727](https://github.com/handsontable/handsontable/pull/12727)
 - **Breaking change**: Removed the deprecated Core-level undo/redo methods (`hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, `hot.undoRedo`). Use `hot.getPlugin('undoRedo')` instead. [#12728](https://github.com/handsontable/handsontable/issues/12728)
 
 ### Fixed

--- a/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
@@ -55,7 +55,7 @@ For more information about this release, see:
 
 #### Removed
 - **Breaking change**: Removed the numbro, moment.js, DOMPurify, and @handsontable/pikaday dependencies. [#12689](https://github.com/handsontable/handsontable/issues/12689)
-- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. [#12727](https://github.com/handsontable/handsontable/pull/12727)
+- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. Removed from the source tree; the published 17.0 release already shipped without it (see [#12015](https://github.com/handsontable/handsontable/pull/12015)). [#12727](https://github.com/handsontable/handsontable/pull/12727)
 - **Breaking change**: Removed the deprecated Core-level undo/redo methods (`hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, `hot.undoRedo`). Use `hot.getPlugin('undoRedo')` instead. [#12728](https://github.com/handsontable/handsontable/issues/12728)
 
 #### Fixed

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -58,7 +58,7 @@ For more information about this release, see:
 
 #### Removed
 - **Breaking change**: Removed the numbro, moment.js, DOMPurify, and @handsontable/pikaday dependencies. [#12689](https://github.com/handsontable/handsontable/issues/12689)
-- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. [#0](https://github.com/handsontable/handsontable/pull/0)
+- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. Removed from the source tree; the published 17.0 release already shipped without it (see [#12015](https://github.com/handsontable/handsontable/pull/12015)). [#12727](https://github.com/handsontable/handsontable/pull/12727)
 - **Breaking change**: Removed the deprecated Core-level undo/redo methods (`hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, `hot.undoRedo`). Use `hot.getPlugin('undoRedo')` instead. [#12728](https://github.com/handsontable/handsontable/issues/12728)
 
 #### Fixed

--- a/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
+++ b/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
@@ -52,20 +52,20 @@ The following dependencies were deprecated in version 17.0 and removed in versio
 
 | Removed | Description | Migration guide |
 | ------- | ----------- | --------------- |
-| **numbro.js** | Handled numeric data formatting. Replace with [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat). | [Migrate from 17.1 to 18.0 -> Numeric formatting](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#2-migrate-numeric-format-from-numbro-js-pattern-and-culture-to-intlnumberformat) |
-| **Pikaday** | Displayed a date picker. The `intl-date` cell type now uses the native browser date picker. | [Migrate from 17.1 to 18.0 -> Date/Time](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#3-migrate-date-and-time-cells-to-iso-8601-format) |
-| **moment.js** | Parsed, validated, and displayed dates. The `intl-date` and `intl-time` cell types use the native `Intl.DateTimeFormat` API. | [Migrate from 17.1 to 18.0 -> Date/Time](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#3-migrate-date-and-time-cells-to-iso-8601-format) |
-| **DOMPurify** | An XSS sanitizer for HTML. Use the `sanitizer` option to provide your own sanitizer function. | [Migrate from 17.1 to 18.0 -> HTML sanitization](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#4-replace-built-in-dompurify-with-a-custom-sanitizer) |
+| **numbro.js** | Handled numeric data formatting. Replace with [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat). | [Migrate from 17.1 to 18.0 -> Numeric formatting](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#migrate-numeric-format-from-numbrojs-pattern-and-culture-to-intlnumberformat) |
+| **Pikaday** | Displayed a date picker. The `intl-date` cell type now uses the native browser date picker. | [Migrate from 17.1 to 18.0 -> Date/Time](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#migrate-date-and-time-cells-to-iso-8601-format) |
+| **moment.js** | Parsed, validated, and displayed dates. The `intl-date` and `intl-time` cell types use the native `Intl.DateTimeFormat` API. | [Migrate from 17.1 to 18.0 -> Date/Time](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#migrate-date-and-time-cells-to-iso-8601-format) |
+| **DOMPurify** | An XSS sanitizer for HTML. Use the `sanitizer` option to provide your own sanitizer function. | [Migrate from 17.1 to 18.0 -> HTML sanitization](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#replace-built-in-dompurify-with-a-custom-sanitizer) |
 
 ### APIs
 
 | Removed | Deprecated in | Replacement | Migration guide |
 | ------- | ------------- | ----------- | --------------- |
-| `PersistentState` plugin, `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks | 16.1 | Persist state in your application code. | [Migrate from 17.1 to 18.0 -> Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#stop-calling-deprecated-resize-state-methods) |
+| `persistentState` option and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. The `PersistentState` plugin itself was removed in 17.0. | 16.1 | Persist state in your application code. | [Changelog 18.0](@/guides/upgrade-and-migration/changelog-18/changelog-18.md) |
 | `hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, and `hot.undoRedo` | Before 16.0 | `hot.getPlugin('undoRedo')` | [Changelog 18.0](@/guides/upgrade-and-migration/changelog-18/changelog-18.md) |
-| `correctFormat` and `datePickerConfig` options | 17.0 | `valueParser` and `valueSetter` | [Migrate from 17.1 to 18.0 -> Date/Time](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#3-migrate-date-and-time-cells-to-iso-8601-format) |
-| `numericFormat.pattern` and `numericFormat.culture` | 17.0 | `Intl.NumberFormat` options and the `locale` option | [Migrate from 17.1 to 18.0 -> Numeric formatting](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#2-migrate-numeric-format-from-numbro-js-pattern-and-culture-to-intlnumberformat) |
-| `handsontable/common` import subpath | -- (never documented) | `handsontable` or `handsontable/base` | [Migrate from 17.1 to 18.0 -> Imports](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#1-replace-handsontable-common-imports) |
+| `correctFormat` and `datePickerConfig` options | 17.0 | `valueParser` and `valueSetter` | [Migrate from 17.1 to 18.0 -> `correctFormat` option](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#correctformat-option) |
+| `numericFormat.pattern` and `numericFormat.culture` | 17.0 | `Intl.NumberFormat` options and the `locale` option | [Migrate from 17.1 to 18.0 -> Numeric formatting](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#migrate-numeric-format-from-numbrojs-pattern-and-culture-to-intlnumberformat) |
+| `handsontable/common` import subpath | -- (never documented) | `handsontable` or `handsontable/base` | [Migrate from 17.1 to 18.0 -> Imports](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#replace-handsontablecommon-imports) |
 
 ## List of current deprecations
 

--- a/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
+++ b/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
@@ -61,11 +61,18 @@ The following dependencies were deprecated in version 17.0 and removed in versio
 
 | Removed | Deprecated in | Replacement | Migration guide |
 | ------- | ------------- | ----------- | --------------- |
-| `persistentState` option and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. The `PersistentState` plugin itself was removed in 17.0. | 16.1 | Persist state in your application code. | [Changelog 18.0](@/guides/upgrade-and-migration/changelog-18/changelog-18.md) |
-| `hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, and `hot.undoRedo` | Before 16.0 | `hot.getPlugin('undoRedo')` | [Changelog 18.0](@/guides/upgrade-and-migration/changelog-18/changelog-18.md) |
 | `correctFormat` and `datePickerConfig` options | 17.0 | `valueParser` and `valueSetter` | [Migrate from 17.1 to 18.0 -> `correctFormat` option](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#correctformat-option) |
 | `numericFormat.pattern` and `numericFormat.culture` | 17.0 | `Intl.NumberFormat` options and the `locale` option | [Migrate from 17.1 to 18.0 -> Numeric formatting](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#migrate-numeric-format-from-numbrojs-pattern-and-culture-to-intlnumberformat) |
 | `handsontable/common` import subpath | -- (never documented) | `handsontable` or `handsontable/base` | [Migrate from 17.1 to 18.0 -> Imports](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#replace-handsontablecommon-imports) |
+
+## Removed in version 17.0
+
+### APIs
+
+| Removed | Deprecated in | Replacement | Migration guide |
+| ------- | ------------- | ----------- | --------------- |
+| `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks | 16.1 | Persist state in your application code. The `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` methods that relied on the plugin are deprecated (see below). | [Changelog 17.0](@/guides/upgrade-and-migration/changelog-17/changelog-17.md) |
+| `hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, and `hot.undoRedo` | Before 16.0 | `hot.getPlugin('undoRedo')` | [Changelog 17.0](@/guides/upgrade-and-migration/changelog-17/changelog-17.md) |
 
 ## List of current deprecations
 
@@ -85,7 +92,7 @@ The following APIs are deprecated. They keep working and print a one-time consol
 
 | Deprecated | Deprecated in | Removal | Replacement | Migration guide |
 | ---------- | ------------- | ------- | ----------- | --------------- |
-| `columnHeaders` (export options of the `exportFile` plugin) | 17.0 | 19.0 | `colHeaders` | [Export to CSV](@/guides/accessories-and-menus/export-to-csv/export-to-csv.md) |
+| `columnHeaders` (export options of the `exportFile` plugin) | 17.1 | 19.0 | `colHeaders` – rename the key; the value keeps its meaning. | [Export to CSV -> Available options](@/guides/accessories-and-menus/export-to-csv/export-to-csv.md#available-options-in-the-export-configuration) |
 
 ### TypeScript types
 

--- a/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
+++ b/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
@@ -92,7 +92,7 @@ The following APIs are deprecated. They keep working and print a one-time consol
 
 | Deprecated | Deprecated in | Removal | Replacement | Migration guide |
 | ---------- | ------------- | ------- | ----------- | --------------- |
-| `columnHeaders` (export options of the `exportFile` plugin) | 17.1 | 19.0 | `colHeaders` – rename the key; the value keeps its meaning. | [Export to CSV -> Available options](@/guides/accessories-and-menus/export-to-csv/export-to-csv.md#available-options-in-the-export-configuration) |
+| `columnHeaders` (export options of the `exportFile` plugin) | 17.1 | 19.0 | `colHeaders` -- rename the key; the value keeps its meaning. | [Export to CSV -> Available options](@/guides/accessories-and-menus/export-to-csv/export-to-csv.md#available-options-in-the-export-configuration) |
 
 ### TypeScript types
 

--- a/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
+++ b/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
@@ -46,27 +46,55 @@ For more details about our versioning policy please visit [Versioning policy](@/
 
 ## Removed in version 18.0
 
+### Dependencies
+
 The following dependencies were deprecated in version 17.0 and removed in version 18.0.
 
 | Removed | Description | Migration guide |
 | ------- | ----------- | --------------- |
-| **numbro.js** | Handled numeric data formatting. Replace with [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat). | [Migrate from 17.1 to 18.0 → Numeric formatting](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#2-migrate-numeric-format-from-numbro-js-pattern-and-culture-to-intlnumberformat) |
-| **Pikaday** | Displayed a date picker. The `intl-date` cell type now uses the native browser date picker. | [Migrate from 17.1 to 18.0 → Date/Time](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#3-migrate-date-and-time-cells-to-iso-8601-format) |
-| **moment.js** | Parsed, validated, and displayed dates. The `intl-date` and `intl-time` cell types use the native `Intl.DateTimeFormat` API. | [Migrate from 17.1 to 18.0 → Date/Time](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#3-migrate-date-and-time-cells-to-iso-8601-format) |
-| **DOMPurify** | An XSS sanitizer for HTML. Use the `sanitizer` option to provide your own sanitizer function. | [Migrate from 17.1 to 18.0 → HTML sanitization](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#4-replace-built-in-dompurify-with-a-custom-sanitizer) |
+| **numbro.js** | Handled numeric data formatting. Replace with [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat). | [Migrate from 17.1 to 18.0 -> Numeric formatting](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#2-migrate-numeric-format-from-numbro-js-pattern-and-culture-to-intlnumberformat) |
+| **Pikaday** | Displayed a date picker. The `intl-date` cell type now uses the native browser date picker. | [Migrate from 17.1 to 18.0 -> Date/Time](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#3-migrate-date-and-time-cells-to-iso-8601-format) |
+| **moment.js** | Parsed, validated, and displayed dates. The `intl-date` and `intl-time` cell types use the native `Intl.DateTimeFormat` API. | [Migrate from 17.1 to 18.0 -> Date/Time](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#3-migrate-date-and-time-cells-to-iso-8601-format) |
+| **DOMPurify** | An XSS sanitizer for HTML. Use the `sanitizer` option to provide your own sanitizer function. | [Migrate from 17.1 to 18.0 -> HTML sanitization](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#4-replace-built-in-dompurify-with-a-custom-sanitizer) |
+
+### APIs
+
+| Removed | Deprecated in | Replacement | Migration guide |
+| ------- | ------------- | ----------- | --------------- |
+| `PersistentState` plugin, `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks | 16.1 | Persist state in your application code. | [Migrate from 17.1 to 18.0 -> Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#stop-calling-deprecated-resize-state-methods) |
+| `hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, and `hot.undoRedo` | Before 16.0 | `hot.getPlugin('undoRedo')` | [Changelog 18.0](@/guides/upgrade-and-migration/changelog-18/changelog-18.md) |
+| `correctFormat` and `datePickerConfig` options | 17.0 | `valueParser` and `valueSetter` | [Migrate from 17.1 to 18.0 -> Date/Time](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#3-migrate-date-and-time-cells-to-iso-8601-format) |
+| `numericFormat.pattern` and `numericFormat.culture` | 17.0 | `Intl.NumberFormat` options and the `locale` option | [Migrate from 17.1 to 18.0 -> Numeric formatting](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#2-migrate-numeric-format-from-numbro-js-pattern-and-culture-to-intlnumberformat) |
+| `handsontable/common` import subpath | -- (never documented) | `handsontable` or `handsontable/base` | [Migrate from 17.1 to 18.0 -> Imports](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#1-replace-handsontable-common-imports) |
 
 ## List of current deprecations
 
-The following methods were deprecated in version 18.0 and are scheduled for removal in a future major release. They are no-ops kept for backward compatibility, as the `PersistentState` plugin has been removed.
+The following APIs are deprecated. They keep working and print a one-time console warning. They are scheduled for removal in version 19.0, the next major release.
 
-| Deprecated | Plugin | Migration guide |
-| ---------- | ------ | --------------- |
-| `saveManualColumnWidths()` | `ManualColumnResize` | [Migrate from 17.1 to 18.0 → Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#stop-calling-deprecated-resize-state-methods) |
-| `loadManualColumnWidths()` | `ManualColumnResize` | [Migrate from 17.1 to 18.0 → Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#stop-calling-deprecated-resize-state-methods) |
-| `saveManualRowHeights()` | `ManualRowResize` | [Migrate from 17.1 to 18.0 → Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#stop-calling-deprecated-resize-state-methods) |
-| `loadManualRowHeights()` | `ManualRowResize` | [Migrate from 17.1 to 18.0 → Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#stop-calling-deprecated-resize-state-methods) |
+### Methods
 
+| Deprecated | Deprecated in | Removal | Replacement | Migration guide |
+| ---------- | ------------- | ------- | ----------- | --------------- |
+| `saveManualColumnWidths()` (`ManualColumnResize`) | 18.0 | 19.0 | No-op. Persist widths in your application code. | [Migrate from 17.1 to 18.0 -> Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#stop-calling-deprecated-resize-state-methods) |
+| `loadManualColumnWidths()` (`ManualColumnResize`) | 18.0 | 19.0 | No-op. Pass an array to `manualColumnResize`. | [Migrate from 17.1 to 18.0 -> Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#stop-calling-deprecated-resize-state-methods) |
+| `saveManualRowHeights()` (`ManualRowResize`) | 18.0 | 19.0 | No-op. Persist heights in your application code. | [Migrate from 17.1 to 18.0 -> Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#stop-calling-deprecated-resize-state-methods) |
+| `loadManualRowHeights()` (`ManualRowResize`) | 18.0 | 19.0 | No-op. Pass an array to `manualRowResize`. | [Migrate from 17.1 to 18.0 -> Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#stop-calling-deprecated-resize-state-methods) |
+| `Handsontable.helper.sanitize()` | 18.0 | 19.0 | Pass-through. Use the `sanitizer` option. | [`sanitizer` option](@/api/options.md#sanitizer) |
 
+### Options
+
+| Deprecated | Deprecated in | Removal | Replacement | Migration guide |
+| ---------- | ------------- | ------- | ----------- | --------------- |
+| `columnHeaders` (export options of the `exportFile` plugin) | 17.0 | 19.0 | `colHeaders` | [Export to CSV](@/guides/accessories-and-menus/export-to-csv/export-to-csv.md) |
+
+### TypeScript types
+
+Type aliases do not print console warnings. Your editor shows them as deprecated.
+
+| Deprecated | Deprecated in | Removal | Replacement |
+| ---------- | ------------- | ------- | ----------- |
+| `Settings` (exported from `handsontable/plugins/exportFile`) | 18.0 | 19.0 | `ExportFileSettings` |
+| `DataProviderOptions` (exported from `handsontable/plugins/dataProvider`) | 18.0 | 19.0 | `DataProviderFetchOptions` |
 
 ## Related
 

--- a/handsontable/.ai/CONVENTIONS.md
+++ b/handsontable/.ai/CONVENTIONS.md
@@ -140,10 +140,9 @@ export function throwWithCause(message) {
 **Available Functions:**
 - `log(...args)` -- General logging
 - `warn(...args)` -- Warning messages
-- `deprecatedWarn(message)` -- Deprecated feature warnings (prefixed with "Deprecated: ")
 - `removedWarnOnce(key, message)` -- For APIs that no longer exist (an option kept in `REMOVED_OPTIONS` in `core.ts`). Same once-per-key record as `deprecatedWarnOnce`, but no `Deprecated:` prefix: a removed API is gone, not deprecated, and the message must name the removing version.
-- `deprecatedWarnOnce(key, message)` -- Preferred for deprecated public APIs: prints `Deprecated: <message>` once per `key` per page. Use `deprecatedWarn` only when repeated output is intended.
-- `_resetDeprecationWarnings()` -- Test-only. The once-per-key record is module-global, so call this in `beforeEach` of any spec asserting on a deprecation warning; otherwise the assertion passes whenever an earlier spec printed that warning.
+- `deprecatedWarnOnce(key, message)` -- Preferred for deprecated public APIs: prints `Deprecated: <message>` once per `key` per page. There is no repeat-every-call variant: a deprecation that must print on every call is a design smell, use `warn` and say why.
+- `_resetDeprecationWarnings()` -- Test-only. The once-per-key record is module-global and shared by `deprecatedWarnOnce` and `removedWarnOnce`, so call this in `beforeEach` of any spec asserting on a deprecation or removal warning; otherwise the assertion passes whenever an earlier spec printed that warning.
 - `info(...args)` -- Informational messages
 - `error(...args)` -- Error messages
 

--- a/handsontable/.ai/CONVENTIONS.md
+++ b/handsontable/.ai/CONVENTIONS.md
@@ -142,6 +142,7 @@ export function throwWithCause(message) {
 - `warn(...args)` -- Warning messages
 - `deprecatedWarn(message)` -- Deprecated feature warnings (prefixed with "Deprecated: ")
 - `deprecatedWarnOnce(key, message)` -- Preferred for deprecated public APIs: prints `Deprecated: <message>` once per `key` per page. Use `deprecatedWarn` only when repeated output is intended.
+- `_resetDeprecationWarnings()` -- Test-only. The once-per-key record is module-global, so call this in `beforeEach` of any spec asserting on a deprecation warning; otherwise the assertion passes whenever an earlier spec printed that warning.
 - `info(...args)` -- Informational messages
 - `error(...args)` -- Error messages
 

--- a/handsontable/.ai/CONVENTIONS.md
+++ b/handsontable/.ai/CONVENTIONS.md
@@ -141,6 +141,7 @@ export function throwWithCause(message) {
 - `log(...args)` -- General logging
 - `warn(...args)` -- Warning messages
 - `deprecatedWarn(message)` -- Deprecated feature warnings (prefixed with "Deprecated: ")
+- `removedWarnOnce(key, message)` -- For APIs that no longer exist (an option kept in `REMOVED_OPTIONS` in `core.ts`). Same once-per-key record as `deprecatedWarnOnce`, but no `Deprecated:` prefix: a removed API is gone, not deprecated, and the message must name the removing version.
 - `deprecatedWarnOnce(key, message)` -- Preferred for deprecated public APIs: prints `Deprecated: <message>` once per `key` per page. Use `deprecatedWarn` only when repeated output is intended.
 - `_resetDeprecationWarnings()` -- Test-only. The once-per-key record is module-global, so call this in `beforeEach` of any spec asserting on a deprecation warning; otherwise the assertion passes whenever an earlier spec printed that warning.
 - `info(...args)` -- Informational messages

--- a/handsontable/.ai/CONVENTIONS.md
+++ b/handsontable/.ai/CONVENTIONS.md
@@ -141,15 +141,16 @@ export function throwWithCause(message) {
 - `log(...args)` -- General logging
 - `warn(...args)` -- Warning messages
 - `deprecatedWarn(message)` -- Deprecated feature warnings (prefixed with "Deprecated: ")
+- `deprecatedWarnOnce(key, message)` -- Preferred for deprecated public APIs: prints `Deprecated: <message>` once per `key` per page. Use `deprecatedWarn` only when repeated output is intended.
 - `info(...args)` -- Informational messages
 - `error(...args)` -- Error messages
 
 **Usage Pattern:**
 ```javascript
-import { warn, deprecatedWarn } from './helpers/console';
+import { warn, deprecatedWarnOnce } from './helpers/console';
 
 warn('Both `rowHeights` and `minRowHeights` are defined. The `minRowHeights` will be ignored.');
-deprecatedWarn('The `getTotalRows()` method is deprecated. Use `countRows()` instead.');
+deprecatedWarnOnce('Core.getTotalRows', 'The `getTotalRows()` method is deprecated. Use `countRows()` instead.');
 ```
 
 **Why not `console` directly:**

--- a/handsontable/.ai/HOOKS.md
+++ b/handsontable/.ai/HOOKS.md
@@ -243,7 +243,7 @@ Behavior, verified against `add` in `index.ts` and `warn` in `src/helpers/consol
 - **Both are warnings, not errors.** Using a removed or deprecated hook does not throw. The action still proceeds; the listener still attaches and runs.
 - **The warning fires every time `add`/`once` runs for that name, not once.** `warn` calls `console.warn` directly with no deduplication. There is no once-guard in the hook path or in `warn`.
 
-> Repo-vs-doc conflict (repo wins). The breaking-changes policy in `handsontable/AGENTS.md` describes removed hooks as showing "an error" and deprecated APIs producing a warning "fired only once." For the **hook** path, the code does neither: removed and deprecated hooks both emit a non-deduplicated `console.warn`. When you remove or rename a public hook, add it to `REMOVED_HOOKS` with the removal version so misuse surfaces in the console. Removing or renaming a public hook is a breaking change — deprecate it first.
+> Repo-vs-doc conflict (repo wins). The breaking-changes policy in `handsontable/AGENTS.md` describes removed hooks as showing "an error" and deprecated APIs producing a warning "fired only once." Method, option, and helper deprecations honor the once rule through `deprecatedWarnOnce` in `helpers/console.ts` (once per page). For the **hook** path, the code does neither: removed and deprecated hooks both emit a non-deduplicated `console.warn` on every `add()`. When you remove or rename a public hook, add it to `REMOVED_HOOKS` with the removal version so misuse surfaces in the console. Removing or renaming a public hook is a breaking change — deprecate it first.
 
 ## Cross-references
 

--- a/handsontable/src/__tests__/core/updateSettings.unit.js
+++ b/handsontable/src/__tests__/core/updateSettings.unit.js
@@ -12,7 +12,7 @@ describe('Core#updateSettings', () => {
     let container;
 
     beforeEach(() => {
-      // `deprecatedWarnOnce` records printed warnings module-globally, so without this each spec
+      // `removedWarnOnce` records printed warnings module-globally, so without this each spec
       // below would depend on the order the specs run in.
       _resetDeprecationWarnings();
 
@@ -24,7 +24,7 @@ describe('Core#updateSettings', () => {
       container.remove();
     });
 
-    it('should warn once when an option removed in 18.0 is configured', () => {
+    it('should warn once, without a `Deprecated:` prefix, when a removed option is configured', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const core = new Core(container, {
         data: [['a']],
@@ -38,7 +38,11 @@ describe('Core#updateSettings', () => {
       const calls = warnSpy.mock.calls.filter(([message]) => String(message).includes('"persistentState"'));
 
       expect(calls.length).toBe(1);
-      expect(calls[0][0]).toMatch(/^Deprecated: .*removed in Handsontable 18\.0\.0/);
+      // A removed option is not deprecated - the message must not borrow the deprecation prefix.
+      expect(calls[0][0]).not.toMatch(/^Deprecated:/);
+      // `#12015` removed `PersistentState` in 17.0.0; the 18.0.0 changelog line describes a
+      // develop-only re-removal after the TypeScript conversion and never reached a published package.
+      expect(calls[0][0]).toMatch(/^The "persistentState" setting was removed in Handsontable 17\.0\.0/);
 
       core.destroy();
       warnSpy.mockRestore();
@@ -76,7 +80,32 @@ describe('Core#updateSettings', () => {
       const calls = warnSpy.mock.calls.filter(([message]) => String(message).includes('"correctFormat"'));
 
       expect(calls.length).toBe(1);
-      expect(calls[0][0]).toMatch(/^Deprecated: .*removed in Handsontable 18\.0\.0/);
+      expect(calls[0][0]).toMatch(/^The "correctFormat" setting was removed in Handsontable 18\.0\.0/);
+
+      core.destroy();
+      warnSpy.mockRestore();
+    });
+
+    it('should warn once when a removed option is configured in the declarative `cell` array', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const core = new Core(container, {
+        data: [['a', 'b']],
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+
+      core.init();
+      // The most cell-specific declarative form. Without the `cell` scan this caller would get a
+      // clean console and silently dropped date auto-correction.
+      core.updateSettings({
+        cell: [
+          { row: 0, col: 0, correctFormat: true },
+          { row: 0, col: 1, correctFormat: true },
+        ],
+      });
+
+      const calls = warnSpy.mock.calls.filter(([message]) => String(message).includes('"correctFormat"'));
+
+      expect(calls.length).toBe(1);
 
       core.destroy();
       warnSpy.mockRestore();
@@ -118,20 +147,27 @@ describe('Core#updateSettings', () => {
       warnSpy.mockRestore();
     });
 
-    it('should point at the migration guide with the framework path segment', () => {
+    it('should point each option at the docs of the release that removed it', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const core = new Core(container, {
         data: [['a']],
         licenseKey: 'non-commercial-and-evaluation',
         persistentState: true,
+        correctFormat: true,
       });
 
       core.init();
 
-      const calls = warnSpy.mock.calls.filter(([message]) => String(message).includes('"persistentState"'));
+      const persistentStateCalls = warnSpy.mock.calls
+        .filter(([message]) => String(message).includes('"persistentState"'));
+      const correctFormatCalls = warnSpy.mock.calls
+        .filter(([message]) => String(message).includes('"correctFormat"'));
 
-      // The bare `/docs/migration-from-...` form 404s; the docs site requires the framework segment.
-      expect(calls[0][0]).toContain('handsontable.com/docs/javascript-data-grid/migration-from-17.1-to-18.0/');
+      // The bare `/docs/<page>` form 404s; the docs site requires the framework segment.
+      // `persistentState` went in 17.0, so the 17.1 -> 18.0 guide has nothing to say about it.
+      expect(persistentStateCalls[0][0]).toContain('handsontable.com/docs/javascript-data-grid/changelog-17/');
+      expect(correctFormatCalls[0][0])
+        .toContain('handsontable.com/docs/javascript-data-grid/migration-from-17.1-to-18.0/');
 
       core.destroy();
       warnSpy.mockRestore();

--- a/handsontable/src/__tests__/core/updateSettings.unit.js
+++ b/handsontable/src/__tests__/core/updateSettings.unit.js
@@ -1,6 +1,7 @@
 import Core from 'handsontable/core';
 import { registerCellType, TextCellType } from 'handsontable/cellTypes';
 import { registerRenderer, baseRenderer, textRenderer } from 'handsontable/renderers';
+import { _resetDeprecationWarnings } from 'handsontable/helpers/console';
 
 registerCellType(TextCellType);
 registerRenderer(baseRenderer);
@@ -11,6 +12,10 @@ describe('Core#updateSettings', () => {
     let container;
 
     beforeEach(() => {
+      // `deprecatedWarnOnce` records printed warnings module-globally, so without this each spec
+      // below would depend on the order the specs run in.
+      _resetDeprecationWarnings();
+
       container = document.createElement('div');
       document.body.appendChild(container);
     });
@@ -52,6 +57,81 @@ describe('Core#updateSettings', () => {
       const calls = warnSpy.mock.calls.filter(([message]) => String(message).includes('was removed in Handsontable'));
 
       expect(calls.length).toBe(0);
+
+      core.destroy();
+      warnSpy.mockRestore();
+    });
+
+    it('should warn once when a removed option is configured on a column', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const core = new Core(container, {
+        data: [['a']],
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+
+      core.init();
+      // `correctFormat` is a cell option, so this is its most common form.
+      core.updateSettings({ columns: [{ correctFormat: true }] });
+
+      const calls = warnSpy.mock.calls.filter(([message]) => String(message).includes('"correctFormat"'));
+
+      expect(calls.length).toBe(1);
+      expect(calls[0][0]).toMatch(/^Deprecated: .*removed in Handsontable 18\.0\.0/);
+
+      core.destroy();
+      warnSpy.mockRestore();
+    });
+
+    it('should warn only once when a removed option is set on several columns', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const core = new Core(container, {
+        data: [['a', 'b']],
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+
+      core.init();
+      core.updateSettings({ columns: [{ correctFormat: true }, { correctFormat: false }] });
+
+      const calls = warnSpy.mock.calls.filter(([message]) => String(message).includes('"correctFormat"'));
+
+      expect(calls.length).toBe(1);
+
+      core.destroy();
+      warnSpy.mockRestore();
+    });
+
+    it('should not warn when `columns` is a function', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const core = new Core(container, {
+        data: [['a']],
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+
+      core.init();
+      core.updateSettings({ columns: () => ({ type: 'text' }) });
+
+      const calls = warnSpy.mock.calls.filter(([message]) => String(message).includes('was removed in Handsontable'));
+
+      expect(calls.length).toBe(0);
+
+      core.destroy();
+      warnSpy.mockRestore();
+    });
+
+    it('should point at the migration guide with the framework path segment', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const core = new Core(container, {
+        data: [['a']],
+        licenseKey: 'non-commercial-and-evaluation',
+        persistentState: true,
+      });
+
+      core.init();
+
+      const calls = warnSpy.mock.calls.filter(([message]) => String(message).includes('"persistentState"'));
+
+      // The bare `/docs/migration-from-...` form 404s; the docs site requires the framework segment.
+      expect(calls[0][0]).toContain('handsontable.com/docs/javascript-data-grid/migration-from-17.1-to-18.0/');
 
       core.destroy();
       warnSpy.mockRestore();

--- a/handsontable/src/__tests__/core/updateSettings.unit.js
+++ b/handsontable/src/__tests__/core/updateSettings.unit.js
@@ -1,0 +1,60 @@
+import Core from 'handsontable/core';
+import { registerCellType, TextCellType } from 'handsontable/cellTypes';
+import { registerRenderer, baseRenderer, textRenderer } from 'handsontable/renderers';
+
+registerCellType(TextCellType);
+registerRenderer(baseRenderer);
+registerRenderer(textRenderer);
+
+describe('Core#updateSettings', () => {
+  describe('removed options', () => {
+    let container;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    it('should warn once when an option removed in 18.0 is configured', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const core = new Core(container, {
+        data: [['a']],
+        licenseKey: 'non-commercial-and-evaluation',
+        persistentState: true,
+      });
+
+      core.init();
+      core.updateSettings({ persistentState: false });
+
+      const calls = warnSpy.mock.calls.filter(([message]) => String(message).includes('"persistentState"'));
+
+      expect(calls.length).toBe(1);
+      expect(calls[0][0]).toMatch(/^Deprecated: .*removed in Handsontable 18\.0\.0/);
+
+      core.destroy();
+      warnSpy.mockRestore();
+    });
+
+    it('should not warn when no removed option is configured', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const core = new Core(container, {
+        data: [['a']],
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+
+      core.init();
+      core.updateSettings({ colHeaders: true });
+
+      const calls = warnSpy.mock.calls.filter(([message]) => String(message).includes('was removed in Handsontable'));
+
+      expect(calls.length).toBe(0);
+
+      core.destroy();
+      warnSpy.mockRestore();
+    });
+  });
+});

--- a/handsontable/src/__tests__/core/updateSettings.unit.js
+++ b/handsontable/src/__tests__/core/updateSettings.unit.js
@@ -56,5 +56,25 @@ describe('Core#updateSettings', () => {
       core.destroy();
       warnSpy.mockRestore();
     });
+
+    it('should leave the `datePickerConfig` warning to the date editor', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const core = new Core(container, {
+        data: [['a']],
+        licenseKey: 'non-commercial-and-evaluation',
+        datePickerConfig: { firstDay: 1 },
+      });
+
+      core.init();
+
+      const calls = warnSpy.mock.calls.filter(([message]) => String(message).includes('"datePickerConfig"'));
+
+      // `DateEditor#prepare` owns this warning (it also covers the column- and cell-level forms),
+      // so `updateSettings` must not print a second one for the same option.
+      expect(calls.length).toBe(0);
+
+      core.destroy();
+      warnSpy.mockRestore();
+    });
   });
 });

--- a/handsontable/src/base.ts
+++ b/handsontable/src/base.ts
@@ -318,7 +318,7 @@ declare namespace Handsontable {
   export type GridSettings = GridSettingsType;
   export type ColumnSettings = ColumnSettingsType;
   export type CellProperties = CellPropertiesType;
-  /** @deprecated Use CellProperties */
+  /** Alias of the top-level `CellMeta` export. */
   export type CellMeta = CellMetaType;
   export type CellChange = CellChangeType;
   export type ChangeSource = ChangeSourceType;

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -145,7 +145,7 @@ const foreignHotInstances = new Map();
  * Configuration options removed from the public API, with the version that removed them.
  * Configuring one prints a one-time warning; the value is ignored.
  *
- * @type {ReadonlyArray<[string, string]>}
+ * @type {Array<Array<string>>}
  */
 const REMOVED_OPTIONS: ReadonlyArray<[string, string]> = [
   ['persistentState', '18.0.0'],

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -145,8 +145,8 @@ const foreignHotInstances = new Map();
  * Configuration options removed from the public API, with the version that removed them.
  * Configuring one prints a one-time warning; the value is ignored.
  *
- * `datePickerConfig` is deliberately absent: `DateEditor#prepare` already warns about it, and
- * it also sees the column- and cell-level forms that this top-level check cannot.
+ * `datePickerConfig` is deliberately absent: `DateEditor#prepare` already warns about it, and it
+ * also sees the per-cell forms that `warnAboutRemovedOptions` cannot.
  *
  * @type {Array<Array<string>>}
  */
@@ -154,6 +154,38 @@ const REMOVED_OPTIONS: ReadonlyArray<[string, string]> = [
   ['persistentState', '18.0.0'],
   ['correctFormat', '18.0.0'],
 ];
+
+/**
+ * Warns once per removed option found anywhere in the passed settings.
+ *
+ * Scans the top level and every entry of an array-form `columns`, because the removed options are
+ * not all global: `correctFormat` is a cell option, so `columns: [{ correctFormat: true }]` is its
+ * most common form and a top-level-only check would leave that caller with a clean console and
+ * silently dropped date auto-correction.
+ *
+ * The per-cell forms - a `cells` function, or meta set through `setCellMeta` - stay uncovered.
+ * Reaching them means inspecting resolved meta for every cell on every render, which costs more
+ * than the warning is worth.
+ *
+ * @param {object} settings Settings object passed to `updateSettings`.
+ */
+function warnAboutRemovedOptions(settings: Record<string, unknown>): void {
+  const columns: unknown[] = Array.isArray(settings.columns) ? settings.columns as unknown[] : [];
+  const scopes: unknown[] = [settings, ...columns];
+
+  REMOVED_OPTIONS.forEach(([option, version]) => {
+    const isUsed = scopes.some(
+      scope => isObject(scope) && isDefined((scope as Record<string, unknown>)[option])
+    );
+
+    if (isUsed) {
+      deprecatedWarnOnce(`Core.removedOption.${option}`,
+        `The "${option}" setting was removed in Handsontable ${version} and is ignored. ` +
+        'See https://handsontable.com/docs/javascript-data-grid/migration-from-17.1-to-18.0/ ' +
+        'for the migration path.');
+    }
+  });
+}
 
 /**
  * Internal Core properties not exposed in HotInstance but accessed by constructor-assigned
@@ -3384,13 +3416,7 @@ export default function Core(
       throwWithCause('Since 8.0.0 the "ganttChart" setting is no longer supported.');
     }
 
-    REMOVED_OPTIONS.forEach(([option, version]) => {
-      if (isDefined((settings as Record<string, unknown>)[option])) {
-        deprecatedWarnOnce(`Core.removedOption.${option}`,
-          `The "${option}" setting was removed in Handsontable ${version} and is ignored. ` +
-          'See https://handsontable.com/docs/migration-from-17.1-to-18.0/ for the migration path.');
-      }
-    });
+    warnAboutRemovedOptions(settings as Record<string, unknown>);
 
     // The `columns` option (or the state its function form reads) may change in this call - drop
     // getColHeader's index translation cache so it rebuilds against the updated settings.

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -60,7 +60,7 @@ import type { ShortcutManager } from './shortcuts';
 import { registerAllShortcutContexts } from './shortcuts/contexts';
 import { getThemeClassName } from './helpers/themes';
 import { StylesHandler } from './utils/stylesHandler';
-import { warn, deprecatedWarnOnce } from './helpers/console';
+import { warn, removedWarnOnce } from './helpers/console';
 import { throwWithCause } from './helpers/errors';
 import {
   install as installAccessibilityAnnouncer,
@@ -142,47 +142,80 @@ function normalizeIndexesGroup(indexes: number[][]): number[][] {
 const foreignHotInstances = new Map();
 
 /**
+ * A configuration option removed from the public API.
+ */
+interface RemovedOption {
+  /**
+   * The option name as it appears in the settings object.
+   */
+  name: string;
+  /**
+   * The release that removed the option.
+   */
+  version: string;
+  /**
+   * Documentation page that describes the migration path. Points at the release that removed the
+   * option, so each entry carries its own URL rather than a shared one.
+   */
+  migrationUrl: string;
+}
+
+/**
  * Configuration options removed from the public API, with the version that removed them.
  * Configuring one prints a one-time warning; the value is ignored.
+ *
+ * `persistentState` says 17.0.0, not 18.0.0: #12015 removed the plugin, its option, and its hooks
+ * in 17.0.0, and no published 17.x or 18.x package carries them. The 18.0.0 changelog entry for
+ * #12727 describes deleting a copy that the TypeScript conversion re-created on `develop` after
+ * 17.1.0 and that never shipped.
  *
  * `datePickerConfig` is deliberately absent: `DateEditor#prepare` already warns about it, and it
  * also sees the per-cell forms that `warnAboutRemovedOptions` cannot.
  *
- * @type {Array<Array<string>>}
+ * @type {Array<RemovedOption>}
  */
-const REMOVED_OPTIONS: ReadonlyArray<[string, string]> = [
-  ['persistentState', '18.0.0'],
-  ['correctFormat', '18.0.0'],
+const REMOVED_OPTIONS: ReadonlyArray<RemovedOption> = [
+  {
+    name: 'persistentState',
+    version: '17.0.0',
+    migrationUrl: 'https://handsontable.com/docs/javascript-data-grid/changelog-17/',
+  },
+  {
+    name: 'correctFormat',
+    version: '18.0.0',
+    migrationUrl: 'https://handsontable.com/docs/javascript-data-grid/migration-from-17.1-to-18.0/',
+  },
 ];
 
 /**
  * Warns once per removed option found anywhere in the passed settings.
  *
- * Scans the top level and every entry of an array-form `columns`, because the removed options are
- * not all global: `correctFormat` is a cell option, so `columns: [{ correctFormat: true }]` is its
- * most common form and a top-level-only check would leave that caller with a clean console and
+ * Scans the top level, every entry of an array-form `columns`, and every entry of the declarative
+ * `cell` array, because the removed options are not all global: `correctFormat` is a cell option,
+ * so `columns: [{ correctFormat: true }]` and `cell: [{ row, col, correctFormat: true }]` are its
+ * common forms, and a top-level-only check would leave those callers with a clean console and
  * silently dropped date auto-correction.
  *
- * The per-cell forms - a `cells` function, or meta set through `setCellMeta` - stay uncovered.
- * Reaching them means inspecting resolved meta for every cell on every render, which costs more
- * than the warning is worth.
+ * The remaining per-cell forms - a `cells` function, or meta set through `setCellMeta` - stay
+ * uncovered. Reaching them means inspecting resolved meta for every cell on every render, which
+ * costs more than the warning is worth.
  *
  * @param {object} settings Settings object passed to `updateSettings`.
  */
 function warnAboutRemovedOptions(settings: Record<string, unknown>): void {
   const columns: unknown[] = Array.isArray(settings.columns) ? settings.columns as unknown[] : [];
-  const scopes: unknown[] = [settings, ...columns];
+  const cells: unknown[] = Array.isArray(settings.cell) ? settings.cell as unknown[] : [];
+  const scopes: unknown[] = [settings, ...columns, ...cells];
 
-  REMOVED_OPTIONS.forEach(([option, version]) => {
+  REMOVED_OPTIONS.forEach(({ name, version, migrationUrl }) => {
     const isUsed = scopes.some(
-      scope => isObject(scope) && isDefined((scope as Record<string, unknown>)[option])
+      scope => isObject(scope) && isDefined((scope as Record<string, unknown>)[name])
     );
 
     if (isUsed) {
-      deprecatedWarnOnce(`Core.removedOption.${option}`,
-        `The "${option}" setting was removed in Handsontable ${version} and is ignored. ` +
-        'See https://handsontable.com/docs/javascript-data-grid/migration-from-17.1-to-18.0/ ' +
-        'for the migration path.');
+      removedWarnOnce(`Core.removedOption.${name}`,
+        `The "${name}" setting was removed in Handsontable ${version} and is ignored. ` +
+        `See ${migrationUrl} for the migration path.`);
     }
   });
 }

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -172,7 +172,7 @@ interface RemovedOption {
  * `datePickerConfig` is deliberately absent: `DateEditor#prepare` already warns about it, and it
  * also sees the per-cell forms that `warnAboutRemovedOptions` cannot.
  *
- * @type {Array<RemovedOption>}
+ * @type {ReadonlyArray<RemovedOption>}
  */
 const REMOVED_OPTIONS: ReadonlyArray<RemovedOption> = [
   {

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -145,12 +145,14 @@ const foreignHotInstances = new Map();
  * Configuration options removed from the public API, with the version that removed them.
  * Configuring one prints a one-time warning; the value is ignored.
  *
+ * `datePickerConfig` is deliberately absent: `DateEditor#prepare` already warns about it, and
+ * it also sees the column- and cell-level forms that this top-level check cannot.
+ *
  * @type {Array<Array<string>>}
  */
 const REMOVED_OPTIONS: ReadonlyArray<[string, string]> = [
   ['persistentState', '18.0.0'],
   ['correctFormat', '18.0.0'],
-  ['datePickerConfig', '18.0.0'],
 ];
 
 /**

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -60,7 +60,7 @@ import type { ShortcutManager } from './shortcuts';
 import { registerAllShortcutContexts } from './shortcuts/contexts';
 import { getThemeClassName } from './helpers/themes';
 import { StylesHandler } from './utils/stylesHandler';
-import { warn } from './helpers/console';
+import { warn, deprecatedWarnOnce } from './helpers/console';
 import { throwWithCause } from './helpers/errors';
 import {
   install as installAccessibilityAnnouncer,
@@ -142,12 +142,16 @@ function normalizeIndexesGroup(indexes: number[][]): number[][] {
 const foreignHotInstances = new Map();
 
 /**
- * A set of deprecated feature names.
+ * Configuration options removed from the public API, with the version that removed them.
+ * Configuring one prints a one-time warning; the value is ignored.
  *
- * @type {Set<string>}
+ * @type {ReadonlyArray<[string, string]>}
  */
-
-const deprecationWarns = new Set();
+const REMOVED_OPTIONS: ReadonlyArray<[string, string]> = [
+  ['persistentState', '18.0.0'],
+  ['correctFormat', '18.0.0'],
+  ['datePickerConfig', '18.0.0'],
+];
 
 /**
  * Internal Core properties not exposed in HotInstance but accessed by constructor-assigned
@@ -3377,6 +3381,14 @@ export default function Core(
     if (isDefined(settings.ganttChart)) {
       throwWithCause('Since 8.0.0 the "ganttChart" setting is no longer supported.');
     }
+
+    REMOVED_OPTIONS.forEach(([option, version]) => {
+      if (isDefined((settings as Record<string, unknown>)[option])) {
+        deprecatedWarnOnce(`Core.removedOption.${option}`,
+          `The "${option}" setting was removed in Handsontable ${version} and is ignored. ` +
+          'See https://handsontable.com/docs/migration-from-17.1-to-18.0/ for the migration path.');
+      }
+    });
 
     // The `columns` option (or the state its function form reads) may change in this call - drop
     // getColHeader's index translation cache so it rebuilds against the updated settings.

--- a/handsontable/src/helpers/__tests__/console.unit.ts
+++ b/handsontable/src/helpers/__tests__/console.unit.ts
@@ -10,6 +10,7 @@ import {
   error,
   deprecatedWarn,
   deprecatedWarnOnce,
+  removedWarnOnce,
   logAggregatedItems,
   _resetDeprecationWarnings,
 } from 'handsontable/helpers/console';
@@ -122,6 +123,47 @@ describe('Console', () => {
       _resetDeprecationWarnings();
 
       deprecatedWarnOnce('test-key-e', 'Feature E is deprecated.');
+
+      expect(console.warn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('removedWarnOnce', () => {
+    it('should warn only once per key and print the message without a prefix', () => {
+      console.warn = jasmine.createSpy('warn');
+
+      removedWarnOnce('removed-key-a', 'The "a" setting was removed in Handsontable 17.0.0.');
+      removedWarnOnce('removed-key-a', 'The "a" setting was removed in Handsontable 17.0.0.');
+      removedWarnOnce('removed-key-b', 'The "b" setting was removed in Handsontable 18.0.0.');
+
+      expect(console.warn).toHaveBeenCalledTimes(2);
+      expect(console.warn).toHaveBeenCalledWith('The "a" setting was removed in Handsontable 17.0.0.');
+      expect(console.warn).toHaveBeenCalledWith('The "b" setting was removed in Handsontable 18.0.0.');
+    });
+
+    it('should not throw when `console` is not exposed', () => {
+      const cachedConsole = console;
+
+      console = undefined;
+
+      expect(() => {
+        removedWarnOnce('removed-key-c', 'x');
+      }).not.toThrow();
+
+      console = cachedConsole;
+    });
+
+    it('should share the once-record and the reset with `deprecatedWarnOnce`', () => {
+      console.warn = jasmine.createSpy('warn');
+
+      removedWarnOnce('shared-key', 'Removed.');
+      deprecatedWarnOnce('shared-key', 'Deprecated.');
+
+      expect(console.warn).toHaveBeenCalledTimes(1);
+
+      _resetDeprecationWarnings();
+
+      removedWarnOnce('shared-key', 'Removed.');
 
       expect(console.warn).toHaveBeenCalledTimes(2);
     });

--- a/handsontable/src/helpers/__tests__/console.unit.ts
+++ b/handsontable/src/helpers/__tests__/console.unit.ts
@@ -9,6 +9,7 @@ import {
   info,
   error,
   deprecatedWarn,
+  deprecatedWarnOnce,
   logAggregatedItems,
 } from 'handsontable/helpers/console';
 
@@ -61,6 +62,32 @@ describe('Console', () => {
 
       deprecatedWarn('Test');
       expect(console.warn).toHaveBeenCalledWith('Deprecated: Test');
+    });
+  });
+
+  describe('deprecatedWarnOnce', () => {
+    it('should warn only once per key and prefix the message', () => {
+      console.warn = jasmine.createSpy('warn');
+
+      deprecatedWarnOnce('test-key-a', 'Feature A is deprecated.');
+      deprecatedWarnOnce('test-key-a', 'Feature A is deprecated.');
+      deprecatedWarnOnce('test-key-b', 'Feature B is deprecated.');
+
+      expect(console.warn).toHaveBeenCalledTimes(2);
+      expect(console.warn).toHaveBeenCalledWith('Deprecated: Feature A is deprecated.');
+      expect(console.warn).toHaveBeenCalledWith('Deprecated: Feature B is deprecated.');
+    });
+
+    it('should not throw when `console` is not exposed', () => {
+      const cachedConsole = console;
+
+      console = undefined;
+
+      expect(() => {
+        deprecatedWarnOnce('test-key-c', 'x');
+      }).not.toThrow();
+
+      console = cachedConsole;
     });
   });
 

--- a/handsontable/src/helpers/__tests__/console.unit.ts
+++ b/handsontable/src/helpers/__tests__/console.unit.ts
@@ -11,9 +11,14 @@ import {
   deprecatedWarn,
   deprecatedWarnOnce,
   logAggregatedItems,
+  _resetDeprecationWarnings,
 } from 'handsontable/helpers/console';
 
 describe('Console', () => {
+  beforeEach(() => {
+    _resetDeprecationWarnings();
+  });
+
   describe('log', () => {
     it('should call function `console.log` with all arguments', () => {
       console.log = jasmine.createSpy('log');
@@ -88,6 +93,37 @@ describe('Console', () => {
       }).not.toThrow();
 
       console = cachedConsole;
+    });
+
+    it('should not consume the key when `console` is not exposed', () => {
+      const cachedConsole = console;
+
+      console = undefined;
+
+      deprecatedWarnOnce('test-key-d', 'Feature D is deprecated.');
+
+      console = cachedConsole;
+      console.warn = jasmine.createSpy('warn');
+
+      deprecatedWarnOnce('test-key-d', 'Feature D is deprecated.');
+
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(console.warn).toHaveBeenCalledWith('Deprecated: Feature D is deprecated.');
+    });
+
+    it('should warn again for the same key after the record is reset', () => {
+      console.warn = jasmine.createSpy('warn');
+
+      deprecatedWarnOnce('test-key-e', 'Feature E is deprecated.');
+      deprecatedWarnOnce('test-key-e', 'Feature E is deprecated.');
+
+      expect(console.warn).toHaveBeenCalledTimes(1);
+
+      _resetDeprecationWarnings();
+
+      deprecatedWarnOnce('test-key-e', 'Feature E is deprecated.');
+
+      expect(console.warn).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/handsontable/src/helpers/__tests__/console.unit.ts
+++ b/handsontable/src/helpers/__tests__/console.unit.ts
@@ -8,7 +8,6 @@ import {
   warnOnce,
   info,
   error,
-  deprecatedWarn,
   deprecatedWarnOnce,
   removedWarnOnce,
   logAggregatedItems,
@@ -59,15 +58,6 @@ describe('Console', () => {
       }).not.toThrow();
 
       console = cachedConsole;
-    });
-  });
-
-  describe('deprecatedWarn', () => {
-    it('should call function `console.warn` with all arguments', () => {
-      console.warn = jasmine.createSpy('warn');
-
-      deprecatedWarn('Test');
-      expect(console.warn).toHaveBeenCalledWith('Deprecated: Test');
     });
   });
 

--- a/handsontable/src/helpers/__tests__/string.unit.ts
+++ b/handsontable/src/helpers/__tests__/string.unit.ts
@@ -51,6 +51,22 @@ describe('String helper', () => {
   // Handsontable.helper.sanitize
   //
   describe('sanitize', () => {
+    // Runs first: the warning is printed once per page, before any other call in this suite.
+    it('should warn once about the deprecation', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      sanitize('<b>a</b>');
+      sanitize('plain');
+
+      const deprecationCalls = warnSpy.mock.calls
+        .filter(([message]) => String(message).includes('`sanitize()`'));
+
+      expect(deprecationCalls.length).toBe(1);
+      expect(deprecationCalls[0][0]).toMatch(/^Deprecated: .*`sanitizer`/);
+
+      warnSpy.mockRestore();
+    });
+
     it('should return the string unchanged (pass-through — DOMPurify removed)', () => {
       expect(sanitize('')).toBe('');
       expect(sanitize('<i aria-label="bar">foo</i>')).toBe('<i aria-label="bar">foo</i>');

--- a/handsontable/src/helpers/__tests__/string.unit.ts
+++ b/handsontable/src/helpers/__tests__/string.unit.ts
@@ -8,8 +8,15 @@ import {
   toHyphen,
   localeLowerCase,
 } from 'handsontable/helpers/string';
+import { _resetDeprecationWarnings } from 'handsontable/helpers/console';
 
 describe('String helper', () => {
+  beforeEach(() => {
+    // `deprecatedWarnOnce` records printed warnings module-globally, so without this the
+    // `sanitize` deprecation assertion below would depend on the order the specs run in.
+    _resetDeprecationWarnings();
+  });
+
   //
   // Handsontable.helper.equalsIgnoreCase
   //

--- a/handsontable/src/helpers/console.ts
+++ b/handsontable/src/helpers/console.ts
@@ -70,17 +70,6 @@ export function warnOnce(scope: object, key: string, ...args: unknown[]): void {
 }
 
 /**
- * Logs deprecated warn to the console if the `console` object is exposed.
- *
- * @param {string} message The message to log.
- */
-export function deprecatedWarn(message: string) {
-  if (isDefined(console)) {
-    console.warn(`Deprecated: ${message}`);
-  }
-}
-
-/**
  * Keys of deprecation and removal warnings that were already printed. Module-level on purpose:
  * a deprecated or removed API is reported once per page, regardless of how many grid instances
  * touch it, which is what the deprecation policy promises.

--- a/handsontable/src/helpers/console.ts
+++ b/handsontable/src/helpers/console.ts
@@ -100,8 +100,26 @@ export function deprecatedWarnOnce(key: string, message: string): void {
     return;
   }
 
+  // Record the key only when the message can actually be printed. Otherwise the first call made
+  // while `console` is missing would burn the key for the whole page and silence every later one.
+  if (!isDefined(console)) {
+    return;
+  }
+
   printedDeprecations.add(key);
   deprecatedWarn(message);
+}
+
+/**
+ * Clears the record of already-printed deprecation warnings.
+ *
+ * Test-only. `printedDeprecations` is module-global and never reset in production, so without this
+ * every spec that asserts on a deprecation warning would depend on the order the specs run in.
+ *
+ * @private
+ */
+export function _resetDeprecationWarnings(): void {
+  printedDeprecations.clear();
 }
 
 /**

--- a/handsontable/src/helpers/console.ts
+++ b/handsontable/src/helpers/console.ts
@@ -81,6 +81,30 @@ export function deprecatedWarn(message: string) {
 }
 
 /**
+ * Keys of deprecation warnings that were already printed. Module-level on purpose:
+ * a deprecated API is reported once per page, regardless of how many grid instances
+ * call it, which is what the deprecation policy promises.
+ */
+const printedDeprecations = new Set<string>();
+
+/**
+ * Logs a deprecation warning to the console only once per `key` if the `console`
+ * object is exposed. Use it for every deprecated public API so the warning does
+ * not flood the console on repeated calls.
+ *
+ * @param {string} key A stable identifier of the deprecated API (for example, the method name).
+ * @param {string} message The message to log.
+ */
+export function deprecatedWarnOnce(key: string, message: string): void {
+  if (printedDeprecations.has(key)) {
+    return;
+  }
+
+  printedDeprecations.add(key);
+  deprecatedWarn(message);
+}
+
+/**
  * Logs info to the console if the `console` object is exposed.
  *
  * @param {...*} args Values which will be logged.

--- a/handsontable/src/helpers/console.ts
+++ b/handsontable/src/helpers/console.ts
@@ -81,21 +81,20 @@ export function deprecatedWarn(message: string) {
 }
 
 /**
- * Keys of deprecation warnings that were already printed. Module-level on purpose:
- * a deprecated API is reported once per page, regardless of how many grid instances
- * call it, which is what the deprecation policy promises.
+ * Keys of deprecation and removal warnings that were already printed. Module-level on purpose:
+ * a deprecated or removed API is reported once per page, regardless of how many grid instances
+ * touch it, which is what the deprecation policy promises.
  */
 const printedDeprecations = new Set<string>();
 
 /**
- * Logs a deprecation warning to the console only once per `key` if the `console`
- * object is exposed. Use it for every deprecated public API so the warning does
- * not flood the console on repeated calls.
+ * Logs `message` to the console only once per `key` if the `console` object is exposed.
+ * Shared by the deprecation and removal warnings, so both draw from one record and one reset.
  *
- * @param {string} key A stable identifier of the deprecated API (for example, the method name).
- * @param {string} message The message to log.
+ * @param {string} key A stable identifier of the reported API.
+ * @param {string} message The final message to log.
  */
-export function deprecatedWarnOnce(key: string, message: string): void {
+function warnOncePerKey(key: string, message: string): void {
   if (printedDeprecations.has(key)) {
     return;
   }
@@ -107,14 +106,39 @@ export function deprecatedWarnOnce(key: string, message: string): void {
   }
 
   printedDeprecations.add(key);
-  deprecatedWarn(message);
+  console.warn(message);
 }
 
 /**
- * Clears the record of already-printed deprecation warnings.
+ * Logs a deprecation warning to the console only once per `key` if the `console`
+ * object is exposed. Use it for every deprecated public API so the warning does
+ * not flood the console on repeated calls.
+ *
+ * @param {string} key A stable identifier of the deprecated API (for example, the method name).
+ * @param {string} message The message to log.
+ */
+export function deprecatedWarnOnce(key: string, message: string): void {
+  warnOncePerKey(key, `Deprecated: ${message}`);
+}
+
+/**
+ * Logs a removal warning to the console only once per `key` if the `console` object is exposed.
+ * Use it when a caller configures an API that no longer exists. Unlike `deprecatedWarnOnce`, the
+ * message carries no `Deprecated:` prefix: a removed API is not deprecated, it is gone, and the
+ * message itself has to say so (the same way the removed-hook warning in `core/hooks` does).
+ *
+ * @param {string} key A stable identifier of the removed API (for example, the option name).
+ * @param {string} message The message to log.
+ */
+export function removedWarnOnce(key: string, message: string): void {
+  warnOncePerKey(key, message);
+}
+
+/**
+ * Clears the record of already-printed deprecation and removal warnings.
  *
  * Test-only. `printedDeprecations` is module-global and never reset in production, so without this
- * every spec that asserts on a deprecation warning would depend on the order the specs run in.
+ * every spec that asserts on one of these warnings would depend on the order the specs run in.
  *
  * @private
  */

--- a/handsontable/src/helpers/console.ts
+++ b/handsontable/src/helpers/console.ts
@@ -1,4 +1,4 @@
-import { substitute } from './string';
+import { substitute } from './templateString';
 /* eslint-disable no-console */
 /* eslint-disable no-restricted-globals */
 

--- a/handsontable/src/helpers/mixed.ts
+++ b/handsontable/src/helpers/mixed.ts
@@ -718,7 +718,7 @@ function _injectEntitlementProductInfo(
     if (notification) {
       // The global `console`, not the `helpers/console` wrappers: importing them would put this
       // module - the leaf that `function`, `object`, `string` and `dateTime` all import - at the top
-      // of a cycle (`console` imports `substitute` from `string`, and `string` imports from here).
+      // of a cycle (`console` imports `isDefined` from here).
       // The frozen legacy path prints the same way. Disabled per line, not per file - the blanket
       // exemptions end above, so everything else here is linted normally.
       // eslint-disable-next-line no-console, no-restricted-globals

--- a/handsontable/src/helpers/string.ts
+++ b/handsontable/src/helpers/string.ts
@@ -1,6 +1,10 @@
 import { stringify } from './mixed';
 import { deprecatedWarnOnce } from './console';
 
+// Re-exported to keep `substitute` reachable from its documented `helpers/string` path. The
+// implementation lives in a leaf module so that `helpers/console` can use it without a cycle.
+export { substitute } from './templateString';
+
 /**
  * Convert string to upper case first letter.
  *
@@ -75,24 +79,6 @@ export function isJSON(string: string) {
  */
 export function isPercentValue(value: string): boolean {
   return /^(?:\d\d?%|100%)$/.test(value);
-}
-
-/**
- * Substitute strings placed between square brackets into value defined in `variables` object. String names defined in
- * square brackets must be the same as property name of `variables` object.
- *
- * @param {string} template Template string.
- * @param {object} variables Object which contains all available values which can be injected into template.
- * @returns {string}
- */
-export function substitute(template: string, variables: Record<string, unknown> = {}): string {
-  return (`${template}`).replace(/(?:\\)?\[([^[\]]+)]/g, (match, name) => {
-    if (match.charAt(0) === '\\') {
-      return match.substr(1, match.length - 1);
-    }
-
-    return variables[name] === undefined ? '' : String(variables[name]);
-  });
 }
 
 /**

--- a/handsontable/src/helpers/string.ts
+++ b/handsontable/src/helpers/string.ts
@@ -1,4 +1,5 @@
 import { stringify } from './mixed';
+import { deprecatedWarnOnce } from './console';
 
 /**
  * Convert string to upper case first letter.
@@ -152,12 +153,17 @@ export function escapeHtml(string: string): string {
 /**
  * Returns the string unchanged.
  *
- * @deprecated Default sanitization is now a pass-through. Use the sanitizer
- * configuration option to supply a custom sanitizer function.
+ * @deprecated Since 18.0.0. Handsontable no longer bundles an HTML sanitizer; this helper is a
+ * pass-through and will be removed in 19.0.0. Supply your own sanitizer through the
+ * `sanitizer` configuration option instead.
  * @param {string} string String to return.
  * @returns {string}
  */
 export function sanitize(string: string): string {
+  deprecatedWarnOnce('helper.sanitize',
+    '`sanitize()` is deprecated and will be removed in Handsontable 19.0.0. ' +
+    'It returns its input unchanged. Use the `sanitizer` option to supply your own sanitizer.');
+
   return string;
 }
 

--- a/handsontable/src/helpers/templateString.ts
+++ b/handsontable/src/helpers/templateString.ts
@@ -1,0 +1,21 @@
+/**
+ * Substitute strings placed between square brackets into value defined in `variables` object. String names defined in
+ * square brackets must be the same as property name of `variables` object.
+ *
+ * Lives in its own module, not in `helpers/string`, so that `helpers/console` can use it without
+ * importing `helpers/string` — `helpers/string` needs `deprecatedWarnOnce` from `helpers/console`,
+ * and the resulting cycle would leave one of the two modules reading an uninitialized binding.
+ *
+ * @param {string} template Template string.
+ * @param {object} variables Object which contains all available values which can be injected into template.
+ * @returns {string}
+ */
+export function substitute(template: string, variables: Record<string, unknown> = {}): string {
+  return (`${template}`).replace(/(?:\\)?\[([^[\]]+)]/g, (match, name) => {
+    if (match.charAt(0) === '\\') {
+      return match.substr(1, match.length - 1);
+    }
+
+    return variables[name] === undefined ? '' : String(variables[name]);
+  });
+}

--- a/handsontable/src/plugins/dataProvider/__tests__/dataProvider.types.ts
+++ b/handsontable/src/plugins/dataProvider/__tests__/dataProvider.types.ts
@@ -4,6 +4,7 @@ import type {
   DataProviderConfig,
   DataProviderFetchOptions,
   DataProviderFetchResult,
+  DataProviderOptions,
   DataProviderQueryParameters,
   RowMutationPayload,
   RowMutationUpdatePayload,
@@ -95,3 +96,8 @@ if (dataProviderPlugin) {
 
 void minimalConfig;
 void hot;
+
+// Deprecated alias must stay assignable until 19.0.0.
+const legacyOptions: DataProviderOptions = { signal: new AbortController().signal } as DataProviderFetchOptions;
+
+void legacyOptions;

--- a/handsontable/src/plugins/dataProvider/dataProvider.ts
+++ b/handsontable/src/plugins/dataProvider/dataProvider.ts
@@ -141,7 +141,8 @@ export interface DataProviderFetchOptions {
 }
 
 /**
- * @deprecated Use DataProviderFetchOptions
+ * @deprecated Since 18.0.0, renamed to `DataProviderFetchOptions`. This alias will be removed in
+ * 19.0.0. Use {@link DataProviderFetchOptions} instead.
  */
 export type DataProviderOptions = DataProviderFetchOptions;
 

--- a/handsontable/src/plugins/exportFile/__tests__/exportFile.types.ts
+++ b/handsontable/src/plugins/exportFile/__tests__/exportFile.types.ts
@@ -5,6 +5,7 @@ import type {
   ConditionalFormattingDescriptor,
   Settings as ExportFileLegacySettings,
 } from 'handsontable/plugins/exportFile';
+import { normalizeExportOptions } from 'handsontable/plugins/exportFile/utils';
 
 // Plugin configuration in GridSettings.
 new Handsontable(document.createElement('div'), {
@@ -168,3 +169,12 @@ async function testExportAsBlobAsync(): Promise<void> {
 const legacySettings: ExportFileLegacySettings = { engines: { xlsx: {} } } as ExportFileSettings;
 
 void legacySettings;
+
+// `normalizeExportOptions` has two overloads: a definite object comes back definite, and a missing
+// options argument (`undefined`) comes back `undefined`. Nothing in `src/` exercises the second one,
+// so pin it here; the first is what makes `DataProvider#setOptions` compile.
+const definiteOptions: { colHeaders?: boolean } = normalizeExportOptions({ colHeaders: true });
+const noOptions: Record<string, unknown> | undefined = normalizeExportOptions(undefined);
+
+void definiteOptions;
+void noOptions;

--- a/handsontable/src/plugins/exportFile/__tests__/exportFile.types.ts
+++ b/handsontable/src/plugins/exportFile/__tests__/exportFile.types.ts
@@ -3,6 +3,7 @@ import type {
   ExportFileSettings,
   SheetOptions,
   ConditionalFormattingDescriptor,
+  Settings as ExportFileLegacySettings,
 } from 'handsontable/plugins/exportFile';
 
 // Plugin configuration in GridSettings.
@@ -162,3 +163,8 @@ async function testExportAsBlobAsync(): Promise<void> {
   const blob: Blob = await exportPlugin.exportAsBlobAsync('xlsx');
   const _size: number = blob.size;
 }
+
+// Deprecated alias must stay assignable until 19.0.0.
+const legacySettings: ExportFileLegacySettings = { engines: { xlsx: {} } } as ExportFileSettings;
+
+void legacySettings;

--- a/handsontable/src/plugins/exportFile/__tests__/exportFile.unit.js
+++ b/handsontable/src/plugins/exportFile/__tests__/exportFile.unit.js
@@ -58,6 +58,22 @@ describe('ExportFile#_createBlob', () => {
 });
 
 describe('DataProvider#setOptions', () => {
+  it('should print a one-time deprecation warning when `columnHeaders` is used', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const dataProvider = new DataProvider({});
+
+    dataProvider.setOptions({ columnHeaders: true });
+    dataProvider.setOptions({ columnHeaders: false });
+
+    const deprecationCalls = warnSpy.mock.calls
+      .filter(([message]) => String(message).includes('`columnHeaders`'));
+
+    expect(deprecationCalls.length).toBe(1);
+    expect(deprecationCalls[0][0]).toMatch(/^Deprecated: .*`columnHeaders`.*`colHeaders`/);
+
+    warnSpy.mockRestore();
+  });
+
   it('should support the deprecated `columnHeaders` alias', () => {
     const dataProvider = new DataProvider({});
 

--- a/handsontable/src/plugins/exportFile/__tests__/exportFile.unit.js
+++ b/handsontable/src/plugins/exportFile/__tests__/exportFile.unit.js
@@ -1,5 +1,14 @@
 import { ExportFile } from '../exportFile';
 import DataProvider from '../dataProvider';
+import BaseType from '../types/_base';
+import { normalizeExportOptions } from '../utils';
+import { _resetDeprecationWarnings } from '../../../helpers/console';
+
+beforeEach(() => {
+  // `deprecatedWarnOnce` records printed warnings module-globally, so without this the
+  // `columnHeaders` assertions below would depend on the order the specs run in.
+  _resetDeprecationWarnings();
+});
 
 function fakeCtx(exportFileSettings) {
   return { hot: { getSettings: () => ({ exportFile: exportFileSettings }) } };
@@ -88,5 +97,68 @@ describe('DataProvider#setOptions', () => {
     dataProvider.setOptions({ columnHeaders: true, colHeaders: false });
 
     expect(dataProvider.options.colHeaders).toBe(false);
+  });
+});
+
+describe('normalizeExportOptions', () => {
+  it('should print a one-time deprecation warning when `columnHeaders` is used', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    normalizeExportOptions({ columnHeaders: true });
+    normalizeExportOptions({ columnHeaders: false });
+
+    const deprecationCalls = warnSpy.mock.calls
+      .filter(([message]) => String(message).includes('`columnHeaders`'));
+
+    expect(deprecationCalls.length).toBe(1);
+    expect(deprecationCalls[0][0]).toMatch(/^Deprecated: .*`columnHeaders`.*`colHeaders`/);
+
+    warnSpy.mockRestore();
+  });
+
+  it('should not warn and not copy the object when `columnHeaders` is absent', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const options = { colHeaders: true };
+
+    expect(normalizeExportOptions(options)).toBe(options);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('should promote `columnHeaders` to `colHeaders`', () => {
+    expect(normalizeExportOptions({ columnHeaders: true }).colHeaders).toBe(true);
+  });
+
+  it('should prefer an explicit `colHeaders`', () => {
+    expect(normalizeExportOptions({ columnHeaders: true, colHeaders: false }).colHeaders).toBe(false);
+  });
+
+  it('should tolerate a missing options object', () => {
+    expect(normalizeExportOptions(undefined)).toBe(undefined);
+  });
+});
+
+describe('BaseType#_mergeOptions', () => {
+  it('should warn once and promote the deprecated `columnHeaders` alias', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const merged = BaseType.prototype._mergeOptions.call(
+      { constructor: BaseType },
+      { columnHeaders: true }
+    );
+
+    const deprecationCalls = warnSpy.mock.calls
+      .filter(([message]) => String(message).includes('`columnHeaders`'));
+
+    expect(deprecationCalls.length).toBe(1);
+    expect(merged.colHeaders).toBe(true);
+
+    warnSpy.mockRestore();
+  });
+
+  it('should keep the default `colHeaders` when neither alias is passed', () => {
+    const merged = BaseType.prototype._mergeOptions.call({ constructor: BaseType }, {});
+
+    expect(merged.colHeaders).toBe(false);
   });
 });

--- a/handsontable/src/plugins/exportFile/dataProvider.ts
+++ b/handsontable/src/plugins/exportFile/dataProvider.ts
@@ -1,4 +1,5 @@
 import type { HotInstance } from '../../core/types';
+import { deprecatedWarnOnce } from '../../helpers/console';
 import type { SummaryEndpoint } from '../columnSummary/columnSummary';
 
 interface MergeCellDescriptor {
@@ -60,10 +61,16 @@ class DataProvider {
    * @param {object} options Object with specified options.
    */
   setOptions(options: Record<string, unknown>) {
-    if (options && 'columnHeaders' in options && !('colHeaders' in options)) {
-      this.options = { ...options, colHeaders: options.columnHeaders };
+    if (options && 'columnHeaders' in options) {
+      deprecatedWarnOnce('ExportFile.columnHeaders',
+        'The `columnHeaders` export option is deprecated and will be removed in Handsontable 19.0.0. ' +
+        'Use `colHeaders` instead.');
 
-      return;
+      if (!('colHeaders' in options)) {
+        this.options = { ...options, colHeaders: options.columnHeaders };
+
+        return;
+      }
     }
 
     this.options = options;

--- a/handsontable/src/plugins/exportFile/dataProvider.ts
+++ b/handsontable/src/plugins/exportFile/dataProvider.ts
@@ -1,5 +1,5 @@
 import type { HotInstance } from '../../core/types';
-import { deprecatedWarnOnce } from '../../helpers/console';
+import { normalizeExportOptions } from './utils';
 import type { SummaryEndpoint } from '../columnSummary/columnSummary';
 
 interface MergeCellDescriptor {
@@ -61,19 +61,7 @@ class DataProvider {
    * @param {object} options Object with specified options.
    */
   setOptions(options: Record<string, unknown>) {
-    if (options && 'columnHeaders' in options) {
-      deprecatedWarnOnce('ExportFile.columnHeaders',
-        'The `columnHeaders` export option is deprecated and will be removed in Handsontable 19.0.0. ' +
-        'Use `colHeaders` instead.');
-
-      if (!('colHeaders' in options)) {
-        this.options = { ...options, colHeaders: options.columnHeaders };
-
-        return;
-      }
-    }
-
-    this.options = options;
+    this.options = normalizeExportOptions(options);
   }
 
   /**

--- a/handsontable/src/plugins/exportFile/exportFile.ts
+++ b/handsontable/src/plugins/exportFile/exportFile.ts
@@ -29,7 +29,10 @@ export interface SheetOptions {
    */
   colHeaders?: boolean;
   /**
-   * @deprecated Use `colHeaders` instead.
+   * Include column headers.
+   *
+   * @deprecated Since 17.0.0, renamed to `colHeaders`. Still accepted as an alias; it will be
+   * removed in 19.0.0. Use `colHeaders` instead.
    */
   columnHeaders?: boolean;
   /**
@@ -169,7 +172,10 @@ export interface ExportOptions {
    */
   colHeaders?: boolean;
   /**
-   * @deprecated Use `colHeaders` instead.
+   * Include column headers.
+   *
+   * @deprecated Since 17.0.0, renamed to `colHeaders`. Still accepted as an alias; it will be
+   * removed in 19.0.0. Use `colHeaders` instead.
    */
   columnHeaders?: boolean;
   /**
@@ -229,7 +235,8 @@ export interface ExportFileSettings {
 }
 
 /**
- * @deprecated Use {@link ExportFileSettings} instead.
+ * @deprecated Since 18.0.0, renamed to `ExportFileSettings`. This alias will be removed in 19.0.0.
+ * Use {@link ExportFileSettings} instead.
  */
 export type Settings = ExportFileSettings;
 export const PLUGIN_PRIORITY = 240;

--- a/handsontable/src/plugins/exportFile/exportFile.ts
+++ b/handsontable/src/plugins/exportFile/exportFile.ts
@@ -31,7 +31,7 @@ export interface SheetOptions {
   /**
    * Include column headers.
    *
-   * @deprecated Since 17.0.0, renamed to `colHeaders`. Still accepted as an alias; it will be
+   * @deprecated Since 17.1.0, renamed to `colHeaders`. Still accepted as an alias; it will be
    * removed in 19.0.0. Use `colHeaders` instead.
    */
   columnHeaders?: boolean;
@@ -174,7 +174,7 @@ export interface ExportOptions {
   /**
    * Include column headers.
    *
-   * @deprecated Since 17.0.0, renamed to `colHeaders`. Still accepted as an alias; it will be
+   * @deprecated Since 17.1.0, renamed to `colHeaders`. Still accepted as an alias; it will be
    * removed in 19.0.0. Use `colHeaders` instead.
    */
   columnHeaders?: boolean;

--- a/handsontable/src/plugins/exportFile/types/_base.ts
+++ b/handsontable/src/plugins/exportFile/types/_base.ts
@@ -1,6 +1,7 @@
 import { extend, clone } from '../../../helpers/object';
 import { substitute } from '../../../helpers/string';
 import { throwWithCause } from '../../../helpers/errors';
+import { normalizeExportOptions } from '../utils';
 import type DataProvider from '../dataProvider';
 
 /**
@@ -96,14 +97,9 @@ class BaseType {
 
     _options = extend(clone(BaseType.DEFAULT_OPTIONS) as Record<string, unknown>, _options) as Record<string, unknown>;
 
-    // Legacy alias: `columnHeaders` was renamed to `colHeaders`. When a caller
-    // passes the old name and does not also pass the new name, promote it so
-    // that the rest of the code only needs to read `colHeaders`.
-    if (options && 'columnHeaders' in options && !('colHeaders' in options)) {
-      options = { ...options, colHeaders: options.columnHeaders };
-    }
-
-    _options = extend(_options, options) as Record<string, unknown>;
+    // Deprecated alias: `columnHeaders` was renamed to `colHeaders`. Promote it here, before the
+    // merge with the defaults, so the rest of the code only ever reads `colHeaders`.
+    _options = extend(_options, normalizeExportOptions(options)) as Record<string, unknown>;
 
     _options.filename = substitute(_options.filename as string, {
       YYYY: date.getFullYear(),

--- a/handsontable/src/plugins/exportFile/types/xlsx.ts
+++ b/handsontable/src/plugins/exportFile/types/xlsx.ts
@@ -3,6 +3,7 @@ import { isKeyValueObject } from '../../../helpers/object';
 import { throwWithCause } from '../../../helpers/errors';
 import DataProvider from '../dataProvider';
 import BaseType from './_base';
+import { normalizeExportOptions } from '../utils';
 import {
   buildSummaryFormula,
   normalizeFormula,
@@ -284,14 +285,9 @@ class Xlsx extends BaseType {
 
       sheets.forEach((sheetConfig) => {
         const dp = new DataProvider(sheetConfig.instance);
-        // Apply the same legacy-alias promotion that _mergeOptions does for top-level
-        // options: if the caller passed the deprecated `columnHeaders` on a per-sheet
-        // config without also passing `colHeaders`, promote it so `dataProvider.js`
-        // (which only reads `colHeaders`) picks it up correctly.
-        const normalizedSheetConfig = ('columnHeaders' in sheetConfig && !('colHeaders' in sheetConfig))
-          ? { ...sheetConfig, colHeaders: sheetConfig.columnHeaders }
-          : sheetConfig;
-        const sheetOptions = { ...this.options, ...normalizedSheetConfig };
+        // Promote the deprecated `columnHeaders` alias on the per-sheet config before it is merged
+        // with the already-normalized top-level options, which carry `colHeaders` either way.
+        const sheetOptions = { ...this.options, ...normalizeExportOptions(sheetConfig) };
 
         dp.setOptions(sheetOptions);
 

--- a/handsontable/src/plugins/exportFile/utils.ts
+++ b/handsontable/src/plugins/exportFile/utils.ts
@@ -1,6 +1,36 @@
 import { html } from '../../helpers/templateLiteralTag';
 import { LOADING_CLASS_NAME } from '../../helpers/constants';
 import { escapeHtml } from '../../helpers/string';
+import { deprecatedWarnOnce } from '../../helpers/console';
+
+/**
+ * Resolves the deprecated `columnHeaders` export option to its current name, `colHeaders`.
+ *
+ * Call this at every entry point that accepts caller-supplied export options. The promotion has to
+ * happen before the options are merged with the defaults, because `BaseType.DEFAULT_OPTIONS`
+ * carries `colHeaders`, and a merged object therefore always has the new key already.
+ *
+ * The warning prints once per page, so calling this on several code paths for one export is safe.
+ *
+ * @param {object} options Caller-supplied export options.
+ * @returns {object} The same object when `columnHeaders` is absent, otherwise a copy with
+ *   `colHeaders` filled in. An explicit `colHeaders` always wins.
+ */
+export function normalizeExportOptions<T extends Record<string, unknown>>(options: T): T {
+  if (!options || !('columnHeaders' in options)) {
+    return options;
+  }
+
+  deprecatedWarnOnce('ExportFile.columnHeaders',
+    'The `columnHeaders` export option is deprecated and will be removed in Handsontable 19.0.0. ' +
+    'Use `colHeaders` instead.');
+
+  if ('colHeaders' in options) {
+    return options;
+  }
+
+  return { ...options, colHeaders: options.columnHeaders };
+}
 
 /**
  * Builds the dialog overlay DOM fragment for the export progress indicator.

--- a/handsontable/src/plugins/exportFile/utils.ts
+++ b/handsontable/src/plugins/exportFile/utils.ts
@@ -3,6 +3,8 @@ import { LOADING_CLASS_NAME } from '../../helpers/constants';
 import { escapeHtml } from '../../helpers/string';
 import { deprecatedWarnOnce } from '../../helpers/console';
 
+export function normalizeExportOptions<T extends Record<string, unknown>>(options: T): T;
+export function normalizeExportOptions<T extends Record<string, unknown>>(options: T | undefined): T | undefined;
 /**
  * Resolves the deprecated `columnHeaders` export option to its current name, `colHeaders`.
  *
@@ -12,11 +14,16 @@ import { deprecatedWarnOnce } from '../../helpers/console';
  *
  * The warning prints once per page, so calling this on several code paths for one export is safe.
  *
- * @param {object} options Caller-supplied export options.
- * @returns {object} The same object when `columnHeaders` is absent, otherwise a copy with
- *   `colHeaders` filled in. An explicit `colHeaders` always wins.
+ * The overloads keep the contract honest at both kinds of call site: a caller that passes a definite
+ * object gets a definite object back, while a caller that may pass `undefined` (a missing options
+ * argument) gets `undefined` back and has to handle it.
+ *
+ * @param {object|undefined} options Caller-supplied export options, or `undefined` when the caller
+ *   passed none.
+ * @returns {object|undefined} The input as-is when it is `undefined` or `columnHeaders` is absent,
+ *   otherwise a copy with `colHeaders` filled in. An explicit `colHeaders` always wins.
  */
-export function normalizeExportOptions<T extends Record<string, unknown>>(options: T): T {
+export function normalizeExportOptions<T extends Record<string, unknown>>(options: T | undefined): T | undefined {
   if (!options || !('columnHeaders' in options)) {
     return options;
   }

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.unit.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.unit.js
@@ -1,0 +1,64 @@
+import { ManualColumnResize } from '../manualColumnResize';
+import { _resetDeprecationWarnings } from '../../../helpers/console';
+
+describe('ManualColumnResize deprecated resize-state methods', () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    // `deprecatedWarnOnce` records printed warnings module-globally, so without this each spec
+    // below would depend on the order the specs run in.
+    _resetDeprecationWarnings();
+
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  function deprecationCalls(methodName) {
+    return warnSpy.mock.calls.filter(([message]) => String(message).includes(`\`${methodName}()\``));
+  }
+
+  describe('saveManualColumnWidths', () => {
+    it('should warn once, no matter how many times it is called', () => {
+      // The methods read no state, so the prototype call keeps this a unit test.
+      ManualColumnResize.prototype.saveManualColumnWidths.call({});
+      ManualColumnResize.prototype.saveManualColumnWidths.call({});
+      ManualColumnResize.prototype.saveManualColumnWidths.call({});
+
+      const calls = deprecationCalls('saveManualColumnWidths');
+
+      expect(calls.length).toBe(1);
+      expect(calls[0][0]).toMatch(/^Deprecated: .*removed in Handsontable 19\.0\.0/);
+    });
+
+    it('should return undefined', () => {
+      expect(ManualColumnResize.prototype.saveManualColumnWidths.call({})).toBe(undefined);
+    });
+  });
+
+  describe('loadManualColumnWidths', () => {
+    it('should warn once, no matter how many times it is called', () => {
+      ManualColumnResize.prototype.loadManualColumnWidths.call({});
+      ManualColumnResize.prototype.loadManualColumnWidths.call({});
+
+      const calls = deprecationCalls('loadManualColumnWidths');
+
+      expect(calls.length).toBe(1);
+      expect(calls[0][0]).toMatch(/^Deprecated: .*removed in Handsontable 19\.0\.0/);
+    });
+
+    it('should return an empty array', () => {
+      expect(ManualColumnResize.prototype.loadManualColumnWidths.call({})).toEqual([]);
+    });
+  });
+
+  it('should warn separately for each method', () => {
+    ManualColumnResize.prototype.saveManualColumnWidths.call({});
+    ManualColumnResize.prototype.loadManualColumnWidths.call({});
+
+    expect(deprecationCalls('saveManualColumnWidths').length).toBe(1);
+    expect(deprecationCalls('loadManualColumnWidths').length).toBe(1);
+  });
+});

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
@@ -13,7 +13,7 @@ import {
 } from '../../helpers/dom/element';
 import { arrayEach } from '../../helpers/array';
 import { rangeEach } from '../../helpers/number';
-import { deprecatedWarn } from '../../helpers/console';
+import { deprecatedWarnOnce } from '../../helpers/console';
 import type { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
 import {
   getElementScaleFactor,
@@ -226,25 +226,29 @@ export class ManualColumnResize extends BasePlugin {
   }
 
   /**
-   * Deprecated. The `PersistentState` plugin has been removed. This method is a no-op and will be removed in a
-   * future major release.
+   * Deprecated. The `PersistentState` plugin has been removed. This method is a no-op.
    *
-   * @deprecated
+   * @deprecated Since 18.0.0. The `PersistentState` plugin was removed in 17.0.0, so this method
+   * does nothing. It will be removed in 19.0.0. Persist column widths yourself with
+   * the `afterColumnResize` hook and the `manualColumnResize` option.
    */
   saveManualColumnWidths(): void {
-    deprecatedWarn('`saveManualColumnWidths()` is deprecated and will be removed in a future major release. ' +
+    deprecatedWarnOnce('ManualColumnResize.saveManualColumnWidths',
+      '`saveManualColumnWidths()` is deprecated and will be removed in Handsontable 19.0.0. ' +
       'The PersistentState plugin has been removed.');
   }
 
   /**
-   * Deprecated. The `PersistentState` plugin has been removed. This method is a no-op and will be removed in a
-   * future major release.
+   * Deprecated. The `PersistentState` plugin has been removed. This method is a no-op.
    *
-   * @deprecated
+   * @deprecated Since 18.0.0. The `PersistentState` plugin was removed in 17.0.0, so this method
+   * returns an empty array. It will be removed in 19.0.0. Restore column widths yourself
+   * by passing an array to the `manualColumnResize` option.
    * @returns {Array}
    */
   loadManualColumnWidths(): Array<number | null> {
-    deprecatedWarn('`loadManualColumnWidths()` is deprecated and will be removed in a future major release. ' +
+    deprecatedWarnOnce('ManualColumnResize.loadManualColumnWidths',
+      '`loadManualColumnWidths()` is deprecated and will be removed in Handsontable 19.0.0. ' +
       'The PersistentState plugin has been removed.');
 
     return [];

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.unit.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.unit.js
@@ -1,0 +1,64 @@
+import { ManualRowResize } from '../manualRowResize';
+import { _resetDeprecationWarnings } from '../../../helpers/console';
+
+describe('ManualRowResize deprecated resize-state methods', () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    // `deprecatedWarnOnce` records printed warnings module-globally, so without this each spec
+    // below would depend on the order the specs run in.
+    _resetDeprecationWarnings();
+
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  function deprecationCalls(methodName) {
+    return warnSpy.mock.calls.filter(([message]) => String(message).includes(`\`${methodName}()\``));
+  }
+
+  describe('saveManualRowHeights', () => {
+    it('should warn once, no matter how many times it is called', () => {
+      // The methods read no state, so the prototype call keeps this a unit test.
+      ManualRowResize.prototype.saveManualRowHeights.call({});
+      ManualRowResize.prototype.saveManualRowHeights.call({});
+      ManualRowResize.prototype.saveManualRowHeights.call({});
+
+      const calls = deprecationCalls('saveManualRowHeights');
+
+      expect(calls.length).toBe(1);
+      expect(calls[0][0]).toMatch(/^Deprecated: .*removed in Handsontable 19\.0\.0/);
+    });
+
+    it('should return undefined', () => {
+      expect(ManualRowResize.prototype.saveManualRowHeights.call({})).toBe(undefined);
+    });
+  });
+
+  describe('loadManualRowHeights', () => {
+    it('should warn once, no matter how many times it is called', () => {
+      ManualRowResize.prototype.loadManualRowHeights.call({});
+      ManualRowResize.prototype.loadManualRowHeights.call({});
+
+      const calls = deprecationCalls('loadManualRowHeights');
+
+      expect(calls.length).toBe(1);
+      expect(calls[0][0]).toMatch(/^Deprecated: .*removed in Handsontable 19\.0\.0/);
+    });
+
+    it('should return an empty array', () => {
+      expect(ManualRowResize.prototype.loadManualRowHeights.call({})).toEqual([]);
+    });
+  });
+
+  it('should warn separately for each method', () => {
+    ManualRowResize.prototype.saveManualRowHeights.call({});
+    ManualRowResize.prototype.loadManualRowHeights.call({});
+
+    expect(deprecationCalls('saveManualRowHeights').length).toBe(1);
+    expect(deprecationCalls('loadManualRowHeights').length).toBe(1);
+  });
+});

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.ts
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.ts
@@ -13,7 +13,7 @@ import {
 } from '../../helpers/dom/element';
 import { arrayEach } from '../../helpers/array';
 import { rangeEach } from '../../helpers/number';
-import { deprecatedWarn } from '../../helpers/console';
+import { deprecatedWarnOnce } from '../../helpers/console';
 import type { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
 import {
   getElementScaleFactor,
@@ -220,25 +220,29 @@ export class ManualRowResize extends BasePlugin {
   }
 
   /**
-   * Deprecated. The `PersistentState` plugin has been removed. This method is a no-op and will be removed in a
-   * future major release.
+   * Deprecated. The `PersistentState` plugin has been removed. This method is a no-op.
    *
-   * @deprecated
+   * @deprecated Since 18.0.0. The `PersistentState` plugin was removed in 17.0.0, so this method
+   * does nothing. It will be removed in 19.0.0. Persist row heights yourself with
+   * the `afterRowResize` hook and the `manualRowResize` option.
    */
   saveManualRowHeights(): void {
-    deprecatedWarn('`saveManualRowHeights()` is deprecated and will be removed in a future major release. ' +
+    deprecatedWarnOnce('ManualRowResize.saveManualRowHeights',
+      '`saveManualRowHeights()` is deprecated and will be removed in Handsontable 19.0.0. ' +
       'The PersistentState plugin has been removed.');
   }
 
   /**
-   * Deprecated. The `PersistentState` plugin has been removed. This method is a no-op and will be removed in a
-   * future major release.
+   * Deprecated. The `PersistentState` plugin has been removed. This method is a no-op.
    *
-   * @deprecated
+   * @deprecated Since 18.0.0. The `PersistentState` plugin was removed in 17.0.0, so this method
+   * returns an empty array. It will be removed in 19.0.0. Restore row heights yourself
+   * by passing an array to the `manualRowResize` option.
    * @returns {Array}
    */
   loadManualRowHeights(): Array<number | null> {
-    deprecatedWarn('`loadManualRowHeights()` is deprecated and will be removed in a future major release. ' +
+    deprecatedWarnOnce('ManualRowResize.loadManualRowHeights',
+      '`loadManualRowHeights()` is deprecated and will be removed in Handsontable 19.0.0. ' +
       'The PersistentState plugin has been removed.');
 
     return [];

--- a/handsontable/src/translations/indexMapper.ts
+++ b/handsontable/src/translations/indexMapper.ts
@@ -21,14 +21,6 @@ import { ChangesObservable } from './changesObservable/observable';
 import { throwWithCause } from '../helpers/errors';
 
 /**
- * A set of deprecated feature names.
- *
- * @type {Set<string>}
- */
-// eslint-disable-next-line no-unused-vars
-const deprecationWarns = new Set();
-
-/**
  * @class IndexMapper
  * @description
  *


### PR DESCRIPTION
### Context

The PR changes how deprecated APIs report themselves, so that every API marked `@deprecated` in the codebase behaves the same way before the 18.1 release: a JSDoc `@deprecated` message that names the deprecating and removing versions, a one-time `console.warn` at runtime, and a row in the documented deprecation list. Nothing is removed – 18.1 is a minor release, and every message names 19.0 as the removal version.

Before this change:

- `deprecatedWarn()` printed on **every** call, although the deprecation policy promises a warning "fired only once" (`.ai/BREAKING-CHANGES.md`). Calling `saveManualColumnWidths()` in a loop flooded the console.
- The four resize-state methods carried a bare `@deprecated` tag, which the API reference renders as an empty warning box.
- The `exportFile` `columnHeaders` alias, `Handsontable.helper.sanitize()`, and the `Settings` / `DataProviderOptions` type aliases were tagged `@deprecated` in the typings but produced no runtime warning and were missing from the deprecation list in the docs.
- `Handsontable.CellMeta` (namespace alias) was tagged `@deprecated Use CellProperties`, while 18.0 promoted `CellMeta` to a top-level named export (#11240). The two now agree: the alias is no longer marked deprecated.
- Removed options (`persistentState`, removed in 17.0; `correctFormat`, removed in 18.0) were silently ignored. `updateSettings()` now warns once (it never throws).

Code changes:

- `helpers/console.ts`: new `deprecatedWarnOnce(key, message)` – prints `Deprecated: <message>` once per key per page – and `removedWarnOnce(key, message)` – same once-per-key record, no prefix, for APIs that no longer exist. The repeat-every-call `deprecatedWarn()` is removed (last caller moved to the once variant; not on `Handsontable.helper`).
- `ManualColumnResize` / `ManualRowResize`: `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, `loadManualRowHeights()` use it and carry versioned `@deprecated` messages.
- `exportFile` `DataProvider#setOptions`: warns once when `columnHeaders` is passed; the alias keeps working.
- `helpers/string.ts` `sanitize()`: warns once and points at the `sanitizer` option.
- `exportFile` `Settings` and `dataProvider` `DataProviderOptions`: versioned `@deprecated` messages.
- `core.ts` `updateSettings()`: warn-once guard for removed options (`REMOVED_OPTIONS`). It scans the top level, the array-form `columns`, and the declarative `cell` array. Each option links to the docs of the release that removed it.
- Removed the unused `deprecationWarns` sets in `core.ts` and `translations/indexMapper.ts`.

Docs changes:

- `deprecation-policy.md`: lists the APIs removed in 18.0 next to the removed dependencies, adds a "Removed in version 17.0" section (`PersistentState`, legacy `hot.undo()` family), and adds the missing current deprecations with "Deprecated in" / "Removal" columns.
- `CHANGELOG.md`, `changelog-18.md`, `changelog/changelog.md`: the 18.0.0 PersistentState removal entry linked `pull/0` (it is #12727), and now states that the published 17.0 release already shipped without the plugin (#12015), so it no longer contradicts the "Removed in version 17.0" section.
- `.ai/BREAKING-CHANGES.md` (deprecation checklist; "next stable release" → "next major release"), `handsontable/.ai/CONVENTIONS.md`, `handsontable/.ai/HOOKS.md`.

Version facts verified against git history:

- `columnHeaders` was renamed and deprecated in **17.1.0** (#12224, commit `53df95b073`).
- `persistentState` (plugin, option, hooks) was removed in **17.0.0** (#12015). The TypeScript conversion (#12011) re-created the plugin on `develop` after 17.1.0; #12727 deleted that copy before 18.0.0. No published 17.x or 18.x package carries it, so the 18.0.0 changelog line describes a develop-only cleanup. The `REMOVED_OPTIONS` JSDoc records this.

Out of scope, on purpose: removing any deprecated code (19.0 only) and the migration guides (left untouched). The released 18.0.0 changelog entry keeps its wording; it only gains the clause about the 17.0 release.

[skip changelog] – the branch carries only deprecation metadata and warning-consistency work on APIs that are already deprecated or removed; no new user-facing deprecation. The checklist's step 5 stays as written for PRs that introduce a deprecation.

Open points for reviewers:

1. `.changelogs/12727.json` is still pending on `develop` although the entry already shipped under 18.0.0, so it will be compiled again into the 18.1 notes. Release owner to decide which version keeps it.
2. `columnHeaders` stays *deprecated* (warn + removal in 19.0), not legacy: the tag has been in the published typings since 17.1, so this PR completes a deprecation that shipped without a runtime warning.

### How has this been tested?

- Unit tests added:
  - `handsontable/src/helpers/__tests__/console.unit.ts` – `deprecatedWarnOnce` and `removedWarnOnce` warn once per key, tolerate a missing `console`, and share the once-record and the reset. The `deprecatedWarn` block is gone with the function.
  - `handsontable/src/plugins/exportFile/__tests__/exportFile.unit.js` – `columnHeaders` warns once and still maps to `colHeaders`.
  - `handsontable/src/helpers/__tests__/string.unit.ts` – `sanitize()` warns once and stays a pass-through.
  - `handsontable/src/__tests__/core/updateSettings.unit.js` – removed options warn once (top level, `columns`, `cell`), without a `Deprecated:` prefix, with the removing version and the per-release docs URL; unaffected settings do not warn.
- Type tests extended: `exportFile.types.ts`, `dataProvider.types.ts` – deprecated aliases stay assignable; both `normalizeExportOptions()` overloads are pinned.
- Ran locally:
  ```bash
  npm --prefix handsontable run test:unit    # 322 suites, 3834 tests pass
  npm --prefix handsontable run test:types
  npm --prefix handsontable run eslint       # 0 errors
  npm --prefix handsontable run stylelint
  npm --prefix handsontable run build        # both bundles
  cd docs && npm run docs:api                # ManualColumnResize/ManualRowResize pages render the "Deprecated" tag + warning text
  ```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #12727 (PersistentState removal – deprecated the resize-state methods)
2. #12224 (`columnHeaders` → `colHeaders` rename)
3. #12015 (17.0.0 removal of `PersistentState` and the legacy undo/redo methods)

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.
