### PR TITLE
docs(migration): name registerTheme, not the internal createTheme

### DIFF
--- a/docs/content/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md
@@ -354,7 +354,7 @@ Handsontable 18.0 simplifies the table border theme variables. The `--ht-wrapper
 You are affected if any of the following apply:
 
 - Your CSS overrides `--ht-wrapper-border-radius`, `--ht-wrapper-border-width`, or `--ht-wrapper-border-color`.
-- You pass `wrapperBorderRadius`, `wrapperBorderWidth`, or `wrapperBorderColor` tokens to `createTheme()` or `params()`.
+- You pass `wrapperBorderRadius`, `wrapperBorderWidth`, or `wrapperBorderColor` tokens to `registerTheme()` or `params()`.
 
 ### How to migrate
 
@@ -388,7 +388,7 @@ For the JS theme API, rename `wrapperBorderRadius` to `borderRadius` and remove 
 **Before:**
 
 ```javascript
-createTheme('my-theme', {
+registerTheme('my-theme', {
   tokens: {
     wrapperBorderRadius: '8px',
     wrapperBorderWidth: '1px',
@@ -400,7 +400,7 @@ createTheme('my-theme', {
 **After:**
 
 ```javascript
-createTheme('my-theme', {
+registerTheme('my-theme', {
   tokens: {
     borderRadius: '8px'
   }


### PR DESCRIPTION
## What is wrong

The 17.1 → 18.0 migration guide tells readers to pass theme tokens to `createTheme()`, in three places (lines 357, 391, 403).

`createTheme` is internal. It lives in `src/themes/engine/builder.ts` and is not re-exported from `handsontable/themes` — only the `ThemeBuilder` *type* is. A reader following the guide cannot import it.

The public function is `registerTheme()` (`src/themes/registry.ts:90`), and it already takes the `(name, config)` shape the guide shows. So this is a wrong name on an otherwise correct example.

This file is the only place that says `createTheme`. The Themes guide and the Theme Builder's generated code both use `registerTheme`.

## Change

Three occurrences renamed. Nothing else.

Refs SU-784. [skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no runtime or API behavior changes.
> 
> **Overview**
> The **17.1 → 18.0 migration guide** incorrectly told readers to pass theme tokens via **`createTheme()`**, which is internal and not exported from the public themes API.
> 
> This PR renames those references to **`registerTheme()`** in the “who is affected” bullet and in both before/after JS examples for wrapper border theme tokens, so the guide matches the public API used elsewhere in the docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 902e24a86065fff8ae487ba438216000ae7235c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->