### PR TITLE
PRO-493, PRO-499, PRO-582: Document stretching, dialog blocking, and listen()

### DIFF
--- a/docs/content/guides/cell-features/read-only-cells/read-only-cells.md
+++ b/docs/content/guides/cell-features/read-only-cells/read-only-cells.md
@@ -324,6 +324,10 @@ To make specific cells non-editable, set `editor: false` in the cell configurati
 
 :::
 
+## Block the entire grid
+
+The [`readOnly`](@/api/options.md#readonly) and [`editor`](@/api/options.md#editor) options control editing, but users can still navigate and select cells. To block all interaction with the grid temporarily -- for example, during a loading state or a blocking workflow step -- use the [Dialog](@/guides/dialog/dialog/dialog.md) plugin. An open dialog overlays the grid and moves keyboard input into its own [focus scope](@/guides/navigation/focus-scopes/focus-scopes.md), so users can't reach the cells until the dialog closes. The grid regains focus automatically.
+
 ## Accessibility
 
 When [`ariaTags`](@/api/options.md#ariatags) is enabled (the default), Handsontable adds `aria-readonly="true"` to the DOM element of every read-only cell, so screen readers announce that the cell can't be edited. Non-editable cells (`editor: false`) don't get this attribute, because Handsontable doesn't treat them as read-only in the data model -- only their editor is disabled.

--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -441,6 +441,12 @@ If you don't define any dimensions, Handsontable generates as many rows and colu
 
 If your grid's contents don't fit in the viewport, the browser's native scrollbars are used for scrolling. For this to work properly, Handsontable's [layout direction](@/guides/internationalization/layout-direction/layout-direction.md) (e.g., [`layoutDirection: 'rtl'`](@/api/options.md#layoutdirection)) must be the same as your HTML document's layout direction (`<html dir='rtl'>`). Otherwise, horizontal scrolling doesn't work.
 
+## Stretch columns to fit the grid width
+
+Setting the grid's width doesn't change the width of your columns. When the columns are narrower than the grid, the space on the right stays empty. To redistribute the column widths so they fill the grid's width, use the [`stretchH`](@/api/options.md#stretchh) option: `'all'` stretches all columns proportionally, and `'last'` stretches only the last column.
+
+For live examples of both modes, see the [column stretching](@/guides/columns/column-width/column-width.md#column-stretching) section of the Column width guide.
+
 ## Autoresizing
 
 Handsontable observes window resizing. If the window's dimensions have changed, then we check if Handsontable should resize itself too. Due to the performance issue, we use the debounce method to respond on window resize.

--- a/docs/content/guides/navigation/focus-scopes/focus-scopes.md
+++ b/docs/content/guides/navigation/focus-scopes/focus-scopes.md
@@ -21,6 +21,7 @@ vue:
   metaTitle: Focus scopes - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation
+menuTag: updated
 ---
 Use focus scopes to create isolated focus boundaries within a Handsontable instance and control which keyboard shortcuts are active for each part of the UI. Focus scopes come in two types: `inline` (default) allows natural DOM tab order, and `modal` blocks focus outside the scope -- useful for dialogs and overlays.
 
@@ -363,6 +364,36 @@ The focus scope manager automatically:
 - Updates the [`Core#isListening`](@/api/core.md#islistening) state based on scope activity
 - Switches the shortcuts context to the scope's specified context name when the scope is activated
 - Handles tab navigation between scopes
+
+## Keyboard listening state
+
+Only one Handsontable instance at a time listens to keyboard input on the document. When a grid is not listening, it ignores keyboard events -- navigation and shortcuts stop working until the grid becomes active again. You can check the current state with [`isListening()`](@/api/core.md#islistening).
+
+When the user clicks or tabs to an element outside the table -- an external input, a button, or a custom panel -- the grid stops listening automatically. This is the most common cause of keyboard navigation issues in applications that combine Handsontable with external UI elements.
+
+To hand keyboard input back to the grid without forcing the user to click a cell, call [`listen()`](@/api/core.md#listen):
+
+```js
+// return keyboard input to the grid
+// after the user interacts with an external element
+hot.listen();
+```
+
+Calling `listen()` also deactivates listening on every other Handsontable instance on the page, so on multi-grid pages exactly one grid receives keyboard input. To make the grid ignore keyboard input explicitly, call [`unlisten()`](@/api/core.md#unlisten).
+
+::: only-for react
+
+::: tip
+
+To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
+
+For more information, see the [Instance methods](@/guides/getting-started/react-methods/react-methods.md) page.
+
+:::
+
+:::
+
+For UI elements registered as [focus scopes](#register-a-focus-scope), you don't need to call these methods -- the focus scope manager updates the listening state automatically as scopes activate and deactivate.
 
 ## Result
 


### PR DESCRIPTION
### Context

The PR fills three small, long-standing gaps from the Documentation improvements backlog. All three are prose-level additions to existing guides -- no new pages, no new examples, no sidebar changes.

**PRO-493 -- Grid size guide never mentions column stretching.** Setting the grid's width doesn't change column widths, and the guide didn't say what to do about the empty space that leaves. Added a short "Stretch columns to fit the grid width" section introducing `stretchH` (`'all'` / `'last'`) and linking to the [column stretching](https://handsontable.com/docs/javascript-data-grid/column-width/#column-stretching) section of the Column width guide, which already has live examples of both modes.

**PRO-499 -- Read-only cells guide should mention the Dialog plugin.** The guide covers `readOnly` and `editor: false` but not how to block interaction with the whole grid. Added a "Block the entire grid" section pointing to the Dialog plugin. The wording follows the plugin's actual mechanism (verified in `handsontable/src/plugins/dialog/dialog.ts`): an open dialog overlays the grid and activates its own focus scope, and the grid regains focus when it closes. (The ticket references the old `/disabled-cells` URL -- the guide was renamed to Read-only cells in DEV-760, and the gap survived the DEV-640 content-gap pass.)

**PRO-582 -- `listen()` is not documented in any guide.** The method existed only in the API reference, which has caused recurring focus/interaction confusion in applications that combine Handsontable with external UI elements (reported twice by SAP teams). Added a "Keyboard listening state" section to the Focus scopes guide covering:

- the single-listener model (one instance listens to document keyboard input at a time, checked with `isListening()`),
- the automatic loss of listening when focus moves to elements outside the table -- the usual cause of "keyboard navigation stopped working",
- when to call `listen()` / `unlisten()` manually, including the multi-grid implication (`listen()` deactivates every other instance),
- that elements registered as focus scopes need none of this -- the focus scope manager updates the listening state automatically.

`[skip changelog]` -- docs content only.

### How has this been tested?

- Rendered all three pages on the local docs dev server and verified: the new sections render in every framework variant, all internal links resolve (including the `#column-stretching` anchor on the column-width page), the code snippet renders with highlighting, and the React-only instance-access tip appears only on the React pages.
- `npm run docs:test:plugins` -- 250/250 passing.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. PRO-493
2. PRO-499
3. PRO-582

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Documentation content only -- `docs/content/guides/`.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp tasks:
- https://app.clickup.com/t/86c7ag9je (PRO-493)
- https://app.clickup.com/t/86c7akhjn (PRO-499)
- https://app.clickup.com/t/86c7hppz7 (PRO-582)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to guide markdown; no runtime or API behavior changes.
> 
> **Overview**
> Adds three short sections to existing guides (no new pages or examples), closing backlog gaps **PRO-493**, **PRO-499**, and **PRO-582**.
> 
> The **Grid size** guide now explains that setting grid width does not widen columns and introduces **`stretchH`** (`'all'` / `'last'`), with a link to the Column width guide’s column-stretching examples.
> 
> The **Read-only cells** guide adds **Block the entire grid**, describing how the **Dialog** plugin temporarily blocks cell interaction by overlaying the grid and routing keyboard input into a modal **focus scope** until the dialog closes.
> 
> The **Focus scopes** guide adds **Keyboard listening state** (and marks the page **updated** in the menu): one instance listens to document keyboard input at a time (`**isListening()**`), focus outside the grid stops listening, and **`listen()`** / **`unlisten()`** restore or suppress input—including deactivating other grids on multi-instance pages—with a React-only instance-access tip and a note that registered focus scopes handle this automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6173c7b732ef2873c11e822e306f303fd0a8c849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->