### PR TITLE
DEV-2585: Fix loadData() and updateData() discarding a changed formula

### DIFF
--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -2762,6 +2762,61 @@ describe('Formulas general', () => {
     expect(getDataAtCell(1, 0)).toBe(101);
   });
 
+  it('should replace an existing formula with a literal value when the `loadData` method is called', async() => {
+    handsontable({
+      data: [
+        [1],
+        ['=A1+1'],
+      ],
+      formulas: {
+        engine: HyperFormula,
+      }
+    });
+
+    const formulasPlugin = getPlugin('formulas');
+
+    // The same defect as in the two cases above, with the loaded value no longer being a formula.
+    // The `modifySourceData` projection answers a formula cell with the formula the engine holds, so
+    // reading the newly loaded data through it resurrects `=A1+1` into what is now a value cell.
+    await loadData([
+      [1],
+      [5],
+    ]);
+
+    expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual([
+      [1],
+      [5],
+    ]);
+
+    expect(getDataAtCell(1, 0)).toBe(5);
+  });
+
+  it('should replace an existing formula with a literal value when the `updateData` method is called', async() => {
+    handsontable({
+      data: [
+        [1],
+        ['=A1+1'],
+      ],
+      formulas: {
+        engine: HyperFormula,
+      }
+    });
+
+    const formulasPlugin = getPlugin('formulas');
+
+    await updateData([
+      [1],
+      [5],
+    ]);
+
+    expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual([
+      [1],
+      [5],
+    ]);
+
+    expect(getDataAtCell(1, 0)).toBe(5);
+  });
+
   it('should display calculated formula after changing value using `beforeChange` hook #6932', async() => {
     handsontable({
       data: [

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -2817,6 +2817,129 @@ describe('Formulas general', () => {
     expect(getDataAtCell(1, 0)).toBe(5);
   });
 
+  it('should replace an existing formula\'s text when the data is replaced through `updateSettings`', async() => {
+    handsontable({
+      data: [
+        [1],
+        ['=A1+1'],
+      ],
+      formulas: {
+        engine: HyperFormula,
+      }
+    });
+
+    const formulasPlugin = getPlugin('formulas');
+
+    // A third public entry point for the same defect, and it reaches the engine through a different
+    // site: `#onAfterLoadData` returns early for the `updateSettings` source, so the data is fed to
+    // the engine from `#onAfterCellMetaReset` instead.
+    await updateSettings({
+      data: [
+        [1],
+        ['=A1+100'],
+      ],
+    });
+
+    expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual([
+      [1],
+      ['=A1+100'],
+    ]);
+
+    expect(getDataAtCell(1, 0)).toBe(101);
+  });
+
+  it('should replace an existing formula\'s text when the `loadData` method is called for array of objects', async() => {
+    handsontable({
+      data: [
+        { value: 1 },
+        { value: '=A1+1' },
+      ],
+      columns: [
+        { data: 'value' },
+      ],
+      formulas: {
+        engine: HyperFormula,
+      }
+    });
+
+    const formulasPlugin = getPlugin('formulas');
+
+    await loadData([
+      { value: 1 },
+      { value: '=A1+100' },
+    ]);
+
+    expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual([
+      [1],
+      ['=A1+100'],
+    ]);
+
+    expect(getDataAtCell(1, 0)).toBe(101);
+  });
+
+  it('should replace an existing formula\'s text when the `loadData` method is called for data with skipped columns',
+    async() => {
+      handsontable({
+        data: [
+          [1, 'skipped', '=A1+1'],
+          [2, 'skipped', 3],
+        ],
+        // Only the physical columns 0 and 2 are visible, so `#getProcessedSourceDataArray` projects
+        // the rows down to the visible ones before feeding them to the engine - a different branch
+        // than the one the cases above take.
+        columns: [
+          { data: 0 },
+          { data: 2 },
+        ],
+        formulas: {
+          engine: HyperFormula,
+        }
+      });
+
+      const formulasPlugin = getPlugin('formulas');
+
+      await loadData([
+        [1, 'skipped', '=A1+100'],
+        [2, 'skipped', 3],
+      ]);
+
+      expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual([
+        [1, '=A1+100'],
+        [2, 3],
+      ]);
+
+      expect(getDataAtCell(0, 1)).toBe(101);
+    });
+
+  it('should keep an array formula spilling when the `loadData` method is called', async() => {
+    handsontable({
+      data: [
+        [1, 2],
+        ['=TRANSPOSE(A1:B1)', null],
+        [null, null],
+      ],
+      formulas: {
+        engine: HyperFormula,
+      }
+    });
+
+    // A spill cell reports the `ARRAY` cell type, not `ARRAYFORMULA`, so it passes the
+    // `VALUE`/`EMPTY` early return in `#onModifySourceData` and gets projected as well - as its
+    // calculated value. Feeding that back puts a literal inside the range the array formula needs,
+    // and the engine answers the whole load with `#SPILL!`.
+    await loadData([
+      [10, 20],
+      ['=TRANSPOSE(A1:B1)', null],
+      [null, null],
+    ]);
+
+    expect(getData()).toEqual([
+      [10, 20],
+      [10, null],
+      [20, null],
+    ]);
+  });
+
   it('should display calculated formula after changing value using `beforeChange` hook #6932', async() => {
     handsontable({
       data: [

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -2851,9 +2851,13 @@ describe('Formulas general', () => {
   it('should replace an existing formula\'s text when the `loadData` method is called for array of objects', async() => {
     handsontable({
       data: [
-        { value: 1 },
-        { value: '=A1+1' },
+        { value: 1, note: 'skipped' },
+        { value: '=A1+1', note: 'skipped' },
       ],
+      // The second key is deliberately left out of `columns`, so `countCols()` is lower than
+      // `countSourceCols()` and the shape check in `#getProcessedSourceDataArray` is actually
+      // evaluated. With a single key it would short-circuit and the array-of-objects branch would
+      // be selected without the check ever running.
       columns: [
         { data: 'value' },
       ],
@@ -2865,8 +2869,8 @@ describe('Formulas general', () => {
     const formulasPlugin = getPlugin('formulas');
 
     await loadData([
-      { value: 1 },
-      { value: '=A1+100' },
+      { value: 1, note: 'skipped' },
+      { value: '=A1+100', note: 'skipped' },
     ]);
 
     expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual([
@@ -2906,6 +2910,39 @@ describe('Formulas general', () => {
       expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual([
         [1, '=A1+100'],
         [2, 3],
+      ]);
+
+      expect(getDataAtCell(0, 1)).toBe(101);
+    });
+
+  it('should replace an existing formula\'s text when the `loadData` method is called for data with an empty row',
+    async() => {
+      handsontable({
+        data: [
+          [1, 'skipped', '=A1+1'],
+          null,
+        ],
+        // The shape check in `#getProcessedSourceDataArray` reads the first row only, so a row that
+        // is not an array still reaches the branch projecting rows down to the visible columns.
+        columns: [
+          { data: 0 },
+          { data: 2 },
+        ],
+        formulas: {
+          engine: HyperFormula,
+        }
+      });
+
+      const formulasPlugin = getPlugin('formulas');
+
+      await loadData([
+        [1, 'skipped', '=A1+100'],
+        null,
+      ]);
+
+      // The engine drops the trailing empty row, so only the first one is serialized.
+      expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual([
+        [1, '=A1+100'],
       ]);
 
       expect(getDataAtCell(0, 1)).toBe(101);

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -2706,6 +2706,62 @@ describe('Formulas general', () => {
     expect(getDataAtCell(1, 4)).toEqual(3);
   });
 
+  it('should replace an existing formula\'s text when the `loadData` method is called', async() => {
+    handsontable({
+      data: [
+        [1],
+        ['=A1+1'],
+      ],
+      formulas: {
+        engine: HyperFormula,
+      }
+    });
+
+    const formulasPlugin = getPlugin('formulas');
+
+    // The sheet is reused across `loadData` calls, so at this point the engine still holds the
+    // PREVIOUS formula. The data fed to the engine has to come from what the grid stores, not from
+    // the `modifySourceData` projection – that projection answers a formula cell with the engine's
+    // own formula, which would write the stale `=A1+1` straight back and drop the loaded one.
+    await loadData([
+      [1],
+      ['=A1+100'],
+    ]);
+
+    expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual([
+      [1],
+      ['=A1+100'],
+    ]);
+
+    expect(getDataAtCell(1, 0)).toBe(101);
+  });
+
+  it('should replace an existing formula\'s text when the `updateData` method is called', async() => {
+    handsontable({
+      data: [
+        [1],
+        ['=A1+1'],
+      ],
+      formulas: {
+        engine: HyperFormula,
+      }
+    });
+
+    const formulasPlugin = getPlugin('formulas');
+
+    await updateData([
+      [1],
+      ['=A1+100'],
+    ]);
+
+    expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual([
+      [1],
+      ['=A1+100'],
+    ]);
+
+    expect(getDataAtCell(1, 0)).toBe(101);
+  });
+
   it('should display calculated formula after changing value using `beforeChange` hook #6932', async() => {
     handsontable({
       data: [

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -1334,8 +1334,10 @@ export class Formulas extends BasePlugin {
     // the guarded window - and one that calls `getDataAtCell()` on a formula cell has to keep
     // receiving the calculated value, not the raw formula.
     //
-    // The previous value is saved and restored rather than cleared, so callers that already hold
-    // the flag keep it.
+    // No other site sets the flag, so the previous value is saved and restored rather than cleared
+    // for one reason only: those same third-party handlers run inside the window, and one that
+    // reaches this method again - synchronously, through `updateSettings()` or `loadData()` - would
+    // otherwise leave the rest of the outer read unguarded, which is the very defect above.
     const wasProjectionSuspended = this.#sourceDataProjectionSuspended;
 
     this.#sourceDataProjectionSuspended = true;

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -292,6 +292,10 @@ export class Formulas extends BasePlugin {
    * behalf. Read by `#onModifySourceData` alone, so the read reports what Handsontable stores
    * without also suspending the value projection every other hook depends on.
    *
+   * `#syncFormulasToSourceData` reads the source data with the same intent but deliberately keeps
+   * the broader `#internalOperationPending`: there the flag doubles as the re-entry guard its own
+   * early return checks, which this narrow flag does not provide.
+   *
    * @private
    * @type {boolean}
    */
@@ -1375,7 +1379,11 @@ export class Formulas extends BasePlugin {
     // containing only visible columns so HF cell coordinates stay in sync.
     const columnOffset = column ?? 0;
 
-    return dataArray.map((rowArray, rowIndex) => {
+    return dataArray.map((row, rowIndex) => {
+      // `getSourceDataArray` hands back a falsy row as-is for a hole or a `null` entry, and the
+      // shape check above only reads row 0, so such a row can reach this branch. Treated as empty,
+      // exactly as the pass-through branch above treats it.
+      const rowArray = Array.isArray(row) ? row : [];
       const projected = [];
 
       for (let visualCol = 0; visualCol < visibleColumnCount; visualCol++) {

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -1312,7 +1312,24 @@ export class Formulas extends BasePlugin {
    * @returns {Array} The source data array to be passed to the formula engine.
    */
   #getProcessedSourceDataArray(row?: number, column?: number, row2?: number, column2?: number) {
-    const dataArray = this.hot.getSourceDataArray(row, column, row2, column2);
+    // Every caller feeds the result to the engine, so this read has to report what Handsontable
+    // actually stores – not what it reports. Left unguarded, `#onModifySourceData` answers every
+    // formula cell with the formula the engine already holds, so a `loadData()`/`updateData()` call
+    // that changes a formula's text reads the engine's PREVIOUS formula back and writes it straight
+    // into the engine again, silently discarding the newly loaded one. The previous value is saved
+    // and restored rather than cleared, so callers that already hold the flag keep it.
+    const wasInternalOperationPending = this.#internalOperationPending;
+
+    this.#internalOperationPending = true;
+
+    let dataArray;
+
+    try {
+      dataArray = this.hot.getSourceDataArray(row, column, row2, column2);
+    } finally {
+      this.#internalOperationPending = wasInternalOperationPending;
+    }
+
     const visibleColumnCount = this.hot.countCols();
     const physicalColumnCount = this.hot.countSourceCols();
     const isAoAWithSkippedColumns = visibleColumnCount < physicalColumnCount

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -288,6 +288,16 @@ export class Formulas extends BasePlugin {
   #sourceDataSyncPending = false;
 
   /**
+   * Guard flag set while `#getProcessedSourceDataArray` reads the source data on the engine's
+   * behalf. Read by `#onModifySourceData` alone, so the read reports what Handsontable stores
+   * without also suspending the value projection every other hook depends on.
+   *
+   * @private
+   * @type {boolean}
+   */
+  #sourceDataProjectionSuspended = false;
+
+  /**
    * The changes that the engine reported while undoing or redoing an action. They are collected in
    * `beforeUndo`/`beforeRedo` and consumed in `afterUndo`/`afterRedo`, where the dependent cells get
    * validated.
@@ -1316,24 +1326,35 @@ export class Formulas extends BasePlugin {
     // actually stores – not what it reports. Left unguarded, `#onModifySourceData` answers every
     // formula cell with the formula the engine already holds, so a `loadData()`/`updateData()` call
     // that changes a formula's text reads the engine's PREVIOUS formula back and writes it straight
-    // into the engine again, silently discarding the newly loaded one. The previous value is saved
-    // and restored rather than cleared, so callers that already hold the flag keep it.
-    const wasInternalOperationPending = this.#internalOperationPending;
+    // into the engine again, silently discarding the newly loaded one.
+    //
+    // The projection is suspended through a dedicated flag rather than `#internalOperationPending`,
+    // which also gates `#onModifyData` and `#onAfterRenderer`. This read runs the `modifyRowData`
+    // and `modifySourceData` hooks for every row and cell, so third-party handlers execute inside
+    // the guarded window - and one that calls `getDataAtCell()` on a formula cell has to keep
+    // receiving the calculated value, not the raw formula.
+    //
+    // The previous value is saved and restored rather than cleared, so callers that already hold
+    // the flag keep it.
+    const wasProjectionSuspended = this.#sourceDataProjectionSuspended;
 
-    this.#internalOperationPending = true;
+    this.#sourceDataProjectionSuspended = true;
 
     let dataArray;
 
     try {
       dataArray = this.hot.getSourceDataArray(row, column, row2, column2);
     } finally {
-      this.#internalOperationPending = wasInternalOperationPending;
+      this.#sourceDataProjectionSuspended = wasProjectionSuspended;
     }
 
     const visibleColumnCount = this.hot.countCols();
     const physicalColumnCount = this.hot.countSourceCols();
+    // Only the shape of the data matters, and it is the same for every row, so one row answers it.
+    // `getSourceData()` would rebuild the whole dataset - through the per-cell `modifySourceData`
+    // hook, and outside the guard above - just to run `isArrayOfArrays` over it.
     const isAoAWithSkippedColumns = visibleColumnCount < physicalColumnCount
-      && isArrayOfArrays(this.hot.getSourceData());
+      && Array.isArray(this.hot.getSourceDataAtRow(0));
 
     if (!isAoAWithSkippedColumns) {
       return dataArray.map((rowObject, rowIndex) => {
@@ -1765,6 +1786,8 @@ export class Formulas extends BasePlugin {
       // value to build the `afterSetSourceDataAtCell` payload, and projecting the engine's formula
       // onto it would hand listeners an old value equal to the new one.
       this.#sourceDataSyncPending ||
+      // Same reason, for the read that feeds the engine: see `#getProcessedSourceDataArray`.
+      this.#sourceDataProjectionSuspended ||
       this.sheetName === null ||
       !this.engine?.doesSheetExist(this.sheetName)
     ) {
@@ -2117,8 +2140,15 @@ export class Formulas extends BasePlugin {
    *
    * Row and column *moves* (and sorting) are deliberately excluded: they reorder the engine's
    * indexes without touching the source data, so the two stop sharing a reference frame. While that
-   * is the case nothing is written back at all - the read-time projection keeps handling it, exactly
-   * as it did before.
+   * is the case nothing is written back at all, and the stored text keeps whatever the last sync
+   * left there.
+   *
+   * Ordinary reads are unaffected: `#onModifySourceData` still projects the engine's current
+   * formula, so the grid keeps reporting the up-to-date text. The reads that feed the engine
+   * (`#getProcessedSourceDataArray`) deliberately do not - they have to report what is stored, or a
+   * data load could never replace a formula - so in a moved or sorted frame those reads hand the
+   * engine the stored, possibly stale text. Narrowing the order guard above so a structural change
+   * in that state still syncs is tracked separately.
    *
    * @private
    */


### PR DESCRIPTION
### Context

The PR fixes a regression on `develop`: `loadData()`, `updateData()` and `updateSettings({ data })` cannot replace an existing formula's text. The old formula silently survives the load, and a load that turns a formula cell into a plain literal resurrects the old formula instead.

Follow-up to #13215 (DEV-2585), which is the change that exposed it.

`#getProcessedSourceDataArray()` reads the source data through the `modifySourceData` hook, and the plugin's own `#onModifySourceData` answers any formula cell with the formula the **engine** already holds. That projection is correct in general — it is how the grid reports `=A1+1` rather than a cached value. But #13215 made the plugin reuse its HyperFormula sheet across data loads instead of recreating it (a legitimate memory-leak fix), so the engine still holds the **previous** content at the moment `#onAfterLoadData` reads the newly loaded data. The stale formula is read back and written straight into the engine again, discarding the load.

Before #13215 every load got a fresh, empty sheet, so `getCellType()` returned `EMPTY` for every cell, the projection never fired, and the real data reached the engine. Neither change is wrong on its own; the sheet reuse simply unmasked a latent bug in the load path.

Reproduction on `develop`, with no cell types and no date handling involved:

```js
const hot = new Handsontable(container, {
  data: [[1], ['=A1+1']],
  formulas: { engine: HyperFormula },
});

hot.loadData([[1], ['=A1+100']]);
// engine keeps `=A1+1` and computes 2, instead of `=A1+100` and 101
```

The fix suppresses the projection for the duration of that read, using a dedicated `#sourceDataProjectionSuspended` flag that only `#onModifySourceData` reads.

The guard belongs in the helper rather than at each call site because all five of its callers feed the result **to** the engine, and handing the engine back its own projected formulas is never meaningful.

**Why a dedicated flag rather than `#internalOperationPending`.** The first revision of this PR reused `#internalOperationPending`, which is the flag `#syncFormulasToSourceData` and `#onAfterDetachChild` already use for the same "compare against what Handsontable stores" purpose. That flag is too broad here. It also gates `#onModifyData` and `#onAfterRenderer`, and this read runs the `modifyRowData` and `modifySourceData` hooks for **every row and cell** — so third-party handlers execute inside the guarded window. A handler that called `getDataAtCell()` on a formula cell would have received the raw `=A1+1` instead of the calculated value. The dedicated flag scopes the suspension to the one hook the fix is about.

The previous flag value is saved and restored rather than cleared. No other site sets it, so this is not about a caller that already holds it; it is about those same third-party handlers, one of which could re-enter this method synchronously (through `updateSettings()` or `loadData()`) and otherwise leave the rest of the outer read unguarded.

**Blast radius.** `#getProcessedSourceDataArray` has five callers, and behavior changes at **two** of them — `#onAfterCellMetaReset` and `#onAfterLoadData`. The two `addSheet` sites are gated on `!doesSheetExist(sheetName)` and `sheetName === null` respectively, and `#onModifySourceData` already bails on both conditions, so the projection was inert there. `#onAfterDetachChild` already holds `#internalOperationPending` across the call.

**Two adjacent changes**, both from review:

- `#getProcessedSourceDataArray` now checks the data shape with `Array.isArray(getSourceDataAtRow(0))` instead of `isArrayOfArrays(getSourceData())`. The latter rebuilt the whole dataset through the per-cell `modifySourceData` hook — and outside the guard, so fully projected — to inspect the shape of one row. `#doesEngineHoldPhysicalColumns` already uses that form for the same reason.
- The `#syncFormulasToSourceData` doc comment claimed that moves and sorting are covered because "the read-time projection keeps handling it". That is no longer true at the engine-feeding reads, so the comment now says what actually holds: ordinary reads are still projected, the engine-feeding reads are not, and in a moved or sorted frame those reads hand the engine the stored, possibly stale text.

**Why this was not caught earlier:** the neighbouring `loadData`/`updateData` recalculation specs all start from `data: [[0]]`, a single non-formula cell, so none of them ever *replaced* an existing formula.

**Known limitation, pre-existing and not addressed here.** While rows or columns are moved or sorted, the engine and the source data stop sharing a reference frame, `#syncFormulasToSourceData` bails out entirely, and any engine-feeding read maps the formula's references a second time. The result is `#REF!` — both with and without this fix, verified by measurement. A data-less `updateSettings({ colHeaders: true })` on a moved frame is enough to reproduce it on `develop`:

```js
const hot = new Handsontable(container, {
  data: [[1], [2], ['=A1+1']],
  manualRowMove: true,
  formulas: { engine: HyperFormula },
});

hot.getPlugin('manualRowMove').moveRow(2, 0);
hot.render();
// grid shows 2 — correct

hot.updateSettings({ colHeaders: true });
// grid shows #REF! — with this PR and without it, byte-identical
```

Narrowing the `isHfOrderPhysical()` bail so a structural change in that state still syncs is a separate design question for the team, tracked separately.

[skip changelog]

No changelog entry: this regression is unreleased. The `settingsSheetName ?? this.sheetName` line traces only to `c0d25ef1c1` on `develop` and the `18.1.0-rc` / `18.1.0-rc1` tags, so no user of a stable release ever saw it. An entry would document a defect that never shipped. Flagging explicitly because `[skip changelog]` is normally reserved for docs-, test-, and CI-only PRs — this is a source change, and the skip is deliberate.

### Test evidence (required for source changes)

- Unit tests added/modified (`*.unit.js`): none — the defect is in hook interplay across a data load, which the E2E tier exercises
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none — extended the existing Jasmine formulas spec instead, alongside the `loadData`/`updateData` recalculation cases it belongs with
- Type tests (`*.types.ts`) updated if public API changed: none — no public API change
- Demo page / recorded trace (for UI changes): n/a

For a bug fix — the specs that fail without this fix, all in `handsontable/src/plugins/formulas/__tests__/formulas.spec.js`:

1. `should replace an existing formula's text when the loadData method is called`
2. the same for `updateData`
3. and 4. the two formula-becomes-a-literal counterparts
5. `should replace an existing formula's text when the data is replaced through updateSettings` — a third public entry point, and it reaches the engine through a different site: `#onAfterLoadData` returns early for the `updateSettings` source, so the data is fed from `#onAfterCellMetaReset` instead
6. `... for array of objects` — the first four cases are all array-of-arrays
7. `... for data with skipped columns` — `columns: [{ data: 0 }, { data: 2 }]` over three-column data, the only way to reach the projected branch of `#getProcessedSourceDataArray`
8. `should keep an array formula spilling when the loadData method is called` — spill cells report the `ARRAY` cell type, not `ARRAYFORMULA`, so they pass the `VALUE`/`EMPTY` early return and get projected as their calculated literals. Feeding those back puts a literal inside the range the array formula needs, and the load collapses to `#SPILL!`

Discrimination was verified by removing the production guard, rebuilding and re-running: **exactly those eight cases fail** (372 specs, 8 failures), and they all pass again once it is restored (372 specs, 0 failures).

### Commands run

```
$ npm --prefix handsontable run test:e2e
9726 specs, 0 failures, 8 pending specs

$ npm --prefix handsontable run test:e2e -- --testPathPattern=formulas
372 specs, 0 failures

$ npm --prefix handsontable run test:unit
Tests: 3802 passed, 3802 total (319 suites)

$ npm --prefix handsontable run test:types
pass

$ npm --prefix handsontable run eslint
0 errors (602 pre-existing warnings in untouched files, 0 on changed files)

$ npm --prefix handsontable run build
handsontable.js, handsontable.min.js, handsontable.full.js, handsontable.full.min.js
```

With the production guard temporarily removed, to prove the tests discriminate:

```
$ npm --prefix handsontable run test:e2e -- --testPathPattern=formulas
372 specs, 8 failures
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2585
2. #13215

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.
- [ ] This change needs a manual QA pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formula engine sync on bulk data reload paths in the formulas plugin; blast radius is limited to reads that feed HyperFormula, with broad E2E coverage added for the failure modes.
> 
> **Overview**
> Fixes a regression where **`loadData()`**, **`updateData()`**, and **`updateSettings({ data })`** could not replace an existing formula: the HyperFormula sheet is reused across loads, and reads that feed the engine went through **`modifySourceData`**, which projected each formula cell back to the engine’s **previous** formula and silently dropped the newly loaded text (including formula → literal cases).
> 
> The formulas plugin now suspends that projection only while **`#getProcessedSourceDataArray`** reads source data, via a dedicated **`#sourceDataProjectionSuspended`** flag (narrower than **`#internalOperationPending`** so third-party hooks still get calculated values from **`getDataAtCell`**). **`#onModifySourceData`** respects the same flag for those engine-feeding reads.
> 
> Adjacent fixes: the array-of-arrays shape check uses **`getSourceDataAtRow(0)`** instead of rebuilding all source data through unguarded hooks; skipped-column projection handles **`null`** / non-array rows; **`#syncFormulasToSourceData`** docs note that engine-feeding reads no longer project formulas after row/column moves or sorting.
> 
> Eight new Jasmine specs cover **`loadData`/`updateData`**, **`updateSettings`**, array-of-objects, skipped columns, empty rows, and array-formula spill on reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77d4bfbff2d9ac3f0568946706c4adfa6fb5890f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->