### PR TITLE
DEV-2638: Fix pivot() dropping cells for a ragged input

### DIFF
--- a/.changelogs/10268.json
+++ b/.changelogs/10268.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `populateFromArray()` with the `shift_down` method silently dropping cells when the input rows had unequal lengths.",
+  "type": "fixed",
+  "issueOrPR": 10268,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/10268.json
+++ b/.changelogs/10268.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "public",
-  "title": "Fixed `populateFromArray()` with the `shift_down` method silently dropping cells when the input rows had unequal lengths.",
-  "type": "fixed",
-  "issueOrPR": 10268,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/13254.json
+++ b/.changelogs/13254.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed `populateFromArray()` with the `shift_down` method, and the `Handsontable.helper.pivot()` helper, silently dropping cells when the input rows had unequal lengths.",
+  "type": "fixed",
+  "issueOrPR": 13254,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
+++ b/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
@@ -404,39 +404,45 @@ const accessor = columnIndex => function(row, value) {
   }
 };
 
-const hot = new Handsontable(container, {
+const settings = {
   data: rows,
   columns: source.map((column, columnIndex) => ({ data: accessor(columnIndex) })),
   dataSchema: () => ({ index: -1 }),
-  licenseKey: 'non-commercial-and-evaluation',
-});
+};
 ```
+
+Pass `settings` to Handsontable the way your framework does -- as the second argument to the constructor, or as the component's settings.
 
 The grid now renders one row per position across the columns. Columns of unequal length leave empty cells at the bottom of the shorter ones. An edit writes straight into `source`, so no copy can fall behind.
 
 That is the whole setup for reading and writing existing cells. Adding and removing rows needs two more hooks.
 
-A row the grid creates has no slot in your column arrays yet. Until you make one, that row renders empty and discards whatever the end user types into it, without an error. So if anything can create a row -- the context menu, [`minSpareRows`](@/api/options.md#minsparerows), or [`alter()`](@/api/core.md#alter) -- keep the column arrays in step through [`afterCreateRow`](@/api/hooks.md#aftercreaterow) and [`afterRemoveRow`](@/api/hooks.md#afterremoverow).
+A row the grid creates has no slot in your column arrays yet. Its row object still holds the [`dataSchema`](@/api/options.md#dataschema) marker `-1`, so the accessor writes a value typed into that row to `source[columnIndex][-1]` -- a property on the array object, not one of its elements. The grid displays the value, because the accessor reads the same slot back, but the value never joins your data, and every row the grid creates shares that one slot. So if anything can create a row -- the context menu, [`minSpareRows`](@/api/options.md#minsparerows), or [`alter()`](@/api/core.md#alter) -- keep the column arrays in step through [`afterCreateRow`](@/api/hooks.md#aftercreaterow) and [`afterRemoveRow`](@/api/hooks.md#afterremoverow).
 
 Both hooks report a **visual** row index, while the column arrays are physical, so translate before you splice. For an insert, the new row object still carries the [`dataSchema`](@/api/options.md#dataschema) marker, and its position in `rows` is the physical index. For a removal, use the hook's `physicalRows` argument and splice the highest index first:
 
 ```javascript
-afterCreateRow(index, amount) {
-  const at = rows.findIndex(row => row.index === -1);
+const settings = {
+  // ... the options above
+  afterCreateRow(index, amount) {
+    const at = rows.findIndex(row => row.index === -1);
 
-  source.forEach(column => {
-    column.splice(at === -1 ? index : at, 0, ...new Array(amount).fill(null));
-  });
-  restamp(rows);
-  hot.render();
-},
-afterRemoveRow(index, amount, physicalRows) {
-  [...physicalRows].sort((a, b) => b - a).forEach(row => {
-    source.forEach(column => column.splice(row, 1));
-  });
-  restamp(rows);
-  hot.render();
-},
+    source.forEach(column => {
+      column.splice(at === -1 ? index : at, 0, ...new Array(amount).fill(null));
+    });
+    restamp(rows);
+    // Call `this.render()`, not a variable holding the instance: with `minSpareRows` this hook
+    // runs while Handsontable is still starting up, before that variable holds anything.
+    this.render();
+  },
+  afterRemoveRow(index, amount, physicalRows) {
+    [...physicalRows].sort((a, b) => b - a).forEach(row => {
+      source.forEach(column => column.splice(row, 1));
+    });
+    restamp(rows);
+    this.render();
+  },
+};
 ```
 
 Three more things to know about this setup:

--- a/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
+++ b/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
@@ -366,6 +366,85 @@ The example below shows how to use such objects:
 
 :::
 
+### Column-oriented data source
+
+Handsontable reads its data row by row. If your data arrives as one array per column, you don't have to keep a transposed copy in sync -- point each column's [`data`](@/api/options.md#data) option at the array it belongs to.
+
+Handsontable can't tell the two orientations apart on its own. `[['a', 'b'], ['c', 'd']]` is the same value whether you mean it as two rows or as two columns, so you state which one you mean through [`columns`](@/api/options.md#columns).
+
+The [`data`](@/api/options.md#data) option still needs one entry per row. Use a small object per row that records its own index, and mint new ones through [`dataSchema`](@/api/options.md#dataschema):
+
+```javascript
+const source = [
+  ['a', 'b'],      // column A
+  ['c', 'd', 'e'], // column B
+];
+
+const rowCount = source.reduce((max, column) => Math.max(max, column.length), 0);
+const restamp = rows => {
+  rows.forEach((row, index) => {
+    row.index = index;
+  });
+
+  return rows;
+};
+
+// Handsontable splices this array in place, so it stays a live view of the row order.
+const rows = restamp(Array.from({ length: rowCount }, () => ({ index: 0 })));
+
+// A regular function, not an arrow function: `arguments.length` tells a read from a write.
+const accessor = columnIndex => function(row, value) {
+  if (arguments.length === 1) {
+    // The row can be missing while the grid measures sizes or replays an undo step.
+    return row ? source[columnIndex][row.index] ?? null : null;
+  }
+
+  if (row) {
+    source[columnIndex][row.index] = value;
+  }
+};
+
+const hot = new Handsontable(container, {
+  data: rows,
+  columns: source.map((column, columnIndex) => ({ data: accessor(columnIndex) })),
+  dataSchema: () => ({ index: -1 }),
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+The grid now renders one row per position across the columns. Columns of unequal length leave empty cells at the bottom of the shorter ones. An edit writes straight into `source`, so no copy can fall behind.
+
+That is the whole setup for reading and writing existing cells. Adding and removing rows needs two more hooks.
+
+A row the grid creates has no slot in your column arrays yet. Until you make one, that row renders empty and discards whatever the end user types into it, without an error. So if anything can create a row -- the context menu, [`minSpareRows`](@/api/options.md#minsparerows), or [`alter()`](@/api/core.md#alter) -- keep the column arrays in step through [`afterCreateRow`](@/api/hooks.md#aftercreaterow) and [`afterRemoveRow`](@/api/hooks.md#afterremoverow).
+
+Both hooks report a **visual** row index, while the column arrays are physical, so translate before you splice. For an insert, the new row object still carries the [`dataSchema`](@/api/options.md#dataschema) marker, and its position in `rows` is the physical index. For a removal, use the hook's `physicalRows` argument and splice the highest index first:
+
+```javascript
+afterCreateRow(index, amount) {
+  const at = rows.findIndex(row => row.index === -1);
+
+  source.forEach(column => {
+    column.splice(at === -1 ? index : at, 0, ...new Array(amount).fill(null));
+  });
+  restamp(rows);
+  hot.render();
+},
+afterRemoveRow(index, amount, physicalRows) {
+  [...physicalRows].sort((a, b) => b - a).forEach(row => {
+    source.forEach(column => column.splice(row, 1));
+  });
+  restamp(rows);
+  hot.render();
+},
+```
+
+Three more things to know about this setup:
+
+- [`getSourceData()`](@/api/core.md#getsourcedata) returns copies of the row objects, so you can't re-stamp the row indexes through it. Hold on to the array you passed as [`data`](@/api/options.md#data).
+- Undo of a row removal restores the row object, which carries no cell values. To bring the values back, record them in [`beforeRemoveRow`](@/api/hooks.md#beforeremoverow) and put them back in [`afterCreateRow`](@/api/hooks.md#aftercreaterow) when `source` is `'UndoRedo.undo'`.
+- [`columns`](@/api/options.md#columns) fixes the number of columns, so [`alter()`](@/api/core.md#alter) can't insert one. To add a column, push a new array onto your source and call [`updateSettings()`](@/api/core.md#updatesettings) with a new [`columns`](@/api/options.md#columns) array.
+
 ### Identify changed columns in hooks
 
 When you use a [function data source](#function-data-source-and-schema), each column's [`data`](@/api/options.md#data) option is a getter/setter function. In [`beforeChange`](@/api/hooks.md#beforechange) and [`afterChange`](@/api/hooks.md#afterchange), the second element of each change tuple is `prop`. With function-based columns, `prop` is that accessor function -- not a property name or a column index.

--- a/handsontable/src/__tests__/core/populateFromArray.spec.js
+++ b/handsontable/src/__tests__/core/populateFromArray.spec.js
@@ -394,6 +394,24 @@ describe('Core_populateFromArray', () => {
       expect(getDataAtCol(2)).toEqual([null, 'y3', 'C1', 'C2']);
     });
 
+    it('should not throw when every input row is empty', async() => {
+      handsontable({
+        data: [
+          ['A1', 'B1'],
+          ['A2', 'B2'],
+        ],
+      });
+
+      // `[[], []]` has rows, so the `input.length === 0` guard does not catch it. Without an early
+      // return the column lookup divides by zero, reads `NaN` and throws on `.concat`.
+      await populateFromArray(0, 0, [[], []], 1, 1, 'test', 'shift_down');
+
+      expect(getData()).toEqual([
+        ['A1', 'B1'],
+        ['A2', 'B2'],
+      ]);
+    });
+
     it('should fill the gap left by a short row with an empty cell', async() => {
       handsontable({
         data: [

--- a/handsontable/src/__tests__/core/populateFromArray.spec.js
+++ b/handsontable/src/__tests__/core/populateFromArray.spec.js
@@ -355,6 +355,64 @@ describe('Core_populateFromArray', () => {
         [9, 0, null, null], [9, 1, null, null], [9, 2, null, null], [9, 3, null, null], [9, 4, null, null], [9, 5, null, null],
       ], 'populateFromArray');
     });
+
+    it('should keep every cell of a ragged input when a later row is wider than the first one', async() => {
+      handsontable({
+        data: [
+          ['A1', 'B1', 'C1'],
+          ['A2', 'B2', 'C2'],
+          ['A3', 'B3', 'C3'],
+        ],
+      });
+
+      // The first row holds one value, the second holds three. The width of the whole input has
+      // to come from the widest row, or 'y2' and 'y3' are dropped without a word.
+      await populateFromArray(0, 0, [['x'], ['y1', 'y2', 'y3']], null, null, null, 'shift_down');
+
+      expect(getData()).toEqual([
+        ['x', null, null],
+        ['y1', 'y2', 'y3'],
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+      ]);
+    });
+
+    it('should push the pushed-down rows all the way down, not only under the first input column', async() => {
+      handsontable({
+        data: [
+          ['A1', 'B1', 'C1'],
+          ['A2', 'B2', 'C2'],
+        ],
+      });
+
+      await populateFromArray(0, 0, [['x'], ['y1', 'y2', 'y3']], null, null, null, 'shift_down');
+
+      // Columns B and C must move down with column A. Reading the input width from the first row
+      // left them untouched at the top and padded them with `null` at the bottom instead.
+      expect(getDataAtCol(1)).toEqual([null, 'y2', 'B1', 'B2']);
+      expect(getDataAtCol(2)).toEqual([null, 'y3', 'C1', 'C2']);
+    });
+
+    it('should fill the gap left by a short row with an empty cell', async() => {
+      handsontable({
+        data: [
+          ['A1', 'B1', 'C1'],
+          ['A2', 'B2', 'C2'],
+        ],
+      });
+
+      // Here the FIRST row is the widest, so the width was already right. What changes is that the
+      // positions the short row does not reach hold `null` rather than `undefined`.
+      await populateFromArray(0, 0, [['a1', 'a2', 'a3'], ['b1']], null, null, null, 'shift_down');
+
+      expect(getData()).toEqual([
+        ['a1', 'a2', 'a3'],
+        ['b1', null, null],
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+      ]);
+    });
   });
 
   describe('should shift values right', () => {

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -1304,15 +1304,22 @@ export default function Core(
       switch (method) {
         case 'shift_down':
           // translate data from a list of rows to a list of columns
-          const populatedDataByColumns: unknown[][] = pivot(input) as unknown[][];
+          const populatedDataByColumns: unknown[][] = pivot(input);
           const numberOfDataColumns = populatedDataByColumns.length;
+
+          // Every input row is empty, so there is nothing to populate. Bailing out here also keeps
+          // the `c % numberOfDataColumns` lookup below from dividing by zero and reading `NaN`.
+          if (numberOfDataColumns === 0) {
+            return false;
+          }
+
           // method's argument can extend the range of data population (data would be repeated)
 
           const numberOfColumnsToPopulate = Math.max(numberOfDataColumns, columnsPopulationEnd);
           const pushedDownDataByRows = instance.getData().slice(startRow!);
 
           // translate data from a list of rows to a list of columns
-          const pushedDownDataByColumns: unknown[][] = (pivot(pushedDownDataByRows) as unknown[][])
+          const pushedDownDataByColumns: unknown[][] = pivot(pushedDownDataByRows)
             .slice(startColumn!, startColumn! + numberOfColumnsToPopulate);
 
           for (c = 0; c < numberOfColumnsToPopulate; c += 1) {
@@ -1338,7 +1345,7 @@ export default function Core(
             }
           }
 
-          instance.populateFromArray(startRow!, startColumn!, pivot(newDataByColumns) as unknown[][]);
+          instance.populateFromArray(startRow!, startColumn!, pivot(newDataByColumns));
 
           break;
 
@@ -2484,6 +2491,8 @@ export default function Core(
    * @param {number} [endCol] End visual column index (use when you want to cut input when certain column is reached).
    * @param {string} [source=populateFromArray] Used to identify this call in the resulting events (beforeChange, afterChange).
    * @param {string} [method=overwrite] Populate method, possible values: `'shift_down'`, `'shift_right'`, `'overwrite'`.
+   * The `input` rows may differ in length. The widest row sets the width of the populated area, and
+   * a shorter row fills the positions it does not reach with the empty-cell value (`null`).
    * @returns {object|undefined} Ending td in pasted area (only if any cell was changed).
    */
   this.populateFromArray = function(

--- a/handsontable/src/helpers/__tests__/array.unit.ts
+++ b/handsontable/src/helpers/__tests__/array.unit.ts
@@ -572,5 +572,20 @@ describe('Array helper', () => {
     it('should preserve a `null` that was in the input', () => {
       expect(pivot([[null, 'b'], ['c', null]])).toStrictEqual([[null, 'c'], ['b', null]]);
     });
+
+    it('should replace an explicit `undefined` with the empty-cell value', () => {
+      // This also holds for a full-width row, so the output of a rectangular input changes when it
+      // carries an explicit `undefined`. Keeping every returned row dense is the point.
+      expect(pivot([[1, undefined], [3, 4]])).toStrictEqual([[1, 3], [null, 4]]);
+    });
+
+    it('should skip a row that is not an array', () => {
+      expect(pivot([['a', 'b'], null as unknown as unknown[], ['c', 'd']]))
+        .toStrictEqual([['a', null, 'c'], ['b', null, 'd']]);
+    });
+
+    it('should return an empty array when every row is empty', () => {
+      expect(pivot([[], []])).toStrictEqual([]);
+    });
   });
 });

--- a/handsontable/src/helpers/__tests__/array.unit.ts
+++ b/handsontable/src/helpers/__tests__/array.unit.ts
@@ -10,6 +10,7 @@ import {
   arraySum,
   arrayUnique,
   insertValuesInPlace,
+  pivot,
   removeIndexesInPlace,
   stringToArray,
   getDifferenceOfArrays,
@@ -532,6 +533,44 @@ describe('Array helper', () => {
       it('should return array of strings.', () => {
         expect(stringToArray('class-1,class-2,class-3', ',')).toStrictEqual(['class-1', 'class-2', 'class-3']);
       });
+    });
+  });
+
+  //
+  // Handsontable.helper.pivot
+  //
+  describe('pivot', () => {
+    it('should turn the rows of a rectangular array into columns', () => {
+      expect(pivot([[1, 2, 3], [4, 5, 6]])).toStrictEqual([[1, 4], [2, 5], [3, 6]]);
+    });
+
+    it('should keep the values of a row that is wider than the first one', () => {
+      expect(pivot([['a', 'b'], ['c', 'd', 'e']])).toStrictEqual([['a', 'c'], ['b', 'd'], [null, 'e']]);
+    });
+
+    it('should take the width from the widest row, wherever it sits', () => {
+      expect(pivot([['a'], ['b', 'c'], ['d', 'e', 'f'], ['g']])).toStrictEqual([
+        ['a', 'b', 'd', 'g'],
+        [null, 'c', 'e', null],
+        [null, null, 'f', null],
+      ]);
+    });
+
+    it('should fill the positions a shorter row does not reach with `null`', () => {
+      expect(pivot([['a', 'b', 'c'], ['d']])).toStrictEqual([['a', 'd'], ['b', null], ['c', null]]);
+    });
+
+    it('should not lose the rows that follow an empty first row', () => {
+      expect(pivot([[], ['a', 'b']])).toStrictEqual([[null, 'a'], [null, 'b']]);
+    });
+
+    it('should return an empty array for an empty input', () => {
+      expect(pivot([])).toStrictEqual([]);
+      expect(pivot([[]])).toStrictEqual([]);
+    });
+
+    it('should preserve a `null` that was in the input', () => {
+      expect(pivot([[null, 'b'], ['c', null]])).toStrictEqual([[null, 'c'], ['b', null]]);
     });
   });
 });

--- a/handsontable/src/helpers/array.ts
+++ b/handsontable/src/helpers/array.ts
@@ -28,13 +28,16 @@ export function extendArray(arr: unknown[], extension: unknown[]): void {
 /**
  * Transposes a two-dimensional array, turning its rows into columns.
  *
- * Rows of unequal length are supported: the widest row decides how many columns come out, and
- * a shorter row contributes the empty-cell value (`null`) for the positions it does not reach.
+ * The rows may differ in length. The widest row decides how many columns come out, and a shorter
+ * row yields the empty-cell value (`null`) for the positions it does not reach.
+ *
+ * The output holds `null` wherever the input held `undefined`, including in a full-width row, so
+ * that every returned row is dense.
  *
  * @param {Array} arr An array to pivot.
  * @returns {Array}
  */
-export function pivot(arr: unknown[][]): unknown[] {
+export function pivot(arr: unknown[][]): unknown[][] {
   const pivotedArr: unknown[][] = [];
 
   if (!arr || arr.length === 0) {

--- a/handsontable/src/helpers/array.ts
+++ b/handsontable/src/helpers/array.ts
@@ -26,27 +26,47 @@ export function extendArray(arr: unknown[], extension: unknown[]): void {
 }
 
 /**
+ * Transposes a two-dimensional array, turning its rows into columns.
+ *
+ * Rows of unequal length are supported: the widest row decides how many columns come out, and
+ * a shorter row contributes the empty-cell value (`null`) for the positions it does not reach.
+ *
  * @param {Array} arr An array to pivot.
  * @returns {Array}
  */
 export function pivot(arr: unknown[][]): unknown[] {
   const pivotedArr: unknown[][] = [];
 
-  if (!arr || arr.length === 0 || !arr[0] || arr[0].length === 0) {
+  if (!arr || arr.length === 0) {
     return pivotedArr;
   }
 
   const rowCount = arr.length;
-  const colCount = arr[0].length;
+  let colCount = 0;
 
+  // The widest row decides the width. Taking it from the first row alone silently drops every
+  // cell past that width, which is data loss for a ragged input.
   for (let i = 0; i < rowCount; i++) {
-    for (let j = 0; j < colCount; j++) {
-      if (!pivotedArr[j]) {
-        pivotedArr[j] = [];
-      }
+    const row = arr[i];
 
-      pivotedArr[j][i] = arr[i][j];
+    if (row && row.length > colCount) {
+      colCount = row.length;
     }
+  }
+
+  for (let j = 0; j < colCount; j++) {
+    const pivotedRow: unknown[] = new Array(rowCount);
+
+    for (let i = 0; i < rowCount; i++) {
+      const row = arr[i];
+      const value = row ? row[j] : undefined;
+
+      // A row shorter than the widest one has no value here. Keep the output dense with the
+      // empty-cell value rather than leaving a hole for the caller to trip over.
+      pivotedRow[i] = value === undefined ? null : value;
+    }
+
+    pivotedArr[j] = pivotedRow;
   }
 
   return pivotedArr;


### PR DESCRIPTION
### Context

The PR fixes silent data loss in `populateFromArray()` when the input rows have unequal lengths, and documents column-oriented data binding.

`populateFromArray()` routes its `shift_down` method through the `pivot()` helper (`handsontable/src/helpers/array.ts`), which took the number of output columns from the **first input row only**:

```js
const colCount = arr[0].length;
```

Every cell past that width was never copied. On a 3x3 grid:

```js
hot.populateFromArray(0, 0, [['X'], ['Y1', 'Y2', 'Y3']], null, null, null, 'shift_down');
```

`'Y2'` and `'Y3'` are dropped, with no error and no hook to intercept. The same call with `'shift_right'` handles the ragged input correctly, because that branch does not use `pivot()` — one API, two orientations, and only one of them loses data.

This is the same "first row decides the width" family as the ragged-paste fix in #13237. **Paste is not affected**: `copyPaste` already pads the pasted array rectangular before it reaches `populateFromArray()`.

`pivot()` now takes the width from the widest row, and fills the gaps a shorter row leaves with `null` — the same choice `copyPaste` already makes, so the two paths agree.

A rectangular input keeps the same width. One output change does reach it: an explicit `undefined` now comes back as `null`, in a full-width row too, so that every returned row is dense. `core.ts` skips a change where the old and new values are both null-or-undefined, so no extra write reaches `datamap.set`, but `beforeChange` / `afterChange` tuples now carry `null` where they carried `undefined`.

The old `translateRowsToColumns` helper (removed in #8867) is deliberately **not** restored. It was never correct either: on a ragged input it *misplaces* the extra cell into column 0 rather than dropping it.

**Docs.** Issue #10268 asked to bind a column-major array of arrays with two-way binding. That needs **no new option** — `columns[].data` accessor functions already cover it. A new "Column-oriented data source" section in the *Binding to data* guide documents the recipe, along with the traps found while verifying it in a browser: a row the grid creates writes to an off-array slot that every created row shares, until the structural hooks give it a real one, `getSourceData()` returns copies of the row objects, and `afterCreateRow`/`afterRemoveRow` report visual indexes while the column arrays are physical.

### How has this been tested?

10 new unit tests for `pivot()` and 4 new E2E cases in the existing `shift_down` block of `populateFromArray.spec.js`.

Red/green was confirmed in both directions: with the width fix reverted, the new unit tests and E2E cases fail with exactly the data-loss shape; with it restored, they pass.

```bash
# Unit tests for the helper
npm run test:unit --prefix handsontable -- --testPathPattern=helpers/__tests__/array

# E2E for the fixed method and the helper's other consumers
npm run test:e2e --prefix handsontable -- --testPathPattern='autocompleteEditor|populateFromArray|autofill|copyPaste'

# Full gates
npm run test:unit --prefix handsontable      # 3809 passed
npm run test:types --prefix handsontable
npm run eslint --prefix handsontable         # 0 errors
npm run docs:lint --prefix docs
```

The documented guide snippet was also run verbatim in Chrome to confirm the recipe works as written.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2638
2. #10268

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2638

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `populateFromArray` / `pivot` behavior for ragged 2D arrays; fixes incorrect data loss but alters outcomes for that edge case, with broad downstream use of `pivot` in core and editors.
> 
> **Overview**
> Fixes **silent data loss** when `populateFromArray()` runs with the `shift_down` method on input where rows have different lengths. That path transposes the input via `pivot()` in `handsontable/src/helpers/array.ts`, which previously sized the result from the **first row only**—extra cells in wider rows were never copied.
> 
> `pivot()` now derives width from the **widest row**, pads shorter rows with `null` (aligned with copy/paste padding), and still returns empty output for `[]` / `[[]]`. Rectangular inputs behave as before.
> 
> Adds unit tests for `pivot()` and E2E cases for `shift_down`, a changelog entry for #10268, and a new **Column-oriented data source** section in the Binding to data guide (accessor-based binding to column arrays, plus row create/remove hooks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 893c59ba5c4ed872c975082cc565ec91e68e8386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
