### PR TITLE
RELEASE-843: Remove 18.0.0 entries duplicated into the 18.1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [18.1.0-rc3] - 2026-08-26
 
 ### Added
-- Added the `modifySinglePassLayout` hook. The grid now renders in a single pass by predicting whether scrollbars will appear before rendering; return `false` from the hook to force the previous measure-then-render path. [#12951](https://github.com/handsontable/handsontable/pull/12951)
+- Added the `modifySinglePassLayout` hook, which forces the previous measure-then-render layout path for a table. [#12951](https://github.com/handsontable/handsontable/pull/12951)
 - Added the `selectionHandles` option, which shows draggable handles at each edge midpoint of a selected range for resizing the selection, and the `moveCells` option for moving a cell selection to a new location by dragging its border. [#13076](https://github.com/handsontable/handsontable/pull/13076)
 - Added Persian language RTL direction support. [#13101](https://github.com/handsontable/handsontable/issues/13101)
 - Added support for entitlement license keys, and made a missing or invalid license key block the grid with a modal that cannot be closed. [#13106](https://github.com/handsontable/handsontable/pull/13106)
@@ -31,6 +31,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Improved vertical scrolling performance for grids with pinned bottom rows (`fixedRowsBottom`). [#12894](https://github.com/handsontable/handsontable/issues/12894)
 - Improved the performance of sorting, filtering, hiding, and inserting/removing rows/columns on large datasets by removing redundant per-operation work in the index translation layer. [#12898](https://github.com/handsontable/handsontable/pull/12898)
 - Improved the performance of the internal hooks (events) dispatch: each hook's callbacks are now stored in a linked list, and removing a hook frees it immediately instead of accumulating skipped entries that were iterated over on every run. [#12925](https://github.com/handsontable/handsontable/pull/12925)
+- The grid now renders in a single pass, predicting whether scrollbars will appear instead of rendering, measuring, and re-rendering. The `mergeCells` plugin keeps the previous path, and the `modifySinglePassLayout` hook opts out of it. [#12951](https://github.com/handsontable/handsontable/pull/12951)
 - Improved vertical scrolling performance by skipping the column header re-render when the column layout is unchanged. [#12987](https://github.com/handsontable/handsontable/pull/12987)
 - Improved vertical scrolling performance by re-rendering only the rows entering the viewport and reusing the rows that stay. [#12995](https://github.com/handsontable/handsontable/pull/12995)
 - Improved scrolling performance for grids embedded in complex pages by keeping the rendered cells in place during scroll instead of re-inserting them. [#13020](https://github.com/handsontable/handsontable/pull/13020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [18.1.0-rc3] - 2026-08-26
 
 ### Added
-- Added the `singlePassLayout` option, which renders the grid in a single pass by predicting whether scrollbars will appear before rendering. [#12951](https://github.com/handsontable/handsontable/pull/12951)
+- Added the `modifySinglePassLayout` hook. The grid now renders in a single pass by predicting whether scrollbars will appear before rendering; return `false` from the hook to force the previous measure-then-render path. [#12951](https://github.com/handsontable/handsontable/pull/12951)
 - Added the `selectionHandles` option, which shows draggable handles at each edge midpoint of a selected range for resizing the selection, and the `moveCells` option for moving a cell selection to a new location by dragging its border. [#13076](https://github.com/handsontable/handsontable/pull/13076)
 - Added Persian language RTL direction support. [#13101](https://github.com/handsontable/handsontable/issues/13101)
 - Added support for entitlement license keys, and made a missing or invalid license key block the grid with a modal that cannot be closed. [#13106](https://github.com/handsontable/handsontable/pull/13106)
@@ -23,7 +23,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added the `formulas.hyperlinks` option, which renders cells holding a `HYPERLINK` formula as clickable links. [#13223](https://github.com/handsontable/handsontable/pull/13223)
 
 ### Changed
-- Reduced memory usage and improved initialization time for large datasets by no longer materializing cell metadata for every cell during source data validation. [#12847](https://github.com/handsontable/handsontable/pull/12847)
 - Reduced memory usage when scrolling large datasets by releasing cell metadata for rows scrolled out of the viewport. [#12854](https://github.com/handsontable/handsontable/pull/12854)
 - Improved the performance of sorting, filtering, and row/column hiding on large datasets by speeding up internal index translation. [#12880](https://github.com/handsontable/handsontable/pull/12880)
 - Improved initialization time for large date-typed datasets by validating ISO dates arithmetically instead of constructing a `Date` object for every cell. [#12881](https://github.com/handsontable/handsontable/pull/12881)
@@ -51,7 +50,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Improved sizing plugins performance: AutoColumnSize measures only the changed cells on edits instead of rescanning whole columns, its background width sweep is budgeted and runs on browser idle time, AutoRowSize reuses the cached header height on selection-driven renders, and a multi-column resize triggers one height recalculation instead of one per column. [#13097](https://github.com/handsontable/handsontable/issues/13097)
 
 ### Removed
-- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. [#12727](https://github.com/handsontable/handsontable/pull/12727)
 - Removed leftover Pikaday styles from the themes. [#13156](https://github.com/handsontable/handsontable/pull/13156)
 
 ### Fixed
@@ -65,14 +63,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed merged cells breaking after filtering, `trimRows`/`nestedRows` collapse, or sorting — merges now stay whole and follow the visible rows. [#12792](https://github.com/handsontable/handsontable/issues/12792)
 - Fixed nested headers not following the data when moving columns; labels now travel with their columns, a group split across non-adjacent columns renders as separate banners, and a collapsed group either follows the move or expands when the move would split it. [#12793](https://github.com/handsontable/handsontable/issues/12793)
 - Fixed nested column headers ignoring `stopImmediatePropagation()` called in the `beforeOnCellMouseOver` hook, so a header drag-selection can now be blocked the same way as for regular column headers. [#12794](https://github.com/handsontable/handsontable/issues/12794)
-- Fixed clears stale cell meta after a merge is removed (unmerge) [#12798](https://github.com/handsontable/handsontable/issues/12798)
+- Fixed stale cell metadata left behind after unmerging cells, which made `toHTML()` output extra cells. [#12798](https://github.com/handsontable/handsontable/issues/12798)
 - Fixed undo not restoring merged cells after removing a column that overlapped a merge. [#12801](https://github.com/handsontable/handsontable/issues/12801)
 - Fixed missing selection border edges and active header highlight accents along frozen-pane boundaries (`fixedRowsTop` / `fixedRowsBottom` / `fixedColumnsStart`). [#12802](https://github.com/handsontable/handsontable/issues/12802)
 - Fixed context menu inserting two rows instead of one when tapping "Insert row above" or "Insert row below" on iPad (Safari). [#12804](https://github.com/handsontable/handsontable/issues/12804)
-- Fixed cell meta set with `setCellMeta` (for example, `readOnly`) being reset by `updateSettings`. [#12811](https://github.com/handsontable/handsontable/issues/12811)
 - Fixed `multiselect` cell type displaying a neighbouring column's value after moving the column with `manualColumnMove`. [#12827](https://github.com/handsontable/handsontable/issues/12827)
 - Fixed a bug where Ctrl/Cmd+clicking an already-selected cell in a multi-cell selection caused the active highlight to jump to a different cell [#12841](https://github.com/handsontable/handsontable/pull/12841)
-- Reduced memory usage during scrolling and fixed potential out-of-memory errors on very large datasets. [#12844](https://github.com/handsontable/handsontable/pull/12844)
 - Reduced memory usage when filtering large datasets: the Filters plugin no longer permanently retains a cell meta object for every source row of each filtered column. [#12878](https://github.com/handsontable/handsontable/pull/12878)
 - Fixed an error thrown when removing a frozen column while using the legacy fixedColumnsLeft option. [#12883](https://github.com/handsontable/handsontable/pull/12883)
 - Fixed the `multiselect` cell type so its option filtering folds case in a locale-aware way, consistent with the `autocomplete` editor, for Turkish, Azeri, and Lithuanian locales. [#12902](https://github.com/handsontable/handsontable/issues/12902)
@@ -151,7 +147,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 - **Breaking change**: Removed the numbro, moment.js, DOMPurify, and @handsontable/pikaday dependencies. [#12689](https://github.com/handsontable/handsontable/issues/12689)
-- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. [#0](https://github.com/handsontable/handsontable/pull/0)
+- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. [#12727](https://github.com/handsontable/handsontable/pull/12727)
 - **Breaking change**: Removed the deprecated Core-level undo/redo methods (`hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, `hot.undoRedo`). Use `hot.getPlugin('undoRedo')` instead. [#12728](https://github.com/handsontable/handsontable/issues/12728)
 
 ### Fixed

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -34,7 +34,7 @@ For more information about this release, see:
 - [Documentation (18.1)](https://handsontable.com/docs/18.1)
 
 #### Added
-- Added the `singlePassLayout` option, which renders the grid in a single pass by predicting whether scrollbars will appear before rendering. [#12951](https://github.com/handsontable/handsontable/pull/12951)
+- Added the `modifySinglePassLayout` hook. The grid now renders in a single pass by predicting whether scrollbars will appear before rendering; return `false` from the hook to force the previous measure-then-render path. [#12951](https://github.com/handsontable/handsontable/pull/12951)
 - Added the `selectionHandles` option, which shows draggable handles at each edge midpoint of a selected range for resizing the selection, and the `moveCells` option for moving a cell selection to a new location by dragging its border. [#13076](https://github.com/handsontable/handsontable/pull/13076)
 - Added Persian language RTL direction support. [#13101](https://github.com/handsontable/handsontable/issues/13101)
 - Added support for entitlement license keys, and made a missing or invalid license key block the grid with a modal that cannot be closed. [#13106](https://github.com/handsontable/handsontable/pull/13106)
@@ -45,7 +45,6 @@ For more information about this release, see:
 - Added the `formulas.hyperlinks` option, which renders cells holding a `HYPERLINK` formula as clickable links. [#13223](https://github.com/handsontable/handsontable/pull/13223)
 
 #### Changed
-- Reduced memory usage and improved initialization time for large datasets by no longer materializing cell metadata for every cell during source data validation. [#12847](https://github.com/handsontable/handsontable/pull/12847)
 - Reduced memory usage when scrolling large datasets by releasing cell metadata for rows scrolled out of the viewport. [#12854](https://github.com/handsontable/handsontable/pull/12854)
 - Improved the performance of sorting, filtering, and row/column hiding on large datasets by speeding up internal index translation. [#12880](https://github.com/handsontable/handsontable/pull/12880)
 - Improved initialization time for large date-typed datasets by validating ISO dates arithmetically instead of constructing a `Date` object for every cell. [#12881](https://github.com/handsontable/handsontable/pull/12881)
@@ -73,7 +72,6 @@ For more information about this release, see:
 - Improved sizing plugins performance: AutoColumnSize measures only the changed cells on edits instead of rescanning whole columns, its background width sweep is budgeted and runs on browser idle time, AutoRowSize reuses the cached header height on selection-driven renders, and a multi-column resize triggers one height recalculation instead of one per column. [#13097](https://github.com/handsontable/handsontable/issues/13097)
 
 #### Removed
-- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. [#12727](https://github.com/handsontable/handsontable/pull/12727)
 - Removed leftover Pikaday styles from the themes. [#13156](https://github.com/handsontable/handsontable/pull/13156)
 
 #### Fixed
@@ -87,14 +85,12 @@ For more information about this release, see:
 - Fixed merged cells breaking after filtering, `trimRows`/`nestedRows` collapse, or sorting — merges now stay whole and follow the visible rows. [#12792](https://github.com/handsontable/handsontable/issues/12792)
 - Fixed nested headers not following the data when moving columns; labels now travel with their columns, a group split across non-adjacent columns renders as separate banners, and a collapsed group either follows the move or expands when the move would split it. [#12793](https://github.com/handsontable/handsontable/issues/12793)
 - Fixed nested column headers ignoring `stopImmediatePropagation()` called in the `beforeOnCellMouseOver` hook, so a header drag-selection can now be blocked the same way as for regular column headers. [#12794](https://github.com/handsontable/handsontable/issues/12794)
-- Fixed clears stale cell meta after a merge is removed (unmerge) [#12798](https://github.com/handsontable/handsontable/issues/12798)
+- Fixed stale cell metadata left behind after unmerging cells, which made `toHTML()` output extra cells. [#12798](https://github.com/handsontable/handsontable/issues/12798)
 - Fixed undo not restoring merged cells after removing a column that overlapped a merge. [#12801](https://github.com/handsontable/handsontable/issues/12801)
 - Fixed missing selection border edges and active header highlight accents along frozen-pane boundaries (`fixedRowsTop` / `fixedRowsBottom` / `fixedColumnsStart`). [#12802](https://github.com/handsontable/handsontable/issues/12802)
 - Fixed context menu inserting two rows instead of one when tapping "Insert row above" or "Insert row below" on iPad (Safari). [#12804](https://github.com/handsontable/handsontable/issues/12804)
-- Fixed cell meta set with `setCellMeta` (for example, `readOnly`) being reset by `updateSettings`. [#12811](https://github.com/handsontable/handsontable/issues/12811)
 - Fixed `multiselect` cell type displaying a neighbouring column's value after moving the column with `manualColumnMove`. [#12827](https://github.com/handsontable/handsontable/issues/12827)
 - Fixed a bug where Ctrl/Cmd+clicking an already-selected cell in a multi-cell selection caused the active highlight to jump to a different cell [#12841](https://github.com/handsontable/handsontable/pull/12841)
-- Reduced memory usage during scrolling and fixed potential out-of-memory errors on very large datasets. [#12844](https://github.com/handsontable/handsontable/pull/12844)
 - Reduced memory usage when filtering large datasets: the Filters plugin no longer permanently retains a cell meta object for every source row of each filtered column. [#12878](https://github.com/handsontable/handsontable/pull/12878)
 - Fixed an error thrown when removing a frozen column while using the legacy fixedColumnsLeft option. [#12883](https://github.com/handsontable/handsontable/pull/12883)
 - Fixed the `multiselect` cell type so its option filtering folds case in a locale-aware way, consistent with the `autocomplete` editor, for Turkish, Azeri, and Lithuanian locales. [#12902](https://github.com/handsontable/handsontable/issues/12902)
@@ -178,7 +174,7 @@ For more information about this release, see:
 
 #### Removed
 - **Breaking change**: Removed the numbro, moment.js, DOMPurify, and @handsontable/pikaday dependencies. [#12689](https://github.com/handsontable/handsontable/issues/12689)
-- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. [#0](https://github.com/handsontable/handsontable/pull/0)
+- **Breaking change**: Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release. [#12727](https://github.com/handsontable/handsontable/pull/12727)
 - **Breaking change**: Removed the deprecated Core-level undo/redo methods (`hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, `hot.undoRedo`). Use `hot.getPlugin('undoRedo')` instead. [#12728](https://github.com/handsontable/handsontable/issues/12728)
 
 #### Fixed

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -34,7 +34,7 @@ For more information about this release, see:
 - [Documentation (18.1)](https://handsontable.com/docs/18.1)
 
 #### Added
-- Added the `modifySinglePassLayout` hook. The grid now renders in a single pass by predicting whether scrollbars will appear before rendering; return `false` from the hook to force the previous measure-then-render path. [#12951](https://github.com/handsontable/handsontable/pull/12951)
+- Added the `modifySinglePassLayout` hook, which forces the previous measure-then-render layout path for a table. [#12951](https://github.com/handsontable/handsontable/pull/12951)
 - Added the `selectionHandles` option, which shows draggable handles at each edge midpoint of a selected range for resizing the selection, and the `moveCells` option for moving a cell selection to a new location by dragging its border. [#13076](https://github.com/handsontable/handsontable/pull/13076)
 - Added Persian language RTL direction support. [#13101](https://github.com/handsontable/handsontable/issues/13101)
 - Added support for entitlement license keys, and made a missing or invalid license key block the grid with a modal that cannot be closed. [#13106](https://github.com/handsontable/handsontable/pull/13106)
@@ -53,6 +53,7 @@ For more information about this release, see:
 - Improved vertical scrolling performance for grids with pinned bottom rows (`fixedRowsBottom`). [#12894](https://github.com/handsontable/handsontable/issues/12894)
 - Improved the performance of sorting, filtering, hiding, and inserting/removing rows/columns on large datasets by removing redundant per-operation work in the index translation layer. [#12898](https://github.com/handsontable/handsontable/pull/12898)
 - Improved the performance of the internal hooks (events) dispatch: each hook's callbacks are now stored in a linked list, and removing a hook frees it immediately instead of accumulating skipped entries that were iterated over on every run. [#12925](https://github.com/handsontable/handsontable/pull/12925)
+- The grid now renders in a single pass, predicting whether scrollbars will appear instead of rendering, measuring, and re-rendering. The `mergeCells` plugin keeps the previous path, and the `modifySinglePassLayout` hook opts out of it. [#12951](https://github.com/handsontable/handsontable/pull/12951)
 - Improved vertical scrolling performance by skipping the column header re-render when the column layout is unchanged. [#12987](https://github.com/handsontable/handsontable/pull/12987)
 - Improved vertical scrolling performance by re-rendering only the rows entering the viewport and reusing the rows that stay. [#12995](https://github.com/handsontable/handsontable/pull/12995)
 - Improved scrolling performance for grids embedded in complex pages by keeping the rendered cells in place during scroll instead of re-inserting them. [#13020](https://github.com/handsontable/handsontable/pull/13020)


### PR DESCRIPTION
### Context

The PR removes four entries from the `18.1.0` section of `CHANGELOG.md` whose code shipped in `18.0.0`, and fixes two entries that cannot be quoted as they stand. This is a prerequisite for the `18.1.0` release notes page (RELEASE-843), which copies its entry list from this section.

**The four duplicated entries.** Each is a verbatim copy of an entry already published in the `18.0.0` section:

| Cited | Entry |
|---|---|
| #12847 | Reduced memory usage and improved initialization time... no longer materializing cell metadata |
| #12727 | **Breaking change**: Removed the deprecated `PersistentState` plugin |
| #12811 | Fixed cell meta set with `setCellMeta`... being reset by `updateSettings` |
| #12844 | Reduced memory usage during scrolling and fixed potential out-of-memory errors |

Two independent checks each found exactly these four, and no others:

1. **Commit ancestry.** The `18.0.0` tag is a merge commit (`892378293`) whose parents are develop (`8d5c5329b`) and the release branch (`9b82d4be6`), so the tag is not a usable oracle - it counts develop commits that never shipped. Tested against `9b82d4be6`, the `18.0.0` version-bump commit on `origin/release/18.0.0`: 4 of the 105 cited numbers resolve to a commit that shipped in `18.0.0`.
2. **Verbatim title comparison** between the two sections, links stripped: the same 4. Also compared against every section from `17.1.0` down: no overlap.

Two further checks bound the result rather than re-count it:

3. **`.changelogs` file lifecycle**, which separates the two root causes rather than corroborating the count. For every JSON consumed by `8f12dfcd2` (`18.1.0-rc1`) and `5aa1e2125` (rc2), the commit that added the file was tested against `9b82d4be6`. It returns **only #12727**, and that is the expected result: the other three had their JSON re-added on develop after the release, so the file itself is not a pre-18.0 artifact even though the code is. The single hit is what tells the two causes apart.
4. **Reworded duplicates.** Checks 1 and 2 both key on exact text or an exact `(#N)` subject match, so a duplicate whose JSON was edited on one branch would slip through. Six consumed JSON files have no matching `(#N)` commit subject in `18.0.0..HEAD`; tracing each file's add commit shows five were created after the `18.0.0` release on 2026-06-30 (genuine `18.1` work: #10672, #12719, #12987, #13068, #13120) and only #12727 predates it. No reworded duplicates exist.

**Why it happened**, for the record - two distinct mechanisms, both of which leave a pending JSON on develop that the release-to-develop merge-back does not remove:

- #12811, #12844, #12847 were each merged to `release/18.0.0` and to `develop` as two separate commits with identical subjects (#12811 is `6714c8743` on the release branch and `6bc43a7a7` on develop). The release side reads as add-then-delete, so no net change against the merge base, while develop's own add is the only change on either side.
- #12727 is not a double-merge. Its JSON was consumed on schedule by `18.0.0-rc1` (`fd8cddd0bc`, 2026-06-16), then `d68ea7f92e` (#12810, RELEASE-628, 2026-06-22) modified `.changelogs/12727.json` on develop six days later. At merge-back that is a modify/delete resolved in favour of develop's copy. The hand-written `[#0]` link in the `18.0.0` section is the trace of the same episode, and this PR corrects it to `#12727`.

### The two entry fixes

Both entries are quoted directly into the release notes, so they are fixed here rather than there.

**#12951 announced "the `singlePassLayout` option", which does not exist.** It is absent from `metaSchema.ts`. `singlePassLayout` is a Walkontable-internal setting (`handsontable/src/3rdparty/walkontable/src/settings/defaults.ts:113`, default `true`) that user code reaches only through the new `modifySinglePassLayout` hook.

**Please confirm this call:** the PR **splits the entry in two** rather than rewording it in place, because the change has two halves that belong under different headings. The hook is new API, so it stays in `### Added`. Single-pass rendering being the default is a change to existing behavior, so it goes in `### Changed`, where a reader looks for it - a reworded single `### Added` line would have hidden a default-behavior change under "Added". Both lines cite #12951, and the `### Changed` line is placed to keep that section's ascending-number order (between #12925 and #12987). This is the one place where the PR adds an entry instead of only removing or rewriting, so say the word and I will collapse it back to one line.

**#12798 read "Fixed clears stale cell meta after a merge is removed (unmerge)"**, which is ungrammatical and has no closing period. Reworded to the user-facing symptom from the originating task (DEV-482): stale metadata after unmerging made `toHTML()` emit extra cells.

### Scope notes

**Three copies of the `18.0.0` section exist; two needed the `#0` fix.** The root `CHANGELOG.md` and the aggregate `docs/.../changelog/changelog.md` both carried the broken `[#0](.../pull/0)` link and are fixed here. The third copy, `docs/.../changelog-18/changelog-18.md`, already links `#12727` correctly - PR #12808 fixed it there when it created the page - and carries none of the `18.1` entries, so it is untouched. PR 2 (the `18.1.0` release notes) will be the first change to that file since.

**Deliberately not in this PR:** the `## [18.1.0-rc3]` to `## [18.1.0]` retitle. The release script owns that - `9560f7cf7` shows it patching the heading and the released-on date in both files - so doing it here would conflict at release time.

**Target branch.** This targets `release/18.1.0` because the `18.1.0` section exists only there: `origin/develop`'s `CHANGELOG.md` still tops out at `## [18.0.0]`, so there is nothing to clean on develop. The fix reaches develop and master through the release merge. Note for whoever performs that merge: the propagation argument is pure-git reasoning, and the identical reasoning was falsified once already, so re-check develop's `CHANGELOG.md` for the four titles and for `pull/0` afterwards.

### How has this been tested?

No source code changed, so the lint, build, and test suites are not affected. Verification is on the file contents:

```bash
# each formerly duplicated entry now appears exactly once per file
for f in CHANGELOG.md docs/content/guides/upgrade-and-migration/changelog/changelog.md; do
  for n in "no longer materializing cell metadata" \
           "Removed the deprecated .PersistentState. plugin" \
           "being reset by .updateSettings." \
           "out-of-memory errors on very large"; do
    echo "$(grep -c "$n" "$f")  $n"
  done
  echo "pull/0 occurrences: $(grep -c 'pull/0)' "$f")"
done
```

Result: `1` for every entry in both files, and `0` occurrences of the broken `pull/0` link.

```bash
# entry counts per section
awk 'NR>=13 && NR<=123' CHANGELOG.md | awk '/^### /{s=$2} /^- /{c[s]++} END{for(k in c) print k, c[k]}'
```

The `18.1.0` section goes from 105 entries (9 Added, 26 Changed, 2 Removed, 68 Fixed) to **102** (9 Added, 26 Changed, 1 Removed, 66 Fixed): four removed, one added by the #12951 split. The `18.0.0` section keeps all 105 of its entries; its only change is the `[#0]` link.

Also checked that the `### Changed` section keeps its ascending-number ordering after the insertion, and that both files received identical edits.

One consequence worth flagging for the release notes: with #12727 gone, **`18.1.0` carries no breaking change at all**, which matches the code and is the expected shape for a minor release.

**Note on the local pre-push hook.** `scripts/pre-push.mjs:29-38` resolves its diff base only against `origin/develop`, so on a branch cut from `release/18.1.0` it treats all 145 files of the release diff as the push's own and tries to run unrelated unit tests. The real diff here is two markdown files. Pushed with `--no-verify`, which the script itself documents as the escape hatch; CI evaluates against the correct base, and `Checks / changelog` and `Checks / test presence` both pass.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. RELEASE-843

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/RELEASE-843

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown changelog and docs only; no runtime code paths change.
> 
> **Overview**
> **Changelog-only** edits to `CHANGELOG.md` and the docs aggregate changelog so the **18.1.0** section matches what actually ships in that release and reads correctly in RELEASE-843 release notes.
> 
> **Removes four entries** from **18.1.0** that were already documented under **18.0.0** (#12847, #12727 PersistentState removal, #12811, #12844). The **18.1.0** section drops from 105 to **102** entries and no longer lists a breaking change for PersistentState.
> 
> **Corrects two quoted lines:** #12951 is split—the nonexistent public `singlePassLayout` option is replaced by **`modifySinglePassLayout`** under **Added**, and default single-pass layout behavior under **Changed**; #12798 is reworded for grammar and the `toHTML()` extra-cells symptom.
> 
> **Fixes the 18.0.0** PersistentState breaking-change link from **`pull/0`** to **#12727** in both files (docs `changelog-18` was already correct).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c77c76f0d9588f35a7a2760badca68e96f25b34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->