### PR TITLE
PRO-1316: Fix British spelling of license in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Thank you for your contribution!
 
 ## Contributor License Agreement
 
-Handsoncode publishes the code it merges — in open-source releases and in commercial products. Doing that requires the right to use, relicense, and distribute your contribution, and the Contributor License Agreement (CLA) is the record of that permission. You keep the copyright to your work; the CLA grants Handsoncode a licence to it.
+Handsoncode publishes the code it merges — in open-source releases and in commercial products. Doing that requires the right to use, relicense, and distribute your contribution, and the Contributor License Agreement (CLA) is the record of that permission. You keep the copyright to your work; the CLA grants Handsoncode a license to it.
 
 **Sign it once, for every project.** The signature is recorded against your GitHub account, not against a repository, and covers both [Handsontable](https://github.com/handsontable/handsontable) and [HyperFormula](https://github.com/handsontable/hyperformula). If you have already signed for either one, you are done.
 


### PR DESCRIPTION
### Context

The PR fixes one word in `CONTRIBUTING.md`: the CLA section added in #13175 uses "licence" (British spelling), and the documentation standard is American English. Flagged in a post-merge review comment: https://github.com/handsontable/handsontable/pull/13175#discussion_r3756771342

Verified repo-wide that this is the only occurrence -- `relicense` and every other use of the word are already American.

`[skip changelog]` -- repository docs only.

### How has this been tested?

- `grep -ri '\blicenc'` across the repository confirms no remaining British spellings.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. PRO-1316 (follow-up to PRO-1312 / #13175)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Repository documentation only -- `CONTRIBUTING.md`.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86cbaf3g1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-word documentation fix with no effect on code, builds, or contributor workflow beyond spelling consistency.
> 
> **Overview**
> Aligns **CONTRIBUTING.md** with the repo’s American English docs standard by changing **licence** → **license** in the Contributor License Agreement paragraph (the CLA grants Handsoncode a license to your work).
> 
> Follow-up to the CLA wording added in #13175; no runtime or API impact. Changelog skipped for docs-only change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcaaef6bfc358e17f9bd4878ee7d92c9a49b7f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->