### PR TITLE
DEV-2629: Measure the scenario action, not the harness overhead around it

### DIFF
--- a/.claude/skills/performance-testing/SKILL.md
+++ b/.claude/skills/performance-testing/SKILL.md
@@ -147,11 +147,15 @@ await injectHookTimer(page, 'beforeFilter', 'afterFilter');
 const hookDeltas: number[] = [];
 const outputDir = path.resolve('output', config.name);
 
-// Inside actionFn, capture timing after the action:
-const timing = await getHookTiming(page, 'beforeFilter', 'afterFilter');
-if (timing.deltaMs != null) {
-  hookDeltas.push(timing.deltaMs);
-}
+// In afterActionFn -- NOT actionFn. getHookTiming is a page.evaluate, and inside
+// actionFn its CDP round trip falls inside the marked window, so it is measured as
+// part of the operation on measured iterations only:
+afterActionFn: async() => {
+  const timing = await getHookTiming(page, 'beforeFilter', 'afterFilter');
+  if (timing.deltaMs != null) {
+    hookDeltas.push(timing.deltaMs);
+  }
+},
 
 // Inside resetFn, call injectHookTimer again to reset the store
 // (it is idempotent -- prevents duplicate listener registration):
@@ -228,9 +232,25 @@ Push retries with rebase (up to 3 attempts) protect against concurrent gh-pages 
 
 Understanding the data flow helps when debugging or extending:
 
-1. **Spec** calls `runTracedScenario()` -> CDP `Tracing.start` / `Tracing.end` -> raw JSON per iteration
+### The measured window (read before adding a scenario)
+
+Everything published describes the slice between the two `performance.mark`s that
+`runTracedScenario()` writes around the action. Two rules follow:
+
+- **No harness round trips inside `actionFn`.** A `page.evaluate` that reads a value back
+  is measured as part of the operation. Put readbacks in `afterActionFn`, which runs after
+  the end mark.
+- **A `resetFn` must leave no frame behind.** The runner settles after `setupFn` and
+  `resetFn` for this reason, and `skipSettle` does not turn those off. Note that
+  `scrollToRow`/`scrollToColumn` report trimming, not scroll position, so their
+  `waitForFunction` returns before the scroll has rendered.
+
+A category measured as exactly `0`, or a CV of `141.42%` (the CV of `{x, 0, 0}` at three
+iterations), means the window is wrong -- not that the operation was cheap.
+
+1. **Spec** calls `runTracedScenario()` -> CDP `Tracing.start`, start mark, action, settle, end mark, `Tracing.end` -> raw JSON per iteration
 2. **Teardown** (`lib/teardown.mjs`) discovers `output/*/iteration-*.json`, calls `parseTrace()` from `trace-parser.mjs`
-3. **trace-parser.mjs** categorizes events into DevTools categories (scripting, rendering, painting, loading, system, idle), computes the auto-zoomed window, synthesizes ProfileCall scripting from CPU profile data
+3. **trace-parser.mjs** categorizes events into DevTools categories (scripting, rendering, painting, loading, system, idle), measures the window `runTracedScenario()` marked around the action (falling back to the auto-zoomed window only for traces recorded without marks), synthesizes ProfileCall scripting from CPU profile data
 4. **Teardown** averages across iterations via `averageParsedTraces()`, collects per-iteration values for CV% calculation, strips internal fields (`_iterationValues`, `_debug`) from saved snapshots
 5. **report-builder.mjs** assembles a compact markdown PR comment; **html-report-builder.mjs** generates a full interactive HTML report with inline SVG charts from **chart-generator.mjs**
 6. If `PERF_MODE=golden`: `snapshot-store.mjs` saves averaged results, deployed to gh-pages

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "npm run eslint && npm run all lint -- --if-present && npm run lint --prefix performance-tests && npm run lint --prefix tests",
     "eslint": "eslint .github/scripts/ bin/changelog scripts/",
     "test": "npm run all test -- -e=examples",
-    "test:tooling": "node --test .github/scripts/__tests__/*.test.mjs scripts/__tests__/*.test.mjs scripts/claude/__tests__/*.test.mjs evals/__tests__/*.test.mjs",
+    "test:tooling": "node --test .github/scripts/__tests__/*.test.mjs scripts/__tests__/*.test.mjs scripts/claude/__tests__/*.test.mjs evals/__tests__/*.test.mjs performance-tests/lib/__tests__/*.test.mjs",
     "build": "npm run all build -- -e=examples",
     "freeze": "node scripts/freeze.mjs",
     "release": "node scripts/release.mjs",

--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -101,17 +101,42 @@ performance-tests/
 
 ### Trace pipeline
 
-1. The **spec file** calls `runTracedScenario()`, which starts CDP tracing (`Tracing.start`), executes the action, stops tracing (`Tracing.end`), and writes the raw JSON per iteration.
+1. The **spec file** calls `runTracedScenario()`, which starts CDP tracing (`Tracing.start`), marks the start of the measured window, executes the action, waits for the resulting frame to reach the compositor, marks the end, stops tracing (`Tracing.end`), and writes the raw JSON per iteration.
 
 2. The **globalTeardown** (`lib/teardown.mjs`) discovers all `output/*/iteration-*.json` files and feeds them to the trace parser.
 
-3. The **trace parser** (`trace-parser.mjs`) categorizes every trace event into DevTools-equivalent categories: scripting, rendering, painting, loading, system (other), and idle. It computes the auto-zoomed window (matching DevTools' `MainThreadActivity.calculateWindow`), synthesizes ProfileCall scripting from CPU profile data, and extracts UpdateCounters (heap, nodes, listeners).
+3. The **trace parser** (`trace-parser.mjs`) categorizes every trace event into DevTools-equivalent categories: scripting, rendering, painting, loading, system (other), and idle. It measures the window the runner marked around the action, synthesizes ProfileCall scripting from CPU profile data, and extracts UpdateCounters (heap, nodes, listeners). Traces recorded without the marks fall back to the auto-zoomed window (matching DevTools' `MainThreadActivity.calculateWindow`); teardown warns when that happens, because the two are not comparable -- see [The measured window](#the-measured-window).
 
 4. Results are **averaged** across iterations with per-iteration values retained for CV% (coefficient of variation) calculation.
 
 5. Two **report builders** produce output:
    - **Markdown** (`report-builder.mjs`): compact summary table with regression callouts, posted as a sticky PR comment.
    - **HTML** (`html-report-builder.mjs`): self-contained interactive page with inline SVG bar charts, sortable tables, and scenario detail views. Deployed to GitHub Pages per branch.
+
+### The measured window
+
+Everything the suite publishes describes one slice of the trace, and picking that slice
+correctly is the difference between measuring the grid and measuring the harness.
+
+`runTracedScenario()` brackets the action with `performance.mark` (recorded via the
+`blink.user_timing` category) and the parser measures between those marks. It does **not**
+auto-zoom onto the busiest region of the trace, because for any scenario driven through
+`page.evaluate` the busiest region is the V8 interrupt CDP uses to enter the isolate -- a
+blob of a few hundred milliseconds that maps to no category, lands in `other`, and is
+excluded from `Total`. Worse, a window fitted to it closes before the `Paint`, `Layout` and
+`Commit` events the action caused, so rendering and painting score exactly zero.
+
+Two rules follow for anyone writing or changing a scenario:
+
+- **Keep harness round trips out of the window.** A `page.evaluate` inside `actionFn` that
+  reads a value back is billed to the action. Use `afterActionFn`, which runs after the end
+  mark, for readbacks such as hook timings.
+- **Let the reset settle.** A reset renders synchronously but paints a frame later. The
+  runner settles after `resetFn` for this reason; a `resetFn` that returns before its work is
+  queued will still leak into the next iteration.
+
+A category measured as exactly `0`, or a CV of `141.42%` (the CV of `{x, 0, 0}` at three
+iterations), means the window is wrong -- not that the operation was cheap.
 
 ### Golden baseline workflow
 
@@ -214,7 +239,9 @@ test(config.name, async({ page }) => {
     actionFn: async() => {
       // The measured action
     },
-    // Optional: resetFn to restore state between iterations
+    // Optional: resetFn to restore state between iterations (the runner settles after it)
+    // Optional: afterActionFn for readbacks, which run once the measured window has closed
+    // Optional: settleFn to replace the default settle, or skipSettle to opt out of it
   });
 });
 ```
@@ -224,7 +251,7 @@ test(config.name, async({ page }) => {
 For scenarios that measure a specific Handsontable hook pair (like filtering or sorting):
 
 1. Call `injectHookTimer(page, beforeHook, afterHook)` once before `runTracedScenario`. It is idempotent -- safe to call again in `resetFn` to reset the timer store.
-2. Inside `actionFn`, call `getHookTiming(page, beforeHook, afterHook)` and push `timing.deltaMs` to a deltas array.
+2. In `afterActionFn` -- **not** `actionFn` -- call `getHookTiming(page, beforeHook, afterHook)` and push `timing.deltaMs` to a deltas array. It is a `page.evaluate`, so inside the action its CDP round trip would be measured as part of the operation.
 3. After `runTracedScenario`, call `saveHookTimings(outputDir, deltas)` to persist the data.
 
 All three functions are exported from `lib/hook-timing.mjs`. See the `filtering` or `sorting` scenario specs for the complete pattern.

--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -132,8 +132,10 @@ Two rules follow for anyone writing or changing a scenario:
   reads a value back is billed to the action. Use `afterActionFn`, which runs after the end
   mark, for readbacks such as hook timings.
 - **Let the reset settle.** A reset renders synchronously but paints a frame later. The
-  runner settles after `resetFn` for this reason; a `resetFn` that returns before its work is
-  queued will still leak into the next iteration.
+  runner settles after `setupFn` and `resetFn` for this reason, and `skipSettle` does not
+  reach those -- it gates only the in-window settle. Note that `scrollToRow` and
+  `scrollToColumn` wait on trimming, not scroll position, so they return before the scroll
+  has rendered; the settle is what makes those resets deterministic.
 
 A category measured as exactly `0`, or a CV of `141.42%` (the CV of `{x, 0, 0}` at three
 iterations), means the window is wrong -- not that the operation was cheap.

--- a/performance-tests/lib/__tests__/trace-window.test.mjs
+++ b/performance-tests/lib/__tests__/trace-window.test.mjs
@@ -1,0 +1,92 @@
+// Unit tests for the explicit measurement window.
+//
+// The window decides which slice of a CDP trace the published numbers describe.
+// Before it existed the parser auto-zoomed onto the busiest region, which for a
+// page.evaluate-driven scenario is the V8 interrupt CDP uses to enter the isolate:
+// the window then closed before the Paint and Commit events the action caused, so
+// rendering and painting were published as 0 ms while ~420 ms of harness overhead
+// was published as System.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  measurementWindowFromMarks,
+  MEASURE_START_MARK,
+  MEASURE_END_MARK,
+} from '../../trace-parser.mjs';
+
+/**
+ * @param {string} name
+ * @param {number} ts -- microseconds, matching the trace format
+ * @returns {object} a trace event
+ */
+function markEvent(name, ts) {
+  return { name, ts, ph: 'R', pid: 1, tid: 1 };
+}
+
+describe('measurementWindowFromMarks', () => {
+  test('returns the span between the runner marks, in microseconds', () => {
+    const window = measurementWindowFromMarks([
+      markEvent('RunTask', 500),
+      markEvent(MEASURE_START_MARK, 1000),
+      markEvent('Paint', 1500),
+      markEvent(MEASURE_END_MARK, 3000),
+      markEvent('RunTask', 4000),
+    ]);
+
+    assert.deepEqual(window, { min: 1000, max: 3000, range: 2000 });
+  });
+
+  test('returns null when the trace carries no marks, so the caller falls back to auto-zoom', () => {
+    assert.equal(measurementWindowFromMarks([markEvent('RunTask', 500)]), null);
+  });
+
+  test('returns null when only one side of the window was marked', () => {
+    assert.equal(measurementWindowFromMarks([markEvent(MEASURE_START_MARK, 1000)]), null);
+    assert.equal(measurementWindowFromMarks([markEvent(MEASURE_END_MARK, 1000)]), null);
+  });
+
+  test('returns null on a zero-width or inverted window rather than a bogus range', () => {
+    assert.equal(measurementWindowFromMarks([
+      markEvent(MEASURE_START_MARK, 1000),
+      markEvent(MEASURE_END_MARK, 1000),
+    ]), null);
+
+    assert.equal(measurementWindowFromMarks([
+      markEvent(MEASURE_START_MARK, 3000),
+      markEvent(MEASURE_END_MARK, 1000),
+    ]), null);
+  });
+
+  test('spans the outermost pair when a trace carries more than one of each mark', () => {
+    const window = measurementWindowFromMarks([
+      markEvent(MEASURE_START_MARK, 2000),
+      markEvent(MEASURE_END_MARK, 3000),
+      markEvent(MEASURE_START_MARK, 1000),
+      markEvent(MEASURE_END_MARK, 4000),
+    ]);
+
+    assert.deepEqual(window, { min: 1000, max: 4000, range: 3000 });
+  });
+
+  test('matches mark names exactly, not by substring', () => {
+    // Each case pairs one near-miss name with one real mark, so a substring match
+    // on either side alone produces a window and fails the assertion.
+    assert.equal(measurementWindowFromMarks([
+      markEvent(`${MEASURE_START_MARK}-nested`, 1000),
+      markEvent(MEASURE_END_MARK, 3000),
+    ]), null, 'a name containing the start mark must not open the window');
+
+    assert.equal(measurementWindowFromMarks([
+      markEvent(MEASURE_START_MARK, 1000),
+      markEvent(`prefixed-${MEASURE_END_MARK}`, 3000),
+    ]), null, 'a name containing the end mark must not close the window');
+  });
+
+  test('the mark names are stable -- the runner and the parser must agree on them', () => {
+    // Emitted by lib/trace-runner.mjs, read back here. A rename on one side only
+    // sends every scenario silently back to auto-zoom.
+    assert.equal(MEASURE_START_MARK, 'hot-perf-measure-start');
+    assert.equal(MEASURE_END_MARK, 'hot-perf-measure-end');
+  });
+});

--- a/performance-tests/lib/__tests__/trace-window.test.mjs
+++ b/performance-tests/lib/__tests__/trace-window.test.mjs
@@ -2,43 +2,95 @@
 //
 // The window decides which slice of a CDP trace the published numbers describe.
 // Before it existed the parser auto-zoomed onto the busiest region, which for a
-// page.evaluate-driven scenario is the V8 interrupt CDP uses to enter the isolate:
-// the window then closed before the Paint and Commit events the action caused, so
-// rendering and painting were published as 0 ms while ~420 ms of harness overhead
-// was published as System.
+// page.evaluate-driven scenario can be the V8 interrupt CDP uses to enter the isolate
+// (426.9 ms in a real `sorting` trace). The window then closed before the Paint and
+// Commit events the action caused, so rendering and painting were published as 0 ms
+// while the harness overhead was published as System.
+//
+// The fixtures below mirror the real event shapes, checked against a recorded trace:
+// performance.mark arrives as `ph: 'I'`, `s: 't'`, `cat: 'blink.user_timing'`. Keeping
+// them faithful is what lets these tests fail when the matcher or the window changes.
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  parseTrace,
   measurementWindowFromMarks,
   MEASURE_START_MARK,
   MEASURE_END_MARK,
 } from '../../trace-parser.mjs';
 
+const PID = 100;
+const TID = 200;
+
 /**
  * @param {string} name
  * @param {number} ts -- microseconds, matching the trace format
- * @returns {object} a trace event
+ * @param {object} [overrides]
+ * @returns {object} a user-timing mark as Chrome emits it
  */
-function markEvent(name, ts) {
-  return { name, ts, ph: 'R', pid: 1, tid: 1 };
+function markEvent(name, ts, overrides = {}) {
+  return { name, ts, ph: 'I', s: 't', cat: 'blink.user_timing', pid: PID, tid: TID, ...overrides };
+}
+
+/**
+ * @param {string} name
+ * @param {number} ts -- microseconds
+ * @param {number} dur -- microseconds
+ * @param {object} [overrides]
+ * @returns {object} a complete (ph 'X') main-thread event
+ */
+function durationEvent(name, ts, dur, overrides = {}) {
+  return { name, ts, dur, ph: 'X', cat: 'devtools.timeline', pid: PID, tid: TID, ...overrides };
+}
+
+/**
+ * Build a trace shaped like the defect this window exists to fix: a large interrupt
+ * blob that the auto-zoom would settle on, and the real work plus its paint sitting
+ * after it, inside the marks.
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.withMarks=true]
+ * @returns {{traceEvents: Array<object>}} a parseable trace
+ */
+function buildTrace({ withMarks = true } = {}) {
+  const events = [
+    { name: 'thread_name', ph: 'M', pid: PID, tid: TID, args: { name: 'CrRendererMain' } },
+    { name: 'TracingStartedInBrowser', ph: 'I', ts: 0, pid: PID, tid: TID },
+
+    // The decoy: harness overhead, far larger than the work, and first in the trace.
+    durationEvent('RunTask', 1_000, 500_000),
+    durationEvent('V8.InvokeApiInterruptCallbacks', 1_100, 499_000),
+
+    // The work the scenario actually performs, and the frame it produces.
+    durationEvent('RunTask', 600_000, 100_000),
+    durationEvent('FunctionCall', 600_500, 99_000),
+    durationEvent('Layout', 720_000, 30_000),
+    durationEvent('Paint', 760_000, 40_000),
+  ];
+
+  if (withMarks) {
+    events.push(markEvent(MEASURE_START_MARK, 600_000));
+    events.push(markEvent(MEASURE_END_MARK, 900_000));
+  }
+
+  return { traceEvents: events };
 }
 
 describe('measurementWindowFromMarks', () => {
   test('returns the span between the runner marks, in microseconds', () => {
     const window = measurementWindowFromMarks([
-      markEvent('RunTask', 500),
+      durationEvent('RunTask', 500, 100),
       markEvent(MEASURE_START_MARK, 1000),
-      markEvent('Paint', 1500),
+      durationEvent('Paint', 1500, 100),
       markEvent(MEASURE_END_MARK, 3000),
-      markEvent('RunTask', 4000),
     ]);
 
     assert.deepEqual(window, { min: 1000, max: 3000, range: 2000 });
   });
 
   test('returns null when the trace carries no marks, so the caller falls back to auto-zoom', () => {
-    assert.equal(measurementWindowFromMarks([markEvent('RunTask', 500)]), null);
+    assert.equal(measurementWindowFromMarks([durationEvent('RunTask', 500, 100)]), null);
   });
 
   test('returns null when only one side of the window was marked', () => {
@@ -83,10 +135,104 @@ describe('measurementWindowFromMarks', () => {
     ]), null, 'a name containing the end mark must not close the window');
   });
 
-  test('the mark names are stable -- the runner and the parser must agree on them', () => {
-    // Emitted by lib/trace-runner.mjs, read back here. A rename on one side only
-    // sends every scenario silently back to auto-zoom.
-    assert.equal(MEASURE_START_MARK, 'hot-perf-measure-start');
-    assert.equal(MEASURE_END_MARK, 'hot-perf-measure-end');
+  test('ignores marks from a thread whose stats are never computed', () => {
+    // An out-of-process frame carrying the same name would otherwise set bounds over
+    // a thread this parse does not read, and the near-empty categories that produces
+    // would be published as a real improvement.
+    const foreign = { pid: PID + 1, tid: TID + 1 };
+    const events = [
+      markEvent(MEASURE_START_MARK, 1000, foreign),
+      markEvent(MEASURE_END_MARK, 3000, foreign),
+    ];
+
+    assert.equal(measurementWindowFromMarks(events, { pid: PID, tid: TID }), null);
+    assert.deepEqual(measurementWindowFromMarks(events, foreign), { min: 1000, max: 3000, range: 2000 });
+  });
+
+  test('ignores same-named events that are not user-timing marks', () => {
+    // performance.measure emits ph 'b'/'e' on the same category, and other tooling can
+    // emit anything at all. Only the instant user-timing mark bounds the window.
+    assert.equal(measurementWindowFromMarks([
+      markEvent(MEASURE_START_MARK, 1000, { ph: 'b' }),
+      markEvent(MEASURE_END_MARK, 3000, { ph: 'e' }),
+    ]), null);
+
+    assert.equal(measurementWindowFromMarks([
+      markEvent(MEASURE_START_MARK, 1000, { cat: 'devtools.timeline' }),
+      markEvent(MEASURE_END_MARK, 3000, { cat: 'devtools.timeline' }),
+    ]), null);
+  });
+});
+
+describe('parseTrace window selection', () => {
+  test('measures between the marks, not the busiest region of the trace', () => {
+    const parsed = parseTrace(buildTrace());
+
+    assert.equal(parsed._debug.windowSource, 'marks');
+    assert.equal(parsed.rangeEnd, 300, 'window is the 300 ms between the marks');
+
+    // The work and its frame are inside the window; the 499 ms interrupt blob is not.
+    assert.ok(parsed.categories.rendering > 0, 'Layout inside the window must be scored');
+    assert.ok(parsed.categories.painting > 0, 'Paint inside the window must be scored');
+    assert.ok(
+      parsed.categories.other < 100,
+      `the interrupt blob must stay outside the window, got other=${parsed.categories.other}`
+    );
+  });
+
+  test('falls back to the auto-zoomed window when a trace carries no marks, and says so', () => {
+    const parsed = parseTrace(buildTrace({ withMarks: false }));
+
+    assert.equal(parsed._debug.windowSource, 'auto-zoom');
+
+    // This is the defect the marks exist to avoid, asserted so the fallback's cost is
+    // visible: the auto-zoom lands on the interrupt blob and scores it as System.
+    assert.ok(
+      parsed.categories.other > 100,
+      `auto-zoom is expected to absorb the interrupt blob, got other=${parsed.categories.other}`
+    );
+  });
+
+  test('ignores marks belonging to another renderer and falls back instead', () => {
+    // parseTrace computes every statistic for one resolved main thread. Marks from an
+    // out-of-process frame must not bound a window over a thread it never reads, or the
+    // near-empty categories that produces get published as a real improvement -- with
+    // windowSource: 'marks' vouching for them.
+    const trace = buildTrace({ withMarks: false });
+
+    trace.traceEvents.push(markEvent(MEASURE_START_MARK, 600_000, { pid: PID + 1, tid: TID + 1 }));
+    trace.traceEvents.push(markEvent(MEASURE_END_MARK, 900_000, { pid: PID + 1, tid: TID + 1 }));
+
+    const parsed = parseTrace(trace);
+
+    assert.equal(parsed._debug.windowSource, 'auto-zoom', 'a foreign thread must not supply the window');
+  });
+
+  test('confines UpdateCounters extrema to the measured window', () => {
+    // Heap, nodes and listeners are running extrema. Unwindowed, a longer trace can only
+    // push a maximum up, so work after the end mark -- the settle, a readback, teardown --
+    // would inflate jsHeapMaxBytes with no timing change at all. report-builder runs that
+    // number through the same regression threshold as timing.
+    const trace = buildTrace();
+    const counter = (ts, jsHeapSizeUsed) => ({
+      name: 'UpdateCounters',
+      ph: 'I',
+      ts,
+      pid: PID,
+      tid: TID,
+      cat: 'disabled-by-default-devtools.timeline',
+      args: { data: { jsHeapSizeUsed, documents: 1, nodes: 10, jsEventListeners: 5 } },
+    });
+
+    trace.traceEvents.push(counter(700_000, 1_000_000));
+    trace.traceEvents.push(counter(950_000, 9_000_000)); // after the end mark
+
+    const parsed = parseTrace(trace);
+
+    assert.equal(
+      parsed.updateCounters.jsHeapMaxBytes,
+      1_000_000,
+      'a sample taken after the end mark must not raise the maximum'
+    );
   });
 });

--- a/performance-tests/lib/teardown.mjs
+++ b/performance-tests/lib/teardown.mjs
@@ -50,6 +50,23 @@ async function collectScenarioResults() {
 
     console.log(' done');
 
+    // Every number this suite publishes assumes the window came from the marks the
+    // runner writes around the action. Without them the parser silently falls back to
+    // the DevTools auto-zoom, which lands on the CDP interrupt rather than the grid
+    // work -- the exact defect the marks exist to avoid. windowSource lives in _debug,
+    // which is stripped before the snapshot is saved, so say it out loud here or it is
+    // invisible everywhere.
+    const fellBack = parsedResults
+      .map((result, index) => (result._debug?.windowSource === 'marks' ? null : index + 1))
+      .filter(iteration => iteration !== null);
+
+    if (fellBack.length > 0) {
+      console.warn(
+        `  WARN: ${entry.name} iteration(s) ${fellBack.join(', ')} carried no measurement marks; ` +
+        'these fell back to the auto-zoomed window and are not comparable to marked runs.'
+      );
+    }
+
     // Collect per-iteration values for CV% calculation
     const iterationValues = collectIterationValues(parsedResults);
 

--- a/performance-tests/lib/teardown.mjs
+++ b/performance-tests/lib/teardown.mjs
@@ -48,6 +48,14 @@ async function collectScenarioResults() {
       process.stdout.write('.');
     }
 
+    // From the filename, not the position: the list is lexicographically sorted, so at ten
+    // or more iterations the order runs 1, 10, 11, 2 and a position would mislabel them.
+    const iterationNumbers = traceFiles.map((fp) => {
+      const matched = /iteration-(\d+)\.json$/.exec(fp);
+
+      return matched ? matched[1] : '?';
+    });
+
     console.log(' done');
 
     // Every number this suite publishes assumes the window came from the marks the
@@ -57,14 +65,23 @@ async function collectScenarioResults() {
     // which is stripped before the snapshot is saved, so say it out loud here or it is
     // invisible everywhere.
     const fellBack = parsedResults
-      .map((result, index) => (result._debug?.windowSource === 'marks' ? null : index + 1))
+      .map((result, index) => (result._debug?.windowSource === 'marks' ? null : iterationNumbers[index]))
       .filter(iteration => iteration !== null);
 
     if (fellBack.length > 0) {
-      console.warn(
-        `  WARN: ${entry.name} iteration(s) ${fellBack.join(', ')} carried no measurement marks; ` +
-        'these fell back to the auto-zoomed window and are not comparable to marked runs.'
-      );
+      const detail = `${entry.name} iteration(s) ${fellBack.join(', ')} carried no measurement marks, ` +
+        'so they fell back to the auto-zoomed window and are not comparable to marked runs.';
+
+      // A compare run is read once and thrown away, so a warning is proportionate. A golden
+      // run is not: averageParsedTraces folds the bad iteration into the mean, the develop
+      // push deploys that mean as the baseline for every later PR, and _debug is stripped on
+      // the way out -- so nothing downstream can ever tell. Re-running develop is cheap;
+      // a poisoned baseline is silent forever.
+      if (process.env.PERF_MODE === 'golden') {
+        throw new Error(`${detail} Refusing to record a golden baseline from it.`);
+      }
+
+      console.warn(`  WARN: ${detail}`);
     }
 
     // Collect per-iteration values for CV% calculation
@@ -74,6 +91,11 @@ async function collectScenarioResults() {
     const averaged = averageParsedTraces(parsedResults);
 
     averaged._iterationValues = iterationValues;
+
+    // Survives stripInternalFields, unlike _debug. A snapshot recorded before the marks
+    // existed carries no windowSource at all, which is exactly how a comparison against a
+    // pre-marks baseline is recognised -- see the mismatch check below.
+    averaged.windowSource = fellBack.length > 0 ? 'auto-zoom' : 'marks';
 
     // Load hook timing if saved alongside traces
     const hookTimingPath = join(scenarioDir, 'hook-timing.json');
@@ -156,6 +178,13 @@ export default async function teardown() {
     await copyFile(savedPath, join(OUTPUT_DIR, 'snapshots.json'));
   }
 
+  // A delta between a marked run and an auto-zoomed baseline is not a measurement of
+  // anything: the two describe different slices of their traces. Say so rather than
+  // letting the sticky comment publish four-figure percentages as regressions.
+  const windowSourceOf = scenario => scenario.windowSource ?? 'auto-zoom';
+  const crossWindow = (current, baseline) => Object.keys(current)
+    .filter(name => baseline?.[name] && windowSourceOf(baseline[name]) !== windowSourceOf(current[name]));
+
   // Load golden for comparison
   let golden = null;
 
@@ -177,12 +206,24 @@ export default async function teardown() {
     }
   }
 
+  const mismatched = golden ? crossWindow(scenarioResults, golden.scenarios || {}) : [];
+
+  if (mismatched.length > 0) {
+    console.warn(
+      `\n  WARN: ${mismatched.length} scenario(s) are being compared against a baseline measured ` +
+      `over a different window -- ${mismatched.join(', ')}. ` +
+      'The deltas below are not measurements of a code change; they are the two windows disagreeing. ' +
+      'A fresh golden run on develop clears this.\n'
+    );
+  }
+
   // Build reports
   const meta = {
     prNumber: process.env.PR_NUMBER || null,
     branch: process.env.GITHUB_HEAD_REF || (mode === 'golden' ? 'develop' : 'unknown'),
     baseBranch: 'develop',
     pagesUrl: process.env.PAGES_URL || null,
+    crossWindowScenarios: mismatched,
   };
 
   const report = buildReport(scenarioResults, golden, meta);

--- a/performance-tests/lib/trace-runner.mjs
+++ b/performance-tests/lib/trace-runner.mjs
@@ -94,22 +94,34 @@ const SETTLE_TIMEOUT_MS = 1000;
  *
  * Two animation frames, because the paint for frame N happens after frame N's
  * callbacks: once frame N+1's callback runs, frame N has been committed. The
- * idle callback then catches trailing work (deferred layout, async paint), and
- * is bounded so a busy main thread cannot hang the run.
+ * idle callback then catches trailing work (deferred layout, async paint).
+ *
+ * The whole wait races a timer, not just the idle callback: requestAnimationFrame
+ * does not fire at all in a throttled or occluded page, so without the race a
+ * stalled renderer would hang until Playwright's per-test timeout instead of the
+ * bound named here.
  *
  * @param {import('@playwright/test').Page} page
  * @param {number} [timeoutMs=SETTLE_TIMEOUT_MS] -- upper bound for the idle wait
  */
 export async function settleFrames(page, timeoutMs = SETTLE_TIMEOUT_MS) {
   await page.evaluate(timeout => new Promise((resolve) => {
+    const done = () => resolve(null);
+    // Hard ceiling on the whole wait, including the animation frames.
+    const bail = setTimeout(done, timeout);
+    const finish = () => {
+      clearTimeout(bail);
+      done();
+    };
+
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         const idle = /** @type {any} */ (window).requestIdleCallback;
 
         if (typeof idle === 'function') {
-          idle(() => resolve(null), { timeout });
+          idle(finish, { timeout });
         } else {
-          setTimeout(() => resolve(null), 0);
+          setTimeout(finish, 0);
         }
       });
     });
@@ -122,6 +134,8 @@ export async function settleFrames(page, timeoutMs = SETTLE_TIMEOUT_MS) {
  * @param {(isMeasured: boolean) => Promise<void>} options.actionFn -- the traced action; receives true during measured iterations, false during warmup
  * @param {() => Promise<void>} [options.setupFn] -- pre-trace setup (run once before warmup)
  * @param {() => Promise<void>} [options.resetFn] -- reset state between iterations
+ * @param {(isMeasured: boolean) => Promise<void>} [options.afterActionFn] -- runs after the measured
+ *   window closes; put readbacks here so their CDP round trip is not billed to the action
  * @param {() => Promise<void>} [options.settleFn] -- overrides the default post-action settle
  * @param {boolean} [options.skipSettle=false] -- opt out of settling before the trace stops
  * @param {number} [options.warmupRuns=1]
@@ -133,6 +147,7 @@ export async function runTracedScenario({
   actionFn,
   setupFn,
   resetFn,
+  afterActionFn,
   settleFn,
   skipSettle = false,
   warmupRuns = 1,
@@ -140,6 +155,15 @@ export async function runTracedScenario({
   outputDir,
 }) {
   await mkdir(outputDir, { recursive: true });
+
+  // A reset renders synchronously but paints a frame later, and specs typically wait
+  // only for the render (cell-editing waits on countRenderedRows). Left unsettled, that
+  // paint lands inside the next iteration's window and is billed to the next action.
+  const settleAfterReset = async() => {
+    if (!skipSettle) {
+      await (settleFn ? settleFn() : settleFrames(page));
+    }
+  };
 
   // Run setup once (e.g., scrollViewportTo for scroll-up)
   if (setupFn) {
@@ -161,6 +185,7 @@ export async function runTracedScenario({
 
     if (resetFn) {
       await resetFn();
+      await settleAfterReset();
     }
   }
 
@@ -186,6 +211,11 @@ export async function runTracedScenario({
 
     await mark(page, MEASURE_END_MARK);
 
+    // Outside the window: a readback here is harness overhead, not measured work.
+    if (afterActionFn) {
+      await afterActionFn(true);
+    }
+
     clearInterval(heartbeat);
 
     process.stdout.write(' stopping');
@@ -198,6 +228,7 @@ export async function runTracedScenario({
 
     if (resetFn && i < iterations) {
       await resetFn();
+      await settleAfterReset();
     }
   }
 }

--- a/performance-tests/lib/trace-runner.mjs
+++ b/performance-tests/lib/trace-runner.mjs
@@ -63,11 +63,50 @@ export async function stopTracing(cdp) {
 }
 
 /**
+ * Upper bound on how long the post-action settle may wait, in milliseconds.
+ */
+const SETTLE_TIMEOUT_MS = 1000;
+
+/**
+ * Wait for the work an action queued to reach the compositor.
+ *
+ * Without this the trace is stopped on the same turn the action returns, so the
+ * rendering and painting that follow the last JS turn fall outside the trace
+ * window and are recorded as zero. A category measured as exactly 0 is not a
+ * cheap operation -- it is a capture that ended too early.
+ *
+ * Two animation frames, because the paint for frame N happens after frame N's
+ * callbacks: once frame N+1's callback runs, frame N has been committed. The
+ * idle callback then catches trailing work (deferred layout, async paint), and
+ * is bounded so a busy main thread cannot hang the run.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {number} [timeoutMs=SETTLE_TIMEOUT_MS] -- upper bound for the idle wait
+ */
+export async function settleFrames(page, timeoutMs = SETTLE_TIMEOUT_MS) {
+  await page.evaluate(timeout => new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const idle = /** @type {any} */ (window).requestIdleCallback;
+
+        if (typeof idle === 'function') {
+          idle(() => resolve(null), { timeout });
+        } else {
+          setTimeout(() => resolve(null), 0);
+        }
+      });
+    });
+  }), timeoutMs);
+}
+
+/**
  * @param {object} options
  * @param {import('@playwright/test').Page} options.page
  * @param {(isMeasured: boolean) => Promise<void>} options.actionFn -- the traced action; receives true during measured iterations, false during warmup
  * @param {() => Promise<void>} [options.setupFn] -- pre-trace setup (run once before warmup)
  * @param {() => Promise<void>} [options.resetFn] -- reset state between iterations
+ * @param {() => Promise<void>} [options.settleFn] -- overrides the default post-action settle
+ * @param {boolean} [options.skipSettle=false] -- opt out of settling before the trace stops
  * @param {number} [options.warmupRuns=1]
  * @param {number} [options.iterations=3]
  * @param {string} options.outputDir -- where to write trace JSON files
@@ -77,6 +116,8 @@ export async function runTracedScenario({
   actionFn,
   setupFn,
   resetFn,
+  settleFn,
+  skipSettle = false,
   warmupRuns = 1,
   iterations = 3,
   outputDir,
@@ -94,6 +135,11 @@ export async function runTracedScenario({
   for (let w = 0; w < warmupRuns; w++) {
     process.stdout.write(`  Warmup ${w + 1}/${warmupRuns}...`);
     await actionFn(false);
+
+    if (!skipSettle) {
+      await (settleFn ? settleFn() : settleFrames(page));
+    }
+
     console.log(' done');
 
     if (resetFn) {
@@ -111,6 +157,12 @@ export async function runTracedScenario({
     const heartbeat = setInterval(() => process.stdout.write('.'), 5000);
 
     await actionFn(true);
+
+    // Inside the trace on purpose: the frame this waits for is the work being measured.
+    if (!skipSettle) {
+      await (settleFn ? settleFn() : settleFrames(page));
+    }
+
     clearInterval(heartbeat);
 
     process.stdout.write(' stopping');

--- a/performance-tests/lib/trace-runner.mjs
+++ b/performance-tests/lib/trace-runner.mjs
@@ -76,7 +76,12 @@ export async function stopTracing(cdp) {
  * @param {string} markName
  */
 async function mark(page, markName) {
-  await page.evaluate(name => performance.mark(name), markName);
+  // Block body on purpose: a concise arrow returns the PerformanceMark, which Playwright
+  // then serializes and ships back across CDP -- a round trip inside the window, and a
+  // dependency on the serializer accepting that object at all.
+  await page.evaluate((name) => {
+    performance.mark(name);
+  }, markName);
 }
 
 /**
@@ -102,16 +107,19 @@ const SETTLE_TIMEOUT_MS = 1000;
  * bound named here.
  *
  * @param {import('@playwright/test').Page} page
- * @param {number} [timeoutMs=SETTLE_TIMEOUT_MS] -- upper bound for the idle wait
+ * @param {number} [timeoutMs=SETTLE_TIMEOUT_MS] -- upper bound for the whole wait, frames included
+ * @returns {Promise<boolean>} true when the settle completed, false when the bound expired first
  */
 export async function settleFrames(page, timeoutMs = SETTLE_TIMEOUT_MS) {
-  await page.evaluate(timeout => new Promise((resolve) => {
-    const done = () => resolve(null);
-    // Hard ceiling on the whole wait, including the animation frames.
-    const bail = setTimeout(done, timeout);
+  return page.evaluate(timeout => new Promise((resolve) => {
+    // The ceiling races the animation frames, so a frame that needs more main-thread
+    // work than the bound can lose it. That would close the window before Paint and
+    // Commit and hand back painting: 0 with the marks still in place -- indistinguishable
+    // from a cheap operation. Report it instead of resolving silently.
+    const bail = setTimeout(() => resolve(false), timeout);
     const finish = () => {
       clearTimeout(bail);
-      done();
+      resolve(true);
     };
 
     requestAnimationFrame(() => {
@@ -134,10 +142,13 @@ export async function settleFrames(page, timeoutMs = SETTLE_TIMEOUT_MS) {
  * @param {(isMeasured: boolean) => Promise<void>} options.actionFn -- the traced action; receives true during measured iterations, false during warmup
  * @param {() => Promise<void>} [options.setupFn] -- pre-trace setup (run once before warmup)
  * @param {() => Promise<void>} [options.resetFn] -- reset state between iterations
- * @param {(isMeasured: boolean) => Promise<void>} [options.afterActionFn] -- runs after the measured
- *   window closes; put readbacks here so their CDP round trip is not billed to the action
+ * @param {() => Promise<void>} [options.afterActionFn] -- runs after the measured window closes,
+ *   on measured iterations only; put readbacks here so their CDP round trip is not billed to
+ *   the action
  * @param {() => Promise<void>} [options.settleFn] -- overrides the default post-action settle
- * @param {boolean} [options.skipSettle=false] -- opt out of settling before the trace stops
+ * @param {boolean} [options.skipSettle=false] -- opt out of the in-window settle only; the settles
+ *   after setupFn and resetFn always run, since their frames would otherwise leak into the
+ *   next measured window
  * @param {number} [options.warmupRuns=1]
  * @param {number} [options.iterations=3]
  * @param {string} options.outputDir -- where to write trace JSON files
@@ -156,19 +167,30 @@ export async function runTracedScenario({
 }) {
   await mkdir(outputDir, { recursive: true });
 
-  // A reset renders synchronously but paints a frame later, and specs typically wait
-  // only for the render (cell-editing waits on countRenderedRows). Left unsettled, that
-  // paint lands inside the next iteration's window and is billed to the next action.
-  const settleAfterReset = async() => {
-    if (!skipSettle) {
-      await (settleFn ? settleFn() : settleFrames(page));
+  const settle = async(label) => {
+    const settled = settleFn ? await settleFn() : await settleFrames(page);
+
+    // settleFn is free to return nothing; only an explicit false means the bound expired.
+    if (settled === false) {
+      console.warn(`\n  WARN: settle after ${label} hit its ${SETTLE_TIMEOUT_MS} ms bound; ` +
+        'the frame may not have reached the compositor, so rendering and painting for this ' +
+        'iteration may be understated.');
     }
   };
+
+  // Preparation settles unconditionally, and skipSettle does not reach it. A reset renders
+  // synchronously but paints a frame later, and specs wait only for the render -- cell-editing
+  // waits on countRenderedRows(), scrollToRow's waitForFunction reports trimming rather than
+  // scroll position. That paint would otherwise land in the next iteration's window and be
+  // billed to the next action. Opting out of measuring a frame is a scenario's call; opting
+  // into a contaminated window is not.
+  const settleAfterPrepare = label => settle(label);
 
   // Run setup once (e.g., scrollViewportTo for scroll-up)
   if (setupFn) {
     process.stdout.write('  Setup...');
     await setupFn();
+    await settleAfterPrepare('setup');
     console.log(' done');
   }
 
@@ -178,14 +200,14 @@ export async function runTracedScenario({
     await actionFn(false);
 
     if (!skipSettle) {
-      await (settleFn ? settleFn() : settleFrames(page));
+      await settle('warmup action');
     }
 
     console.log(' done');
 
     if (resetFn) {
       await resetFn();
-      await settleAfterReset();
+      await settleAfterPrepare('reset');
     }
   }
 
@@ -206,14 +228,14 @@ export async function runTracedScenario({
 
     // Inside the window on purpose: the frame this waits for is the work being measured.
     if (!skipSettle) {
-      await (settleFn ? settleFn() : settleFrames(page));
+      await settle(`iteration ${i}`);
     }
 
     await mark(page, MEASURE_END_MARK);
 
     // Outside the window: a readback here is harness overhead, not measured work.
     if (afterActionFn) {
-      await afterActionFn(true);
+      await afterActionFn();
     }
 
     clearInterval(heartbeat);
@@ -228,7 +250,7 @@ export async function runTracedScenario({
 
     if (resetFn && i < iterations) {
       await resetFn();
-      await settleAfterReset();
+      await settleAfterPrepare('reset');
     }
   }
 }

--- a/performance-tests/lib/trace-runner.mjs
+++ b/performance-tests/lib/trace-runner.mjs
@@ -3,6 +3,7 @@
 
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
+import { MEASURE_START_MARK, MEASURE_END_MARK } from '../trace-parser.mjs';
 
 /**
  * @param {import('@playwright/test').Page} page
@@ -17,6 +18,8 @@ export async function startTracing(page) {
       'v8.execute',
       'disabled-by-default-devtools.timeline',
       'disabled-by-default-v8.cpu_profiler',
+      // Carries performance.mark, which is how the measurement window is bounded.
+      'blink.user_timing',
     ].join(','),
     transferMode: 'ReturnAsStream',
   });
@@ -60,6 +63,20 @@ export async function stopTracing(cdp) {
   });
 
   return traceJson;
+}
+
+/**
+ * Mark a point in the trace, bounding the region the parser will measure.
+ *
+ * Without an explicit window the parser auto-zooms onto the busiest part of the
+ * trace, which for a page.evaluate-driven action is the V8 interrupt CDP uses to
+ * enter the isolate, not the grid work. See measurementWindowFromMarks().
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} markName
+ */
+async function mark(page, markName) {
+  await page.evaluate(name => performance.mark(name), markName);
 }
 
 /**
@@ -156,12 +173,18 @@ export async function runTracedScenario({
     // Heartbeat: print dots during actionFn to keep GH Actions log alive
     const heartbeat = setInterval(() => process.stdout.write('.'), 5000);
 
+    // The mark is taken after CDP has already entered the isolate once, so the
+    // interrupt that carries it stays outside the window it opens.
+    await mark(page, MEASURE_START_MARK);
+
     await actionFn(true);
 
-    // Inside the trace on purpose: the frame this waits for is the work being measured.
+    // Inside the window on purpose: the frame this waits for is the work being measured.
     if (!skipSettle) {
       await (settleFn ? settleFn() : settleFrames(page));
     }
+
+    await mark(page, MEASURE_END_MARK);
 
     clearInterval(heartbeat);
 

--- a/performance-tests/scenarios/filtering/filtering.spec.ts
+++ b/performance-tests/scenarios/filtering/filtering.spec.ts
@@ -21,7 +21,7 @@ test(config.name, async({ page }) => {
     warmupRuns: config.warmupRuns,
     iterations: config.iterations,
     outputDir,
-    actionFn: async(isMeasured) => {
+    actionFn: async() => {
       // Apply a filter on column 0: contains "1"
       await page.evaluate(() => {
         const hot = (window as any).__hot;
@@ -30,14 +30,15 @@ test(config.name, async({ page }) => {
         filtersPlugin.addCondition(0, 'contains', ['1']);
         filtersPlugin.filter();
       });
+    },
+    // Read back after the window closes -- this is a CDP round trip, and inside the
+    // window it would be billed to the action on measured iterations only, making them
+    // a different shape from the warmups.
+    afterActionFn: async() => {
+      const timing = await getHookTiming(page, 'beforeFilter', 'afterFilter');
 
-      // Capture hook timing only during measured iterations
-      if (isMeasured) {
-        const timing = await getHookTiming(page, 'beforeFilter', 'afterFilter');
-
-        if (timing.deltaMs != null) {
-          hookDeltas.push(timing.deltaMs);
-        }
+      if (timing.deltaMs != null) {
+        hookDeltas.push(timing.deltaMs);
       }
     },
     resetFn: async() => {

--- a/performance-tests/scenarios/scroll-down/scroll-down.spec.ts
+++ b/performance-tests/scenarios/scroll-down/scroll-down.spec.ts
@@ -1,6 +1,7 @@
 import { test } from '@playwright/test';
 import path from 'node:path';
 import { runTracedScenario } from '../../lib/trace-runner.mjs';
+import { scrollToRow } from '../../lib/scroll-utils.mjs';
 import config from './scenario.config.mjs';
 
 const fixturePath = path.resolve(import.meta.dirname, 'fixture.html');
@@ -22,6 +23,9 @@ test(config.name, async({ page }) => {
       for (let i = 0; i < 500; i++) {
         await page.mouse.wheel(0, 350);
       }
+    },
+    resetFn: async() => {
+      await scrollToRow(page, 0);
     },
   });
 });

--- a/performance-tests/scenarios/scroll-right/scroll-right.spec.ts
+++ b/performance-tests/scenarios/scroll-right/scroll-right.spec.ts
@@ -1,6 +1,7 @@
 import { test } from '@playwright/test';
 import path from 'node:path';
 import { runTracedScenario } from '../../lib/trace-runner.mjs';
+import { scrollToColumn } from '../../lib/scroll-utils.mjs';
 import config from './scenario.config.mjs';
 
 const fixturePath = path.resolve(import.meta.dirname, 'fixture.html');
@@ -22,6 +23,9 @@ test(config.name, async({ page }) => {
       for (let i = 0; i < 500; i++) {
         await page.mouse.wheel(350, 0);
       }
+    },
+    resetFn: async() => {
+      await scrollToColumn(page, 0);
     },
   });
 });

--- a/performance-tests/scenarios/sorting/sorting.spec.ts
+++ b/performance-tests/scenarios/sorting/sorting.spec.ts
@@ -22,7 +22,7 @@ test(config.name, async({ page }) => {
     warmupRuns: config.warmupRuns,
     iterations: config.iterations,
     outputDir,
-    actionFn: async(isMeasured) => {
+    actionFn: async() => {
       const sortOrder = sortAscending ? 'asc' : 'desc';
 
       // Alternate sort direction across iterations
@@ -35,13 +35,15 @@ test(config.name, async({ page }) => {
 
       sortAscending = !sortAscending;
 
-      // Capture hook timing only during measured iterations
-      if (isMeasured) {
-        const timing = await getHookTiming(page, 'beforeColumnSort', 'afterColumnSort');
+    },
+    // Read back after the window closes -- this is a CDP round trip, and inside the
+    // window it would be billed to the action on measured iterations only, making them
+    // a different shape from the warmups.
+    afterActionFn: async() => {
+      const timing = await getHookTiming(page, 'beforeColumnSort', 'afterColumnSort');
 
-        if (timing.deltaMs != null) {
-          hookDeltas.push(timing.deltaMs);
-        }
+      if (timing.deltaMs != null) {
+        hookDeltas.push(timing.deltaMs);
       }
     },
     resetFn: async() => {

--- a/performance-tests/trace-parser.mjs
+++ b/performance-tests/trace-parser.mjs
@@ -482,6 +482,42 @@ function computeTraceBounds(events) {
   };
 }
 
+// Explicit measurement window, emitted by lib/trace-runner.mjs around the scenario action.
+export const MEASURE_START_MARK = 'hot-perf-measure-start';
+export const MEASURE_END_MARK = 'hot-perf-measure-end';
+
+/**
+ * Read the measurement window the runner marked around the scenario action.
+ *
+ * Preferred over calculateWindow because the auto-zoom picks the busiest region
+ * of the trace, and on scenarios driven through page.evaluate that region is the
+ * ~420ms V8.InvokeApiInterruptCallbacks blob CDP produces to enter the isolate.
+ * The window then closes ~60ms before the Paint, Layout and Commit events the
+ * action caused, so rendering and painting are scored as zero while the harness
+ * overhead is scored as System.
+ *
+ * @param {Array<object>} events -- raw trace events
+ * @returns {{min: number, max: number, range: number}|null} bounds in us, or null when unmarked
+ */
+export function measurementWindowFromMarks(events) {
+  let min = null;
+  let max = null;
+
+  for (const event of events) {
+    if (event.name === MEASURE_START_MARK && (min === null || event.ts < min)) {
+      min = event.ts;
+    } else if (event.name === MEASURE_END_MARK && (max === null || event.ts > max)) {
+      max = event.ts;
+    }
+  }
+
+  if (min === null || max === null || max <= min) {
+    return null;
+  }
+
+  return { min, max, range: max - min };
+}
+
 // calculateWindow from devtools-frontend/front_end/models/trace/extras/MainThreadActivity.ts
 // Finds the "interesting" region of the trace by detecting low utilization at edges
 // Uses ALL main thread entries (not just visible) - matches DevTools behavior
@@ -849,8 +885,10 @@ export function parseTrace(traceJson) {
     e.tid === mainThread.tid
   );
 
-  // Calculate the auto-zoomed window using DevTools's MainThreadActivity.calculateWindow
-  const windowUs = calculateWindow(traceBoundsUs, allMainThreadEntries);
+  // Prefer the window the runner marked around the action. Fall back to DevTools's
+  // MainThreadActivity.calculateWindow for traces recorded without the marks.
+  const markedWindowUs = measurementWindowFromMarks(events);
+  const windowUs = markedWindowUs ?? calculateWindow(traceBoundsUs, allMainThreadEntries);
   const windowMinMs = windowUs.min / 1000;
   const windowMaxMs = windowUs.max / 1000;
   const windowRangeMs = windowUs.range / 1000;
@@ -903,6 +941,7 @@ export function parseTrace(traceJson) {
       windowMinMs,
       windowMaxMs,
       windowRangeMs,
+      windowSource: markedWindowUs ? 'marks' : 'auto-zoom',
       profileCallMs,
       updateCountersSampleCount: updateCounters?.sampleCount ?? 0,
     }

--- a/performance-tests/trace-parser.mjs
+++ b/performance-tests/trace-parser.mjs
@@ -489,21 +489,37 @@ export const MEASURE_END_MARK = 'hot-perf-measure-end';
 /**
  * Read the measurement window the runner marked around the scenario action.
  *
- * Preferred over calculateWindow because the auto-zoom picks the busiest region
- * of the trace, and on scenarios driven through page.evaluate that region is the
- * ~420ms V8.InvokeApiInterruptCallbacks blob CDP produces to enter the isolate.
- * The window then closes ~60ms before the Paint, Layout and Commit events the
- * action caused, so rendering and painting are scored as zero while the harness
- * overhead is scored as System.
+ * Preferred over calculateWindow because the auto-zoom picks the busiest region of
+ * the trace, and on a scenario driven through page.evaluate that region can be the
+ * V8.InvokeApiInterruptCallbacks blob CDP produces to enter the isolate -- measured
+ * at 426.9 ms in a real `sorting` trace. The window then closes about 60 ms before
+ * the Paint, Layout and Commit events the action caused, so rendering and painting
+ * are scored as zero while the harness overhead is scored as System.
+ *
+ * Marks are matched on the thread whose stats are actually computed. A second
+ * renderer (an out-of-process frame) carrying the same name would otherwise set
+ * bounds over a thread this parse never reads, and the near-empty categories that
+ * produces would be published as a real improvement.
  *
  * @param {Array<object>} events -- raw trace events
+ * @param {{pid: number, tid: number}} [mainThread] -- restrict marks to this thread
  * @returns {{min: number, max: number, range: number}|null} bounds in us, or null when unmarked
  */
-export function measurementWindowFromMarks(events) {
+export function measurementWindowFromMarks(events, mainThread) {
   let min = null;
   let max = null;
 
   for (const event of events) {
+    // Chrome emits performance.mark as an instant event on blink.user_timing. Requiring
+    // the category keeps a same-named performance.measure (ph 'b'/'e') out of the bounds.
+    if (event.ph !== 'I' || event.cat !== 'blink.user_timing') {
+      continue;
+    }
+
+    if (mainThread && (event.pid !== mainThread.pid || event.tid !== mainThread.tid)) {
+      continue;
+    }
+
     if (event.name === MEASURE_START_MARK && (min === null || event.ts < min)) {
       min = event.ts;
     } else if (event.name === MEASURE_END_MARK && (max === null || event.ts > max)) {
@@ -796,14 +812,25 @@ function formatHeapMaxBytesLabel(bytes) {
 /**
  * Min/max from UpdateCounters instant events (args.data: jsHeapSizeUsed, documents, nodes, jsEventListeners).
  * Matches DevTools decimal labels: kB = bytes/1000, MB = bytes/1e6.
+ *
+ * These are running extrema, so they must be confined to the same window the timing
+ * categories use. Otherwise a longer trace can only push a maximum up: samples taken
+ * after the measured action -- during the settle, a readback, or teardown -- would
+ * raise jsHeapMaxBytes without a single millisecond of timing changing, and
+ * report-builder runs that number through the same regression threshold as timing.
+ *
+ * @param {Array<object>} events -- raw trace events
+ * @param {{pid: number, tid: number}} [mainThread] -- restrict samples to this thread
+ * @param {{min: number, max: number}} [windowUs] -- restrict samples to this window, in us
  */
-export function computeUpdateCountersRanges(events, mainThread) {
+export function computeUpdateCountersRanges(events, mainThread, windowUs) {
   const list = events.filter(
     e =>
       e.name === 'UpdateCounters' &&
       e.ph === 'I' &&
       e.args?.data &&
-      (!mainThread || (e.pid === mainThread.pid && e.tid === mainThread.tid)),
+      (!mainThread || (e.pid === mainThread.pid && e.tid === mainThread.tid)) &&
+      (!windowUs || (e.ts >= windowUs.min && e.ts <= windowUs.max)),
   );
 
   if (list.length === 0) {
@@ -887,7 +914,7 @@ export function parseTrace(traceJson) {
 
   // Prefer the window the runner marked around the action. Fall back to DevTools's
   // MainThreadActivity.calculateWindow for traces recorded without the marks.
-  const markedWindowUs = measurementWindowFromMarks(events);
+  const markedWindowUs = measurementWindowFromMarks(events, mainThread);
   const windowUs = markedWindowUs ?? calculateWindow(traceBoundsUs, allMainThreadEntries);
   const windowMinMs = windowUs.min / 1000;
   const windowMaxMs = windowUs.max / 1000;
@@ -924,7 +951,7 @@ export function parseTrace(traceJson) {
     // Actually no change needed since we moved time from other→scripting, both non-idle
   }
 
-  const updateCounters = computeUpdateCountersRanges(events, mainThread);
+  const updateCounters = computeUpdateCountersRanges(events, mainThread, windowUs);
 
   return {
     rangeStart: 0,


### PR DESCRIPTION
### Context

The PR fixes the performance suite's measurement so the numbers it publishes describe the grid work a scenario performs, rather than the harness overhead around it.

The suite posts a sticky comment on every pull request, and it is the first performance signal a reviewer sees. On #13236 it flagged three regressions that a reading of the diff ruled out, and an external contributor drew a conclusion about the change from the table. DEV-2629 was filed against the reporting layer. Investigating it turned up measurement defects underneath, which this PR fixes. The reporting fixes the task asks for come in a follow-up, because the threshold they need has to be re-derived against measurement that works.

**1. Two scroll scenarios measured nothing after the first iteration.** `scroll-up` and `scroll-left` pass a `resetFn` to `runTracedScenario`; `scroll-down` and `scroll-right` did not. Each iteration issues 500 wheel events, so the grid was already at the far edge by iteration 2. Iterations are averaged, so the published `Total` for Scroll Down was understated roughly 4x (1016 ms against 4070 ms) and Scroll Right roughly 5x.

Controlled before/after on one machine, scripting per iteration in ms:

| | iter 1 | iter 2 | iter 3 | CV |
|---|---|---|---|---|
| scroll-down before | 1107.8 | 70.2 | 83.8 | 115.5% |
| scroll-down after | 1518.1 | 1614.0 | 1446.6 | **4.5%** |
| scroll-right before | 345.7 | 55.2 | 61.7 | 87.8% |
| scroll-right after | 735.5 | 740.6 | 696.2 | **2.7%** |

**2. Nothing waited for the browser to settle before the trace stopped.** `runTracedScenario` called `actionFn` and `Tracing.end` back to back, so rendering and painting that follow the last JS turn fell outside the trace.

**3. The measured window was the harness overhead, not the grid work.** This is the big one, and it is why the zero-baselines in the task exist.

`parseTrace` auto-zoomed onto the busiest region of the trace, following DevTools's `MainThreadActivity.calculateWindow`. For any scenario driven through `page.evaluate`, that region is the V8 interrupt CDP uses to enter the isolate. Sorting, iteration 1:

```
RunTask                          512.2ms
V8.InvokeApiInterruptCallbacks   425.9ms
```

`V8.InvokeApiInterruptCallbacks` maps to no category, so it landed in `other`, which `sumActive()` excludes. Worse, the window it attracted closed at `501595954` while every `Paint`, `Layout`, `PrePaint` and `Commit` sat between `501596016` and `501596034` — roughly 60 ms past the edge. All of them scored zero.

So the recurring `rendering: 0` / `painting: 0` baselines and the `141.42%` CV (which is exactly the CV of `{x, 0, 0}` at n=3) were never cheap operations, and not merely a short trace. They were work that fell outside the window. Fixing #2 alone does not help: the settle puts the paint inside the trace, and the window calculation then discards it.

The clearest symptom is that the published number was smaller than the operation it named. Filtering reported a 25 ms `Total` against a 47 ms measured filter hook; sorting reported 16 ms against an 80 ms sort hook.

The fix brackets the measured action with `performance.mark`, records `blink.user_timing`, and has the parser prefer that window. Traces recorded without the marks still fall back to `calculateWindow`, and teardown now warns when that happens.

**4. Harness work was still landing inside the new window** (found by code review on this PR, commit `5f4d316b8`). Three paths: a `resetFn` renders synchronously but paints a frame later, and the runner did not settle after it, so that paint was billed to the next iteration's action; `getHookTiming()` is a `page.evaluate` that ran inside `actionFn` under `if (isMeasured)`, giving measured iterations a CDP round trip the warmups did not have, on filtering and sorting only; and the settle's stated 1 s bound only covered its idle callback, not the two `requestAnimationFrame` waits ahead of it.

### Results

Intra-run CV of scripting, the currently published baseline against this branch:

| Scenario | before | after | | Scenario | before | after |
|---|---|---|---|---|---|---|
| scroll-down | 126.8% | **1.2%** | | sorting | 97.8% | **3.6%** |
| scroll-right | 105.9% | **5.3%** | | cell-editing | 3.3% | **3.7%** |
| scroll-left | 2.3% | **1.5%** | | source-data-validator-load | 10.8% | **3.7%** |
| scroll-up | 0.6% | **2.4%** | | filtering | 58.9% | **12-23%** |
| | | | | initial-load | 53.5% | **17-24%** |

Rendering and painting CV was `141.42%` on four scenarios and is now under 10% on all nine.

Filtering and initial-load are given as ranges because they genuinely move between runs, and that is worth stating plainly rather than quoting whichever single run looked best. **`initial-load`'s spread is the scenario, not the harness.** Across four consecutive runs its third iteration is systematically slower than the first two — `(14.2, 14.9, 23.6)`, `(16.7, 14.8, 22.0)`, `(14.9, 14.9, 23.6)`, `(16.0, 15.0, 23.9)` — which is the grid being built a fourth time on an accumulated heap. The marked window exposes that; the auto-zoom window was measuring something else. Surfacing it is PR 3's job, not suppressing it.

The cross-check that the window is now correct, per iteration: trace-derived `sorting` scripting reads `74.7 / 84.0 / 78.3` against independent `beforeColumnSort`/`afterColumnSort` hook deltas of `79.9 / 85.1 / 76.0`. Two unrelated measurements of the same operation now agree.

### :warning: This invalidates every existing baseline

The marked window changes every scenario's numbers, in both directions:

- `source-data-validator-load` scripting goes from `14 ms` to roughly `1300 ms`. This is real. Its fixture is identical to `initial-load`'s except for one option, `sourceDataValidator`, over the same 100000 x 100 dataset, and the marked window brackets only `__build()`. The gap against `initial-load`'s `~15 ms` is the per-cell validator across 10 million cells, which the old window was hiding.
- `cell-editing` goes from `324 ms` to roughly `127 ms` — partly setup that used to sit inside the window, partly the reset paint removed by fix #4.

The first golden snapshot recorded on `develop` after this merges is incomparable to every prior one, so **every open pull request will show a wave of large deltas the moment this lands**. That is the fix surfacing, not causing, the problem.

### Follow-up

This is the first of three PRs on DEV-2629. It fixes measurement only. Still to come:

- **PR 2 — baseline comparability.** Stop stripping `_iterationValues` before the golden snapshot is written, add provenance (commit SHA, run id) to the snapshot, and compare against a rolling median of the last N `develop` snapshots instead of whatever `latest.json` holds at the moment. Six consecutive `develop` baselines measuring identical code currently spread 4x on filtering. The median window must exclude pre-PR-1 snapshots, which is why the provenance field comes first.
- **PR 3 — reporting.** The three items the task actually filed: guard the total against an incomplete baseline, surface CV in the markdown comment (`fmtCv()` has zero callers today), and gate the regression callouts on it. `REGRESSION_CALLOUT_THRESHOLD` is 5 against an empirical noise floor of 12-38%, so it has to be re-derived — which needs this PR merged and several `develop` pushes accumulated first. The HTML report's "Trace window" row also needs attention: mark-to-mark now spans harness wall clock, including `cell-editing`'s ~1.8 s of `delay: 10` typing, and that row still gets a red/green classification.

### How has this been tested?

New unit tests for the window selection, run by the existing tooling runner:

```bash
npm run test:tooling          # 114 tests, includes performance-tests/lib/__tests__/trace-window.test.mjs
npm --prefix performance-tests run lint
npm --prefix performance-tests run typecheck
```

The tests were mutation-checked rather than merely written: flipping the zero-width guard from `max <= min` to `max < min`, and flipping either mark comparison from an exact match to a substring match, each fail the suite independently.

Full suite run locally, all nine scenarios, plus three extra repeats of `initial-load` and `cell-editing` to establish that the remaining spread is systematic rather than a single bad run:

```bash
npm --prefix performance-tests test
```

Verified across all 9 scenarios x 3 iterations (27 traces), not only the ones probed during development:

- `_debug.windowSource` reads `marks` on all 27. No scenario silently fell back to auto-zoom while still looking healthy in the CV table.
- `V8.InvokeApiInterruptCallbacks` inside the marked window: 0 events, 0.0 ms, on all 27.
- `other` collapsed accordingly — sorting `429 ms` to `4.3-9.8 ms`, filtering `487 ms` to `7.5-27.0 ms`.

This PR touches `performance-tests/**`, which sets the `test-performance` scope flag, so the suite runs against itself here.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2629
2. Found while answering a review question on #13236

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Test tooling only. The one file outside `performance-tests/` is the repository-root `package.json`, which wires `performance-tests/lib/__tests__/*.test.mjs` into the existing `test:tooling` script. No library source is touched.

[skip changelog]

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation. `performance-tests/README.md` is updated in `87d3b3bc2`.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2629

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only the performance-test harness and baselines, not library runtime code, but golden snapshots and PR compare semantics change materially—wrong windows or mixed baselines could mislead reviewers until develop is re-baselined.
> 
> **Overview**
> Fixes **performance-tests** so published CDP numbers describe grid work inside an explicit window, not harness overhead or the wrong trace slice.
> 
> **Runner (`trace-runner.mjs`)** records `blink.user_timing`, brackets each measured iteration with `performance.mark` start/end, waits for compositor settle (double rAF + idle, with timeout warnings) inside that window, settles after `setupFn`/`resetFn` (not gated by `skipSettle`), and adds **`afterActionFn`** for harness readbacks after the end mark.
> 
> **Parser (`trace-parser.mjs`)** prefers the mark-defined window via `measurementWindowFromMarks`; unmarked traces still use DevTools auto-zoom. **UpdateCounters** heap/node extrema are confined to the same window.
> 
> **Teardown** warns on auto-zoom fallback, **fails golden** runs without marks, records `windowSource` on snapshots, and warns when comparing marked runs against pre-marks baselines (`crossWindowScenarios` in report meta).
> 
> **Scenarios:** filtering/sorting move hook timing to `afterActionFn`; scroll-down/right add `resetFn` with scroll helpers. New **`trace-window.test.mjs`**; root **`test:tooling`** includes perf lib tests. README and performance-testing skill document the measured-window rules.
> 
> **Note:** merging invalidates existing golden baselines; expect large PR deltas until a fresh develop golden run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a8ce633f83ef9534e66afaf786b4ee10305473. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->