### PR TITLE
RELEASE-843: Add the 18.1.0 release notes to the changelog-18 page

### DIFF
--- a/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
@@ -19,7 +19,7 @@ These are the release notes for Handsontable 18.x.
 
 ## 18.1.0
 
-Released on TODO
+Released on September 1st, 2026
 
 For more information about this release, see:
 

--- a/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
@@ -17,6 +17,129 @@ category: Upgrade and migration
 
 These are the release notes for Handsontable 18.x.
 
+## 18.1.0
+
+Released on TODO
+
+For more information about this release, see:
+
+<div class="boxes-list gray">
+
+- [Documentation (18.1)](https://handsontable.com/docs/18.1)
+- [Migration guide (18.0 → 18.1)](@/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md)
+
+</div>
+
+#### Added
+- Added the `modifySinglePassLayout` hook, which forces the previous measure-then-render layout path for a table. [#12951](https://github.com/handsontable/handsontable/pull/12951)
+- Added the `selectionHandles` option, which shows draggable handles at each edge midpoint of a selected range for resizing the selection, and the `moveCells` option for moving a cell selection to a new location by dragging its border. [#13076](https://github.com/handsontable/handsontable/pull/13076)
+- Added Persian language RTL direction support. [#13101](https://github.com/handsontable/handsontable/issues/13101)
+- Added support for entitlement license keys, and made a missing or invalid license key block the grid with a modal that cannot be closed. [#13106](https://github.com/handsontable/handsontable/pull/13106)
+- Added the `intl-datetime` cell type, with a native date-time picker, `Intl.DateTimeFormat` display via the new `dateTimeFormat` option, and column sorting, filtering, and Excel export support. [#13151](https://github.com/handsontable/handsontable/issues/13151)
+- Added the `preserveNumericLiteral` option to the numeric cell type, which keeps the exact value you type in the cell editor (preserving trailing decimal zeros and large-number precision). [#13170](https://github.com/handsontable/handsontable/pull/13170)
+- Added the `colorScheme` and `density` options, which set the color scheme and the spacing of the grid without declaring a theme. [#13205](https://github.com/handsontable/handsontable/pull/13205)
+- Added a public API to the `NestedRows` plugin for collapsing and expanding parent rows: `collapseAll()`, `expandAll()`, `collapseParent()`, `expandParent()`, `toggleParent()`, `getCollapsedParents()`, `isParentCollapsed()`, `isParent()`, `getRowLevel()`, `getRowParent()`, `countChildren()`, `expandToRow()`, and `expandToLevel()`, plus the new `beforeRowCollapse`, `afterRowCollapse`, `beforeRowExpand`, and `afterRowExpand` hooks. The plugin also no longer loses its collapsed rows on an `updateSettings()` call, and no longer throws when asked for the index, parent, or nesting level of a row object held from before a `loadData()` or `updateData()` call. [#13206](https://github.com/handsontable/handsontable/pull/13206)
+- Added the `formulas.hyperlinks` option, which renders cells holding a `HYPERLINK` formula as clickable links. [#13223](https://github.com/handsontable/handsontable/pull/13223)
+
+#### Changed
+- Reduced memory usage when scrolling large datasets by releasing cell metadata for rows scrolled out of the viewport. [#12854](https://github.com/handsontable/handsontable/pull/12854)
+- Improved the performance of sorting, filtering, and row/column hiding on large datasets by speeding up internal index translation. [#12880](https://github.com/handsontable/handsontable/pull/12880)
+- Improved initialization time for large date-typed datasets by validating ISO dates arithmetically instead of constructing a `Date` object for every cell. [#12881](https://github.com/handsontable/handsontable/pull/12881)
+- Improved initial render time and memory usage for large datasets with uniform row heights and column widths. [#12884](https://github.com/handsontable/handsontable/pull/12884)
+- Improved filtering performance on large datasets by writing the row-trimming state in a single bulk operation instead of scanning and updating it row by row. [#12886](https://github.com/handsontable/handsontable/pull/12886)
+- Improved vertical scrolling performance for grids with pinned bottom rows (`fixedRowsBottom`). [#12894](https://github.com/handsontable/handsontable/issues/12894)
+- Improved the performance of sorting, filtering, hiding, and inserting/removing rows/columns on large datasets by removing redundant per-operation work in the index translation layer. [#12898](https://github.com/handsontable/handsontable/pull/12898)
+- Improved the performance of the internal hooks (events) dispatch: each hook's callbacks are now stored in a linked list, and removing a hook frees it immediately instead of accumulating skipped entries that were iterated over on every run. [#12925](https://github.com/handsontable/handsontable/pull/12925)
+- The grid now renders in a single pass, predicting whether scrollbars will appear instead of rendering, measuring, and re-rendering. The `mergeCells` plugin keeps the previous path, and the `modifySinglePassLayout` hook opts out of it. [#12951](https://github.com/handsontable/handsontable/pull/12951)
+- Improved vertical scrolling performance by skipping the column header re-render when the column layout is unchanged. [#12987](https://github.com/handsontable/handsontable/pull/12987)
+- Improved vertical scrolling performance by re-rendering only the rows entering the viewport and reusing the rows that stay. [#12995](https://github.com/handsontable/handsontable/pull/12995)
+- Improved scrolling performance for grids embedded in complex pages by keeping the rendered cells in place during scroll instead of re-inserting them. [#13020](https://github.com/handsontable/handsontable/pull/13020)
+- Improved scrolling smoothness: the `auto` mode of `viewportRowRenderingOffset` and `viewportColumnRenderingOffset` now extends the rendered viewport dynamically in the scroll direction, so consecutive scroll steps reuse already-rendered cells. [#13055](https://github.com/handsontable/handsontable/issues/13055)
+- Improved the performance and memory usage of the cell meta storage. Reading cell settings stays fast on large grids. Memory used by settings of scrolled-away rows is released. Bulk operations - sorting, copying, pasting, filling, exporting, validation, checkbox toggling, and automatic size sampling - no longer permanently cache settings for every visited cell. Added the `getCellMetaTransient()` method for reading the effective cell configuration without caching it. [#13063](https://github.com/handsontable/handsontable/pull/13063)
+- Improved memory usage of read-only cell settings lookups. The context menu, filters dropdown, formulas synchronization, data type detection, column summaries, and clearing large selections no longer permanently cache settings for every visited cell. [#13068](https://github.com/handsontable/handsontable/pull/13068)
+- Improved scroll-to-row performance on large grids: keyboard navigation and `scrollViewportTo` near the bottom of the dataset now compute the scroll offset in constant time instead of summing every row height from the top. [#13075](https://github.com/handsontable/handsontable/issues/13075)
+- Improved performance of copy, autofill, bulk edits, header resize, and custom borders on large selections by replacing linear membership scans with set-based lookups. [#13077](https://github.com/handsontable/handsontable/issues/13077)
+- Improved rendering performance of grids with wrapped or content-sized rows: the row-height cache is no longer rebuilt on every render, edit, or scroll step when row heights have not changed, and rebuilds triggered by newly measured rows now scale with the number of taller rows instead of the total row count. [#13078](https://github.com/handsontable/handsontable/issues/13078)
+- Improved index-map performance: writing an unchanged value into scalar-valued index maps (hiding, trimming, order sequence, and the automatic or manual row/column size maps) no longer rebuilds the index caches. [#13080](https://github.com/handsontable/handsontable/issues/13080)
+- Improved the performance of the MergeCells plugin: scrolling, extending large selections, and moving the focus with the keyboard no longer slow down with the grid or selection size. [#13083](https://github.com/handsontable/handsontable/issues/13083)
+- Improved Formulas plugin performance on large grids: faster rendering and sorting through cached index translations, and bulk row/column removals now issue batched engine calls. [#13085](https://github.com/handsontable/handsontable/issues/13085)
+- Improved sorting performance on large datasets: date and time columns no longer re-parse values on every comparison, and text columns no longer re-lowercase values on every comparison. [#13087](https://github.com/handsontable/handsontable/issues/13087)
+- Improved Filters plugin performance: batch changes into a filtered column update the filter list once per column instead of once per changed cell, importing conditions updates once per column instead of once per condition, and applying filters no longer re-reads rows already rejected by earlier columns. [#13090](https://github.com/handsontable/handsontable/issues/13090)
+- Improved the performance of bulk grid alterations: removing many rows or columns, inserting multiple columns, pasting data that extends the grid, and edits with the `minSpareCols` or `minCols` options on large datasets. [#13091](https://github.com/handsontable/handsontable/issues/13091)
+- Improved `getColHeader` performance: the index translation derived from the `columns` function is now cached instead of being rebuilt on every call, which also speeds up grid initialization and `updateSettings` on grids with many columns. [#13096](https://github.com/handsontable/handsontable/issues/13096)
+- Improved sizing plugins performance: AutoColumnSize measures only the changed cells on edits instead of rescanning whole columns, its background width sweep is budgeted and runs on browser idle time, AutoRowSize reuses the cached header height on selection-driven renders, and a multi-column resize triggers one height recalculation instead of one per column. [#13097](https://github.com/handsontable/handsontable/issues/13097)
+
+#### Removed
+- Removed leftover Pikaday styles from the themes. [#13156](https://github.com/handsontable/handsontable/pull/13156)
+
+#### Fixed
+- Fixed a `Sheet size limit exceeded` error thrown when grids sharing one HyperFormula instance used different `maxRows` values. The grid's `maxRows` and `maxCols` no longer limit the engine, so an oversized insert is now capped at the limit instead of being rejected. [#10672](https://github.com/handsontable/handsontable/issues/10672)
+- Fixed a bug where dragging a selection handle to the edge of the grid on a mobile device did not scroll the viewport, so the selection stopped growing at the last visible cell. [#11658](https://github.com/handsontable/handsontable/issues/11658)
+- Fixed the `columnSummary` plugin misbehaving when another plugin trimmed rows (for example a collapsed `nestedRows` group): false out-of-bounds warnings, results written into the wrong row, a crash when the destination row was hidden, and hidden summary rows being counted as data by other summaries. [#11674](https://github.com/handsontable/handsontable/issues/11674)
+- Fixed the "filter by value" list dropping the values that the column's own filter condition filtered out, which made them impossible to select again. [#12226](https://github.com/handsontable/handsontable/issues/12226)
+- Fixed open menus (context menu, dropdown menu, and filters) becoming detached from the grid when a scrollable parent container or the grid viewport was scrolled. Menus now follow their anchor and close when it scrolls out of view. [#12719](https://github.com/handsontable/handsontable/issues/12719)
+- Fixed a nested header bug where a wide column group's label jumped while scrolling horizontally. [#12783](https://github.com/handsontable/handsontable/issues/12783)
+- Fixed an error thrown by `countRowHeaders()` and `countColHeaders()` when they were called while the table view was unavailable (during initialization or after the instance was destroyed). [#12790](https://github.com/handsontable/handsontable/pull/12790)
+- Fixed merged cells breaking after filtering, `trimRows`/`nestedRows` collapse, or sorting — merges now stay whole and follow the visible rows. [#12792](https://github.com/handsontable/handsontable/issues/12792)
+- Fixed nested headers not following the data when moving columns; labels now travel with their columns, a group split across non-adjacent columns renders as separate banners, and a collapsed group either follows the move or expands when the move would split it. [#12793](https://github.com/handsontable/handsontable/issues/12793)
+- Fixed nested column headers ignoring `stopImmediatePropagation()` called in the `beforeOnCellMouseOver` hook, so a header drag-selection can now be blocked the same way as for regular column headers. [#12794](https://github.com/handsontable/handsontable/issues/12794)
+- Fixed stale cell metadata left behind after unmerging cells, which made `toHTML()` output extra cells. [#12798](https://github.com/handsontable/handsontable/issues/12798)
+- Fixed undo not restoring merged cells after removing a column that overlapped a merge. [#12801](https://github.com/handsontable/handsontable/issues/12801)
+- Fixed missing selection border edges and active header highlight accents along frozen-pane boundaries (`fixedRowsTop` / `fixedRowsBottom` / `fixedColumnsStart`). [#12802](https://github.com/handsontable/handsontable/issues/12802)
+- Fixed context menu inserting two rows instead of one when tapping "Insert row above" or "Insert row below" on iPad (Safari). [#12804](https://github.com/handsontable/handsontable/issues/12804)
+- Fixed `multiselect` cell type displaying a neighbouring column's value after moving the column with `manualColumnMove`. [#12827](https://github.com/handsontable/handsontable/issues/12827)
+- Fixed a bug where Ctrl/Cmd+clicking an already-selected cell in a multi-cell selection caused the active highlight to jump to a different cell [#12841](https://github.com/handsontable/handsontable/pull/12841)
+- Reduced memory usage when filtering large datasets: the Filters plugin no longer permanently retains a cell meta object for every source row of each filtered column. [#12878](https://github.com/handsontable/handsontable/pull/12878)
+- Fixed an error thrown when removing a frozen column while using the legacy fixedColumnsLeft option. [#12883](https://github.com/handsontable/handsontable/pull/12883)
+- Fixed the `multiselect` cell type so its option filtering folds case in a locale-aware way, consistent with the `autocomplete` editor, for Turkish, Azeri, and Lithuanian locales. [#12902](https://github.com/handsontable/handsontable/issues/12902)
+- Fixed the horizon theme row header background color not cascading from headerRowBackgroundColor for even rows. [#12908](https://github.com/handsontable/handsontable/issues/12908)
+- Restored the `multiSelect` camelCase alias for the MultiSelect cell type, so both `multiselect` and `multiSelect` resolve to the same cell type. [#12921](https://github.com/handsontable/handsontable/pull/12921)
+- Fixed a load-time slowdown where `loadData()` and `updateData()` resolved cell metadata for the entire dataset when a `cells` function was configured, even with no validators defined. [#12933](https://github.com/handsontable/handsontable/issues/12933)
+- Fixed the `multiselect` cell type not firing `beforeChange` and `afterChange` (or running validation) when a value was removed by clicking the chip's X icon. [#12968](https://github.com/handsontable/handsontable/issues/12968)
+- Fixed date filter conditions returning no results by rendering native date and time inputs in the filter menu instead of free-text fields. [#12976](https://github.com/handsontable/handsontable/issues/12976)
+- Fixed an autofill bug where dragging the fill handle of the last column slightly diagonally, past the table's edge, drew the fill border but did not apply the values. [#12997](https://github.com/handsontable/handsontable/pull/12997)
+- Fixed the `modifyCopyableRange` hook's type declaration to reflect that its return value is used. [#13022](https://github.com/handsontable/handsontable/pull/13022)
+- Fixed the `ContextMenu.SEPARATOR` constant missing from the TypeScript type declarations. [#13037](https://github.com/handsontable/handsontable/issues/13037)
+- Fixed a doubled separator line under the "Filter by value" list in the dropdown menu. [#13047](https://github.com/handsontable/handsontable/pull/13047)
+- Fixed removing rows throwing a "Maximum call stack size exceeded" error on grids with roughly 125,000 rows or more. [#13070](https://github.com/handsontable/handsontable/pull/13070)
+- Fixed the `Events` type resolving every hook callback to `any`, so callbacks typed through `Events[hookName]` and `addHook` now get correct parameter types and autocomplete. [#13079](https://github.com/handsontable/handsontable/issues/13079)
+- Restored the horizon theme alternating stripe on even row headers, which stopped showing after the even row header background was made to cascade from headerRowBackgroundColor. [#13084](https://github.com/handsontable/handsontable/issues/13084)
+- Fixed a grid configured with a `width` and no `height` collapsing vertically. Relative widths (`100%`, percentages, viewport units, `calc()` with them) keep scrolling horizontally with the window, while definite pixel/`em` widths clip to their box. [#13104](https://github.com/handsontable/handsontable/issues/13104)
+- Fixed autofill dragging near vertically merged cells — the fill handle can now target rows inside a merged band in a neighboring column instead of jumping past the whole merge. [#13105](https://github.com/handsontable/handsontable/pull/13105)
+- Fixed an error thrown on touch devices when the grid was destroyed while a momentum scroll was still coasting. [#13120](https://github.com/handsontable/handsontable/issues/13120)
+- Fixed custom editors created with `editorFactory` throwing an error when `shortcuts` were defined without `shortcutsGroup`. [#13130](https://github.com/handsontable/handsontable/issues/13130)
+- Fixed an error thrown on every focus change when the grid failed to initialize. [#13131](https://github.com/handsontable/handsontable/pull/13131)
+- Fixed a failed `fetchRows` call in the `dataProvider` plugin surfacing as an unhandled promise rejection. [#13133](https://github.com/handsontable/handsontable/issues/13133)
+- Fixed the autocomplete editor and several internal utilities using `Array.prototype.toSorted` and `Array.prototype.at`, which are not available in every browser the library declares support for. [#13139](https://github.com/handsontable/handsontable/pull/13139)
+- Fixed an `Error: TR was expected to be rendered but is not` thrown when a `beforeDraw` hook cancels a render after the rendered row range has already advanced. [#13141](https://github.com/handsontable/handsontable/pull/13141)
+- Fixed a spurious scrollbar appearing when a cell in the last column or row was selected in a grid with frozen columns or rows — the fill handle now stays inside the viewport instead of overflowing it. [#13143](https://github.com/handsontable/handsontable/issues/13143)
+- Fixed the `Formulas` plugin leaving its internal redo state active after a redo operation, which made the plugin treat subsequent operations as undo/redo replay. [#13148](https://github.com/handsontable/handsontable/pull/13148)
+- Fixed the grid's cell styling (borders, padding, background, box-sizing, and corner radius) leaking into a table or other element rendered inside a cell. [#13150](https://github.com/handsontable/handsontable/issues/13150)
+- Fixed several `CustomBorders` bugs: borders now follow their cell when rows or columns are inserted, removed, or moved (and stay removable from the context menu afterward), and ranges defined with a top-level `border` object - including overlapping ranges - now render with the configured width, color, and style. Also added the `customBordersProgressive` option, which applies a large `customBorders` configuration in background batches so the grid renders immediately, together with the `afterCustomBordersUpdate` hook that fires once all custom borders have been applied. [#13166](https://github.com/handsontable/handsontable/issues/13166)
+- Fixed the license notification bar content overflowing on grids narrower than 300px. [#13167](https://github.com/handsontable/handsontable/pull/13167)
+- Fixed Handsontable errors not carrying their identifying cause on Safari below 15. [#13176](https://github.com/handsontable/handsontable/pull/13176)
+- Fixed rows losing their alignment when the tallest cell in a row was in a frozen column. [#13178](https://github.com/handsontable/handsontable/pull/13178)
+- Fixed a formula cell staying marked as invalid after an undo or redo restored a correct value. [#13182](https://github.com/handsontable/handsontable/pull/13182)
+- Fixed being unable to move a column by dragging its header while column sorting is enabled. Sorting by clicking a header now happens on mouse up instead of mouse down, and only the header label and its sort indicator sort on click. A click on a column header no longer fires `beforeColumnMove` and `afterColumnMove`, which previously ran even though no column moved. [#13184](https://github.com/handsontable/handsontable/pull/13184)
+- Fixed mobile selection handles not being visible on touch devices. [#13185](https://github.com/handsontable/handsontable/pull/13185)
+- Fixed the full bundle failing to load on pages with an AMD loader present (RequireJS, SharePoint). [#13187](https://github.com/handsontable/handsontable/issues/13187)
+- Fixed an error thrown when a grid initialized in a hidden container was destroyed right as it became visible. [#13190](https://github.com/handsontable/handsontable/pull/13190)
+- Fixed `autoRowSize` and `autoColumnSize` measuring cells without the styling applied through their `className` and without the formatting applied by the renderer's own `valueFormatter`, which left the row headers misaligned with the data cells. [#13191](https://github.com/handsontable/handsontable/pull/13191)
+- Fixed grid interactions inside Shadow DOM and sandboxed hosts such as Salesforce Lightning Web Components: the cell editor no longer closes when clicked, copy and paste work, focus is released when it leaves the grid, outside clicks clear the selection, and the grid's internal z-index values no longer paint above the host page UI. [#13194](https://github.com/handsontable/handsontable/pull/13194)
+- Fixed the dropdown and autocomplete editor list rendering narrower than the edited column when `trimDropdown` is set to `false`. [#13197](https://github.com/handsontable/handsontable/pull/13197)
+- Fixed the `fixedRowsTop`, `fixedRowsBottom`, and `fixedColumnsStart` options losing their value after undoing a row or column insertion, which un-pinned a frozen row or column. [#13200](https://github.com/handsontable/handsontable/pull/13200)
+- Fixed autofill dragging near horizontally merged cells — the fill handle can now target columns inside a merged band in a row below the merge instead of snapping back to the merge anchor. [#13201](https://github.com/handsontable/handsontable/pull/13201)
+- Fixed the autocomplete and dropdown option list collapsing to zero height, hiding every option, when less than one option of space was left below the edited cell. [#13202](https://github.com/handsontable/handsontable/pull/13202)
+- Fixed misaligned column headers and frozen columns, and a grid that filled its container only after a click, when it was created in a container that had no size yet. [#13208](https://github.com/handsontable/handsontable/pull/13208)
+- Fixed a memory leak where each `loadData()` or `updateData()` call added another formula engine sheet, so repeated data loads kept slowing the grid down. [#13215](https://github.com/handsontable/handsontable/pull/13215)
+- Fixed the autofill fill handle being cut in half at the bottom freeze line. [#13220](https://github.com/handsontable/handsontable/pull/13220)
+- Fixed a bug where the `afterSelectionEnd` and `afterSelectionEndByProp` hooks fired twice when selecting rows or columns by dragging over their headers. [#7133](https://github.com/handsontable/handsontable/issues/7133)
+- Vue: Fixed the Vue 3 wrapper not updating the grid when `HotColumn` components were added, removed, or reordered dynamically. [#12800](https://github.com/handsontable/handsontable/issues/12800)
+- React: Fixed a memory leak in the React wrapper where the portal containers used by component-based renderers were retained for every scrolled cell instead of being released once a cell left the viewport. [#12895](https://github.com/handsontable/handsontable/pull/12895)
+- React: Fixed missing TypeScript autocomplete and type checking for `<HotTable>` and `<HotColumn>` props. [#13007](https://github.com/handsontable/handsontable/issues/13007)
+- Angular: Fixed custom editor shortcut groups in the Angular wrapper. [#13160](https://github.com/handsontable/handsontable/pull/13160)
+- Fixed an issue where clicking focusable plugin UI placed in the grid's layout slots (for example, pagination controls) closed the open cell editor and deselected the grid. [#13243](https://github.com/handsontable/handsontable/pull/13243)
+
 ## 18.0.0
 
 Released on June 30th, 2026

--- a/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
@@ -70,6 +70,7 @@ For more information about this release, see:
 - Improved the performance of bulk grid alterations: removing many rows or columns, inserting multiple columns, pasting data that extends the grid, and edits with the `minSpareCols` or `minCols` options on large datasets. [#13091](https://github.com/handsontable/handsontable/issues/13091)
 - Improved `getColHeader` performance: the index translation derived from the `columns` function is now cached instead of being rebuilt on every call, which also speeds up grid initialization and `updateSettings` on grids with many columns. [#13096](https://github.com/handsontable/handsontable/issues/13096)
 - Improved sizing plugins performance: AutoColumnSize measures only the changed cells on edits instead of rescanning whole columns, its background width sweep is budgeted and runs on browser idle time, AutoRowSize reuses the cached header height on selection-driven renders, and a multi-column resize triggers one height recalculation instead of one per column. [#13097](https://github.com/handsontable/handsontable/issues/13097)
+- Changed how touch opens the cell editor on devices that report both touch and mouse input, such as iPad: a double-tap opens it (taps up to 1 second apart), and a single tap on an already selected cell no longer opens it as it did in 18.0.0, where duplicated mouse events after the tap triggered the double-click. [#13306](https://github.com/handsontable/handsontable/pull/13306)
 
 #### Removed
 - Removed leftover Pikaday styles from the themes. [#13156](https://github.com/handsontable/handsontable/pull/13156)
@@ -142,6 +143,7 @@ For more information about this release, see:
 - Angular: Fixed custom editor shortcut groups in the Angular wrapper. [#13160](https://github.com/handsontable/handsontable/pull/13160)
 - Fixed the grid no longer responding to keyboard shortcuts after clicking focusable plugin UI placed in the grid's layout slots (for example, pagination controls). [#13243](https://github.com/handsontable/handsontable/pull/13243)
 - Fixed an open cell editor staying visible over an unrelated row, and committing to a row you could no longer see, when the edited cell was hidden - for example by turning a Pagination page or hiding its row or column. [#13245](https://github.com/handsontable/handsontable/pull/13245)
+- Fixed an expired trial license key not blocking the grid when the key carried the `no-ui-warns` flag. [#13312](https://github.com/handsontable/handsontable/pull/13312)
 
 #### Security
 - Fixed pasted HTML being able to run scripts, and applied the `sanitizer` option to the surfaces that previously skipped it. [#13236](https://github.com/handsontable/handsontable/pull/13236)

--- a/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
@@ -25,6 +25,7 @@ For more information about this release, see:
 
 <div class="boxes-list gray">
 
+- [Blog post (18.1.0)](https://handsontable.com/blog/handsontable-18.1.0-shadow-dom-support-for-salesforce-and-web-components-a-faster-grid-and-a-new-demo-playground)
 - [Documentation (18.1)](https://handsontable.com/docs/18.1)
 - [Migration guide (18.0 → 18.1)](@/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md)
 

--- a/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
@@ -41,6 +41,7 @@ For more information about this release, see:
 - Added the `colorScheme` and `density` options, which set the color scheme and the spacing of the grid without declaring a theme. [#13205](https://github.com/handsontable/handsontable/pull/13205)
 - Added a public API to the `NestedRows` plugin for collapsing and expanding parent rows: `collapseAll()`, `expandAll()`, `collapseParent()`, `expandParent()`, `toggleParent()`, `getCollapsedParents()`, `isParentCollapsed()`, `isParent()`, `getRowLevel()`, `getRowParent()`, `countChildren()`, `expandToRow()`, and `expandToLevel()`, plus the new `beforeRowCollapse`, `afterRowCollapse`, `beforeRowExpand`, and `afterRowExpand` hooks. The plugin also no longer loses its collapsed rows on an `updateSettings()` call, and no longer throws when asked for the index, parent, or nesting level of a row object held from before a `loadData()` or `updateData()` call. [#13206](https://github.com/handsontable/handsontable/pull/13206)
 - Added the `formulas.hyperlinks` option, which renders cells holding a `HYPERLINK` formula as clickable links. [#13223](https://github.com/handsontable/handsontable/pull/13223)
+- Added the `SanitizerContext` type, which lists the write surfaces the `sanitizer` option receives. [#13240](https://github.com/handsontable/handsontable/pull/13240)
 
 #### Changed
 - Reduced memory usage when scrolling large datasets by releasing cell metadata for rows scrolled out of the viewport. [#12854](https://github.com/handsontable/handsontable/pull/12854)
@@ -139,7 +140,12 @@ For more information about this release, see:
 - React: Fixed a memory leak in the React wrapper where the portal containers used by component-based renderers were retained for every scrolled cell instead of being released once a cell left the viewport. [#12895](https://github.com/handsontable/handsontable/pull/12895)
 - React: Fixed missing TypeScript autocomplete and type checking for `<HotTable>` and `<HotColumn>` props. [#13007](https://github.com/handsontable/handsontable/issues/13007)
 - Angular: Fixed custom editor shortcut groups in the Angular wrapper. [#13160](https://github.com/handsontable/handsontable/pull/13160)
-- Fixed an issue where clicking focusable plugin UI placed in the grid's layout slots (for example, pagination controls) closed the open cell editor and deselected the grid. [#13243](https://github.com/handsontable/handsontable/pull/13243)
+- Fixed the grid no longer responding to keyboard shortcuts after clicking focusable plugin UI placed in the grid's layout slots (for example, pagination controls). [#13243](https://github.com/handsontable/handsontable/pull/13243)
+- Fixed an open cell editor staying visible over an unrelated row, and committing to a row you could no longer see, when the edited cell was hidden - for example by turning a Pagination page or hiding its row or column. [#13245](https://github.com/handsontable/handsontable/pull/13245)
+
+#### Security
+- Fixed pasted HTML being able to run scripts, and applied the `sanitizer` option to the surfaces that previously skipped it. [#13236](https://github.com/handsontable/handsontable/pull/13236)
+- Fixed the `dialog` plugin interpolating an unvalidated `template.id` into the dialog's `id` attribute, and the `loading` plugin rendering its `title` and `description` options as HTML. Those two `loading` options now render as text, so markup passed in them shows up literally instead of being interpreted; use `icon` for markup. The button `type` option of the `dialog`, `emptyDataState`, and `notification` plugins is now resolved where the markup is built. [#13242](https://github.com/handsontable/handsontable/pull/13242)
 
 ## 18.0.0
 


### PR DESCRIPTION
### Context

The PR adds the `18.1.0` release notes, compiled from the `18.1.0` section of `CHANGELOG.md`.

**This is a section, not a new page.** `changelog-18` is a per-major page and minors stack inside it, newest first, exactly as `changelog-17.md` holds `17.1.0`, `17.0.1`, and `17.0.0`. So this PR prepends a `## 18.1.0` section above `## 18.0.0` and changes nothing else: no new file, no `sidebar.js` entry, and no `docs/tests/paths.js` entry, because `changelog-18` is already registered in both. That is the one way this PR differs from #12808, which had to create the page and register it.

**The frontmatter deliberately still reads "Changelog 18.0".** `changelog-17.md` does the same while holding `17.1.0`, so this follows the existing convention rather than fixing it unilaterally. Please do not "correct" the `title` and `description` in review; if the convention should change, that is its own PR across both pages.

### Entry list

The 102 entries are copied verbatim from the `18.1.0` section of `CHANGELOG.md` as it stands after #13250: 9 Added, 26 Changed, 1 Removed, 66 Fixed.

That count reflects #13250, which removed four entries from the `18.1.0` section whose code shipped in `18.0.0` (#12727, #12811, #12844, #12847) and rewrote two entries that could not be quoted as they stood. Worth flagging one consequence for whoever writes the announcement: **with #12727 gone, `18.1.0` carries no breaking change at all.** The `Removed` section is a single non-breaking entry, and no entry in the section is marked `**Breaking change**`. That matches the code and is the expected shape for a minor release.

### How has this been tested?

No source code changed, and no `.js` file changed, so neither the `handsontable` suites nor `docs:lint` (which covers `.js`, `.mjs`, `.ts`, and `.astro` under `docs/src` and `docs/content`) have anything new to check here.

The verification that matters is that the section is a faithful copy of `CHANGELOG.md`. Both sides were parsed into `(subsection, entry-text)` pairs and compared:

```
source entries: 102   page entries: 102
IDENTICAL (section + text, in order): True
```

Every entry matches byte for byte, sits under the same subsection, and appears in the same order. Per-section counts on both sides: Added 9, Changed 26, Removed 1, Fixed 66.

Also checked against the `18.0.0` block on the same page: `#### Added` / `#### Changed` / `#### Removed` / `#### Fixed` at the same heading level, the first entry on the line directly below each heading with no blank line, the same `<div class="boxes-list gray">` wrapper, and the same `→` character in the migration-guide label.

Please use the `Docs / preview / deploy` check to confirm the `18.1.0` section renders above `18.0.0`, that the page's table of contents picks it up, and that the box list renders as a box list.

**Note on the local pre-push hook.** `scripts/pre-push.mjs:29-38` resolves its diff base only against `origin/develop`, so on a branch cut from `release/18.1.0` it treats the entire release delta as this push's own change and tries to run unrelated unit tests. The real diff here is one markdown file. Pushed with `--no-verify`, which the script's own header documents as the escape hatch; CI evaluates against the correct base.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. RELEASE-843

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/RELEASE-843

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only markdown update with no runtime or build logic changes.
> 
> **Overview**
> **Prepends a full `## 18.1.0` section** to `changelog-18.md`, above the existing `18.0.0` block, following the same stacked-minor layout as `changelog-17.md`.
> 
> The new section includes the September 1, 2026 release date, links to the blog post, 18.1 docs, and the 18.0 → 18.1 migration guide, plus **102 changelog bullets** copied from `CHANGELOG.md` under **Added**, **Changed**, **Removed**, **Fixed**, and **Security**. Page frontmatter, sidebar, and path registration are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e466f8c77a06d11012453716a10176916ddedb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->