### PR TITLE
DEV-2647: Fix the React row-moving getData() recipe

### DIFF
--- a/docs/content/guides/columns/column-moving/column-moving.md
+++ b/docs/content/guides/columns/column-moving/column-moving.md
@@ -218,7 +218,11 @@ initialState: {
 
 The array both enables column moving and sets the starting order, so don't also pass [`manualColumnMove`](@/api/options.md#manualcolumnmove) at the top level. A regular setting takes precedence over the same key in [`initialState`](@/api/options.md#initialstate), so `manualColumnMove: true` alongside the code above would discard the order.
 
-If you own the order yourself, cancel the move by returning `false` from [`beforeColumnMove`](@/api/hooks.md#beforecolumnmove) and reorder your own data. Reordering columns means reordering each row's cells, or reordering your [`columns`](@/api/options.md#columns) definitions, so it takes more work than reordering rows.
+If you own the order yourself, cancel the move by returning `false` from [`beforeColumnMove`](@/api/hooks.md#beforecolumnmove) and reorder your own data. Two things follow from that.
+
+[`afterColumnMove`](@/api/hooks.md#aftercolumnmove) never fires. The move stops at [`beforeColumnMove`](@/api/hooks.md#beforecolumnmove), before that hook runs, so persist the order from your own update rather than from the snapshot recipe above.
+
+Reordering columns also takes more work than reordering rows. You either reorder each row's cells, or reorder your [`columns`](@/api/options.md#columns) definitions. Reordering the cells is the safer route: passing `columns` through [`updateSettings()`](@/api/core.md#updatesettings) resets the states tied to rows and columns, including the row and column sequence, column widths, row heights, and frozen columns.
 
 :::
 

--- a/docs/content/guides/columns/column-moving/column-moving.md
+++ b/docs/content/guides/columns/column-moving/column-moving.md
@@ -191,6 +191,37 @@ The array must contain all physical column indexes (its length must equal the to
 
 For more on how physical and visual indexes relate, see [Understanding data and indexes](@/guides/getting-started/understanding-data-and-indexes/understanding-data-and-indexes.md).
 
+## Data model behavior
+
+Moving columns does not reorder your source data. Handsontable stores the new order as index metadata through its [`IndexMapper`](@/api/indexMapper.md), and leaves the original data untouched. This affects how you read and save the data:
+
+- [`getData()`](@/api/core.md#getdata) returns cells in their current visual order, so it reflects any moves. Call it inside the [`afterColumnMove`](@/api/hooks.md#aftercolumnmove) hook to get an order-accurate snapshot to persist.
+- [`getSourceData()`](@/api/core.md#getsourcedata) returns cells in their original physical order, ignoring any moves.
+
+### Don't feed the snapshot back into the grid
+
+Sending the reordered snapshot back to the grid as its new data applies the move a second time. [`updateData()`](@/api/core.md#updatedata) keeps the current column order on purpose, so Handsontable re-applies the order map it already holds on top of your already-reordered data. One drag then moves the column twice.
+
+Treat the snapshot as output only. Send it to your backend, and leave the grid's own data alone.
+
+::: only-for react angular vue
+
+The data you bind to [`data`](@/api/options.md#data) does not change when a user moves a column, so you have to decide who owns the order. The two models are the same as for rows, and mixing them causes the same double move -- see [Choose who owns the row order](@/guides/rows/row-moving/row-moving.md#choose-who-owns-the-row-order).
+
+If you let Handsontable own the order, seed the starting order with [`initialState`](@/api/options.md#initialstate) rather than [`manualColumnMove`](@/api/options.md#manualcolumnmove). Handsontable reads [`initialState`](@/api/options.md#initialstate) only when it creates the grid, so a re-render can't apply the order a second time:
+
+```js
+initialState: {
+  manualColumnMove: [1, 0, 2],
+},
+```
+
+The array both enables column moving and sets the starting order, so don't also pass [`manualColumnMove`](@/api/options.md#manualcolumnmove) at the top level. A regular setting takes precedence over the same key in [`initialState`](@/api/options.md#initialstate), so `manualColumnMove: true` alongside the code above would discard the order.
+
+If you own the order yourself, cancel the move by returning `false` from [`beforeColumnMove`](@/api/hooks.md#beforecolumnmove) and reorder your own data. Reordering columns means reordering each row's cells, or reordering your [`columns`](@/api/options.md#columns) definitions, so it takes more work than reordering rows.
+
+:::
+
 ## Control column moving
 
 Use the [`beforeColumnMove`](@/api/hooks.md#beforecolumnmove) hook to decide whether each column move is allowed. Returning `false` cancels the move while keeping the [`manualColumnMove`](@/api/options.md#manualcolumnmove) plugin enabled.

--- a/docs/content/guides/rows/row-moving/row-moving.md
+++ b/docs/content/guides/rows/row-moving/row-moving.md
@@ -155,6 +155,11 @@ Return `false` from [`beforeRowMove`](@/api/hooks.md#beforerowmove) to cancel Ha
 
 In this model you also own the order's history. Reverting a move is your code's job, not the grid's.
 
+Two limits come with it:
+
+- The hook reports visual row indexes, and the helper below uses them as positions in your array. Those match only while nothing else reorders or hides rows. Add [`columnSorting`](@/api/options.md#columnsorting), [`filters`](@/api/options.md#filters), or trimmed rows, and a visual index no longer points at the same row in your array, so you have to translate the indexes yourself. `finalIndex` is a visual index too.
+- Cell metadata is keyed by the physical row. Reordering your own array moves the values but not the metadata, so per-row settings such as [`readOnly`](@/api/options.md#readonly), a cell `className`, or a comment stay on the position they were set on and end up on a different row.
+
 This helper applies a move to a plain array. `movedRows` holds visual row indexes, and `finalIndex` is the index that the first moved row lands on:
 
 ```js
@@ -206,7 +211,9 @@ const ExampleComponent = () => {
 
 ::: only-for angular
 
-Keep the rows in a component property, and bind it through the `[data]` input:
+Keep the rows in a component property, and bind it through the `[data]` input.
+
+The grid is created outside Angular's zone, so the hook also runs outside it. Assigning to a bound property there does not start change detection on its own, and the `[data]` input never sees the new array. Re-enter the zone to write the property, and defer it with `setTimeout` so a synchronous write inside the hook can't trigger `NG0100`:
 
 ```ts
 @Component({
@@ -216,6 +223,8 @@ Keep the rows in a component property, and bind it through the `[data]` input:
   imports: [HotTableModule],
 })
 export class AppComponent {
+  private readonly ngZone = inject(NgZone);
+
   rows = initialRows;
 
   readonly hotSettings: GridSettings = {
@@ -225,9 +234,13 @@ export class AppComponent {
         return;
       }
 
-      this.rows = reorderRows(this.rows, movedRows, finalIndex);
+      setTimeout(() => {
+        this.ngZone.run(() => {
+          this.rows = reorderRows(this.rows, movedRows, finalIndex);
+        });
+      }, 0);
 
-      // cancel the grid's own move -- the assignment above already applied it
+      // cancel the grid's own move -- the assignment above applies it instead
       return false;
     },
   };

--- a/docs/content/guides/rows/row-moving/row-moving.md
+++ b/docs/content/guides/rows/row-moving/row-moving.md
@@ -99,16 +99,175 @@ afterRowMove(movedRows, finalIndex, dropIndex, movePossible, orderChanged) {
   if (orderChanged) {
     const reorderedData = this.getData();
 
-    // persist reorderedData to your backend or local state
+    // persist reorderedData to your backend
   }
+}
+```
+
+### Don't feed the snapshot back into the grid
+
+Sending the reordered snapshot back to the grid as its new data applies the move a second time. [`updateData()`](@/api/core.md#updatedata) keeps the current row order on purpose, so Handsontable re-applies the order map it already holds on top of your already-reordered array. One drag then moves the row twice.
+
+Treat the snapshot as output only. Send it to your backend, and leave the grid's own data alone.
+
+::: only-for javascript
+
+To replace the data and reset the order together, call [`loadData()`](@/api/core.md#loaddata) instead. It clears the row order map along with the data. It also clears the undo history.
+
+:::
+
+:::: only-for react angular vue
+
+### Choose who owns the row order
+
+The array you bind to [`data`](@/api/options.md#data) does not change when a user moves a row. The order lives in Handsontable's index map, not in your array. There are two ways to handle that, and you have to stay inside one of them:
+
+- **Handsontable owns the order.** You bind the data once, and read the order out when you need it.
+- **Your app owns the order.** You cancel each move, and reorder your own array instead.
+
+Writing [`getData()`](@/api/core.md#getdata) back into the bound `data` mixes the two models. The grid still holds the order map for a move it has already made, so it applies that order on top of your already-reordered array. Your data and the grid end up out of sync, and the row can jump a second time.
+
+#### Let Handsontable own the order
+
+This is the default. Bind `data` once and leave it alone. Read the current order with [`getData()`](@/api/core.md#getdata) whenever you need to persist it.
+
+To start the grid with a non-default order, pass the array through [`initialState`](@/api/options.md#initialstate) rather than [`manualRowMove`](@/api/options.md#manualrowmove). Handsontable reads [`initialState`](@/api/options.md#initialstate) only when it creates the grid, so a re-render can't apply the order a second time:
+
+```js
+initialState: {
+  manualRowMove: [2, 0, 1],
+},
+```
+
+The array both enables row moving and sets the starting order, so don't also pass [`manualRowMove`](@/api/options.md#manualrowmove) at the top level. A regular setting takes precedence over the same key in [`initialState`](@/api/options.md#initialstate), so `manualRowMove: true` alongside the code above would discard the order.
+
+A `manualRowMove` array passed as a regular option can be re-applied on a later update, which reorders the rows again on top of the order they are already in. How often that happens depends on the framework, so don't rely on it not happening.
+
+::: only-for react
+
+For more on this, see [Non-idempotent options](@/guides/getting-started/configuration-options/configuration-options.md#non-idempotent-options).
+
+:::
+
+#### Let your app own the order
+
+Return `false` from [`beforeRowMove`](@/api/hooks.md#beforerowmove) to cancel Handsontable's move, then apply the same move to your own array. Handsontable keeps its rows in physical order, so your array is the only place the order is stored.
+
+In this model you also own the order's history. Reverting a move is your code's job, not the grid's.
+
+This helper applies a move to a plain array. `movedRows` holds visual row indexes, and `finalIndex` is the index that the first moved row lands on:
+
+```js
+function reorderRows(rows, movedRows, finalIndex) {
+  const result = rows.slice();
+  const moved = movedRows.map(index => rows[index]);
+
+  // remove from the highest index down, so the lower indexes stay valid
+  movedRows
+    .slice()
+    .sort((a, b) => b - a)
+    .forEach(index => result.splice(index, 1));
+
+  result.splice(finalIndex, 0, ...moved);
+
+  return result;
 }
 ```
 
 ::: only-for react
 
-In React, binding the [`data`](@/api/options.md#data) prop to a state variable does not keep that state in sync with row moves. The move updates Handsontable's internal index order, but your bound state still holds the original order. To align your state with the displayed order, update it explicitly from the [`afterRowMove`](@/api/hooks.md#afterrowmove) hook using [`getData()`](@/api/core.md#getdata).
+Keep the rows in state, and write the new order back from the hook:
+
+```jsx
+const ExampleComponent = () => {
+  const [rows, setRows] = useState(initialRows);
+
+  return (
+    <HotTable
+      data={rows}
+      manualRowMove={true}
+      beforeRowMove={(movedRows, finalIndex, dropIndex, movePossible) => {
+        if (!movePossible) {
+          return;
+        }
+
+        setRows(prevRows => reorderRows(prevRows, movedRows, finalIndex));
+
+        // cancel the grid's own move -- the state update above already applied it
+        return false;
+      }}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+```
 
 :::
+
+::: only-for angular
+
+Keep the rows in a component property, and bind it through the `[data]` input:
+
+```ts
+@Component({
+  selector: 'app-example',
+  template: `<hot-table [settings]="hotSettings" [data]="rows"></hot-table>`,
+  standalone: true,
+  imports: [HotTableModule],
+})
+export class AppComponent {
+  rows = initialRows;
+
+  readonly hotSettings: GridSettings = {
+    manualRowMove: true,
+    beforeRowMove: (movedRows, finalIndex, dropIndex, movePossible) => {
+      if (!movePossible) {
+        return;
+      }
+
+      this.rows = reorderRows(this.rows, movedRows, finalIndex);
+
+      // cancel the grid's own move -- the assignment above already applied it
+      return false;
+    },
+  };
+}
+```
+
+:::
+
+::: only-for vue
+
+The Vue wrapper reads the bound array by reference, so change that array in place. Assigning a new array to `rows` leaves the grid rendering the old one:
+
+```vue
+<script setup>
+const rows = reactive(initialRows);
+
+const hotSettings = {
+  manualRowMove: true,
+  beforeRowMove(movedRows, finalIndex, dropIndex, movePossible) {
+    if (!movePossible) {
+      return;
+    }
+
+    // replace the contents in place, so the grid sees the new order
+    rows.splice(0, rows.length, ...reorderRows(rows, movedRows, finalIndex));
+
+    // cancel the grid's own move -- the line above already applied it
+    return false;
+  },
+};
+</script>
+
+<template>
+  <HotTable :data="rows" :settings="hotSettings" />
+</template>
+```
+
+:::
+
+::::
 
 For more on how physical and visual indexes relate, see [Understanding data and indexes](@/guides/getting-started/understanding-data-and-indexes/understanding-data-and-indexes.md).
 

--- a/docs/content/guides/rows/row-moving/row-moving.md
+++ b/docs/content/guides/rows/row-moving/row-moving.md
@@ -112,7 +112,9 @@ Treat the snapshot as output only. Send it to your backend, and leave the grid's
 
 ::: only-for javascript
 
-To replace the data and reset the order together, call [`loadData()`](@/api/core.md#loaddata) instead. It clears the row order map along with the data. It also clears the undo history.
+To replace the data and reset the order together, call [`loadData()`](@/api/core.md#loaddata) instead. It clears the row order map along with the data, and it clears the undo history.
+
+One exception: if you passed [`manualRowMove`](@/api/options.md#manualrowmove) as an array of indexes, the plugin re-applies that array right after the reset. You get the configured order back, not the source order.
 
 :::
 
@@ -155,8 +157,10 @@ Return `false` from [`beforeRowMove`](@/api/hooks.md#beforerowmove) to cancel Ha
 
 In this model you also own the order's history. Reverting a move is your code's job, not the grid's.
 
-Two limits come with it:
+Cancelling the move changes what the grid does for you, so plan for these:
 
+- [`afterRowMove`](@/api/hooks.md#afterrowmove) never fires. The move stops at [`beforeRowMove`](@/api/hooks.md#beforerowmove), before that hook runs, so the snapshot recipe shown earlier on this page does not apply here. Persist the order from your own update instead.
+- The grid does not re-render or restore the selection, because both wait for a move that actually happened. After the drag, the highlighted row headers stay where they were, and those positions now hold different rows. Re-select the moved rows yourself if that matters.
 - The hook reports visual row indexes, and the helper below uses them as positions in your array. Those match only while nothing else reorders or hides rows. Add [`columnSorting`](@/api/options.md#columnsorting), [`filters`](@/api/options.md#filters), or trimmed rows, and a visual index no longer points at the same row in your array, so you have to translate the indexes yourself. `finalIndex` is a visual index too.
 - Cell metadata is keyed by the physical row. Reordering your own array moves the values but not the metadata, so per-row settings such as [`readOnly`](@/api/options.md#readonly), a cell `className`, or a comment stay on the position they were set on and end up on a different row.
 
@@ -264,8 +268,10 @@ const hotSettings = {
       return;
     }
 
-    // replace the contents in place, so the grid sees the new order
-    rows.splice(0, rows.length, ...reorderRows(rows, movedRows, finalIndex));
+    // write the new order into the same array, so the grid sees it
+    reorderRows(rows, movedRows, finalIndex).forEach((row, index) => {
+      rows[index] = row;
+    });
 
     // cancel the grid's own move -- the line above already applied it
     return false;


### PR DESCRIPTION
### Context

The PR fixes wrong advice in the row-moving guide. The `only-for react` block added by DEV-490 told React users that binding `data` to state does not stay in sync with row moves, and that they should "update it explicitly from the `afterRowMove` hook using `getData()`".

Following that instruction **moves the row twice**. Verified against released 18.0.0 with the real `@handsontable/react-wrapper` in Chromium:

| step | result |
|---|---|
| start | `[A,B,C,D]` |
| drag row 0 to the end | grid shows `B,C,D,A` -- correct |
| `setData(getData())` per the docs | grid shows `C,D,A,B` |
| React state | `[B,C,D,A]` |
| `rowIndexMapper.getIndexesSequence()` | `[1,2,3,0]` -- the move is still applied |

One drag, two jumps, and state and grid are still out of sync.

The cause is a chain of three deliberate behaviors:

1. The wrapper sends the changed `data` on to the grid.
2. On a non-first run, `core.ts` routes `settings.data` to `updateData()`, not `loadData()`.
3. `updateData()` keeps the row order on purpose -- it only calls `rowIndexMapper.fitToLength()` -- and `ManualRowMove` resets its order from `afterLoadData` only. There is no `afterUpdateData` listener.

So the already-reordered array arrives and the stale order map is applied on top of it.

The paragraph was the incoherent middle of two valid models: it wrote the order back into `data` while Handsontable still owned the order map. This PR replaces it with the two coherent models instead of a single recipe:

- **Handsontable owns the order.** Seed the starting order with `initialState`, snapshot with `getData()` to persist, and never write it back into `data`.
- **Your app owns the order.** Veto in `beforeRowMove`, reorder your own array, and return `false`.

The controlled section deliberately promises nothing about Ctrl+Z. It frames it as "you own the order, so you own reverting it", which stays correct regardless of DEV-2646.

**Timing.** The broken section exists only in the `18.1.0-rc*` tags. The live 18.0 docs page does not have it, so the wrong advice has not reached any user yet. This corrects a draft rather than a published guide.

Scope notes:

- The block was tagged `only-for react`, but Angular and Vue 3 hit the same trap, and `ManualColumnMove` also hooks only `afterLoadData`. The coverage is widened to all three wrappers, and the column-moving guide gets the parallel section.
- `initialState` appeared zero times in the row-moving guide. It was documented only in the configuration-options guide and the changelog, so a reader on the natural page never learned it exists.
- The existing `getData()`-snapshot advice for persisting to a backend is correct and is kept. Only writing it back into the bound `data` was broken.

Two defects were caught while writing the replacement, and both are fixed in what ships here:

1. The splice helper from the original research repro is **wrong for multi-row moves**. It reinserts moved rows in ascending index order, while `IndexMapper.moveIndexes()` reinserts them in the order given in `movedIndexes`. Checked against a faithful port of that method over every subset of up to 7 rows: **842 of 1823 cases mismatched**. The repro only ever moved one row, which is why it looked correct. The published helper scores 0 mismatches.
2. A first draft of the `initialState` snippet also passed `manualRowMove: true` at the top level. Core merges `{ ...userSettings.initialState, ...userSettings }`, so a regular setting **overrides** the same key in `initialState` and silently discards the order. The guide now says this explicitly.

### How has this been tested?

Docs-only change, so no unit or E2E suites apply. Verification was done against source and with scripted checks:

- Ran the repository's real `filterOnlyForBlocks` transform (`docs/src/plugins/vuepress-preprocessor.mjs`) over both pages for all four framework variants. All balanced: no leftover `only-for` markers, container open/close counts equal, code fences even. The vanilla JS variant correctly omits the wrapper-only section.
- Compared the published `reorderRows()` helper against a faithful port of `IndexMapper.moveIndexes()` (`handsontable/src/translations/indexMapper.ts:705`) over every subset of up to 7 rows, in ascending and non-ascending order: **1823 cases checked, 0 mismatches**.
- Checked both files for en dashes, em dashes, and curly quotes, per the docs site style rules: clean.

Every factual claim in the new text was traced to source:

- `core.ts:281` -- `{ ...userSettings.initialState, ...userSettings }`, so regular settings win over `initialState`.
- `core.ts:3367` -- `loadData` on first run, `updateData` afterwards.
- `core.ts:3096` vs `initIndexMappers` -- `fitToLength` trims or appends only, `initToLength` rebuilds the sequence.
- `manualRowMove.ts:123` and `manualColumnMove.ts:154` -- `afterLoadData` only, no `afterUpdateData` listener in either.
- `undoRedo.ts` `#onAfterChange` -- `loadData` clears undo/redo history.
- `manualRowMove.ts:105` -- any truthy value enables the plugin, so the `initialState` array both enables moving and sets the order.

Per-wrapper mechanisms were confirmed separately, and corrected one assumption:

- **React** -- `data` is not in `DEEP_COMPARABLE_SETTINGS` and not init-only, so it rides the payload into `updateSettings()` and then `updateData()`.
- **Angular** -- the `[data]` input calls `hotInstance.updateData()` **directly**; `updateSettings` is not involved.
- **Vue 3** -- the wrapper **deletes** `data` from the payload and syncs by reference. Replacing the bound array with a new one never reaches the grid. `wrappers/vue3/test/hotTable.spec.ts:181` pins that contract, which is why the Vue snippet changes the array in place.

Because of this, the new text avoids claiming that all wrappers pass `data` through `updateSettings()` -- that is only true for React.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2647
2. Related: DEV-2646 (a vetoed move still records an undo action). The controlled section here is written so it stays correct either way.
3. Closes the docs side of #7517. The original report is by design and unchanged; this task is about our own advice being wrong.

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation only -- no package source is touched.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

[skip changelog] -- documentation only, no package source changed.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2647

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or package code modified.
> 
> **Overview**
> Corrects documentation that told React users to sync bound `data` from `afterRowMove` via `getData()`, which **double-applies** moves when wrappers route updates through `updateData()` while the index map still holds the prior order.
> 
> The row-moving guide now warns not to feed reorder snapshots back into the grid, documents **`loadData()`** for vanilla JS when you need a full reset, and adds a **“choose who owns the order”** section for React, Angular, and Vue: either let Handsontable own order (persist with `getData()`, seed with `initialState.manualRowMove`, never write back to `data`) or veto in `beforeRowMove`, reorder your own array (with a corrected multi-row `reorderRows` helper), and return `false`. Framework-specific snippets cover React state, Angular zone/`setTimeout`, and Vue in-place array updates.
> 
> The column-moving guide gains a matching **data model** section (snapshot vs source, double-move warning) and wrapper guidance that points to the row-moving ownership model, including `initialState` vs top-level `manualRowMove` precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4843fbcdc18febaf514c85cc02698caf8583577d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->