### PR TITLE
DEV-2646: Stop a vetoed row or column move recording an undo action

### DIFF
--- a/.changelogs/13257.json
+++ b/.changelogs/13257.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a cancelled row or column move still adding an entry to the undo stack. Blocking a move by returning `false` from `beforeRowMove` or `beforeColumnMove` no longer leaves an action that makes the next undo do nothing. Moves that were impossible, or that left the order unchanged, are no longer recorded either.",
+  "type": "fixed",
+  "issueOrPR": 13257,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13257.json
+++ b/.changelogs/13257.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed a cancelled row or column move still adding an entry to the undo stack. Blocking a move by returning `false` from `beforeRowMove` or `beforeColumnMove` no longer leaves an action that makes the next undo do nothing. Moves that were impossible, or that left the order unchanged, are no longer recorded either.",
+  "title": "Fixed a row or column move blocked by `beforeRowMove` or `beforeColumnMove` still adding an entry to the undo stack; impossible moves and moves that leave the order unchanged are no longer recorded either.",
   "type": "fixed",
   "issueOrPR": 13257,
   "breaking": false,

--- a/handsontable/src/plugins/undoRedo/actions/columnMove.ts
+++ b/handsontable/src/plugins/undoRedo/actions/columnMove.ts
@@ -29,16 +29,24 @@ export class ColumnMoveAction extends BaseAction {
   }
 
   /**
-   * Registers the `beforeColumnMove` hook listener that records a new ColumnMoveAction whenever columns are moved.
+   * Registers the `afterColumnMove` hook listener that records a new ColumnMoveAction whenever columns are moved.
+   *
+   * Recording runs on `afterColumnMove`, not `beforeColumnMove`. `Hooks.run` threads a listener's return
+   * value into the next listener's first argument, so a `beforeColumnMove` listener only sees a veto raised
+   * by a listener registered before it — a `return false` from user settings lands too late and a cancelled
+   * move still reached the stack. `afterColumnMove` never fires for a vetoed move, and its `orderChanged`
+   * argument is `false` when the move was impossible or left the order intact, so gating on it also keeps
+   * no-op moves off the stack.
    */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
-    hot.addHook('beforeColumnMove', (columns: unknown, finalIndex: unknown) => {
-      if (columns === false) {
+    hot.addHook('afterColumnMove', (movedColumns, finalIndex, _dropIndex, _movePossible, orderChanged) => {
+      // `Array.isArray` also covers garbage folded into the argument by a preceding listener.
+      if (!orderChanged || !Array.isArray(movedColumns)) {
         return;
       }
 
       (undoRedoPlugin as { done: (...args: unknown[]) => void }).done(
-        () => new ColumnMoveAction({ columns: columns as number[], finalIndex: finalIndex as number })
+        () => new ColumnMoveAction({ columns: movedColumns, finalIndex })
       );
     });
   }

--- a/handsontable/src/plugins/undoRedo/actions/columnMove.ts
+++ b/handsontable/src/plugins/undoRedo/actions/columnMove.ts
@@ -31,16 +31,19 @@ export class ColumnMoveAction extends BaseAction {
   /**
    * Registers the `afterColumnMove` hook listener that records a new ColumnMoveAction whenever columns are moved.
    *
-   * Recording runs on `afterColumnMove`, not `beforeColumnMove`. `Hooks.run` threads a listener's return
-   * value into the next listener's first argument, so a `beforeColumnMove` listener only sees a veto raised
-   * by a listener registered before it — a `return false` from user settings lands too late and a cancelled
-   * move still reached the stack. `afterColumnMove` never fires for a vetoed move, and its `orderChanged`
-   * argument is `false` when the move was impossible or left the order intact, so gating on it also keeps
-   * no-op moves off the stack.
+   * Recording runs on `afterColumnMove`, not `beforeColumnMove`. UndoRedo registers its actions from its
+   * own constructor, while plugins register in `enablePlugin` (via `beforeInit`) and settings hooks are
+   * attached later still, so this is always the first instance listener on the hook. `Hooks.run` threads
+   * a listener's return value into the next listener's first argument, so every veto is raised after this
+   * listener has already run: the old `columns === false` guard caught no plugin or settings veto at all,
+   * and a cancelled move always reached the stack. `afterColumnMove` never fires for a vetoed move, and its
+   * `orderChanged` argument is `false` when the move was impossible or left the order intact, so gating on
+   * it also keeps no-op moves off the stack.
    */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('afterColumnMove', (movedColumns, finalIndex, _dropIndex, _movePossible, orderChanged) => {
-      // `Array.isArray` also covers garbage folded into the argument by a preceding listener.
+      // Only a global `Handsontable.hooks.add` listener runs ahead of this one, and its return value
+      // would replace `movedColumns` — guard the shape before `ColumnMoveAction` calls `.slice()` on it.
       if (!orderChanged || !Array.isArray(movedColumns)) {
         return;
       }

--- a/handsontable/src/plugins/undoRedo/actions/rowMove.ts
+++ b/handsontable/src/plugins/undoRedo/actions/rowMove.ts
@@ -29,16 +29,24 @@ export class RowMoveAction extends BaseAction {
   }
 
   /**
-   * Registers the `beforeRowMove` hook listener that records a new RowMoveAction whenever rows are moved.
+   * Registers the `afterRowMove` hook listener that records a new RowMoveAction whenever rows are moved.
+   *
+   * Recording runs on `afterRowMove`, not `beforeRowMove`. `Hooks.run` threads a listener's return value
+   * into the next listener's first argument, so a `beforeRowMove` listener only sees a veto raised by a
+   * listener registered before it — a `return false` from user settings lands too late and a cancelled
+   * move still reached the stack. `afterRowMove` never fires for a vetoed move, and its `orderChanged`
+   * argument is `false` when the move was impossible or left the order intact, so gating on it also keeps
+   * no-op moves off the stack.
    */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
-    hot.addHook('beforeRowMove', (rows: unknown, finalIndex: unknown) => {
-      if (rows === false) {
+    hot.addHook('afterRowMove', (movedRows, finalIndex, _dropIndex, _movePossible, orderChanged) => {
+      // `Array.isArray` also covers garbage folded into the argument by a preceding listener.
+      if (!orderChanged || !Array.isArray(movedRows)) {
         return;
       }
 
       (undoRedoPlugin as { done: (...args: unknown[]) => void }).done(
-        () => new RowMoveAction({ rows: rows as number[], finalIndex: finalIndex as number })
+        () => new RowMoveAction({ rows: movedRows, finalIndex })
       );
     });
   }

--- a/handsontable/src/plugins/undoRedo/actions/rowMove.ts
+++ b/handsontable/src/plugins/undoRedo/actions/rowMove.ts
@@ -31,16 +31,19 @@ export class RowMoveAction extends BaseAction {
   /**
    * Registers the `afterRowMove` hook listener that records a new RowMoveAction whenever rows are moved.
    *
-   * Recording runs on `afterRowMove`, not `beforeRowMove`. `Hooks.run` threads a listener's return value
-   * into the next listener's first argument, so a `beforeRowMove` listener only sees a veto raised by a
-   * listener registered before it — a `return false` from user settings lands too late and a cancelled
-   * move still reached the stack. `afterRowMove` never fires for a vetoed move, and its `orderChanged`
-   * argument is `false` when the move was impossible or left the order intact, so gating on it also keeps
-   * no-op moves off the stack.
+   * Recording runs on `afterRowMove`, not `beforeRowMove`. UndoRedo registers its actions from its own
+   * constructor, while plugins register in `enablePlugin` (via `beforeInit`) and settings hooks are
+   * attached later still, so this is always the first instance listener on the hook. `Hooks.run` threads
+   * a listener's return value into the next listener's first argument, so every veto is raised after this
+   * listener has already run: the old `rows === false` guard caught no plugin or settings veto at all, and
+   * a cancelled move always reached the stack. `afterRowMove` never fires for a vetoed move, and its
+   * `orderChanged` argument is `false` when the move was impossible or left the order intact, so gating on
+   * it also keeps no-op moves off the stack.
    */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('afterRowMove', (movedRows, finalIndex, _dropIndex, _movePossible, orderChanged) => {
-      // `Array.isArray` also covers garbage folded into the argument by a preceding listener.
+      // Only a global `Handsontable.hooks.add` listener runs ahead of this one, and its return value
+      // would replace `movedRows` — guard the shape before `RowMoveAction` calls `.slice()` on it.
       if (!orderChanged || !Array.isArray(movedRows)) {
         return;
       }

--- a/tests/e2e/row-column-move-undo.spec.ts
+++ b/tests/e2e/row-column-move-undo.spec.ts
@@ -90,4 +90,40 @@ test.describe('row and column move undo bookkeeping', () => {
     expect(await grid.rowOrder()).toEqual(IDENTITY);
     expect(await grid.doneActionsCount()).toBe(0);
   });
+
+  test('a column move that leaves the order unchanged records no undo action', async () => {
+    await grid.moveColumns([0], 0);
+
+    expect(await grid.columnOrder()).toEqual(IDENTITY);
+    expect(await grid.doneActionsCount()).toBe(0);
+  });
+
+  test('an impossible row move records no undo action', async () => {
+    // 10 rows, so a destination of 20 fails `isMovePossible` and nothing is reordered.
+    await grid.moveRows([0], 20);
+
+    expect(await grid.rowOrder()).toEqual(IDENTITY);
+    expect(await grid.doneActionsCount()).toBe(0);
+    expect(await grid.isUndoAvailable()).toBe(false);
+  });
+
+  test('a move vetoed by manualColumnFreeze records no undo action', async () => {
+    await grid.initGrid({ manualColumnMove: true, manualColumnFreeze: true, undo: true });
+
+    // manualColumnFreeze only guards moves after its own first use. Freezing reorders through the
+    // index mapper directly rather than through moveColumns, so it registers no undo action itself.
+    await grid.freezeColumn(3);
+
+    const afterFreeze = await grid.columnOrder();
+
+    expect(await grid.doneActionsCount()).toBe(0);
+
+    // Visual column 0 now sits inside the frozen area, so the plugin vetoes moving it. This is a
+    // real shipped veto path, not the fixture's test-only toggle.
+    await grid.moveColumns([0], 5);
+
+    expect(await grid.columnOrder()).toEqual(afterFreeze);
+    expect(await grid.doneActionsCount()).toBe(0);
+    expect(await grid.isUndoAvailable()).toBe(false);
+  });
 });

--- a/tests/e2e/row-column-move-undo.spec.ts
+++ b/tests/e2e/row-column-move-undo.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '../fixtures/test';
+import { SelectionFeaturesPage } from '../fixtures/pages/SelectionFeaturesPage';
+
+/**
+ * Undo-stack bookkeeping for ManualRowMove and ManualColumnMove.
+ *
+ * The undo listener used to record from `beforeRowMove` / `beforeColumnMove`. `Hooks.run` threads a
+ * listener's return value into the next listener's first argument, so a veto raised by a listener
+ * registered later — which is where a settings hook lands — was invisible there. A cancelled move
+ * still reached the undo stack, and the user's next Ctrl+Z was spent undoing nothing.
+ *
+ * The fixture's data is `R<row+1>C<col+1>` over a 10x10 grid, so cell (0, 0) reads `R1C1`.
+ */
+const IDENTITY = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+test.describe('row and column move undo bookkeeping', () => {
+  let grid: SelectionFeaturesPage;
+
+  test.beforeEach(async ({ page, theme }) => {
+    grid = new SelectionFeaturesPage(page, theme);
+    await grid.goto();
+    await grid.initGrid({ manualRowMove: true, manualColumnMove: true, undo: true });
+  });
+
+  test('a vetoed row move records no undo action', async () => {
+    expect(await grid.doneActionsCount()).toBe(0);
+
+    await grid.setBeforeRowMoveVeto(true);
+    await grid.moveRows([0], 3);
+
+    // The veto really did block the move — without this the stack assertion below proves nothing.
+    expect(await grid.rowOrder()).toEqual(IDENTITY);
+
+    expect(await grid.doneActionsCount()).toBe(0);
+    expect(await grid.isUndoAvailable()).toBe(false);
+  });
+
+  test('a vetoed column move records no undo action', async () => {
+    expect(await grid.doneActionsCount()).toBe(0);
+
+    await grid.setBeforeColumnMoveVeto(true);
+    await grid.moveColumns([0], 3);
+
+    expect(await grid.columnOrder()).toEqual(IDENTITY);
+
+    expect(await grid.doneActionsCount()).toBe(0);
+    expect(await grid.isUndoAvailable()).toBe(false);
+  });
+
+  test('a vetoed row move does not swallow the previous action', async () => {
+    await grid.setCellValue(0, 0, 'edited');
+
+    expect(await grid.doneActionsCount()).toBe(1);
+
+    await grid.setBeforeRowMoveVeto(true);
+    await grid.moveRows([0], 3);
+
+    // The user-visible symptom: one Ctrl+Z must reach the edit, not a phantom move action.
+    await grid.undo();
+
+    expect(await grid.cellValue(0, 0)).toBe('R1C1');
+    expect(await grid.isUndoAvailable()).toBe(false);
+  });
+
+  test('a real row move still records one undo action, and undo reverses it', async () => {
+    await grid.moveRows([0], 3);
+
+    expect(await grid.rowOrder()).toEqual([1, 2, 3, 0, 4, 5, 6, 7, 8, 9]);
+    expect(await grid.doneActionsCount()).toBe(1);
+
+    await grid.undo();
+
+    expect(await grid.rowOrder()).toEqual(IDENTITY);
+  });
+
+  test('a real column move still records one undo action, and undo reverses it', async () => {
+    await grid.moveColumns([0], 3);
+
+    expect(await grid.columnOrder()).toEqual([1, 2, 3, 0, 4, 5, 6, 7, 8, 9]);
+    expect(await grid.doneActionsCount()).toBe(1);
+
+    await grid.undo();
+
+    expect(await grid.columnOrder()).toEqual(IDENTITY);
+  });
+
+  test('a row move that leaves the order unchanged records no undo action', async () => {
+    await grid.moveRows([0], 0);
+
+    expect(await grid.rowOrder()).toEqual(IDENTITY);
+    expect(await grid.doneActionsCount()).toBe(0);
+  });
+});

--- a/tests/e2e/row-column-move-undo.spec.ts
+++ b/tests/e2e/row-column-move-undo.spec.ts
@@ -107,6 +107,58 @@ test.describe('row and column move undo bookkeeping', () => {
     expect(await grid.isUndoAvailable()).toBe(false);
   });
 
+  test('after a vetoed row move, the undo keyboard shortcut still reaches the previous action', async () => {
+    await grid.setCellValue(0, 0, 'edited');
+
+    await grid.setBeforeRowMoveVeto(true);
+    await grid.moveRows([0], 3);
+
+    // Driven from the keyboard, because a swallowed Ctrl+Z is the reported symptom.
+    await grid.selectCells(0, 0, 0, 0);
+    await grid.pressUndoShortcut();
+
+    expect(await grid.cellValue(0, 0)).toBe('R1C1');
+    expect(await grid.isUndoAvailable()).toBe(false);
+  });
+
+  test('redo re-applies a row move and leaves one action on the stack', async () => {
+    await grid.moveRows([0], 3);
+    await grid.undo();
+
+    expect(await grid.rowOrder()).toEqual(IDENTITY);
+    expect(await grid.isRedoAvailable()).toBe(true);
+
+    // redo() replays the arguments recorded by the new listener, so it exercises the changed path.
+    await grid.redo();
+
+    expect(await grid.rowOrder()).toEqual([1, 2, 3, 0, 4, 5, 6, 7, 8, 9]);
+    expect(await grid.doneActionsCount()).toBe(1);
+  });
+
+  test('a multi-row move records one action, and undo reverses all of it', async () => {
+    await grid.moveRows([0, 1], 3);
+
+    expect(await grid.rowOrder()).toEqual([2, 3, 4, 0, 1, 5, 6, 7, 8, 9]);
+    expect(await grid.doneActionsCount()).toBe(1);
+
+    await grid.undo();
+
+    expect(await grid.rowOrder()).toEqual(IDENTITY);
+  });
+
+  test('a row move still records one action while trimRows is active', async () => {
+    await grid.initGrid({ manualRowMove: true, undo: true, trimRows: [3] });
+
+    await grid.moveRows([0], 2);
+
+    expect(await grid.rowOrder()).not.toEqual(IDENTITY);
+    expect(await grid.doneActionsCount()).toBe(1);
+
+    await grid.undo();
+
+    expect(await grid.rowOrder()).toEqual(IDENTITY);
+  });
+
   test('a move vetoed by manualColumnFreeze records no undo action', async () => {
     await grid.initGrid({ manualColumnMove: true, manualColumnFreeze: true, undo: true });
 

--- a/tests/fixtures/demo/selection-features.html
+++ b/tests/fixtures/demo/selection-features.html
@@ -48,6 +48,8 @@
     // a move. Reset on every init together with the grid.
     window.moveCellsHookLog = [];
     window.vetoBeforeMoveCells = false;
+    window.vetoBeforeRowMove = false;
+    window.vetoBeforeColumnMove = false;
 
     window.initSelectionGrid = (overrides = {}) => {
       if (window.hot) {
@@ -84,6 +86,10 @@
             isCopy,
           });
         },
+        // Registered through the settings on purpose: a settings hook is added after the plugin
+        // hooks, which is what lets a veto slip past a `beforeRowMove`-based undo listener.
+        beforeRowMove: () => (window.vetoBeforeRowMove ? false : undefined),
+        beforeColumnMove: () => (window.vetoBeforeColumnMove ? false : undefined),
         data: buildData(),
         width: 500,
         height: 400,
@@ -102,6 +108,19 @@
     // Toggles the beforeMoveCells veto for the veto tests.
     window.setBeforeMoveCellsVeto = (shouldVeto) => {
       window.vetoBeforeMoveCells = shouldVeto;
+
+      return true;
+    };
+
+    // Toggles the beforeRowMove / beforeColumnMove vetoes for the move-undo tests.
+    window.setBeforeRowMoveVeto = (shouldVeto) => {
+      window.vetoBeforeRowMove = shouldVeto;
+
+      return true;
+    };
+
+    window.setBeforeColumnMoveVeto = (shouldVeto) => {
+      window.vetoBeforeColumnMove = shouldVeto;
 
       return true;
     };

--- a/tests/fixtures/demo/selection-features.html
+++ b/tests/fixtures/demo/selection-features.html
@@ -56,7 +56,12 @@
         window.hot.destroy();
       }
 
+      // Reset the hook log and every veto flag with the grid, so a test that re-inits after
+      // arming a veto does not carry it into the new instance.
       window.moveCellsHookLog = [];
+      window.vetoBeforeMoveCells = false;
+      window.vetoBeforeRowMove = false;
+      window.vetoBeforeColumnMove = false;
 
       window.hot = new Handsontable(container, Object.assign({
         beforeMoveCells: (source, target, isCopy) => {

--- a/tests/fixtures/pages/SelectionFeaturesPage.ts
+++ b/tests/fixtures/pages/SelectionFeaturesPage.ts
@@ -223,6 +223,14 @@ export class SelectionFeaturesPage {
   }
 
   /**
+   * Freeze a column through the ManualColumnFreeze plugin API. Also arms that plugin's own
+   * `beforeColumnMove` veto, which only applies after its first use.
+   */
+  async freezeColumn(column: number): Promise<void> {
+    await this.page.evaluate(c => window.hot.getPlugin('manualColumnFreeze').freezeColumn(c), column);
+  }
+
+  /**
    * The current visual-to-physical row order held by the index mapper.
    */
   async rowOrder(): Promise<number[]> {

--- a/tests/fixtures/pages/SelectionFeaturesPage.ts
+++ b/tests/fixtures/pages/SelectionFeaturesPage.ts
@@ -151,6 +151,16 @@ export class SelectionFeaturesPage {
   }
 
   /**
+   * Write a cell value through the grid, producing one undoable data change.
+   */
+  async setCellValue(row: number, col: number, value: CellValue): Promise<void> {
+    await this.page.evaluate(
+      ({ r, c, v }) => window.hot.setDataAtCell(r, c, v),
+      { r: row, c: col, v: value }
+    );
+  }
+
+  /**
    * Read a raw source value without applying valueGetter.
    */
   async sourceCellValue(row: number, col: number): Promise<CellValue> {
@@ -176,6 +186,54 @@ export class SelectionFeaturesPage {
    */
   async setBeforeMoveCellsVeto(shouldVeto: boolean): Promise<void> {
     await this.page.evaluate(veto => window.setBeforeMoveCellsVeto(veto), shouldVeto);
+  }
+
+  /**
+   * Make the fixture's `beforeRowMove` listener veto the next row move.
+   */
+  async setBeforeRowMoveVeto(shouldVeto: boolean): Promise<void> {
+    await this.page.evaluate(veto => window.setBeforeRowMoveVeto(veto), shouldVeto);
+  }
+
+  /**
+   * Make the fixture's `beforeColumnMove` listener veto the next column move.
+   */
+  async setBeforeColumnMoveVeto(shouldVeto: boolean): Promise<void> {
+    await this.page.evaluate(veto => window.setBeforeColumnMoveVeto(veto), shouldVeto);
+  }
+
+  /**
+   * Move rows through the ManualRowMove plugin API.
+   */
+  async moveRows(rows: number[], finalIndex: number): Promise<void> {
+    await this.page.evaluate(
+      ({ r, i }) => window.hot.getPlugin('manualRowMove').moveRows(r, i),
+      { r: rows, i: finalIndex }
+    );
+  }
+
+  /**
+   * Move columns through the ManualColumnMove plugin API.
+   */
+  async moveColumns(columns: number[], finalIndex: number): Promise<void> {
+    await this.page.evaluate(
+      ({ c, i }) => window.hot.getPlugin('manualColumnMove').moveColumns(c, i),
+      { c: columns, i: finalIndex }
+    );
+  }
+
+  /**
+   * The current visual-to-physical row order held by the index mapper.
+   */
+  async rowOrder(): Promise<number[]> {
+    return this.page.evaluate(() => window.hot.rowIndexMapper.getIndexesSequence());
+  }
+
+  /**
+   * The current visual-to-physical column order held by the index mapper.
+   */
+  async columnOrder(): Promise<number[]> {
+    return this.page.evaluate(() => window.hot.columnIndexMapper.getIndexesSequence());
   }
 
   /**

--- a/tests/fixtures/pages/SelectionFeaturesPage.ts
+++ b/tests/fixtures/pages/SelectionFeaturesPage.ts
@@ -223,6 +223,14 @@ export class SelectionFeaturesPage {
   }
 
   /**
+   * Press the undo keyboard shortcut, the way a user does. Needs a selected cell so the grid holds
+   * focus. `ControlOrMeta` maps to Cmd on macOS and Ctrl elsewhere.
+   */
+  async pressUndoShortcut(): Promise<void> {
+    await this.page.keyboard.press('ControlOrMeta+z');
+  }
+
+  /**
    * Freeze a column through the ManualColumnFreeze plugin API. Also arms that plugin's own
    * `beforeColumnMove` veto, which only applies after its first use.
    */

--- a/tests/fixtures/pages/windowTypes.ts
+++ b/tests/fixtures/pages/windowTypes.ts
@@ -49,6 +49,10 @@ export interface FixtureHotInstance {
   getPlugin(name: 'manualColumnMove'): {
     moveColumns(columns: number[], finalIndex: number): boolean,
   };
+  getPlugin(name: 'manualColumnFreeze'): {
+    freezeColumn(column: number): void,
+    unfreezeColumn(column: number): void,
+  };
   getPlugin(name: 'dragToScroll'): { isListening(): boolean };
   getPlugin(name: 'multipleSelectionHandles'): { isDragged(): boolean };
   getPlugin(name: 'nestedRows'): {

--- a/tests/fixtures/pages/windowTypes.ts
+++ b/tests/fixtures/pages/windowTypes.ts
@@ -43,6 +43,12 @@ export interface FixtureHotInstance {
     enablePlugin(): void,
     disablePlugin(): void,
   };
+  getPlugin(name: 'manualRowMove'): {
+    moveRows(rows: number[], finalIndex: number): boolean,
+  };
+  getPlugin(name: 'manualColumnMove'): {
+    moveColumns(columns: number[], finalIndex: number): boolean,
+  };
   getPlugin(name: 'dragToScroll'): { isListening(): boolean };
   getPlugin(name: 'multipleSelectionHandles'): { isDragged(): boolean };
   getPlugin(name: 'nestedRows'): {
@@ -104,6 +110,8 @@ export interface FixtureHotInstance {
   updateData(data: unknown[]): void;
   updateSettings(settings: Record<string, unknown>): void;
   countCols(): number;
+  rowIndexMapper: { getIndexesSequence(): number[] };
+  columnIndexMapper: { getIndexesSequence(): number[] };
   _createCellCoords(row: number, col: number): unknown;
   _createCellRange(highlight: unknown, from: unknown, to: unknown): unknown;
 }
@@ -141,5 +149,9 @@ declare global {
     hookLog: { name: string, args: unknown[] }[];
     /** Makes the fixture's `beforeMoveCells` listener return `false`. */
     setBeforeMoveCellsVeto(shouldVeto: boolean): boolean;
+    /** Makes the fixture's `beforeRowMove` listener return `false`. */
+    setBeforeRowMoveVeto(shouldVeto: boolean): boolean;
+    /** Makes the fixture's `beforeColumnMove` listener return `false`. */
+    setBeforeColumnMoveVeto(shouldVeto: boolean): boolean;
   }
 }


### PR DESCRIPTION
### Context

The PR fixes a cancelled row or column move still landing on the undo stack.

Returning `false` from `beforeRowMove` cancels the move — nothing moves and the order map stays identity — but a `row_move` action was still recorded. The user's next Ctrl+Z was then spent undoing nothing, silently swallowing the keystroke. `beforeColumnMove` behaved the same way.

This matters more than its size suggests, because blocking the move via `beforeRowMove` is the pattern we ourselves recommend for keeping a framework's own state as the source of truth.

**Root cause.** `RowMoveAction` / `ColumnMoveAction` recorded from the **before** hook and guarded with `if (rows === false)`. That guard checks the *first argument*, not the hook's return value. `Hooks.run` threads a listener's return value into the next listener's first argument, so the guard could only see a veto raised by a listener that runs **before** the undo listener. There is no such instance listener: UndoRedo registers its actions from its own constructor, plugins register in `enablePlugin` (via `beforeInit`), and settings hooks are attached later still. The old guard therefore caught no plugin or settings veto at all — not merely late-registered ones. (Corrected from an earlier, weaker version of this paragraph — thanks @Haxikowy.)

**Fix.** Record from `afterRowMove` / `afterColumnMove` instead. Those never fire for a vetoed move, so the veto no longer needs to be observed at all. This follows the existing `MoveCellsAction` precedent, which already records from `afterMoveCells` for exactly this reason.

**Slightly wider than the title.** The `after` hooks carry an `orderChanged` argument, and the fix gates on it. That also keeps two other dead entries off the stack: a move that was impossible (`movePossible === false`) and a move that left the order intact (for example dropping a row on itself). Both previously recorded an action that undid nothing. Recording a no-op is a defect rather than a contract, so this is treated as part of the same fix — but it is a real behavior change in those two edge cases and is called out here deliberately.

**Known limitation.** `orderChanged` is arithmetic on the requested indexes, not a real sequence diff, so a trimmed-index move or a NestedRows reparent can change the order while the gate reads `false`. Both of those recorded a dud entry before this PR (the trimmed case computes `from === to` on undo; the NestedRows case dies in `displayAPICompatibilityWarning`), so dropping them is not a regression. Tracked as DEV-2651. `formulas.ts:592-601` gates on the same argument and shares the blind spot.

Two casts (`rows as number[]`, `finalIndex as number`) disappear as a side effect, because the typed `addHook` overload infers the callback parameters from `Events['afterRowMove']`.

### How has this been tested?

New Playwright spec `tests/e2e/row-column-move-undo.spec.ts` (13 tests), driven through the `selection-features` fixture, which gained a settings-registered `beforeRowMove` / `beforeColumnMove` veto toggle. One case uses a real shipped veto instead of that toggle: `manualColumnFreeze` refuses to move a frozen column.

The tests were verified against the unfixed build first. With the source reverted the spec goes **8 fail / 5 pass**: the cases that encode the bug go red, while the "a real move still records one action" cases stay green either way — those are regression guards, not bug-catchers, and the split is what shows the tests are not just restating the implementation. The vetoed-**column** test failing there is what confirmed the column case empirically, rather than by reading the source.

```bash
# Playwright (new spec + the neighbouring moveCells undo spec) — 13 passed
npm run build --prefix handsontable
cd tests && npx playwright test e2e/row-column-move-undo.spec.ts e2e/move-cells-undo.spec.ts --project=e2e-main

# Legacy E2E regression sweep — 594 specs, 0 failures
npm run test:e2e --prefix handsontable -- --testPathPattern='undoRedo|manualRowMove|manualColumnMove'

# Lint and types — both clean
npm run eslint --prefix handsontable
npm run test:types --prefix handsontable
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2646
2. DEV-2651 — follow-up for the `orderChanged` limitation above
2. Found while re-analysing #7517. This bug is independent of that issue and of React; #7517 itself is answered by DEV-2647 (documentation).

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

**Note for the reviewer of DEV-2647 (docs):** the controlled-grid recipe going into the row-moving guide previously relied on this bug — the phantom action, when undone, re-entered `beforeRowMove` with the inverse move, which the user's handler applied to their own state. With this fix a vetoed move records nothing, so that recipe must not promise any Ctrl+Z behavior. DEV-2647 is being written that way already.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2646

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when undo actions are recorded for manual row/column moves, including intentional behavior shifts for vetoed, impossible, and no-op moves; regression risk is mitigated by new e2e coverage.
> 
> **Overview**
> Fixes **phantom undo entries** when a row or column move is cancelled via `beforeRowMove` / `beforeColumnMove` (or never actually changes order). Undo recording for `RowMoveAction` and `ColumnMoveAction` now listens on **`afterRowMove`** / **`afterColumnMove`** instead of the before hooks, matching **`MoveCellsAction`**. Vetoed moves never fire those hooks, so they no longer land on the stack and waste the next Ctrl+Z.
> 
> Recording is gated on **`orderChanged`** and a valid moved-index array, so **no-op** moves (e.g. drop on the same index) and **impossible** moves also skip the undo stack.
> 
> Adds a Playwright spec and extends the **selection-features** fixture with settings-registered move vetoes, move/freeze helpers, and index-mapper order assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a894b57e77b39c9e5bfe728b96a3d731d92f60b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
