### PR TITLE
DEV-2649: Patch form-data under jsdom

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ overrides:
   undici: ^6.24.0
   '@astrojs/mdx': ^6.0.1
 
-packageExtensionsChecksum: sha256-HW0fEgNzl97t+n6OP9YhjxMaqHuFQdiKyvrxqn9AYp4=
+packageExtensionsChecksum: sha256-/Nk46+CUh6xzvfK9LyFzqwiAgP2eyOxLaAiH+d9mcO0=
 
 importers:
 
@@ -140,13 +140,13 @@ importers:
         version: 7.2.3
       global-jsdom:
         specifier: ^24.0.0
-        version: 24.0.0(jsdom@24.0.0(form-data@4.0.4))
+        version: 24.0.0(jsdom@24.0.0(form-data@4.0.6))
       inquirer:
         specifier: ^7.3.3
         version: 7.3.3
       jsdom:
         specifier: 24.0.0
-        version: 24.0.0(form-data@4.0.4)
+        version: 24.0.0(form-data@4.0.6)
       lefthook:
         specifier: ^2.1.10
         version: 2.1.10
@@ -561,7 +561,7 @@ importers:
         version: 7.2.3
       global-jsdom:
         specifier: ^24.0.0
-        version: 24.0.0(jsdom@24.0.0(form-data@4.0.4))
+        version: 24.0.0(jsdom@24.0.0(form-data@4.0.6))
       html-parse-stringify:
         specifier: ^3.0.1
         version: 3.0.1
@@ -585,19 +585,19 @@ importers:
         version: 1.0.3
       jest:
         specifier: ^27.5.1
-        version: 27.5.1(form-data@4.0.4)
+        version: 27.5.1(form-data@4.0.6)
       jest-cli:
         specifier: ^27.5.1
-        version: 27.5.1(form-data@4.0.4)
+        version: 27.5.1(form-data@4.0.6)
       jest-environment-jsdom:
         specifier: ^27.5.1
-        version: 27.5.1(form-data@4.0.4)
+        version: 27.5.1(form-data@4.0.6)
       jest-matcher-utils:
         specifier: ^27.5.1
         version: 27.5.1
       jsdom:
         specifier: ^24.0.0
-        version: 24.0.0(form-data@4.0.4)
+        version: 24.0.0(form-data@4.0.6)
       loader-utils:
         specifier: ^1.4.2
         version: 1.4.2
@@ -707,7 +707,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^19.2.23
-        version: 19.2.27(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(@angular/compiler@19.2.25)(@rspack/core@1.7.11(@swc/helpers@0.5.23))(@types/node@20.19.42)(chokidar@4.0.3)(jest-environment-jsdom@29.5.0(form-data@4.0.4))(jest@29.5.0(@types/node@20.19.42))(jiti@1.21.7)(lightningcss@1.32.0)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3))(typescript@5.8.3)(vite@6.4.3(@types/node@20.19.42)(jiti@1.21.7)(less@4.2.2)(lightningcss@1.32.0)(sass@1.85.0)(terser@5.39.0))
+        version: 19.2.27(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(@angular/compiler@19.2.25)(@rspack/core@1.7.11(@swc/helpers@0.5.23))(@types/node@20.19.42)(chokidar@4.0.3)(jest-environment-jsdom@29.5.0(form-data@4.0.6))(jest@29.5.0(@types/node@20.19.42))(jiti@1.21.7)(lightningcss@1.32.0)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3))(typescript@5.8.3)(vite@6.4.3(@types/node@20.19.42)(jiti@1.21.7)(less@4.2.2)(lightningcss@1.32.0)(sass@1.85.0)(terser@5.39.0))
       '@angular-eslint/builder':
         specifier: ~19.8.1
         version: 19.8.1(chokidar@4.0.3)(eslint@8.57.1)(typescript@5.8.3)
@@ -785,10 +785,10 @@ importers:
         version: 29.5.0(@types/node@20.19.42)
       jest-environment-jsdom:
         specifier: 29.5.0
-        version: 29.5.0(form-data@4.0.4)
+        version: 29.5.0(form-data@4.0.6)
       jest-preset-angular:
         specifier: ^14.3.0
-        version: 14.6.2(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser-dynamic@19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.25)(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))))(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(form-data@4.0.4)(jest@29.5.0(@types/node@20.19.42))(jsdom@24.0.0(form-data@4.0.4))(typescript@5.8.3)
+        version: 14.6.2(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser-dynamic@19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.25)(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))))(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(form-data@4.0.6)(jest@29.5.0(@types/node@20.19.42))(jsdom@24.0.0(form-data@4.0.6))(typescript@5.8.3)
       ng-packagr:
         specifier: ^19.2.2
         version: 19.2.2(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)
@@ -870,10 +870,10 @@ importers:
         version: link:../../handsontable/tmp
       jest:
         specifier: ^27.5.1
-        version: 27.5.1(form-data@3.0.4)
+        version: 27.5.1(form-data@3.0.5)
       jest-environment-jsdom:
         specifier: ^27.5.1
-        version: 27.5.1(form-data@3.0.4)
+        version: 27.5.1(form-data@3.0.5)
       prop-types:
         specifier: ^15.7.2
         version: 15.8.1
@@ -966,7 +966,7 @@ importers:
         version: 2.0.0-rc.16(vue@3.5.35(typescript@4.9.5))
       '@vue/vue3-jest':
         specifier: 27.0.0-alpha.4
-        version: 27.0.0-alpha.4(@babel/core@7.29.7)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.4))(ts-jest@27.1.5(@babel/core@7.29.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.4))(typescript@4.9.5))(typescript@4.9.5)(vue@3.5.35(typescript@4.9.5))
+        version: 27.0.0-alpha.4(@babel/core@7.29.7)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.5))(ts-jest@27.1.5(@babel/core@7.29.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.5))(typescript@4.9.5))(typescript@4.9.5)(vue@3.5.35(typescript@4.9.5))
       babel-jest:
         specifier: ^27.5.1
         version: 27.5.1(@babel/core@7.29.7)
@@ -984,10 +984,10 @@ importers:
         version: link:../../handsontable/tmp
       jest:
         specifier: ^27.5.1
-        version: 27.5.1(form-data@3.0.4)
+        version: 27.5.1(form-data@3.0.5)
       jest-environment-jsdom:
         specifier: ^27.5.1
-        version: 27.5.1(form-data@3.0.4)
+        version: 27.5.1(form-data@3.0.5)
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1002,7 +1002,7 @@ importers:
         version: 6.0.0(@vue/compiler-sfc@3.5.35)
       ts-jest:
         specifier: ^27.1.5
-        version: 27.1.5(@babel/core@7.29.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.4))(typescript@4.9.5)
+        version: 27.1.5(@babel/core@7.29.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.5))(typescript@4.9.5)
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
@@ -8297,12 +8297,12 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@3.0.4:
-    resolution: {integrity: sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==}
+  form-data@3.0.5:
+    resolution: {integrity: sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==}
     engines: {node: '>= 6'}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -9545,7 +9545,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       canvas: ^2.5.0
-      form-data: 3.0.4
+      form-data: 3.0.5
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -9555,7 +9555,7 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       canvas: ^2.5.0
-      form-data: 4.0.4
+      form-data: 4.0.6
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -9565,7 +9565,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       canvas: ^2.11.2
-      form-data: 4.0.4
+      form-data: 4.0.6
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -13722,7 +13722,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@19.2.27(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(@angular/compiler@19.2.25)(@rspack/core@1.7.11(@swc/helpers@0.5.23))(@types/node@20.19.42)(chokidar@4.0.3)(jest-environment-jsdom@29.5.0(form-data@4.0.4))(jest@29.5.0(@types/node@20.19.42))(jiti@1.21.7)(lightningcss@1.32.0)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3))(typescript@5.8.3)(vite@6.4.3(@types/node@20.19.42)(jiti@1.21.7)(less@4.2.2)(lightningcss@1.32.0)(sass@1.85.0)(terser@5.39.0))':
+  '@angular-devkit/build-angular@19.2.27(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(@angular/compiler@19.2.25)(@rspack/core@1.7.11(@swc/helpers@0.5.23))(@types/node@20.19.42)(chokidar@4.0.3)(jest-environment-jsdom@29.5.0(form-data@4.0.6))(jest@29.5.0(@types/node@20.19.42))(jiti@1.21.7)(lightningcss@1.32.0)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3))(typescript@5.8.3)(vite@6.4.3(@types/node@20.19.42)(jiti@1.21.7)(less@4.2.2)(lightningcss@1.32.0)(sass@1.85.0)(terser@5.39.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1902.27(chokidar@4.0.3)
@@ -13784,7 +13784,7 @@ snapshots:
     optionalDependencies:
       esbuild: 0.28.0
       jest: 29.5.0(@types/node@20.19.42)
-      jest-environment-jsdom: 29.5.0(form-data@4.0.4)
+      jest-environment-jsdom: 29.5.0(form-data@4.0.6)
       ng-packagr: 19.2.2(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - '@angular/compiler'
@@ -16199,7 +16199,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@27.5.1(form-data@3.0.4)':
+  '@jest/core@27.5.1(form-data@3.0.5)':
     dependencies:
       '@jest/console': 27.5.1
       '@jest/reporters': 27.5.1
@@ -16213,13 +16213,13 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 27.5.1
-      jest-config: 27.5.1(form-data@3.0.4)
+      jest-config: 27.5.1(form-data@3.0.5)
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
       jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1(form-data@3.0.4)
+      jest-runner: 27.5.1(form-data@3.0.5)
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
@@ -16237,7 +16237,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@jest/core@27.5.1(form-data@4.0.4)':
+  '@jest/core@27.5.1(form-data@4.0.6)':
     dependencies:
       '@jest/console': 27.5.1
       '@jest/reporters': 27.5.1
@@ -16251,13 +16251,13 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 27.5.1
-      jest-config: 27.5.1(form-data@4.0.4)
+      jest-config: 27.5.1(form-data@4.0.6)
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
       jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1(form-data@4.0.4)
+      jest-runner: 27.5.1(form-data@4.0.6)
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
@@ -19551,7 +19551,7 @@ snapshots:
       '@vue/compiler-sfc': 3.5.16
       vue: 3.5.35(typescript@4.9.5)
 
-  '@vue/vue3-jest@27.0.0-alpha.4(@babel/core@7.29.7)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.4))(ts-jest@27.1.5(@babel/core@7.29.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.4))(typescript@4.9.5))(typescript@4.9.5)(vue@3.5.35(typescript@4.9.5))':
+  '@vue/vue3-jest@27.0.0-alpha.4(@babel/core@7.29.7)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.5))(ts-jest@27.1.5(@babel/core@7.29.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.5))(typescript@4.9.5))(typescript@4.9.5)(vue@3.5.35(typescript@4.9.5))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
@@ -19559,12 +19559,12 @@ snapshots:
       chalk: 2.4.2
       convert-source-map: 1.9.0
       extract-from-css: 0.4.4
-      jest: 27.5.1(form-data@3.0.4)
+      jest: 27.5.1(form-data@3.0.5)
       source-map: 0.5.6
       tsconfig: 7.0.0
       vue: 3.5.35(typescript@4.9.5)
     optionalDependencies:
-      ts-jest: 27.1.5(@babel/core@7.29.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.4))(typescript@4.9.5)
+      ts-jest: 27.1.5(@babel/core@7.29.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.5))(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
@@ -22096,7 +22096,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@3.0.4:
+  form-data@3.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -22104,7 +22104,7 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
-  form-data@4.0.4:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -22297,9 +22297,9 @@ snapshots:
       minipass: 4.2.8
       path-scurry: 1.11.1
 
-  global-jsdom@24.0.0(jsdom@24.0.0(form-data@4.0.4)):
+  global-jsdom@24.0.0(jsdom@24.0.0(form-data@4.0.6)):
     dependencies:
-      jsdom: 24.0.0(form-data@4.0.4)
+      jsdom: 24.0.0(form-data@4.0.6)
 
   global-modules@2.0.0:
     dependencies:
@@ -23262,16 +23262,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@27.5.1(form-data@3.0.4):
+  jest-cli@27.5.1(form-data@3.0.5):
     dependencies:
-      '@jest/core': 27.5.1(form-data@3.0.4)
+      '@jest/core': 27.5.1(form-data@3.0.5)
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.2.0
-      jest-config: 27.5.1(form-data@3.0.4)
+      jest-config: 27.5.1(form-data@3.0.5)
       jest-util: 27.5.1
       jest-validate: 27.5.1
       prompts: 2.4.2
@@ -23284,16 +23284,16 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-cli@27.5.1(form-data@4.0.4):
+  jest-cli@27.5.1(form-data@4.0.6):
     dependencies:
-      '@jest/core': 27.5.1(form-data@4.0.4)
+      '@jest/core': 27.5.1(form-data@4.0.6)
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.2.0
-      jest-config: 27.5.1(form-data@4.0.4)
+      jest-config: 27.5.1(form-data@4.0.6)
       jest-util: 27.5.1
       jest-validate: 27.5.1
       prompts: 2.4.2
@@ -23325,7 +23325,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@27.5.1(form-data@3.0.4):
+  jest-config@27.5.1(form-data@3.0.5):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 27.5.1
@@ -23337,13 +23337,13 @@ snapshots:
       glob: 7.2.3
       graceful-fs: 4.2.11
       jest-circus: 27.5.1
-      jest-environment-jsdom: 27.5.1(form-data@3.0.4)
+      jest-environment-jsdom: 27.5.1(form-data@3.0.5)
       jest-environment-node: 27.5.1
       jest-get-type: 27.5.1
       jest-jasmine2: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1(form-data@3.0.4)
+      jest-runner: 27.5.1(form-data@3.0.5)
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.8
@@ -23358,7 +23358,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-config@27.5.1(form-data@4.0.4):
+  jest-config@27.5.1(form-data@4.0.6):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 27.5.1
@@ -23370,13 +23370,13 @@ snapshots:
       glob: 7.2.3
       graceful-fs: 4.2.11
       jest-circus: 27.5.1
-      jest-environment-jsdom: 27.5.1(form-data@4.0.4)
+      jest-environment-jsdom: 27.5.1(form-data@4.0.6)
       jest-environment-node: 27.5.1
       jest-get-type: 27.5.1
       jest-jasmine2: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1(form-data@4.0.4)
+      jest-runner: 27.5.1(form-data@4.0.6)
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.8
@@ -23459,7 +23459,7 @@ snapshots:
       jest-util: 29.7.0
       pretty-format: 29.7.0
 
-  jest-environment-jsdom@27.5.1(form-data@3.0.4):
+  jest-environment-jsdom@27.5.1(form-data@3.0.5):
     dependencies:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
@@ -23467,7 +23467,7 @@ snapshots:
       '@types/node': 22.19.20
       jest-mock: 27.5.1
       jest-util: 27.5.1
-      jsdom: 16.7.0(form-data@3.0.4)
+      jsdom: 16.7.0(form-data@3.0.5)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -23475,7 +23475,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-environment-jsdom@27.5.1(form-data@4.0.4):
+  jest-environment-jsdom@27.5.1(form-data@4.0.6):
     dependencies:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
@@ -23483,7 +23483,7 @@ snapshots:
       '@types/node': 22.19.20
       jest-mock: 27.5.1
       jest-util: 27.5.1
-      jsdom: 16.7.0(form-data@4.0.4)
+      jsdom: 16.7.0(form-data@4.0.6)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -23491,7 +23491,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-environment-jsdom@29.5.0(form-data@4.0.4):
+  jest-environment-jsdom@29.5.0(form-data@4.0.6):
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
@@ -23500,14 +23500,14 @@ snapshots:
       '@types/node': 20.19.42
       jest-mock: 29.7.0
       jest-util: 29.7.0
-      jsdom: 20.0.3(form-data@4.0.4)
+      jsdom: 20.0.3(form-data@4.0.6)
     transitivePeerDependencies:
       - bufferutil
       - form-data
       - supports-color
       - utf-8-validate
 
-  jest-environment-jsdom@29.7.0(form-data@4.0.4):
+  jest-environment-jsdom@29.7.0(form-data@4.0.6):
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
@@ -23516,7 +23516,7 @@ snapshots:
       '@types/node': 20.19.42
       jest-mock: 29.7.0
       jest-util: 29.7.0
-      jsdom: 20.0.3(form-data@4.0.4)
+      jsdom: 20.0.3(form-data@4.0.6)
     transitivePeerDependencies:
       - bufferutil
       - form-data
@@ -23667,7 +23667,7 @@ snapshots:
     optionalDependencies:
       jest-resolve: 29.7.0
 
-  jest-preset-angular@14.6.2(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser-dynamic@19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.25)(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))))(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(form-data@4.0.4)(jest@29.5.0(@types/node@20.19.42))(jsdom@24.0.0(form-data@4.0.4))(typescript@5.8.3):
+  jest-preset-angular@14.6.2(@angular/compiler-cli@19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser-dynamic@19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.25)(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))))(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(form-data@4.0.6)(jest@29.5.0(@types/node@20.19.42))(jsdom@24.0.0(form-data@4.0.6))(typescript@5.8.3):
     dependencies:
       '@angular/compiler-cli': 19.2.25(@angular/compiler@19.2.25)(typescript@5.8.3)
       '@angular/core': 19.2.25(rxjs@7.8.2)(zone.js@0.15.1)
@@ -23675,14 +23675,14 @@ snapshots:
       bs-logger: 0.2.6
       esbuild-wasm: 0.28.0
       jest: 29.5.0(@types/node@20.19.42)
-      jest-environment-jsdom: 29.7.0(form-data@4.0.4)
+      jest-environment-jsdom: 29.7.0(form-data@4.0.6)
       jest-util: 29.7.0
       pretty-format: 29.7.0
       ts-jest: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.28.0)(jest-util@29.7.0)(jest@29.5.0(@types/node@20.19.42))(typescript@5.8.3)
       typescript: 5.8.3
     optionalDependencies:
       esbuild: 0.28.0
-      jsdom: 24.0.0(form-data@4.0.4)
+      jsdom: 24.0.0(form-data@4.0.6)
     transitivePeerDependencies:
       - '@babel/core'
       - '@jest/transform'
@@ -23738,7 +23738,7 @@ snapshots:
       resolve.exports: 2.0.3
       slash: 3.0.0
 
-  jest-runner@27.5.1(form-data@3.0.4):
+  jest-runner@27.5.1(form-data@3.0.5):
     dependencies:
       '@jest/console': 27.5.1
       '@jest/environment': 27.5.1
@@ -23750,7 +23750,7 @@ snapshots:
       emittery: 0.8.1
       graceful-fs: 4.2.11
       jest-docblock: 27.5.1
-      jest-environment-jsdom: 27.5.1(form-data@3.0.4)
+      jest-environment-jsdom: 27.5.1(form-data@3.0.5)
       jest-environment-node: 27.5.1
       jest-haste-map: 27.5.1
       jest-leak-detector: 27.5.1
@@ -23768,7 +23768,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-runner@27.5.1(form-data@4.0.4):
+  jest-runner@27.5.1(form-data@4.0.6):
     dependencies:
       '@jest/console': 27.5.1
       '@jest/environment': 27.5.1
@@ -23780,7 +23780,7 @@ snapshots:
       emittery: 0.8.1
       graceful-fs: 4.2.11
       jest-docblock: 27.5.1
-      jest-environment-jsdom: 27.5.1(form-data@4.0.4)
+      jest-environment-jsdom: 27.5.1(form-data@4.0.6)
       jest-environment-node: 27.5.1
       jest-haste-map: 27.5.1
       jest-leak-detector: 27.5.1
@@ -24005,11 +24005,11 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@27.5.1(form-data@3.0.4):
+  jest@27.5.1(form-data@3.0.5):
     dependencies:
-      '@jest/core': 27.5.1(form-data@3.0.4)
+      '@jest/core': 27.5.1(form-data@3.0.5)
       import-local: 3.2.0
-      jest-cli: 27.5.1(form-data@3.0.4)
+      jest-cli: 27.5.1(form-data@3.0.5)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -24018,11 +24018,11 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest@27.5.1(form-data@4.0.4):
+  jest@27.5.1(form-data@4.0.6):
     dependencies:
-      '@jest/core': 27.5.1(form-data@4.0.4)
+      '@jest/core': 27.5.1(form-data@4.0.6)
       import-local: 3.2.0
-      jest-cli: 27.5.1(form-data@4.0.4)
+      jest-cli: 27.5.1(form-data@4.0.6)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -24116,7 +24116,7 @@ snapshots:
       strip-json-comments: 3.1.1
       underscore: 1.13.8
 
-  jsdom@16.7.0(form-data@3.0.4):
+  jsdom@16.7.0(form-data@3.0.5):
     dependencies:
       abab: 2.0.6
       acorn: 8.16.0
@@ -24127,7 +24127,7 @@ snapshots:
       decimal.js: 10.6.0
       domexception: 2.0.1
       escodegen: 2.1.0
-      form-data: 3.0.4
+      form-data: 3.0.5
       html-encoding-sniffer: 2.0.1
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -24150,7 +24150,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsdom@16.7.0(form-data@4.0.4):
+  jsdom@16.7.0(form-data@4.0.6):
     dependencies:
       abab: 2.0.6
       acorn: 8.16.0
@@ -24161,7 +24161,7 @@ snapshots:
       decimal.js: 10.6.0
       domexception: 2.0.1
       escodegen: 2.1.0
-      form-data: 4.0.4
+      form-data: 4.0.6
       html-encoding-sniffer: 2.0.1
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -24184,7 +24184,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsdom@20.0.3(form-data@4.0.4):
+  jsdom@20.0.3(form-data@4.0.6):
     dependencies:
       abab: 2.0.6
       acorn: 8.16.0
@@ -24195,7 +24195,7 @@ snapshots:
       decimal.js: 10.6.0
       domexception: 4.0.0
       escodegen: 2.1.0
-      form-data: 4.0.4
+      form-data: 4.0.6
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
@@ -24217,12 +24217,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsdom@24.0.0(form-data@4.0.4):
+  jsdom@24.0.0(form-data@4.0.6):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
-      form-data: 4.0.4
+      form-data: 4.0.6
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -27904,11 +27904,11 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  ts-jest@27.1.5(@babel/core@7.29.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.4))(typescript@4.9.5):
+  ts-jest@27.1.5(@babel/core@7.29.7)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.29.7))(jest@27.5.1(form-data@3.0.5))(typescript@4.9.5):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1(form-data@3.0.4)
+      jest: 27.5.1(form-data@3.0.5)
       jest-util: 27.5.1
       json5: 2.2.3
       lodash.memoize: 4.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,10 +49,10 @@ packageExtensions:
       'zone.js': '*'
   'jsdom@16':
     peerDependencies:
-      'form-data': '3.0.4'
+      'form-data': '3.0.5'
   'jsdom@24':
     peerDependencies:
-      'form-data': '4.0.4'
+      'form-data': '4.0.6'
   'jsdom@20':
     peerDependencies:
-      'form-data': '4.0.4'
+      'form-data': '4.0.6'


### PR DESCRIPTION
### Context

The PR patches the two remaining `form-data` copies in `pnpm-lock.yaml`, both flagged by Dependabot under CVE-2026-12143 (High): alert 5242 (`form-data@3.0.4`, patched in 3.0.5) and alert 5243 (`form-data@4.0.4`, patched in 4.0.6).

Both copies arrive through the jsdom test environments, not through anything we declare directly:

- `form-data@3.0.4` <- `jsdom@16.7.0` <- `jest-environment-jsdom@27.5.1`
- `form-data@4.0.4` <- `jsdom@16.7.0` / `20.0.3` / `24.0.0` <- `jest-environment-jsdom@27.5.1` / `29.5.0` / `29.7.0`, `global-jsdom@24.0.0`, `jest-preset-angular`

This is build/CI tooling only. `handsontable/package.json` declares no runtime dependencies, so the published package is unaffected and no customer advisory applies.

**No `pnpm.overrides` entry was added.** `jsdom` declares `form-data` as an ordinary dependency with ranges `^3.0.0` / `^4.0.0`, which the patched versions already satisfy. What actually held resolution at 3.0.4/4.0.4 was the exact-version `packageExtensions` pin in `pnpm-workspace.yaml`, added by a9260cccd (#11798) for the previous form-data advisory. This PR bumps those three pins to the patched versions, which is in-kind maintenance of a mechanism the repo already keeps for this exact dependency.

The lockfile diff is symmetric (85 insertions, 85 deletions). Beyond the two `form-data` entries, their integrity hashes and the `packageExtensionsChecksum`, every remaining change is a mechanical version string inside a pnpm peer-suffix key such as `jsdom@16.7.0(form-data@3.0.4)`. No other package's resolved version changed, and there are no downgrades.

### How has this been tested?

`form-data` sits underneath the test runners, so an install alone is not sufficient proof. All four Jest suites that use a jsdom environment were run in full:

```bash
npm --prefix handsontable run build
npm --prefix handsontable run test:unit            # 325 suites, 3963 tests passed
npm --prefix wrappers/react-wrapper run test       # 16 suites, 78 tests passed
npm --prefix wrappers/vue3 run test                # 4 suites, 33 tests passed
npm --prefix wrappers/angular-wrapper run test     # 13 suites, 291 tests passed
```

Verification of the lockfile itself:

```bash
grep -n "^  form-data@" pnpm-lock.yaml                        # only 3.0.5 and 4.0.6
grep -c "form-data@3.0.4\|form-data@4.0.4" pnpm-lock.yaml     # 0
pnpm audit --audit-level=high                                 # no form-data finding
```

Lint was not run: this PR changes only `pnpm-lock.yaml` and `pnpm-workspace.yaml`, with no source files touched.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2649
2. DEV-2608 (parent)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

No package source is changed. The diff is confined to the workspace lockfile and `pnpm-workspace.yaml`.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

[skip changelog] — development dependencies only, no user-facing change.

### Noted for follow-up, not addressed here

The `jsdom@16` pin causes `jsdom@16.7.0`, which declares `form-data: ^3.0.0`, to also resolve against form-data 4.x through other consumers. pnpm reports `unmet peer form-data@3.0.5: found 4.0.6` under `jest@27.5.1 > jest-config > jest-environment-jsdom@27.5.1 > jsdom@16.7.0`, and the store holds both variants. This predates the PR (it dates to a9260cccd) and its severity is unchanged by it.

ClickUp task: https://app.clickup.com/t/86cba9ftw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and workspace pin updates for a transitive test dependency only; no application source or published package runtime deps change.
> 
> **Overview**
> Addresses **CVE-2026-12143** (Dependabot) by bumping the existing `packageExtensions` pins for `jsdom@16`, `jsdom@20`, and `jsdom@24` in `pnpm-workspace.yaml` from `form-data@3.0.4` / `4.0.4` to **3.0.5** / **4.0.6**, and regenerating `pnpm-lock.yaml` so every jsdom/Jest-related resolution reflects those versions.
> 
> **No new overrides** — this continues the same pinning approach used for the prior form-data advisory. The lockfile changes are mostly peer-suffix string updates; resolved versions for other packages are unchanged.
> 
> Scope is **dev/test only** (`jest-environment-jsdom`, `global-jsdom`, `jest-preset-angular`); published `handsontable` has no runtime dependency on `form-data`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34a96718ac7740d809ef3cf4d4b59fd241536fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->