### PR TITLE
RELEASE-862: Add the 18.0 to 18.1 migration guide

### DIFF
--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -199,6 +199,7 @@ const upgradeAndMigrationItems = [
   { path: 'guides/upgrade-and-migration/versioning-policy/versioning-policy' },
   { path: 'guides/upgrade-and-migration/deprecation-policy/deprecation-policy' },
   { path: 'guides/upgrade-and-migration/long-term-support/long-term-support' },
+  { path: 'guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1' },
   { path: 'guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0' },
   { path: 'guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0' },
   { path: 'guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1' },

--- a/docs/content/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md
@@ -1,0 +1,254 @@
+---
+type: how-to
+title: Migrating from 18.0 to 18.1
+metaTitle: Migrating from 18.0 to 18.1 - JavaScript Data Grid | Handsontable
+description: Migrate from Handsontable 18.0 to Handsontable 18.1 -- set a license key in every environment, and update code that reacts to a column-header click.
+permalink: /migration-from-18.0-to-18.1
+canonicalUrl: /migration-from-18.0-to-18.1
+pageClass: migration-guide
+react:
+  metaTitle: Migrate from 18.0 to 18.1 - React Data Grid | Handsontable
+angular:
+  metaTitle: Migrate from 18.0 to 18.1 - Angular Data Grid | Handsontable
+vue:
+  metaTitle: Migrate from 18.0 to 18.1 - Vue Data Grid | Handsontable
+searchCategory: Guides
+category: Upgrade and migration
+---
+
+Migrate from Handsontable 18.0 to Handsontable 18.1.
+
+Handsontable 18.1 is a minor release and removes no public API. Three changes still need your
+attention: one blocks the grid, one changes what a column-header click does, and one makes a
+notification appear that 18.0 suppressed.
+
+For a detailed list of changes in this release, see the [Changelog](@/guides/upgrade-and-migration/changelog/changelog.md).
+
+[[toc]]
+
+## 1. Set a license key in every environment
+
+A missing or invalid [license key](@/guides/getting-started/license-key/license-key.md) now blocks
+the grid. Handsontable covers it with a modal that cannot be closed and repeats the message in the
+console. In 18.0 the same two states only added a notice below the grid, and the grid stayed fully
+usable.
+
+An expired key still does not block anything. Neither does a lapsed subscription: after its
+expiration date the console reports an error and every feature keeps working, so a paying customer
+is never locked out.
+
+### Who is affected
+
+You are affected if a Handsontable instance runs anywhere without a valid key. In practice that
+means one of these:
+
+- You never set [`licenseKey`](@/api/options.md#licensekey), for example because 18.0 let the grid
+  work with a notice below it.
+- You set `licenseKey` in production but not in local development, in CI, in an end-to-end test
+  suite, or in a Storybook or demo build. These are the setups most likely to break on upgrade,
+  because the block appears where nobody looked at the notice before.
+- You set a key that Handsontable cannot read, for example a truncated one, a key for another
+  product, or a placeholder such as an empty string.
+
+### How to migrate
+
+Pass a valid key to every instance, in every environment.
+
+For commercial use, pass your purchased key:
+
+::: only-for javascript
+
+```js
+const hot = new Handsontable(container, {
+  licenseKey: 'your-license-key',
+});
+```
+
+:::
+
+::: only-for react
+
+```jsx
+<HotTable licenseKey="your-license-key" />
+```
+
+:::
+
+::: only-for angular
+
+```html
+<hot-table [settings]="{ licenseKey: 'your-license-key' }"></hot-table>
+```
+
+:::
+
+::: only-for vue
+
+```html
+<hot-table :settings="{ licenseKey: 'your-license-key' }"></hot-table>
+```
+
+:::
+
+For non-commercial or evaluation use, pass the non-commercial key. It is a valid key, so it does not
+block the grid:
+
+::: only-for javascript
+
+```js
+const hot = new Handsontable(container, {
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+:::
+
+::: only-for react
+
+```jsx
+<HotTable licenseKey="non-commercial-and-evaluation" />
+```
+
+:::
+
+::: only-for angular
+
+```html
+<hot-table [settings]="{ licenseKey: 'non-commercial-and-evaluation' }"></hot-table>
+```
+
+:::
+
+::: only-for vue
+
+```html
+<hot-table :settings="{ licenseKey: 'non-commercial-and-evaluation' }"></hot-table>
+```
+
+:::
+
+::: tip
+
+Handsontable reads the license key once, when the instance initializes. Passing a new
+`licenseKey` through [`updateSettings()`](@/api/core.md#updatesettings) does not re-evaluate the
+license. To apply a different key, create the instance again.
+
+:::
+
+## 2. Update code that reacts to a column-header click
+
+A click on a column header used to sort on mouse down, anywhere in the header cell. In 18.1 it sorts
+on mouse up, and only the header label and its sort indicator respond. Pressing the header around
+the label selects the column without sorting it, which is what makes it possible to select a column
+and drag it in the same gesture. Handsontable tells a click from a drag by whether the pointer moves.
+
+As part of the same change, [`beforeColumnMove`](@/api/hooks.md#beforecolumnmove) and
+[`afterColumnMove`](@/api/hooks.md#aftercolumnmove) now run only when the pointer actually drags a
+column. In 18.0 both fired on a plain header click, even though no column moved.
+
+### Who is affected
+
+You are affected if either of these applies:
+
+- You have automated tests or scripts that sort a column by dispatching a `mousedown` event on a
+  column header, or by clicking the header cell rather than its label.
+- You use `beforeColumnMove` or `afterColumnMove` to detect a column-header click, rather than an
+  actual column move.
+
+### How to migrate -- simulated header clicks
+
+Dispatch a full press and release, and target the header label. The label carries the `sortAction`
+class whenever clicking it sorts the column.
+
+Before:
+
+```js
+const header = hot.rootElement.querySelector('thead th:nth-child(2)');
+
+header.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+```
+
+After:
+
+```js
+const header = hot.rootElement.querySelector('thead th:nth-child(2)');
+const sortLabel = header.querySelector('.colHeader.sortAction');
+
+sortLabel.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+sortLabel.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+```
+
+Do not move the pointer between the two events. A pointer move turns the gesture into a column drag
+instead of a sort.
+
+If your tests drive a real browser, click the label element itself. A click at the center of the
+header cell no longer sorts, because the label is sized to its content rather than filling the cell.
+
+### How to migrate -- column-move hooks used as click handlers
+
+Move the logic to a hook that still fires on a click. Use
+[`afterColumnSort`](@/api/hooks.md#aftercolumnsort) to react to the sort, or
+[`afterOnCellMouseUp`](@/api/hooks.md#afteroncellmouseup) to react to the click itself.
+
+Before:
+
+```js
+const hot = new Handsontable(container, {
+  afterColumnMove(movedColumns, finalIndex, dropIndex, movePossible, orderChanged) {
+    // ran on a plain header click too
+    trackHeaderInteraction();
+  },
+});
+```
+
+After:
+
+```js
+const hot = new Handsontable(container, {
+  afterColumnSort(currentSortConfig, destinationSortConfigs) {
+    trackHeaderInteraction();
+  },
+});
+```
+
+Keep `beforeColumnMove` and `afterColumnMove` for the case they now describe: an actual column move.
+
+## 3. Expect expired-key notices to reappear
+
+Handsontable 18.1 detects expired license keys again. In 18.0 that detection silently never ran, so
+an expired key produced no notice and no console message.
+
+After you upgrade, a key that is past its date shows a notice below the grid and reports an error in
+the console. Nothing is blocked, and every feature keeps working. No configuration change causes
+this. The notice appears because the check works again.
+
+### Who is affected
+
+You are affected if you run 18.1 with a key whose date has passed. For a perpetual key that means a
+maintenance date earlier than the build date of your Handsontable version. For a subscription key it
+means an expiration date in the past.
+
+### How to migrate
+
+Nothing to change in your code. To remove the notice, renew the license and pass the new key.
+Contact the [Sales Team](https://handsontable.com/get-a-quote) for a renewal.
+
+## Summary of changes
+
+| Change | Who is affected | Action required |
+| --- | --- | --- |
+| A missing or invalid license key blocks the grid with a modal that cannot be closed | Any instance running without a valid key, including local, CI, test, and demo environments | Pass a valid [`licenseKey`](@/api/options.md#licensekey), or `'non-commercial-and-evaluation'` for non-commercial use |
+| Column sorting runs on mouse up, and only the header label and its sort indicator sort on click | Tests or scripts that dispatch `mousedown` on a header cell to sort | Dispatch `mousedown` and `mouseup` on the `.colHeader.sortAction` label, without moving the pointer |
+| `beforeColumnMove` and `afterColumnMove` no longer fire on a plain header click | Code using either hook to detect a header click | Use [`afterColumnSort`](@/api/hooks.md#aftercolumnsort) or [`afterOnCellMouseUp`](@/api/hooks.md#afteroncellmouseup) instead |
+| Expired license keys are detected again | Instances running a key past its date | Nothing in code. Renew the license to remove the notice |
+
+## Result
+
+Your application now runs on Handsontable 18.1.
+
+## Related resources
+
+- [License key](@/guides/getting-started/license-key/license-key.md)
+- [Rows sorting](@/guides/rows/rows-sorting/rows-sorting.md)
+- [Column moving](@/guides/columns/column-moving/column-moving.md)
+- [Configuration options](@/guides/getting-started/configuration-options/configuration-options.md)

--- a/docs/tests/paths.js
+++ b/docs/tests/paths.js
@@ -455,6 +455,7 @@ const vuePaths = [
   { path: 'guides/upgrade-and-migration/versioning-policy/versioning-policy' },
   { path: 'guides/upgrade-and-migration/deprecation-policy/deprecation-policy' },
   { path: 'guides/upgrade-and-migration/long-term-support/long-term-support' },
+  { path: 'guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migration-from-18.0-to-18.1' },
   { path: 'guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migration-from-17.1-to-18.0' },
   { path: 'guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migration-from-16.2-to-17.0' },
   { path: 'guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migration-from-16.0-to-16.1' },


### PR DESCRIPTION
### Context

The PR adds the `18.0` to `18.1` migration guide, plus its two registration entries.

RELEASE-862 asked whether `18.1.0` needs a migration guide at all. A minor release removes no public API, so the starting assumption was no. **It does.** Reviewing the whole `18.0.0..release/18.1.0` diff turned up three changes that a reader has to act on, one of which changes runtime behavior for anyone who upgrades without touching their configuration. There is precedent for a minor-release guide: `migrating-from-16.0-to-16.1`.

The forbidden-change checks both came back clean, which is why the guide documents behavior rather than API:

- **No grid default changed.** `git diff 18.0.0..HEAD -- handsontable/src/dataMap/metaManager/metaSchema.ts` yields only `+` default lines, no `-foo: X` / `+foo: Y` pair. Every new option defaults to off or undefined.
- **No Walkontable default changed**, despite the settings module being restructured from `settings.ts` to `settings/defaults.ts` - a path diff shows the file as new and cannot detect a flip, so the two `getDefaults()` bodies were compared by value across the rename. All 62 pre-existing entries are present and identical; the 5 additions are new settings.
- **No `--ht-*` theme token removed.**

### The three sections, and why each is in the guide

**1. A missing or invalid license key blocks the grid** (#13106). In `18.0` both states added a notice below the grid and the grid stayed fully usable. In `18.1` Handsontable covers the grid with a modal that cannot be closed. Verified end to end rather than inferred from the copy table: an empty key resolves to `missing` and an unparseable one to `invalid` (`helpers/mixed.ts:574-589`), both come back with `OPEN_CHANNELS` so `channels.ui` is true (`mixed.ts:636-641`), `mountBrandingSurface` finds both states in `LOCK_CONTENT` (`utils/licenseBranding/content.ts:81-113`) and mounts the lock (`licenseBranding/index.ts:38-45`), reached from `core.ts:1649`. Test-backed at `handsontable/src/__tests__/settings/licenseKey.spec.js:56,82`, which assert `.ht-license-lock` is present and that neither state produces a bar any more.

The section leads on the environments most likely to break: local development, CI, end-to-end suites, and demo builds, where nobody was reading the `18.0` notice. It also records that the key is read once at init, so `updateSettings({ licenseKey })` does not re-evaluate it (`licenseBranding/index.ts:52-58`), and that a hard-stopped subscription is deliberately **not** blocked, so no paying customer is locked out.

**2. Column headers sort on release, and only on the label** (#13184, commit `d5ffb84ca`). This is the section that requires real code edits. Two parts: sorting resolves on mouse up rather than mouse down, and only the header label and its sort indicator respond to the click. Separately, `beforeColumnMove` and `afterColumnMove` no longer fire on a plain header click - in `18.0` both ran even though no column moved.

The before/after examples target `.colHeader.sortAction`, which is the class the plugin puts on the header label whenever clicking it sorts (`plugins/columnSorting/domHelpers.ts:10`, applied to `headerSpanElement` at `columnSorting.ts:816`). The prose is aligned with what #13184 already added to the Rows sorting and Column moving guides, so the three pages agree.

**3. Expired keys are detected again** (#13106). `18.0.0` carried a regression: the `typeof process` guard around `process.env.HOT_RELEASE_DATE` was not inlined by the bundler, compiled to `false` in every browser bundle, blanked the release date, and silently killed expired-key detection. `18.1` restores the bare read - see the explicit do-not-guard comment in `utils/licenseNotification.ts`. So an upgrade can surface a notice and a console error that `18.0` hid, with no configuration change. Nothing blocks, and the action is renewing rather than editing code, but a reader who sees a new notice appear after a patch-level-looking upgrade needs to find the explanation somewhere.

### Deliberately left out

These are release-notes and troubleshooting material, not migration steps, and putting them here would bury the three that matter:

- Single-pass layout being on by default (#12951). Narrowly gated - element-scrolled, uniform row heights, uniform column widths (`viewport/calculatorFactory.ts:428`), and `mergeCells` forces it off - with `modifySinglePassLayout` as the opt-out.
- Cell metadata released for scrolled-away rows, and `getCellMetaTransient()` (#13063, #13068, #12878).
- `setCellMeta` values surviving `updateSettings` (#12811).
- `maxRows` / `maxCols` no longer clamping the HyperFormula engine (#10672).
- The `Events` typing fix (#13079). Narrower than it looks: the same commit added a lenient `addHook` / `addHookOnce` / `removeHook` overload rung specifically to keep previously-compiling listener code compiling (`core/types.ts:65-84`), and `GridSettings` keeps its index signature. The React prop typing (#13007, #13041) likewise keeps its `& { [key: string]: any }` escape hatch on purpose.
- Four visual deltas: the `width`-without-`height` fix (#13104), cell styling no longer leaking into a nested table (#13150), Pikaday styles removed from the themes (#13156), and the horizon row-header cascade (#12908, #13084).

### Registration

Mirrors how `migrating-from-17.1-to-18.0` is registered:

- `docs/content/guides/sidebar.js` - one line above the `17.1` to `18.0` entry.
- `docs/tests/paths.js` - one line above the `17.1` to `18.0` entry, using the `migration-from-18.0-to-18.1` permalink form.

Worth knowing for review: that `paths.js` entry goes into `vuePaths` (the array starting at line 317), because every migration guide from `14.6` to `15.0` upward is registered only there. `jsPaths`, `reactPaths`, and `angularPaths` still carry the older `migration-from-*` directory names and stop at `13.1` to `14.0`. This PR follows the existing convention and does not touch the other three arrays.

The guide links the aggregate `changelog/changelog.md` rather than the `18.1.0` release notes section, so nothing here depends on the release-notes PR. That PR (RELEASE-843) will link back to this page.

### How has this been tested?

No source code changed, so the lint, build, and test suites for `handsontable` are not affected.

- `docs:lint` covers `docs/src` and `docs/content` for `.js`, `.mjs`, `.ts`, and `.astro`, which includes `docs/content/guides/sidebar.js`. Ran eslint against the modified file with the docs config: clean.
- Verified every cross-reference resolves to a target that exists, and that each link form is already used elsewhere in the guides: `@/api/options.md#licensekey` (5 existing uses), `@/api/core.md#updatesettings` (53), `@/api/hooks.md#aftercolumnsort` (1), `@/api/hooks.md#afteroncellmouseup` (1). Confirmed `afterColumnSort` and `afterOnCellMouseUp` are both registered in `handsontable/src/core/hooks/constants.ts`.
- Checked the container syntax against repo convention: `::: tip` with three colons is the only form in use across the guides (106 occurrences, no four-colon variant), and `::: only-for vue` is used in existing pages, so the Vue variant renders.
- Confirmed the two registration entries landed in the intended arrays and positions.

The `Docs / preview / deploy` check builds the site with the new page. Please use the preview to confirm the page renders, the sidebar entry appears under **Upgrade and migration**, and the four framework variants of the license-key snippets each show the right syntax.

**Note on the local pre-push hook.** `scripts/pre-push.mjs:29-38` resolves its diff base only against `origin/develop`, so on a branch cut from `release/18.1.0` it treats the entire release delta as this push's own change and tries to run unrelated unit tests. The real diff here is three files under `docs/`. Pushed with `--no-verify`, which the script's own header documents as the escape hatch; CI evaluates against the correct base.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. RELEASE-862

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/RELEASE-862

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes under `docs/` with no Handsontable runtime or package code modified.
> 
> **Overview**
> Adds documentation for upgrading from **18.0 to 18.1**, following the same pattern as the existing **16.0 → 16.1** minor-release migration guide. The new page is wired into the **Upgrade and migration** sidebar and into `docs/tests/paths.js` (Vue path list, using the `migration-from-18.0-to-18.1` permalink form).
> 
> The guide focuses on **three behavioral changes** that need action or awareness, even though 18.1 does not remove public API:
> 
> **Missing or invalid `licenseKey`** now **blocks the grid** with a non-dismissable modal (18.0 only showed a notice). Readers are told to set a valid key in every environment—including local, CI, tests, and demos—or use `'non-commercial-and-evaluation'` where appropriate, and that `updateSettings()` does not re-evaluate the key.
> 
> **Column header interaction** changed: sorting runs on **mouse up** and only on the header label / sort indicator (`.colHeader.sortAction`), not the whole header cell. **`beforeColumnMove` / `afterColumnMove`** no longer fire on a plain header click; tests and hook-based code should use full press/release on the label or switch to **`afterColumnSort`** / **`afterOnCellMouseUp`**.
> 
> **Expired license keys** are detected again in 18.1 (a regression in 18.0 hid notices); the guide explains that features still work and renewal removes the notice—no code change required.
> 
> The page includes framework-specific `licenseKey` examples (JS, React, Angular, Vue), before/after snippets for simulated clicks and hooks, and a summary table plus links to related guides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a96ee8a8f0cbf4a98f7ae2ae9a1a75d6494f1d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->