### PR TITLE
PRO-1303: Move the outdated-version banner to the top on frozen VuePress docs

### DIFF
--- a/docs/README-DEPLOYMENT.md
+++ b/docs/README-DEPLOYMENT.md
@@ -83,6 +83,8 @@ To deploy the documentation to the [production environment](https://handsontable
 
 The workflow assembles the multi-version site (current plus previous versions, pulled from the published GHCR Docker images) using the scripts in `docs/deploy/`, then deploys it to the `handsontable-docs` Cloudflare Pages project on the `production` branch label, which serves it at the apex.
 
+During assembly, two scripts post-process the frozen previous-version builds (which are never rebuilt): `rewriteVersionedPaths.mjs` prefixes root-relative links in Astro builds (>= 17.1) with their version segment, and `injectBannerTopCss.mjs` injects a CSS override into legacy VuePress builds so the "newer version available" banner renders at the top of the page instead of the bottom (PRO-1303). Both changes take effect in production only after they land on the `prod-docs/<MAJOR.MINOR>` branch that triggers the next deploy - a deploy triggered from an older `prod-docs` branch (e.g. a hotfix) assembles from that branch's checkout and reverts any assembly-script change it does not carry.
+
 ### Reverting a production deployment
 
 To revert a production deployment to a previous version:

--- a/docs/deploy/__tests__/injectBannerTopCss.test.mjs
+++ b/docs/deploy/__tests__/injectBannerTopCss.test.mjs
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { injectBannerTopCss } from '../injectBannerTopCss.mjs';
+
+const HEAD = '<head><title>Docs</title></head>';
+
+// The broken layout: the banner renders after the content (14.6-17.0 builds).
+const BOTTOM_BANNER_PAGE =
+  `<html>${HEAD}<body><main class="page">` +
+  '<div class="breadcrumbs">15.0.0</div>' +
+  '<div class="theme-default-content content__default"><h1>Introduction</h1></div>' +
+  '<div class="page-top" style="display:none;"><div class="custom-block tip version-alert">' +
+  '<p>There is a newer version of Handsontable available.</p></div></div>' +
+  '<footer class="footer"></footer>' +
+  '</main></body></html>';
+
+// The already-correct layout: the banner renders before the content (<= 14.0 builds).
+const TOP_BANNER_PAGE =
+  `<html>${HEAD}<body><main class="page">` +
+  '<div class="page-top" style="display:none;"><div class="custom-block tip version-alert">' +
+  '<p>There is a newer version of Handsontable available.</p></div></div>' +
+  '<div class="theme-default-content content__default"><h1>Introduction</h1></div>' +
+  '</main></body></html>';
+
+async function withFixtureDir(files, run) {
+  const dir = await mkdtemp(join(tmpdir(), 'inject-banner-top-css-'));
+
+  try {
+    for (const [relativePath, content] of Object.entries(files)) {
+      const filePath = join(dir, relativePath);
+      await mkdir(join(filePath, '..'), { recursive: true });
+      await writeFile(filePath, content, 'utf-8');
+    }
+
+    await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('injects the reorder CSS before </head> on a bottom-banner page', async () => {
+  await withFixtureDir({ 'javascript-data-grid/index.html': BOTTOM_BANNER_PAGE }, async (dir) => {
+    const changedCount = await injectBannerTopCss(dir);
+    const content = await readFile(join(dir, 'javascript-data-grid/index.html'), 'utf-8');
+
+    assert.equal(changedCount, 1);
+    assert.match(content, /<style id="hot-banner-top">.*<\/style><\/head>/);
+    assert.match(content, /main\.page>\.page-top\{order:-1\}/);
+    // The markup itself is untouched -- only the head gains a style tag.
+    assert.ok(content.includes('<div class="page-top" style="display:none;">'));
+  });
+});
+
+test('injects the style tag exactly once per file', async () => {
+  await withFixtureDir({ 'index.html': BOTTOM_BANNER_PAGE }, async (dir) => {
+    await injectBannerTopCss(dir);
+    const content = await readFile(join(dir, 'index.html'), 'utf-8');
+
+    assert.equal(content.split('hot-banner-top').length - 1, 1);
+  });
+});
+
+test('is idempotent: a second run changes nothing', async () => {
+  await withFixtureDir({ 'index.html': BOTTOM_BANNER_PAGE }, async (dir) => {
+    const firstRun = await injectBannerTopCss(dir);
+    const afterFirst = await readFile(join(dir, 'index.html'), 'utf-8');
+    const secondRun = await injectBannerTopCss(dir);
+    const afterSecond = await readFile(join(dir, 'index.html'), 'utf-8');
+
+    assert.equal(firstRun, 1);
+    assert.equal(secondRun, 0);
+    assert.equal(afterSecond, afterFirst);
+  });
+});
+
+test('skips pages whose banner already renders before the content', async () => {
+  await withFixtureDir({ 'index.html': TOP_BANNER_PAGE }, async (dir) => {
+    const changedCount = await injectBannerTopCss(dir);
+    const content = await readFile(join(dir, 'index.html'), 'utf-8');
+
+    assert.equal(changedCount, 0);
+    assert.equal(content, TOP_BANNER_PAGE);
+  });
+});
+
+test('skips pages without the banner', async () => {
+  const bannerlessPage =
+    `<html>${HEAD}<body><main class="page">` +
+    '<div class="theme-default-content content__default"><h1>Introduction</h1></div>' +
+    '</main></body></html>';
+
+  await withFixtureDir({ 'index.html': bannerlessPage }, async (dir) => {
+    const changedCount = await injectBannerTopCss(dir);
+    const content = await readFile(join(dir, 'index.html'), 'utf-8');
+
+    assert.equal(changedCount, 0);
+    assert.equal(content, bannerlessPage);
+  });
+});
+
+test('only touches .html files', async () => {
+  const jsonContent = '{"pageTop": "theme-default-content then class=\\"page-top\\""}';
+
+  await withFixtureDir({ 'data/common.json': jsonContent }, async (dir) => {
+    const changedCount = await injectBannerTopCss(dir);
+    const content = await readFile(join(dir, 'data/common.json'), 'utf-8');
+
+    assert.equal(changedCount, 0);
+    assert.equal(content, jsonContent);
+  });
+});
+
+test('processes files nested in subdirectories', async () => {
+  await withFixtureDir(
+    {
+      'react-data-grid/installation/index.html': BOTTOM_BANNER_PAGE,
+      'javascript-data-grid/index.html': TOP_BANNER_PAGE,
+    },
+    async (dir) => {
+      const changedCount = await injectBannerTopCss(dir);
+      const nested = await readFile(join(dir, 'react-data-grid/installation/index.html'), 'utf-8');
+
+      assert.equal(changedCount, 1);
+      assert.match(nested, /hot-banner-top/);
+    }
+  );
+});

--- a/docs/deploy/build_current_version.sh
+++ b/docs/deploy/build_current_version.sh
@@ -31,6 +31,14 @@ do
     # ./docs/docs/<version>/, so try the nested path first and fall back to copying the flat root.
     if docker cp "$img_id:/usr/share/nginx/html/docs/$version" "./docs/docs/$version" 2>/dev/null; then
         echo "  copied nested layout (/docs/$version)"
+
+        # Legacy VuePress builds from mid-14.x through 17.0 render the
+        # "newer version available" banner at the bottom of the page, where
+        # readers miss it (PRO-1303). These builds are never rebuilt, so
+        # inject a CSS override that moves the banner to the top. The script
+        # self-gates on the broken layout, leaving older top-banner themes
+        # and bannerless pages byte-identical.
+        node injectBannerTopCss.mjs "./docs/docs/$version"
     else
         docker cp "$img_id:/usr/share/nginx/html/docs" "./docs/docs/$version"
         echo "  copied flat layout (/docs) into /docs/$version"

--- a/docs/deploy/build_previous_versions.sh
+++ b/docs/deploy/build_previous_versions.sh
@@ -25,6 +25,14 @@ do
     # ./docs/docs/<version>/, so try the nested path first and fall back to copying the flat root.
     if docker cp "$img_id:/usr/share/nginx/html/docs/$version" "./docs/docs/$version" 2>/dev/null; then
         echo "  copied nested layout (/docs/$version)"
+
+        # Legacy VuePress builds from mid-14.x through 17.0 render the
+        # "newer version available" banner at the bottom of the page, where
+        # readers miss it (PRO-1303). These builds are never rebuilt, so
+        # inject a CSS override that moves the banner to the top. The script
+        # self-gates on the broken layout, leaving older top-banner themes
+        # and bannerless pages byte-identical.
+        node injectBannerTopCss.mjs "./docs/docs/$version"
     else
         docker cp "$img_id:/usr/share/nginx/html/docs" "./docs/docs/$version"
         echo "  copied flat layout (/docs) into /docs/$version"

--- a/docs/deploy/injectBannerTopCss.mjs
+++ b/docs/deploy/injectBannerTopCss.mjs
@@ -1,0 +1,107 @@
+// Moves the "newer version available" banner to the top of the page on
+// previously-built, frozen VuePress docs versions (PRO-1303).
+//
+// Mid-14.x through 17.0 VuePress builds render the banner (`.page-top`)
+// at the bottom of `<main class="page">`, after the content, where readers
+// miss it. Those builds are extracted verbatim from per-version Docker
+// images on every deploy and are never rebuilt, so the fix has to happen
+// here, at assembly time.
+//
+// The pages are server-rendered Vue apps (VuePress SPA). Relocating the
+// banner node in the static HTML would not stick: hydration re-renders
+// `main.page` from the theme's component template, and any client-side
+// navigation builds the next page's DOM purely from that template. A CSS
+// override survives both, so this script injects a flex-order rule into
+// each page's <head> instead of touching the markup.
+//
+// Only files with the broken layout are touched -- the banner markup
+// (`class="page-top"`) appearing after the content div
+// (`theme-default-content`). Older themes (<= 14.0) that already render
+// the banner on top, pages without the banner, and Astro builds (>= 17.1)
+// are left byte-identical. The `.page-top` element itself (including its
+// inline `display:none` and the frozen client JS that toggles it) is not
+// modified, so the show-only-when-outdated behavior is unchanged.
+//
+// Usage: node injectBannerTopCss.mjs <dir>
+
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { extname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const STYLE_ID = 'hot-banner-top';
+
+// Reorders main.page's direct children (breadcrumbs, content, .page-top,
+// footer -- verified consistent across the affected 14.6-17.0 builds) so the
+// banner lands between the breadcrumbs and the content, matching where the
+// Astro (>= 17.1) builds render it.
+const STYLE_TAG =
+  `<style id="${STYLE_ID}">` +
+  'main.page{display:flex;flex-direction:column}' +
+  'main.page>.breadcrumbs{order:-2}' +
+  'main.page>.page-top{order:-1}' +
+  '</style>';
+
+/**
+ * Injects the banner-repositioning CSS into every `.html` file under `dir`
+ * whose banner markup renders after the content (the broken bottom layout).
+ * Files already carrying the style tag are skipped (idempotent).
+ *
+ * @param {string} dir - Directory containing one version's built docs.
+ * @returns {Promise<number>} Number of files that were changed.
+ */
+export async function injectBannerTopCss(dir) {
+  const entries = await readdir(dir, { recursive: true, withFileTypes: true });
+  const htmlFiles = entries
+    .filter((entry) => entry.isFile() && extname(entry.name) === '.html')
+    .map((entry) => join(entry.parentPath ?? entry.path, entry.name));
+
+  let changedCount = 0;
+
+  for (const file of htmlFiles) {
+    const original = await readFile(file, 'utf-8');
+
+    if (original.includes(STYLE_ID)) {
+      continue;
+    }
+
+    const bannerIndex = original.indexOf('class="page-top"');
+    const contentIndex = original.indexOf('theme-default-content');
+    const headEndIndex = original.indexOf('</head>');
+
+    const hasBottomBanner = bannerIndex !== -1
+      && contentIndex !== -1
+      && bannerIndex > contentIndex;
+
+    if (!hasBottomBanner || headEndIndex === -1) {
+      continue;
+    }
+
+    const rewritten = `${original.slice(0, headEndIndex)}${STYLE_TAG}${original.slice(headEndIndex)}`;
+
+    await writeFile(file, rewritten, 'utf-8');
+    changedCount += 1;
+  }
+
+  return changedCount;
+}
+
+// process.argv[1] is not resolved to an absolute path when the script is
+// invoked with a relative one (e.g. `node injectBannerTopCss.mjs ...`, as
+// build_current_version.sh does), so comparing it to import.meta.url as a
+// plain string would never match. pathToFileURL() resolves it the same way
+// Node resolves import.meta.url, relative to the current working directory,
+// so the comparison works regardless of how the script is invoked.
+const isMainModule = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMainModule) {
+  const [dir] = process.argv.slice(2);
+
+  if (!dir) {
+    console.error('Usage: node injectBannerTopCss.mjs <dir>');
+    process.exitCode = 1;
+  } else {
+    const changedCount = await injectBannerTopCss(dir);
+
+    console.log(`Injected banner-top CSS into ${changedCount} file(s) under ${dir}.`);
+  }
+}


### PR DESCRIPTION
### Context

The PR fixes the placement of the "There is a newer version of Handsontable available" banner on older, frozen docs versions, where it renders at the very bottom of the page (after the content, right before the footer) and readers miss it. Reported in PRO-1303 with a screenshot from `/docs/15.0/`.

**Scope of the bug.** The current docs (Astro, 17.1 and later) already render this banner at the top and hide it on the latest version, so nothing changes there. The bug lives only in the frozen VuePress builds from mid-14.x through 17.0 (verified against live production: 14.6–17.0 render the banner at the bottom; 13.1 and older VuePress themes already render it at the top; 9.0 has no banner).

**Why the fix lives in `docs/deploy/`.** Frozen versions are never rebuilt — every production deploy extracts them verbatim from their per-version Docker images (`build_current_version.sh` / `build_previous_versions.sh`) and nests them under `/docs/<version>/`. A fix in the develop page components can never reach them. The assembly step already post-processes frozen HTML (`rewriteVersionedPaths.mjs`, DEV-1979), so this PR adds a sibling script to that step: `injectBannerTopCss.mjs` injects a small `<style>` block into each affected page's `<head>`:

```css
main.page { display: flex; flex-direction: column }
main.page > .breadcrumbs { order: -2 }
main.page > .page-top { order: -1 }
```

The script self-gates per file on the broken layout (banner markup appearing after the content div), so already-correct themes, bannerless pages, and Astro builds stay byte-identical. It is idempotent, and the banner element itself — including the frozen client JS that shows it only when the version is outdated — is untouched.

**Why not move the banner element in the HTML instead.** The frozen pages are server-rendered Vue apps (VuePress SPA, `data-server-rendered="true"`). Relocating the `.page-top` node in the static HTML does not stick: Vue hydration re-renders `main.page` from the theme's component template on load, and any client-side navigation builds the next page's DOM purely from that template — the banner would return to the bottom on the first sidebar click. A CSS override applies to whatever DOM Vue renders, so it survives both. (Confirmed on the live 15.0 site: with the rule applied at runtime, the banner sits between the breadcrumbs and the `<h1>` — matching the Astro placement — and stays there across SPA navigation.)

**Deployment note.** The assembly scripts run from the `prod-docs/<MAJOR.MINOR>` checkout that triggers the deploy, so this change is inert in production until it is cherry-picked onto that branch — planned after the 18.1.0 release freeze lifts. One deploy then fixes all affected versions at once, since every deploy reassembles every frozen version. Caveat (now documented in `README-DEPLOYMENT.md`): a hotfix deploy triggered from an older `prod-docs` branch assembles from that branch's checkout and would revert any assembly-script change it does not carry.

`[skip changelog]` — deploy tooling and deployment docs only; no package source changes.

### How has this been tested?

- 7 new unit tests in `docs/deploy/__tests__/injectBannerTopCss.test.mjs` (injects on the bottom-banner layout, exactly once, idempotent, skips top-banner/bannerless pages and non-HTML files, handles nested directories). Full docs suite green: `npm run docs:test:plugins` — 250/250.
- Ran the script against downloaded live production pages: injects on 14.6, 15.0, and 17.0; skips 13.1 — exactly the affected set.
- Applied the injected CSS rule at runtime on the live `/docs/15.0/` site in a browser: the banner (shown by the page's own outdated-version JS) renders between the breadcrumbs and the `<h1>`, page layout is intact (breadcrumbs → banner → content → footer, banner rendered once), and the position survives client-side (SPA) navigation between pages.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. PRO-1303

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Docs deployment tooling only — `docs/deploy/` and `docs/README-DEPLOYMENT.md`.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

Documentation updated in the same PR: `docs/README-DEPLOYMENT.md` now describes both frozen-build post-processing scripts and the prod-docs cherry-pick requirement.

ClickUp task: https://app.clickup.com/t/86cacua5f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to docs deploy assembly and static HTML/CSS injection; no Handsontable package or runtime product code.
> 
> **Overview**
> Fixes **PRO-1303** by post-processing frozen VuePress docs (mid-14.x through 17.0) at production assembly time, where the “newer version available” banner sits below the content and is easy to miss.
> 
> Adds **`injectBannerTopCss.mjs`**, which walks each version’s extracted HTML and injects a flex `order` override in `</head>` when the banner markup appears after `theme-default-content`. Markup and show-when-outdated behavior stay unchanged; CSS survives VuePress hydration and SPA navigation. The script skips pages that already show the banner at the top, pages without a banner, non-HTML files, and is idempotent.
> 
> **`build_current_version.sh`** and **`build_previous_versions.sh`** invoke it after copying the nested VuePress image layout (alongside the existing Astro **`rewriteVersionedPaths.mjs`** path for flat layouts). **`README-DEPLOYMENT.md`** documents both assembly post-processors and notes that fixes only ship when the `prod-docs/<MAJOR.MINOR>` branch used for deploy includes them.
> 
> Seven unit tests cover injection, idempotency, and skip conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd54f2130344904857df48d26d0fb35919685ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->