### PR TITLE
DEV-2654: Keep the space between alignment class names (#7122)

### DIFF
--- a/.changelogs/13266.json
+++ b/.changelogs/13266.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the cell's class names losing the space between them after changing the alignment twice, which silently dropped custom classes and the alignment itself.",
+  "type": "fixed",
+  "issueOrPR": 13266,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13266.json
+++ b/.changelogs/13266.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed the cell's class names losing the space between them after changing the alignment twice, which silently dropped custom classes and the alignment itself.",
+  "title": "Fixed the alignment options dropping the cell's other class names, and undoing an alignment leaving the cell aligned left.",
   "type": "fixed",
   "issueOrPR": 13266,
   "breaking": false,

--- a/handsontable/src/plugins/contextMenu/AGENTS.md
+++ b/handsontable/src/plugins/contextMenu/AGENTS.md
@@ -13,6 +13,14 @@
 | **Scope** | Cells and headers across rows and columns | Column-specific operations only |
 | **Hook prefix** | `beforeContextMenu*`, `afterContextMenu*` | `beforeDropdownMenu*`, `afterDropdownMenu*` |
 
+## `className` is `string | string[]` — never do string surgery on it
+
+The `className` cell meta accepts a space-separated string **or** an array (both are documented in `metaSchema`). Always normalize it with `normalizeClassNames()` from `handsontable/src/helpers/dom/element.ts` and then work on whole tokens.
+
+Two shipped bugs came from ignoring this. Both `.replace()`-based: #7427 (an array `className` threw on `.split`) and #7122, where `utils.ts` removed an alignment token with `.replace('htRight', '')` and then "tidied up" with `.replace('  ', '')`. That deleted the double space instead of collapsing it, so the two surviving class names were glued into one (`class_namehtMiddle`) and both stopped matching. The same substring matching also chopped custom classes that merely contained an alignment name (`htTopBar` → `Bar`).
+
+Match alignment classes by exact token (`classNames.includes('htRight')`), as `exportFile/types/xlsx/cell-style.ts` already does — never `indexOf`/`includes` on the raw string.
+
 ## Where to look next
 
 - DropdownMenu specifics: `handsontable/src/plugins/dropdownMenu/AGENTS.md`.

--- a/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/alignment.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/alignment.spec.js
@@ -442,6 +442,78 @@ describe('ContextMenu', () => {
       expect(alignmentClass).toBe('htRight');
     });
 
+    it('should keep the space between the class names when the alignment is picked again (#7122)', async() => {
+      handsontable({
+        data: createSpreadsheetData(4, 4),
+        contextMenu: true,
+        height: 100,
+        cell: [
+          { row: 0, col: 0, className: 'class_name' },
+        ],
+      });
+
+      await selectCell(0, 0);
+      await contextMenu();
+      await selectContextSubmenuOption('Alignment', 'Right');
+
+      await selectCell(0, 0);
+      await contextMenu();
+      await selectContextSubmenuOption('Alignment', 'Middle');
+
+      expect(getCellMeta(0, 0).className).toEqual('class_name htRight htMiddle');
+
+      // Picking a second horizontal alignment used to cut `htRight` out of the middle of the string
+      // and glue its neighbours together, producing 'class_namehtMiddle htJustify'. That silently
+      // dropped both the custom class and the vertical alignment.
+      await selectCell(0, 0);
+      await contextMenu();
+      await selectContextSubmenuOption('Alignment', 'Justify');
+
+      expect(getCellMeta(0, 0).className).toEqual('class_name htMiddle htJustify');
+      expect(getCell(0, 0).classList.contains('class_name')).toBe(true);
+      expect(getCell(0, 0).classList.contains('htMiddle')).toBe(true);
+      expect(getCell(0, 0).classList.contains('htJustify')).toBe(true);
+    });
+
+    it('should keep a custom class that contains an alignment class name (#7122)', async() => {
+      handsontable({
+        data: createSpreadsheetData(4, 4),
+        contextMenu: true,
+        height: 100,
+        cell: [
+          { row: 0, col: 0, className: 'htTopBar' },
+        ],
+      });
+
+      await selectCell(0, 0);
+      await contextMenu();
+      await selectContextSubmenuOption('Alignment', 'Bottom');
+
+      // `htTopBar` used to be chopped down to `Bar`, and the alignment was not applied at all.
+      expect(getCellMeta(0, 0).className).toEqual('htTopBar htBottom');
+      expect(getCell(0, 0).classList.contains('htTopBar')).toBe(true);
+      expect(getCell(0, 0).classList.contains('htBottom')).toBe(true);
+    });
+
+    it('should accept an array `className`, as the documented settings allow (#7122)', async() => {
+      handsontable({
+        data: createSpreadsheetData(4, 4),
+        contextMenu: true,
+        height: 100,
+        cell: [
+          { row: 0, col: 0, className: ['class_name', 'htLeft'] },
+        ],
+      });
+
+      await selectCell(0, 0);
+      await contextMenu();
+      await selectContextSubmenuOption('Alignment', 'Right');
+
+      expect(getCellMeta(0, 0).className).toEqual('class_name htRight');
+      expect(getCell(0, 0).classList.contains('class_name')).toBe(true);
+      expect(getCell(0, 0).classList.contains('htRight')).toBe(true);
+    });
+
     describe('UI', () => {
       it('should display a disabled entry, when there\'s nothing selected', async() => {
         handsontable({

--- a/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/alignment.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/alignment.spec.js
@@ -463,7 +463,7 @@ describe('ContextMenu', () => {
       expect(getCellMeta(0, 0).className).toEqual('class_name htRight htMiddle');
 
       // Picking a second horizontal alignment used to cut `htRight` out of the middle of the string
-      // and glue its neighbours together, producing 'class_namehtMiddle htJustify'. That silently
+      // and glue its neighbors together, producing 'class_namehtMiddle htJustify'. That silently
       // dropped both the custom class and the vertical alignment.
       await selectCell(0, 0);
       await contextMenu();

--- a/handsontable/src/plugins/contextMenu/__tests__/utils.unit.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/utils.unit.js
@@ -1,5 +1,6 @@
 import {
   getAlignmentClasses,
+  getAlignmentComparatorByClass,
   prepareHorizontalAlignClass,
   prepareVerticalAlignClass,
 } from 'handsontable/plugins/contextMenu/utils';
@@ -67,6 +68,11 @@ describe('contextMenu/utils', () => {
       expect(prepareHorizontalAlignClass('htLeftPanel', 'htRight')).toBe('htLeftPanel htRight');
     });
 
+    it('should drop a competing horizontal alignment even when the picked one is already there', () => {
+      expect(prepareHorizontalAlignClass('htLeft htCenter', 'htCenter')).toBe('htCenter');
+      expect(prepareHorizontalAlignClass('class_name htLeft htRight', 'htRight')).toBe('class_name htRight');
+    });
+
     it('should accept an array `className`, as the documented settings allow (#7122)', () => {
       expect(prepareHorizontalAlignClass(['class_name', 'htLeft'], 'htRight')).toBe('class_name htRight');
     });
@@ -93,6 +99,11 @@ describe('contextMenu/utils', () => {
 
     it('should keep a custom class that merely contains an alignment class name (#7122)', () => {
       expect(prepareVerticalAlignClass('htTopBar', 'htBottom')).toBe('htTopBar htBottom');
+    });
+
+    it('should drop a competing vertical alignment even when the picked one is already there', () => {
+      expect(prepareVerticalAlignClass('htTop htMiddle', 'htMiddle')).toBe('htMiddle');
+      expect(prepareVerticalAlignClass('class_name htTop htBottom', 'htBottom')).toBe('class_name htBottom');
     });
 
     it('should accept an array `className`, as the documented settings allow (#7122)', () => {
@@ -123,6 +134,16 @@ describe('contextMenu/utils', () => {
       expect(afterRight).toBe('class_name htMiddle htRight');
       // Used to return 'class_namehtRight htTop'.
       expect(afterTop).toBe('class_name htRight htTop');
+    });
+
+    it('should not report an alignment for a custom class that merely contains its name', () => {
+      const hotMock = className => ({ getCellMetaTransient: () => ({ className }) });
+
+      expect(getAlignmentComparatorByClass('htLeft').call(hotMock('htLeft'), 0, 0)).toBe(true);
+      expect(getAlignmentComparatorByClass('htLeft').call(hotMock(['htLeft']), 0, 0)).toBe(true);
+      expect(getAlignmentComparatorByClass('htLeft').call(hotMock('htLeftPanel'), 0, 0)).toBe(false);
+      expect(getAlignmentComparatorByClass('htTop').call(hotMock('htTopBar htBottom'), 0, 0)).toBe(false);
+      expect(getAlignmentComparatorByClass('htLeft').call(hotMock(undefined), 0, 0)).toBe(false);
     });
 
     it('should never emit doubled, leading or trailing spaces', () => {

--- a/handsontable/src/plugins/contextMenu/__tests__/utils.unit.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/utils.unit.js
@@ -1,4 +1,8 @@
-import { getAlignmentClasses } from 'handsontable/plugins/contextMenu/utils';
+import {
+  getAlignmentClasses,
+  prepareHorizontalAlignClass,
+  prepareVerticalAlignClass,
+} from 'handsontable/plugins/contextMenu/utils';
 
 function createRange(coords) {
   return {
@@ -36,6 +40,103 @@ describe('contextMenu/utils', () => {
       expect(Object.keys(classes)).toEqual(['0', '1']);
       expect(classes[0][0]).toBe('0:0');
       expect(classes[1][1]).toBe('1:1');
+    });
+  });
+
+  describe('prepareHorizontalAlignClass', () => {
+    it('should add the alignment class to a cell that has none', () => {
+      expect(prepareHorizontalAlignClass('', 'htLeft')).toBe('htLeft');
+      expect(prepareHorizontalAlignClass('class_name', 'htRight')).toBe('class_name htRight');
+    });
+
+    it('should replace the previous horizontal alignment and keep the other classes', () => {
+      expect(prepareHorizontalAlignClass('class_name htLeft', 'htRight')).toBe('class_name htRight');
+      expect(prepareHorizontalAlignClass('class_name htCenter htMiddle', 'htJustify'))
+        .toBe('class_name htMiddle htJustify');
+    });
+
+    it('should not touch the vertical alignment class', () => {
+      expect(prepareHorizontalAlignClass('htMiddle', 'htLeft')).toBe('htMiddle htLeft');
+    });
+
+    it('should be idempotent when the same alignment is applied twice', () => {
+      expect(prepareHorizontalAlignClass('class_name htRight', 'htRight')).toBe('class_name htRight');
+    });
+
+    it('should keep a custom class that merely contains an alignment class name (#7122)', () => {
+      expect(prepareHorizontalAlignClass('htLeftPanel', 'htRight')).toBe('htLeftPanel htRight');
+    });
+
+    it('should accept an array `className`, as the documented settings allow (#7122)', () => {
+      expect(prepareHorizontalAlignClass(['class_name', 'htLeft'], 'htRight')).toBe('class_name htRight');
+    });
+  });
+
+  describe('prepareVerticalAlignClass', () => {
+    it('should add the alignment class to a cell that has none', () => {
+      expect(prepareVerticalAlignClass('', 'htTop')).toBe('htTop');
+      expect(prepareVerticalAlignClass('class_name', 'htMiddle')).toBe('class_name htMiddle');
+    });
+
+    it('should replace the previous vertical alignment and keep the other classes', () => {
+      expect(prepareVerticalAlignClass('class_name htTop', 'htBottom')).toBe('class_name htBottom');
+      expect(prepareVerticalAlignClass('class_name htMiddle htRight', 'htTop')).toBe('class_name htRight htTop');
+    });
+
+    it('should not touch the horizontal alignment class', () => {
+      expect(prepareVerticalAlignClass('htRight', 'htTop')).toBe('htRight htTop');
+    });
+
+    it('should be idempotent when the same alignment is applied twice', () => {
+      expect(prepareVerticalAlignClass('class_name htTop', 'htTop')).toBe('class_name htTop');
+    });
+
+    it('should keep a custom class that merely contains an alignment class name (#7122)', () => {
+      expect(prepareVerticalAlignClass('htTopBar', 'htBottom')).toBe('htTopBar htBottom');
+    });
+
+    it('should accept an array `className`, as the documented settings allow (#7122)', () => {
+      expect(prepareVerticalAlignClass(['class_name', 'htTop'], 'htBottom')).toBe('class_name htBottom');
+    });
+  });
+
+  describe('alignment class names, issue #7122', () => {
+    it('should keep the space between the class names through the reported sequence', () => {
+      // Right -> Middle -> Justify, on a cell that already has a custom class.
+      const afterRight = prepareHorizontalAlignClass('class_name', 'htRight');
+      const afterMiddle = prepareVerticalAlignClass(afterRight, 'htMiddle');
+      const afterJustify = prepareHorizontalAlignClass(afterMiddle, 'htJustify');
+
+      expect(afterRight).toBe('class_name htRight');
+      expect(afterMiddle).toBe('class_name htRight htMiddle');
+      // Used to return 'class_namehtMiddle htJustify', losing both `class_name` and `htMiddle`.
+      expect(afterJustify).toBe('class_name htMiddle htJustify');
+    });
+
+    it('should keep the space between the class names through the mirrored sequence', () => {
+      // Middle -> Right -> Top, the same defect on the vertical helper.
+      const afterMiddle = prepareVerticalAlignClass('class_name', 'htMiddle');
+      const afterRight = prepareHorizontalAlignClass(afterMiddle, 'htRight');
+      const afterTop = prepareVerticalAlignClass(afterRight, 'htTop');
+
+      expect(afterMiddle).toBe('class_name htMiddle');
+      expect(afterRight).toBe('class_name htMiddle htRight');
+      // Used to return 'class_namehtRight htTop'.
+      expect(afterTop).toBe('class_name htRight htTop');
+    });
+
+    it('should never emit doubled, leading or trailing spaces', () => {
+      const results = [
+        prepareHorizontalAlignClass('htLeft', 'htRight'),
+        prepareHorizontalAlignClass('class_name htLeft', 'htRight'),
+        prepareVerticalAlignClass('htTop', 'htBottom'),
+        prepareVerticalAlignClass('class_name  htTop', 'htBottom'),
+      ];
+
+      results.forEach((result) => {
+        expect(result).not.toMatch(/ {2}/);
+        expect(result).toBe(result.trim());
+      });
     });
   });
 });

--- a/handsontable/src/plugins/contextMenu/__tests__/utils.unit.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/utils.unit.js
@@ -136,6 +136,12 @@ describe('contextMenu/utils', () => {
       expect(afterTop).toBe('class_name htRight htTop');
     });
 
+    it('should not emit the alignment twice when it is passed to the other axis helper', () => {
+      // Not reachable through `align()`, but both helpers are exported and called directly here.
+      expect(prepareVerticalAlignClass('htLeft', 'htLeft')).toBe('htLeft');
+      expect(prepareHorizontalAlignClass('class_name htTop', 'htTop')).toBe('class_name htTop');
+    });
+
     it('should not report an alignment for a custom class that merely contains its name', () => {
       const hotMock = className => ({ getCellMetaTransient: () => ({ className }) });
 

--- a/handsontable/src/plugins/contextMenu/utils.ts
+++ b/handsontable/src/plugins/contextMenu/utils.ts
@@ -30,7 +30,7 @@ function prepareAlignClass(
   axisClassNames: string[]
 ): string {
   const classNames = normalizeClassNames(className)
-    .filter(name => !axisClassNames.includes(name));
+    .filter(name => name !== alignment && !axisClassNames.includes(name));
 
   return [...classNames, alignment].join(' ');
 }

--- a/handsontable/src/plugins/contextMenu/utils.ts
+++ b/handsontable/src/plugins/contextMenu/utils.ts
@@ -12,40 +12,44 @@ const HORIZONTAL_ALIGNMENT_CLASS_NAMES = ['htLeft', 'htCenter', 'htRight', 'htJu
 /**
  * Swaps the alignment class of one axis, leaving every other class name untouched.
  *
- * The class name is compared token by token. Matching substrings is not enough - it both destroys
+ * The class name is compared token by token. Matching substrings is not enough – it both destroys
  * custom classes that merely contain an alignment name (`htTopBar`) and, once a token is cut out of
- * the middle of the string, glues its two neighbours together (#7122).
+ * the middle of the string, glues its two neighbors together (#7122).
  *
- * @param {string|string[]} className The full element class name to process.
+ * Every class name of the axis is dropped, including the one being applied. Returning early when the
+ * picked alignment is already there would leave a competing class name of the same axis in place.
+ *
+ * @param {string|string[]|undefined} className The full element class name to process.
  * @param {string} alignment The alignment class name to apply.
  * @param {string[]} axisClassNames The alignment class names of the axis being changed.
  * @returns {string}
  */
-function prepareAlignClass(className: string | string[], alignment: string, axisClassNames: string[]): string {
-  const classNames = normalizeClassNames(className);
+function prepareAlignClass(
+  className: string | string[] | undefined,
+  alignment: string,
+  axisClassNames: string[]
+): string {
+  const classNames = normalizeClassNames(className)
+    .filter(name => !axisClassNames.includes(name));
 
-  if (classNames.includes(alignment)) {
-    return classNames.join(' ');
-  }
-
-  return [...classNames.filter(name => !axisClassNames.includes(name)), alignment].join(' ');
+  return [...classNames, alignment].join(' ');
 }
 
 /**
- * @param {string|string[]} className The full element class name to process.
+ * @param {string|string[]|undefined} className The full element class name to process.
  * @param {string} alignment The alignment class name to compare with.
  * @returns {string}
  */
-export function prepareVerticalAlignClass(className: string | string[], alignment: string) {
+export function prepareVerticalAlignClass(className: string | string[] | undefined, alignment: string) {
   return prepareAlignClass(className, alignment, VERTICAL_ALIGNMENT_CLASS_NAMES);
 }
 
 /**
- * @param {string|string[]} className The full element class name to process.
+ * @param {string|string[]|undefined} className The full element class name to process.
  * @param {string} alignment The alignment class name to compare with.
  * @returns {string}
  */
-export function prepareHorizontalAlignClass(className: string | string[], alignment: string) {
+export function prepareHorizontalAlignClass(className: string | string[] | undefined, alignment: string) {
   return prepareAlignClass(className, alignment, HORIZONTAL_ALIGNMENT_CLASS_NAMES);
 }
 
@@ -113,16 +117,10 @@ function applyAlignClassName(
   cellDescriptor: (row: number, col: number) => Record<string, unknown>,
   propertySetter: (row: number, col: number, key: string, value: string) => void
 ) {
-  const cellMeta = cellDescriptor(row, col);
-  let className = alignment;
-
-  if (cellMeta.className) {
-    if (type === 'vertical') {
-      className = prepareVerticalAlignClass(cellMeta.className as string | string[], alignment);
-    } else {
-      className = prepareHorizontalAlignClass(cellMeta.className as string | string[], alignment);
-    }
-  }
+  const { className: currentClassName } = cellDescriptor(row, col) as { className?: string | string[] };
+  const className = type === 'vertical' ?
+    prepareVerticalAlignClass(currentClassName, alignment) :
+    prepareHorizontalAlignClass(currentClassName, alignment);
 
   propertySetter(row, col, 'className', className);
 }
@@ -196,6 +194,7 @@ export function getAlignmentComparatorByClass(htClassName: string) {
   return function(this: HotInstance, row: number, col: number): boolean {
     const className = this.getCellMetaTransient(row, col).className as string | string[] | undefined;
 
-    return Boolean(className && className.indexOf(htClassName) !== -1);
+    // Compared token by token. A substring match would report `htLeftPanel` as being aligned left.
+    return normalizeClassNames(className).includes(htClassName);
   };
 }

--- a/handsontable/src/plugins/contextMenu/utils.ts
+++ b/handsontable/src/plugins/contextMenu/utils.ts
@@ -1,46 +1,52 @@
 import type { HotInstance } from '../../core/types';
 import { arrayEach } from '../../helpers/array';
+import { normalizeClassNames } from '../../helpers/dom/element';
 
 interface CellRangeLike {
   forAll(callback: (row: number, col: number) => void | boolean): void;
 }
 
+const VERTICAL_ALIGNMENT_CLASS_NAMES = ['htTop', 'htMiddle', 'htBottom'];
+const HORIZONTAL_ALIGNMENT_CLASS_NAMES = ['htLeft', 'htCenter', 'htRight', 'htJustify'];
+
 /**
- * @param {string} className The full element class name to process.
- * @param {string} alignment The alignment class name to compare with.
+ * Swaps the alignment class of one axis, leaving every other class name untouched.
+ *
+ * The class name is compared token by token. Matching substrings is not enough - it both destroys
+ * custom classes that merely contain an alignment name (`htTopBar`) and, once a token is cut out of
+ * the middle of the string, glues its two neighbours together (#7122).
+ *
+ * @param {string|string[]} className The full element class name to process.
+ * @param {string} alignment The alignment class name to apply.
+ * @param {string[]} axisClassNames The alignment class names of the axis being changed.
  * @returns {string}
  */
-export function prepareVerticalAlignClass(className: string, alignment: string) {
-  if (className.indexOf(alignment) !== -1) {
-    return className;
+function prepareAlignClass(className: string | string[], alignment: string, axisClassNames: string[]): string {
+  const classNames = normalizeClassNames(className);
+
+  if (classNames.includes(alignment)) {
+    return classNames.join(' ');
   }
 
-  const replacedClassName = className
-    .replace('htTop', '')
-    .replace('htMiddle', '')
-    .replace('htBottom', '')
-    .replace('  ', '');
-
-  return `${replacedClassName} ${alignment}`;
+  return [...classNames.filter(name => !axisClassNames.includes(name)), alignment].join(' ');
 }
 
 /**
- * @param {string} className The full element class name to process.
+ * @param {string|string[]} className The full element class name to process.
  * @param {string} alignment The alignment class name to compare with.
  * @returns {string}
  */
-export function prepareHorizontalAlignClass(className: string, alignment: string) {
-  if (className.indexOf(alignment) !== -1) {
-    return className;
-  }
-  const replacedClassName = className
-    .replace('htLeft', '')
-    .replace('htCenter', '')
-    .replace('htRight', '')
-    .replace('htJustify', '')
-    .replace('  ', '');
+export function prepareVerticalAlignClass(className: string | string[], alignment: string) {
+  return prepareAlignClass(className, alignment, VERTICAL_ALIGNMENT_CLASS_NAMES);
+}
 
-  return `${replacedClassName} ${alignment}`;
+/**
+ * @param {string|string[]} className The full element class name to process.
+ * @param {string} alignment The alignment class name to compare with.
+ * @returns {string}
+ */
+export function prepareHorizontalAlignClass(className: string | string[], alignment: string) {
+  return prepareAlignClass(className, alignment, HORIZONTAL_ALIGNMENT_CLASS_NAMES);
 }
 
 /**
@@ -112,9 +118,9 @@ function applyAlignClassName(
 
   if (cellMeta.className) {
     if (type === 'vertical') {
-      className = prepareVerticalAlignClass(cellMeta.className as string, alignment);
+      className = prepareVerticalAlignClass(cellMeta.className as string | string[], alignment);
     } else {
-      className = prepareHorizontalAlignClass(cellMeta.className as string, alignment);
+      className = prepareHorizontalAlignClass(cellMeta.className as string | string[], alignment);
     }
   }
 

--- a/handsontable/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
@@ -820,67 +820,67 @@ describe('DropdownMenu', () => {
 
     let cellMeta = getCellMeta(0, 0);
 
-    expect(cellMeta.className.includes('htCenter')).toBeTruthy();
-    expect(cellMeta.className.includes('htMiddle')).toBeTruthy();
+    expect(cellMeta.className).toContain('htCenter');
+    expect(cellMeta.className).toContain('htMiddle');
 
     cellMeta = getCellMeta(0, 7);
-    expect(cellMeta.className.includes('htCenter')).toBeTruthy();
-    expect(cellMeta.className.includes('htBottom')).toBeTruthy();
+    expect(cellMeta.className).toContain('htCenter');
+    expect(cellMeta.className).toContain('htBottom');
 
     cellMeta = getCellMeta(5, 1);
-    expect(cellMeta.className.includes('htMiddle')).toBeTruthy();
+    expect(cellMeta.className).toContain('htMiddle');
 
     cellMeta = getCellMeta(5, 7);
-    expect(cellMeta.className.includes('htBottom')).toBeTruthy();
+    expect(cellMeta.className).toContain('htBottom');
 
     cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
-    expect(cellMeta.className.includes('htMiddle')).toBeTruthy();
+    expect(cellMeta.className).toContain('htRight');
+    expect(cellMeta.className).toContain('htMiddle');
 
     cellMeta = getCellMeta(7, 5);
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
+    expect(cellMeta.className).toContain('htRight');
 
     cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
-    expect(cellMeta.className.includes('htBottom')).toBeTruthy();
+    expect(cellMeta.className).toContain('htRight');
+    expect(cellMeta.className).toContain('htBottom');
 
     getPlugin('undoRedo').undo();
     cellMeta = getCellMeta(0, 7);
-    expect(cellMeta.className.includes('htCenter')).toBeTruthy();
-    expect(cellMeta.className.includes('htBottom')).toBeFalsy();
+    expect(cellMeta.className).toContain('htCenter');
+    expect(cellMeta.className ?? '').not.toContain('htBottom');
 
     cellMeta = getCellMeta(5, 7);
-    expect(cellMeta.className.includes('htBottom')).toBeFalsy();
+    expect(cellMeta.className ?? '').not.toContain('htBottom');
 
     cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
-    expect(cellMeta.className.includes('htBottom')).toBeFalsy();
+    expect(cellMeta.className).toContain('htRight');
+    expect(cellMeta.className ?? '').not.toContain('htBottom');
 
     getPlugin('undoRedo').undo();
 
     cellMeta = getCellMeta(0, 0);
-    expect(cellMeta.className.includes('htCenter')).toBeTruthy();
-    expect(cellMeta.className.includes('htMiddle')).toBeFalsy();
+    expect(cellMeta.className).toContain('htCenter');
+    expect(cellMeta.className ?? '').not.toContain('htMiddle');
 
     cellMeta = getCellMeta(5, 1);
-    expect(cellMeta.className.includes('htMiddle')).toBeFalsy();
+    expect(cellMeta.className ?? '').not.toContain('htMiddle');
 
     cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
-    expect(cellMeta.className.includes('htMiddle')).toBeFalsy();
+    expect(cellMeta.className).toContain('htRight');
+    expect(cellMeta.className ?? '').not.toContain('htMiddle');
 
     getPlugin('undoRedo').undo();
 
     cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className.includes('htRight')).toBeFalsy();
-    expect(cellMeta.className.includes('htMiddle')).toBeFalsy();
+    expect(cellMeta.className ?? '').not.toContain('htRight');
+    expect(cellMeta.className ?? '').not.toContain('htMiddle');
 
     cellMeta = getCellMeta(7, 5);
-    expect(cellMeta.className.includes('htRight')).toBeFalsy();
+    expect(cellMeta.className ?? '').not.toContain('htRight');
 
     cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className.includes('htRight')).toBeFalsy();
-    expect(cellMeta.className.includes('htBottom')).toBeFalsy();
+    expect(cellMeta.className ?? '').not.toContain('htRight');
+    expect(cellMeta.className ?? '').not.toContain('htBottom');
   });
 
   it('should be possible redo the alignment process by calling the \'Redo\' action without contextMenu', async() => {
@@ -915,29 +915,29 @@ describe('DropdownMenu', () => {
 
     let cellMeta = getCellMeta(0, 0);
 
-    expect(cellMeta.className.includes('htCenter')).toBeTruthy();
-    expect(cellMeta.className.includes('htMiddle')).toBeTruthy();
+    expect(cellMeta.className).toContain('htCenter');
+    expect(cellMeta.className).toContain('htMiddle');
 
     cellMeta = getCellMeta(0, 7);
-    expect(cellMeta.className.includes('htCenter')).toBeTruthy();
-    expect(cellMeta.className.includes('htBottom')).toBeTruthy();
+    expect(cellMeta.className).toContain('htCenter');
+    expect(cellMeta.className).toContain('htBottom');
 
     cellMeta = getCellMeta(5, 1);
-    expect(cellMeta.className.includes('htMiddle')).toBeTruthy();
+    expect(cellMeta.className).toContain('htMiddle');
 
     cellMeta = getCellMeta(5, 7);
-    expect(cellMeta.className.includes('htBottom')).toBeTruthy();
+    expect(cellMeta.className).toContain('htBottom');
 
     cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
-    expect(cellMeta.className.includes('htMiddle')).toBeTruthy();
+    expect(cellMeta.className).toContain('htRight');
+    expect(cellMeta.className).toContain('htMiddle');
 
     cellMeta = getCellMeta(7, 5);
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
+    expect(cellMeta.className).toContain('htRight');
 
     cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
-    expect(cellMeta.className.includes('htBottom')).toBeTruthy();
+    expect(cellMeta.className).toContain('htRight');
+    expect(cellMeta.className).toContain('htBottom');
 
     getPlugin('undoRedo').undo();
     getPlugin('undoRedo').undo();
@@ -946,39 +946,39 @@ describe('DropdownMenu', () => {
 
     getPlugin('undoRedo').redo();
     cellMeta = getCellMeta(0, 0);
-    expect(cellMeta.className.includes('htCenter')).toBeTruthy();
+    expect(cellMeta.className).toContain('htCenter');
     cellMeta = getCellMeta(1, 5);
-    expect(cellMeta.className.includes('htCenter')).toBeTruthy();
+    expect(cellMeta.className).toContain('htCenter');
     cellMeta = getCellMeta(2, 8);
-    expect(cellMeta.className.includes('htCenter')).toBeTruthy();
+    expect(cellMeta.className).toContain('htCenter');
 
     getPlugin('undoRedo').redo();
     cellMeta = getCellMeta(6, 0);
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
+    expect(cellMeta.className).toContain('htRight');
     cellMeta = getCellMeta(7, 5);
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
+    expect(cellMeta.className).toContain('htRight');
     cellMeta = getCellMeta(8, 8);
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
+    expect(cellMeta.className).toContain('htRight');
 
     getPlugin('undoRedo').redo();
     cellMeta = getCellMeta(0, 0);
-    expect(cellMeta.className.includes('htMiddle')).toBeTruthy();
-    expect(cellMeta.className.includes('htCenter')).toBeTruthy();
+    expect(cellMeta.className).toContain('htMiddle');
+    expect(cellMeta.className).toContain('htCenter');
     cellMeta = getCellMeta(5, 1);
-    expect(cellMeta.className.includes('htMiddle')).toBeTruthy();
+    expect(cellMeta.className).toContain('htMiddle');
     cellMeta = getCellMeta(8, 2);
-    expect(cellMeta.className.includes('htMiddle')).toBeTruthy();
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
+    expect(cellMeta.className).toContain('htMiddle');
+    expect(cellMeta.className).toContain('htRight');
 
     getPlugin('undoRedo').redo();
     cellMeta = getCellMeta(0, 6);
-    expect(cellMeta.className.includes('htBottom')).toBeTruthy();
-    expect(cellMeta.className.includes('htCenter')).toBeTruthy();
+    expect(cellMeta.className).toContain('htBottom');
+    expect(cellMeta.className).toContain('htCenter');
     cellMeta = getCellMeta(5, 7);
-    expect(cellMeta.className.includes('htBottom')).toBeTruthy();
+    expect(cellMeta.className).toContain('htBottom');
     cellMeta = getCellMeta(8, 8);
-    expect(cellMeta.className.includes('htBottom')).toBeTruthy();
-    expect(cellMeta.className.includes('htRight')).toBeTruthy();
+    expect(cellMeta.className).toContain('htBottom');
+    expect(cellMeta.className).toContain('htRight');
   });
 
   it('should not scroll the viewport after clicking the button in the header of the partially visible column', async() => {

--- a/handsontable/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
@@ -410,6 +410,38 @@ describe('DropdownMenu', () => {
       expect(countCols()).toEqual(3);
     });
 
+    it('should keep the space between the class names when the alignment is picked again (#7122)', async() => {
+      handsontable({
+        data: createSpreadsheetData(4, 4),
+        dropdownMenu: true,
+        colHeaders: true,
+        height: 100,
+        cell: [
+          { row: 0, col: 0, className: 'class_name' },
+        ],
+      });
+
+      // The dropdown menu reaches the alignment items through the same shared `align()` helper as
+      // the context menu, so it used to glue the class names together in exactly the same way.
+      const pickAlignment = async(optionName) => {
+        await selectCell(0, 0);
+        await selectDropdownSubmenuOption('Alignment', optionName, 0);
+      };
+
+      await pickAlignment('Right');
+      await pickAlignment('Middle');
+
+      expect(getCellMeta(0, 0).className).toEqual('class_name htRight htMiddle');
+
+      await pickAlignment('Justify');
+
+      // Used to be 'class_namehtMiddle htJustify', dropping both the custom class and htMiddle.
+      expect(getCellMeta(0, 0).className).toEqual('class_name htMiddle htJustify');
+      expect(getCell(0, 0).classList.contains('class_name')).toBe(true);
+      expect(getCell(0, 0).classList.contains('htMiddle')).toBe(true);
+      expect(getCell(0, 0).classList.contains('htJustify')).toBe(true);
+    });
+
     it('should clear column data', async() => {
       handsontable({
         data: createSpreadsheetData(4, 4),

--- a/handsontable/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
@@ -818,69 +818,33 @@ describe('DropdownMenu', () => {
 
     getPlugin('dropdownMenu').executeCommand('alignment:bottom');
 
-    let cellMeta = getCellMeta(0, 0);
+    expect(getCellMeta(0, 0).className).toBe('htCenter htMiddle');
+    expect(getCellMeta(0, 7).className).toBe('htCenter htBottom');
+    expect(getCellMeta(5, 1).className).toBe('htMiddle');
+    expect(getCellMeta(5, 7).className).toBe('htBottom');
+    expect(getCellMeta(7, 1).className).toBe('htRight htMiddle');
+    expect(getCellMeta(7, 5).className).toBe('htRight');
+    expect(getCellMeta(7, 7).className).toBe('htRight htBottom');
 
-    expect(cellMeta.className).toContain('htCenter');
-    expect(cellMeta.className).toContain('htMiddle');
-
-    cellMeta = getCellMeta(0, 7);
-    expect(cellMeta.className).toContain('htCenter');
-    expect(cellMeta.className).toContain('htBottom');
-
-    cellMeta = getCellMeta(5, 1);
-    expect(cellMeta.className).toContain('htMiddle');
-
-    cellMeta = getCellMeta(5, 7);
-    expect(cellMeta.className).toContain('htBottom');
-
-    cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className).toContain('htRight');
-    expect(cellMeta.className).toContain('htMiddle');
-
-    cellMeta = getCellMeta(7, 5);
-    expect(cellMeta.className).toContain('htRight');
-
-    cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className).toContain('htRight');
-    expect(cellMeta.className).toContain('htBottom');
-
+    // Each undo is asserted against the exact expected value, so a class name that is wrongly
+    // wiped fails here just as loudly as one that is wrongly kept.
     getPlugin('undoRedo').undo();
-    cellMeta = getCellMeta(0, 7);
-    expect(cellMeta.className).toContain('htCenter');
-    expect(cellMeta.className ?? '').not.toContain('htBottom');
 
-    cellMeta = getCellMeta(5, 7);
-    expect(cellMeta.className ?? '').not.toContain('htBottom');
-
-    cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className).toContain('htRight');
-    expect(cellMeta.className ?? '').not.toContain('htBottom');
+    expect(getCellMeta(0, 7).className).toBe('htCenter');
+    expect(getCellMeta(5, 7).className).toBeUndefined();
+    expect(getCellMeta(7, 7).className).toBe('htRight');
 
     getPlugin('undoRedo').undo();
 
-    cellMeta = getCellMeta(0, 0);
-    expect(cellMeta.className).toContain('htCenter');
-    expect(cellMeta.className ?? '').not.toContain('htMiddle');
-
-    cellMeta = getCellMeta(5, 1);
-    expect(cellMeta.className ?? '').not.toContain('htMiddle');
-
-    cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className).toContain('htRight');
-    expect(cellMeta.className ?? '').not.toContain('htMiddle');
+    expect(getCellMeta(0, 0).className).toBe('htCenter');
+    expect(getCellMeta(5, 1).className).toBeUndefined();
+    expect(getCellMeta(7, 1).className).toBe('htRight');
 
     getPlugin('undoRedo').undo();
 
-    cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className ?? '').not.toContain('htRight');
-    expect(cellMeta.className ?? '').not.toContain('htMiddle');
-
-    cellMeta = getCellMeta(7, 5);
-    expect(cellMeta.className ?? '').not.toContain('htRight');
-
-    cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className ?? '').not.toContain('htRight');
-    expect(cellMeta.className ?? '').not.toContain('htBottom');
+    expect(getCellMeta(7, 1).className).toBeUndefined();
+    expect(getCellMeta(7, 5).className).toBeUndefined();
+    expect(getCellMeta(7, 7).className).toBeUndefined();
   });
 
   it('should be possible redo the alignment process by calling the \'Redo\' action without contextMenu', async() => {

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/cellAlignment.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/cellAlignment.spec.js
@@ -73,67 +73,67 @@ describe('UndoRedo -> CellAlignment action', () => {
 
     let cellMeta = getCellMeta(0, 0);
 
-    expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htCenter');
+    expect(cellMeta.className).toContain('htMiddle');
 
     cellMeta = getCellMeta(0, 7);
-    expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htBottom')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htCenter');
+    expect(cellMeta.className).toContain('htBottom');
 
     cellMeta = getCellMeta(5, 1);
-    expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htMiddle');
 
     cellMeta = getCellMeta(5, 7);
-    expect(cellMeta.className.indexOf('htBottom')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htBottom');
 
     cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htRight');
+    expect(cellMeta.className).toContain('htMiddle');
 
     cellMeta = getCellMeta(7, 5);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htRight');
 
     cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htBottom')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htRight');
+    expect(cellMeta.className).toContain('htBottom');
 
     getPlugin('undoRedo').undo();
     cellMeta = getCellMeta(0, 7);
-    expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htBottom')).toEqual(-1);
+    expect(cellMeta.className).toContain('htCenter');
+    expect(cellMeta.className ?? '').not.toContain('htBottom');
 
     cellMeta = getCellMeta(5, 7);
-    expect(cellMeta.className.indexOf('htBottom')).toEqual(-1);
+    expect(cellMeta.className ?? '').not.toContain('htBottom');
 
     cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htBottom')).toEqual(-1);
+    expect(cellMeta.className).toContain('htRight');
+    expect(cellMeta.className ?? '').not.toContain('htBottom');
 
     getPlugin('undoRedo').undo();
 
     cellMeta = getCellMeta(0, 0);
-    expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htMiddle')).toEqual(-1);
+    expect(cellMeta.className).toContain('htCenter');
+    expect(cellMeta.className ?? '').not.toContain('htMiddle');
 
     cellMeta = getCellMeta(5, 1);
-    expect(cellMeta.className.indexOf('htMiddle')).toEqual(-1);
+    expect(cellMeta.className ?? '').not.toContain('htMiddle');
 
     cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htMiddle')).toEqual(-1);
+    expect(cellMeta.className).toContain('htRight');
+    expect(cellMeta.className ?? '').not.toContain('htMiddle');
 
     getPlugin('undoRedo').undo();
 
     cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className.indexOf('htRight')).toEqual(-1);
-    expect(cellMeta.className.indexOf('htMiddle')).toEqual(-1);
+    expect(cellMeta.className ?? '').not.toContain('htRight');
+    expect(cellMeta.className ?? '').not.toContain('htMiddle');
 
     cellMeta = getCellMeta(7, 5);
-    expect(cellMeta.className.indexOf('htRight')).toEqual(-1);
+    expect(cellMeta.className ?? '').not.toContain('htRight');
 
     cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className.indexOf('htRight')).toEqual(-1);
-    expect(cellMeta.className.indexOf('htBottom')).toEqual(-1);
+    expect(cellMeta.className ?? '').not.toContain('htRight');
+    expect(cellMeta.className ?? '').not.toContain('htBottom');
 
     getPlugin('undoRedo').undo();
 
@@ -149,6 +149,38 @@ describe('UndoRedo -> CellAlignment action', () => {
         expect(finish).toBe(true);
       }
     }
+  });
+
+  it('should restore no class name at all when the cell had none before the alignment', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      contextMenu: true,
+    });
+
+    await selectCell(0, 0);
+    await contextMenu();
+    await selectContextSubmenuOption('Alignment', 'Middle');
+
+    expect(getCellMeta(0, 0).className).toBe('htMiddle');
+
+    getPlugin('undoRedo').undo();
+
+    await render();
+
+    // The undo used to fall back to ' htLeft' - a leading space plus a horizontal alignment the
+    // user never picked - so undoing left the cell aligned left instead of unaligned.
+    expect(getCellMeta(0, 0).className).toBeUndefined();
+    expect(getCell(0, 0).classList.contains('htLeft')).toBe(false);
+    expect(getCell(0, 0).classList.contains('htMiddle')).toBe(false);
+
+    getPlugin('undoRedo').redo();
+
+    await render();
+
+    // Redo must land back on exactly the original value, not grow the class name.
+    expect(getCellMeta(0, 0).className).toBe('htMiddle');
   });
 
   it('should undo/redo row removal with cell meta', async() => {
@@ -331,29 +363,29 @@ describe('UndoRedo -> CellAlignment action', () => {
 
     let cellMeta = getCellMeta(0, 0);
 
-    expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htCenter');
+    expect(cellMeta.className).toContain('htMiddle');
 
     cellMeta = getCellMeta(0, 7);
-    expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htBottom')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htCenter');
+    expect(cellMeta.className).toContain('htBottom');
 
     cellMeta = getCellMeta(5, 1);
-    expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htMiddle');
 
     cellMeta = getCellMeta(5, 7);
-    expect(cellMeta.className.indexOf('htBottom')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htBottom');
 
     cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htRight');
+    expect(cellMeta.className).toContain('htMiddle');
 
     cellMeta = getCellMeta(7, 5);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htRight');
 
     cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htBottom')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htRight');
+    expect(cellMeta.className).toContain('htBottom');
 
     getPlugin('undoRedo').undo();
     getPlugin('undoRedo').undo();
@@ -375,39 +407,39 @@ describe('UndoRedo -> CellAlignment action', () => {
 
     getPlugin('undoRedo').redo();
     cellMeta = getCellMeta(0, 0);
-    expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htCenter');
     cellMeta = getCellMeta(1, 5);
-    expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htCenter');
     cellMeta = getCellMeta(2, 8);
-    expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htCenter');
 
     getPlugin('undoRedo').redo();
     cellMeta = getCellMeta(6, 0);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htRight');
     cellMeta = getCellMeta(7, 5);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htRight');
     cellMeta = getCellMeta(8, 8);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htRight');
 
     getPlugin('undoRedo').redo();
     cellMeta = getCellMeta(0, 0);
-    expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htMiddle');
+    expect(cellMeta.className).toContain('htCenter');
     cellMeta = getCellMeta(5, 1);
-    expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htMiddle');
     cellMeta = getCellMeta(8, 2);
-    expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htMiddle');
+    expect(cellMeta.className).toContain('htRight');
 
     getPlugin('undoRedo').redo();
     cellMeta = getCellMeta(0, 6);
-    expect(cellMeta.className.indexOf('htBottom')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htBottom');
+    expect(cellMeta.className).toContain('htCenter');
     cellMeta = getCellMeta(5, 7);
-    expect(cellMeta.className.indexOf('htBottom')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htBottom');
     cellMeta = getCellMeta(8, 8);
-    expect(cellMeta.className.indexOf('htBottom')).toBeGreaterThan(-1);
-    expect(cellMeta.className.indexOf('htRight')).toBeGreaterThan(-1);
+    expect(cellMeta.className).toContain('htBottom');
+    expect(cellMeta.className).toContain('htRight');
   });
 
   it('should not throw an error after redoing the row header aligning', async() => {

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/cellAlignment.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/cellAlignment.spec.js
@@ -71,82 +71,40 @@ describe('UndoRedo -> CellAlignment action', () => {
     await selectCell(0, 6, 8, 8);
     getPlugin('contextMenu').executeCommand('alignment:bottom');
 
-    let cellMeta = getCellMeta(0, 0);
+    expect(getCellMeta(0, 0).className).toBe('htCenter htMiddle');
+    expect(getCellMeta(0, 7).className).toBe('htCenter htBottom');
+    expect(getCellMeta(5, 1).className).toBe('htMiddle');
+    expect(getCellMeta(5, 7).className).toBe('htBottom');
+    expect(getCellMeta(7, 1).className).toBe('htRight htMiddle');
+    expect(getCellMeta(7, 5).className).toBe('htRight');
+    expect(getCellMeta(7, 7).className).toBe('htRight htBottom');
 
-    expect(cellMeta.className).toContain('htCenter');
-    expect(cellMeta.className).toContain('htMiddle');
-
-    cellMeta = getCellMeta(0, 7);
-    expect(cellMeta.className).toContain('htCenter');
-    expect(cellMeta.className).toContain('htBottom');
-
-    cellMeta = getCellMeta(5, 1);
-    expect(cellMeta.className).toContain('htMiddle');
-
-    cellMeta = getCellMeta(5, 7);
-    expect(cellMeta.className).toContain('htBottom');
-
-    cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className).toContain('htRight');
-    expect(cellMeta.className).toContain('htMiddle');
-
-    cellMeta = getCellMeta(7, 5);
-    expect(cellMeta.className).toContain('htRight');
-
-    cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className).toContain('htRight');
-    expect(cellMeta.className).toContain('htBottom');
-
+    // Each undo is asserted against the exact expected value, so a class name that is wrongly
+    // wiped fails here just as loudly as one that is wrongly kept.
     getPlugin('undoRedo').undo();
-    cellMeta = getCellMeta(0, 7);
-    expect(cellMeta.className).toContain('htCenter');
-    expect(cellMeta.className ?? '').not.toContain('htBottom');
 
-    cellMeta = getCellMeta(5, 7);
-    expect(cellMeta.className ?? '').not.toContain('htBottom');
-
-    cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className).toContain('htRight');
-    expect(cellMeta.className ?? '').not.toContain('htBottom');
+    expect(getCellMeta(0, 7).className).toBe('htCenter');
+    expect(getCellMeta(5, 7).className).toBeUndefined();
+    expect(getCellMeta(7, 7).className).toBe('htRight');
 
     getPlugin('undoRedo').undo();
 
-    cellMeta = getCellMeta(0, 0);
-    expect(cellMeta.className).toContain('htCenter');
-    expect(cellMeta.className ?? '').not.toContain('htMiddle');
-
-    cellMeta = getCellMeta(5, 1);
-    expect(cellMeta.className ?? '').not.toContain('htMiddle');
-
-    cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className).toContain('htRight');
-    expect(cellMeta.className ?? '').not.toContain('htMiddle');
+    expect(getCellMeta(0, 0).className).toBe('htCenter');
+    expect(getCellMeta(5, 1).className).toBeUndefined();
+    expect(getCellMeta(7, 1).className).toBe('htRight');
 
     getPlugin('undoRedo').undo();
 
-    cellMeta = getCellMeta(7, 1);
-    expect(cellMeta.className ?? '').not.toContain('htRight');
-    expect(cellMeta.className ?? '').not.toContain('htMiddle');
-
-    cellMeta = getCellMeta(7, 5);
-    expect(cellMeta.className ?? '').not.toContain('htRight');
-
-    cellMeta = getCellMeta(7, 7);
-    expect(cellMeta.className ?? '').not.toContain('htRight');
-    expect(cellMeta.className ?? '').not.toContain('htBottom');
+    expect(getCellMeta(7, 1).className).toBeUndefined();
+    expect(getCellMeta(7, 5).className).toBeUndefined();
+    expect(getCellMeta(7, 7).className).toBeUndefined();
 
     getPlugin('undoRedo').undo();
 
-    // check if all cells are either non-adjusted or adjusted to the left (as default)
-    let finish;
-
+    // Every cell is back to carrying no class name at all.
     for (let i = 0; i < 9; i++) {
       for (let j = 0; j < 9; j++) {
-        cellMeta = getCellMeta(i, j);
-        finish = cellMeta.className === undefined || cellMeta.className.trim() === '' ||
-          cellMeta.className.trim() === 'htLeft';
-
-        expect(finish).toBe(true);
+        expect(getCellMeta(i, j).className).toBeUndefined();
       }
     }
   });

--- a/handsontable/src/plugins/undoRedo/actions/cellAlignment.ts
+++ b/handsontable/src/plugins/undoRedo/actions/cellAlignment.ts
@@ -61,7 +61,10 @@ export class CellAlignmentAction extends BaseAction {
       range.forAll((row: number, col: number) => {
         // Alignment classes should only collected within cell ranges. We skip header coordinates.
         if (row >= 0 && col >= 0) {
-          hot.setCellMeta(row, col, 'className', (this.stateBefore as string[][])[row][col] || ' htLeft');
+          // Restored as recorded, including an absent value. Falling back to a horizontal alignment
+          // here used to leave the cell aligned left after undoing a vertical alignment, and made
+          // the class name grow on every undo/redo cycle.
+          hot.setCellMeta(row, col, 'className', (this.stateBefore as string[][])[row][col]);
         }
 
         return true;

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -1101,10 +1101,22 @@ export function openDropdownSubmenuOption(submenuName, cell) {
 export async function selectDropdownSubmenuOption(submenuName, optionName, cell) {
   openDropdownSubmenuOption(submenuName, cell);
 
-  await sleep(300);
+  // Wait for the submenu to open instead of guessing with a fixed delay.
+  let button = $();
 
-  const dropdownSubMenu = $(`.htDropdownMenuSub_${submenuName}`);
-  const button = dropdownSubMenu.find(`.ht_master .htCore tbody td:contains(${optionName})`);
+  for (let attempt = 0; attempt < 30 && button.length === 0; attempt++) {
+    // eslint-disable-next-line no-await-in-loop
+    await waitForNextAnimationFrames(1);
+
+    button = $(`.htDropdownMenuSub_${submenuName}`)
+      .find(`.ht_master .htCore tbody td:contains(${optionName})`);
+  }
+
+  // Without this the `.simulate()` calls below are silent no-ops and the test passes having
+  // clicked nothing.
+  if (button.length === 0) {
+    throw new Error(`The "${optionName}" option of the "${submenuName}" dropdown submenu was not found.`);
+  }
 
   button
     .simulate('mouseenter')

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -1027,6 +1027,13 @@ export function closeContextMenu() {
 }
 
 /**
+ * Closes the dropdown menu.
+ */
+export function closeDropdownMenu() {
+  $(document).simulate('mousedown');
+}
+
+/**
  * Shows dropdown menu.
  *
  * @param {number|HTMLTableCellElement} [columnIndexOrCell=0] The column index or TD element under which the dropdown menu is triggered.
@@ -1082,6 +1089,29 @@ export function openDropdownSubmenuOption(submenuName, cell) {
   item
     .simulate('mouseenter')
     .simulate('mouseover');
+}
+
+/**
+ * Open, execute the sub menu action and close the dropdown menu.
+ *
+ * @param {string} submenuName The dropdown menu item name (it has to be a submenu) to hover.
+ * @param {string} optionName The dropdown menu subitem name to click.
+ * @param {number|HTMLTableCellElement} [cell] The column index or TH element to open the menu under.
+ */
+export async function selectDropdownSubmenuOption(submenuName, optionName, cell) {
+  openDropdownSubmenuOption(submenuName, cell);
+
+  await sleep(300);
+
+  const dropdownSubMenu = $(`.htDropdownMenuSub_${submenuName}`);
+  const button = dropdownSubMenu.find(`.ht_master .htCore tbody td:contains(${optionName})`);
+
+  button
+    .simulate('mouseenter')
+    .simulate('mousedown')
+    .simulate('mouseup')
+    .simulate('click');
+  closeDropdownMenu();
 }
 
 /**


### PR DESCRIPTION
### Context

The PR fixes [#7122](https://github.com/handsontable/handsontable/issues/7122) — open since July 2020, and present in the code since 2015.

Picking a second alignment on the same axis destroyed the cell's other class names. On a cell with a custom class `class_name`:

| Step | Action | `className` after |
|---|---|---|
| 1 | Alignment → Right | `class_name htRight` |
| 2 | Alignment → Middle | `class_name htRight htMiddle` |
| 3 | Alignment → Justify | `class_namehtMiddle htJustify` |

After step 3 the space between `class_name` and `htMiddle` was gone. The browser read one class called `class_namehtMiddle`, which matches nothing, so the user silently lost **two** things: their own class, and the vertical alignment they had just set.

#### Cause

`prepareVerticalAlignClass` and `prepareHorizontalAlignClass` in `handsontable/src/plugins/contextMenu/utils.ts` did string surgery on the class name:

```js
className
  .replace('htLeft', '')
  .replace('htCenter', '')
  .replace('htRight', '')
  .replace('htJustify', '')
  .replace('  ', '');   // deleted the double space instead of collapsing it
```

Removing a token from the middle of the string leaves two spaces. The last line replaced those two spaces with nothing, pushing the neighbours together.

This is also why the bug looked unreproducible to some reviewers on the 2020 thread: gluing only happens when the removed token sits **between** two other tokens. If it is last, you get a harmless stray double space and nothing visibly breaks — so the click order decided whether the bug showed.

The same substring matching had a second effect: a custom class that merely contained an alignment name was chopped up. `htTopBar` + Bottom returned `Bar htBottom`, and the alignment was not applied at all.

#### Fix

Both helpers now delegate to a shared `prepareAlignClass()` that normalizes the value with `normalizeClassNames()` and works on whole tokens — drop the tokens belonging to the axis being changed, append the new one, join with a single space. This matches how `exportFile/types/xlsx/cell-style.ts` already matches alignment classes.

Three side effects worth calling out in review:

1. A custom class containing an alignment name (`htTopBar`) is now preserved **and** the alignment applies. Previously picking that axis was a silent no-op — the old behavior was the defect.
2. An array `className` — documented as supported in `metaSchema` — no longer throws in the alignment path. Same family as #7427.
3. XLSX export alignment self-repairs for cells whose classes were previously glued, since `exportFile` matches by exact token.

No public API, option, default value, or CSS class name changed.

### How has this been tested?

Unit tests (15 new cases) and E2E tests (3 new cases) were written first, confirmed failing against the old code, then confirmed passing after the fix.

```bash
# 15 new unit cases — both axes, the reported sequence, idempotence,
# spacing, substring safety, array className
npm run test:unit --prefix handsontable -- --testPathPattern=contextMenu/__tests__/utils

# 3 new E2E cases driving the real context menu, plus the existing alignment suite
npm run test:e2e --prefix handsontable -- --testPathPattern=alignment

# regression checks on the consumers
npm run test:e2e --prefix handsontable -- --testPathPattern=cellAlignment
npm run test:e2e --prefix handsontable -- --testPathPattern="contextMenu|dropdownMenu"
npm run test:e2e --prefix handsontable -- --testPathPattern=exportFile

# full gates
npm run eslint --prefix handsontable
npm run stylelint --prefix handsontable
npm run test:unit --prefix handsontable
```

Results: unit 3978/3978 pass (325 suites). E2E — alignment 49/49, cellAlignment 14/14, contextMenu+dropdownMenu 786/786, exportFile 272/272 (1 pre-existing pending). ESLint 0 errors, Stylelint clean.

Manual check in Chrome, A/B against the released build. On 18.0.0 the reported three steps drive `class_name` off the cell and its background styling disappears; on this branch all three classes survive and the styling holds. Verified both through real right-click context-menu clicks and through `getPlugin('contextMenu').executeCommand(...)`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2654
2. #7122

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2654

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized bug fix to cell `className` updates and alignment undo with no API changes; behavior change is restoring correct styling rather than new surface area.
> 
> **Overview**
> Fixes **#7122**: context-menu and dropdown-menu alignment no longer corrupt `className` when users pick another alignment on the same axis or mix custom classes with alignment tokens.
> 
> **Alignment helpers** in `contextMenu/utils.ts` stop using substring `.replace()` on the raw string. They normalize with `normalizeClassNames()`, remove only whole horizontal/vertical alignment tokens, append the new one, and join with a single space. That prevents glued names like `class_namehtMiddle`, preserves classes such as `htTopBar`, and supports array `className`. `getAlignmentComparatorByClass` now matches tokens exactly instead of `indexOf` on the full string.
> 
> **Undo** for cell alignment in `undoRedo/actions/cellAlignment.ts` restores the recorded `className` (including `undefined`) instead of falling back to `' htLeft'`, so undo does not leave cells left-aligned or grow class strings on undo/redo cycles.
> 
> Adds changelog entry, **AGENTS.md** guidance on `className` handling, broad unit/E2E coverage, and test helpers `closeDropdownMenu` / `selectDropdownSubmenuOption` for dropdown alignment tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e6711031f3e213ea0877e67198fbc62f45d727f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->