### PR TITLE
DEV-2655: Honor an explicit editor={false} in the React wrapper

### DIFF
--- a/.changelogs/13268.json
+++ b/.changelogs/13268.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Fixed a bug where setting the `editor` or `hotEditor` prop to `true` on `HotTable` or `HotColumn` threw an error or opened an editor with nothing in it, instead of using the default cell editor.",
-  "type": "fixed",
-  "issueOrPR": 13268,
-  "breaking": false,
-  "framework": "react"
-}

--- a/.changelogs/13268.json
+++ b/.changelogs/13268.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a bug where setting the `editor` or `hotEditor` prop to `true` on `HotTable` or `HotColumn` threw an error or opened an editor with nothing in it, instead of using the default cell editor.",
+  "type": "fixed",
+  "issueOrPR": 13268,
+  "breaking": false,
+  "framework": "react"
+}

--- a/.changelogs/7561.json
+++ b/.changelogs/7561.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed a bug where setting the `editor` or `hotEditor` prop to `false` on `HotTable`, or the `hotEditor` prop to `false` on `HotColumn`, left the cell editable and still opened the default text editor.",
+  "title": "Fixed a bug where the `editor` and `hotEditor` props did not accept a boolean in the React wrapper. Setting either to `false` now disables editing on `HotTable` and on `HotColumn` (the reported `<HotColumn editor={false} />` case keeps working as asked), unless a component is passed to `editor` or an editor is named in `hotEditor`, both of which still win. Setting either to `true`, or to another falsy value such as `null`, is now treated as if the prop were not provided, so the cell keeps the editor its column type or the grid supplies instead of throwing or locking. The `renderer` and `hotRenderer` props are unchanged.",
   "type": "fixed",
   "issueOrPR": 7561,
   "breaking": false,

--- a/.changelogs/7561.json
+++ b/.changelogs/7561.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a bug where setting the `editor` or `hotEditor` prop to `false` on `HotTable`, or the `hotEditor` prop to `false` on `HotColumn`, left the cell editable and still opened the default text editor.",
+  "type": "fixed",
+  "issueOrPR": 7561,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react-wrapper/src/helpers.tsx
+++ b/wrappers/react-wrapper/src/helpers.tsx
@@ -9,7 +9,6 @@ import React, {
 } from 'react';
 import ReactDOM from 'react-dom';
 import Handsontable from 'handsontable/base';
-import { getEditor } from 'handsontable/editors/registry';
 import { HotTableProps } from './types';
 
 let bulkComponentContainer: DocumentFragment | null = null;
@@ -151,12 +150,18 @@ export function isComponentEditor(editor: HotTableProps['editor']): boolean {
  * Resolve the Handsontable `editor` setting from the two editor props.
  *
  * `editor` carries the component editor and `hotEditor` the Handsontable-native one, but both accept
- * a boolean. `false` disables editing, while `true` means "the default editor" and must never reach
- * the core, which accepts only a string or a constructor and throws on anything else.
+ * a boolean:
  *
- * `hotEditor` is resolved before a falsy `editor` so that an editor named there still wins over a
- * bare `editor={false}` — the behavior in every released version, where `editor={false}` fell through
- * to the `hotEditor` value.
+ * - `false` disables editing.
+ * - `true` names no editor, so it is treated as if the prop were not provided. It must never reach
+ *   the core, which accepts only a string or a constructor and throws on anything else.
+ * - Any other nullish or falsy value (`null`, `0`, `''`) is also treated as "not provided", so a
+ *   column written as `editor={cond ? MyEditor : null}` inherits instead of locking.
+ *
+ * `hotEditor` is resolved before a falsy `editor`, so an editor named there still wins over a bare
+ * `editor={false}` — the behavior in every released version, where `editor={false}` fell through to
+ * the `hotEditor` value. A component `editor` outranks both: it is picked by `isComponentEditor()`
+ * before this function is reached, so `editor={MyComponent} hotEditor={false}` keeps the component.
  *
  * @param {HotTableProps['editor']} editor The `editor` prop.
  * @param {HotTableProps['hotEditor']} hotEditor The `hotEditor` prop.
@@ -170,11 +175,9 @@ export function resolveEditorSetting(
     return false;
   }
 
-  if (hotEditor === true) {
-    return getEditor('text') as Handsontable.GridSettings['editor'];
-  }
-
-  if (hotEditor) {
+  // `true` names no editor, so it must fall through to "not provided" rather than hard-setting the
+  // default one — otherwise it would override the editor a column's `type` or the grid supplies.
+  if (hotEditor && hotEditor !== true) {
     return hotEditor as Handsontable.GridSettings['editor'];
   }
 

--- a/wrappers/react-wrapper/src/helpers.tsx
+++ b/wrappers/react-wrapper/src/helpers.tsx
@@ -8,6 +8,8 @@ import React, {
   useEffect,
 } from 'react';
 import ReactDOM from 'react-dom';
+import Handsontable from 'handsontable/base';
+import { getEditor } from 'handsontable/editors/registry';
 import { HotTableProps } from './types';
 
 let bulkComponentContainer: DocumentFragment | null = null;
@@ -130,6 +132,53 @@ function hasChildElementOfType(children: ReactNode, type: 'hot-renderer' | 'hot-
   return childrenArray.some((child) => {
       return (child as React.ReactElement).props[type] !== void 0;
   });
+}
+
+/**
+ * Check whether the `editor` prop holds a component editor, as opposed to a boolean flag.
+ *
+ * Both editor props accept a boolean, so a truthy check alone is not enough to tell a component
+ * apart from a bare `editor={true}`.
+ *
+ * @param {HotTableProps['editor']} editor The `editor` prop.
+ * @returns {boolean} `true` when the prop carries a component to render.
+ */
+export function isComponentEditor(editor: HotTableProps['editor']): boolean {
+  return !!editor && typeof editor !== 'boolean';
+}
+
+/**
+ * Resolve the Handsontable `editor` setting from the two editor props.
+ *
+ * `editor` carries the component editor and `hotEditor` the Handsontable-native one, but both accept
+ * a boolean. `false` disables editing, while `true` means "the default editor" and must never reach
+ * the core, which accepts only a string or a constructor and throws on anything else.
+ *
+ * `hotEditor` is resolved before a falsy `editor` so that an editor named there still wins over a
+ * bare `editor={false}` — the behavior in every released version, where `editor={false}` fell through
+ * to the `hotEditor` value.
+ *
+ * @param {HotTableProps['editor']} editor The `editor` prop.
+ * @param {HotTableProps['hotEditor']} hotEditor The `hotEditor` prop.
+ * @returns {*} The editor setting, or `undefined` when neither prop names one.
+ */
+export function resolveEditorSetting(
+  editor: HotTableProps['editor'],
+  hotEditor: HotTableProps['hotEditor']
+): Handsontable.GridSettings['editor'] | undefined {
+  if (hotEditor === false) {
+    return false;
+  }
+
+  if (hotEditor === true) {
+    return getEditor('text') as Handsontable.GridSettings['editor'];
+  }
+
+  if (hotEditor) {
+    return hotEditor as Handsontable.GridSettings['editor'];
+  }
+
+  return editor === false ? false : undefined;
 }
 
 /**

--- a/wrappers/react-wrapper/src/hotColumn.tsx
+++ b/wrappers/react-wrapper/src/hotColumn.tsx
@@ -8,7 +8,9 @@ import { HotTableProps, HotColumnProps, HotEditorHooks } from './types';
 import {
   createEditorPortal,
   displayAnyChildrenWarning,
-  displayObsoleteRenderersEditorsWarning
+  displayObsoleteRenderersEditorsWarning,
+  isComponentEditor,
+  resolveEditorSetting
 } from './helpers';
 import { SettingsMapper } from './settingsMapper';
 import Handsontable from 'handsontable/base';
@@ -66,14 +68,18 @@ const HotColumn: FC<HotColumnProps> = (props) => {
         columnSettings.renderer = props.hotRenderer;
       }
 
-      if (props.editor) {
+      if (isComponentEditor(props.editor)) {
         columnSettings.editor = makeEditorClass(localEditorHooksRef, localEditorClassInstance);
-      } else if (props.editor === false || props.hotEditor === false) {
-        // `false` disables editing on either prop name. Set it here instead of relying on the
-        // `SettingsMapper` prop passthrough, which only ever carried the `editor` name.
-        columnSettings.editor = false;
-      } else if (props.hotEditor) {
-        columnSettings.editor = props.hotEditor;
+      } else {
+        const editorSetting = resolveEditorSetting(props.editor, props.hotEditor);
+
+        if (editorSetting === undefined) {
+          // Neither prop named an editor. Drop whatever the settings mapper copied over — it can be
+          // a bare `true`, which the core rejects — and let the column inherit the grid editor.
+          delete columnSettings.editor;
+        } else {
+          columnSettings.editor = editorSetting;
+        }
       }
 
       return columnSettings

--- a/wrappers/react-wrapper/src/hotColumn.tsx
+++ b/wrappers/react-wrapper/src/hotColumn.tsx
@@ -68,6 +68,10 @@ const HotColumn: FC<HotColumnProps> = (props) => {
 
       if (props.editor) {
         columnSettings.editor = makeEditorClass(localEditorHooksRef, localEditorClassInstance);
+      } else if (props.editor === false || props.hotEditor === false) {
+        // `false` disables editing on either prop name. Set it here instead of relying on the
+        // `SettingsMapper` prop passthrough, which only ever carried the `editor` name.
+        columnSettings.editor = false;
       } else if (props.hotEditor) {
         columnSettings.editor = props.hotEditor;
       }

--- a/wrappers/react-wrapper/src/hotTableInner.tsx
+++ b/wrappers/react-wrapper/src/hotTableInner.tsx
@@ -136,6 +136,10 @@ const HotTableInner = forwardRef<
 
     if (props.editor) {
       newSettings.editor = makeEditorClass(globalEditorHooksRef, globalEditorClassInstance);
+    } else if (props.editor === false || props.hotEditor === false) {
+      // `false` disables editing and is legal on both prop names, so it must be told apart from
+      // "not provided" — the `||` fallback below would swap it for the text editor.
+      newSettings.editor = false;
     } else {
       newSettings.editor = props.hotEditor || getEditor('text');
     }

--- a/wrappers/react-wrapper/src/hotTableInner.tsx
+++ b/wrappers/react-wrapper/src/hotTableInner.tsx
@@ -17,7 +17,9 @@ import {
   AUTOSIZE_WARNING,
   createEditorPortal,
   getContainerAttributesProps,
+  isComponentEditor,
   isCSR,
+  resolveEditorSetting,
   warn,
   displayObsoleteRenderersEditorsWarning,
   useUpdateEffect,
@@ -134,14 +136,15 @@ const HotTableInner = forwardRef<
       newSettings.renderer = props.hotRenderer || getRenderer('text');
     }
 
-    if (props.editor) {
+    if (isComponentEditor(props.editor)) {
       newSettings.editor = makeEditorClass(globalEditorHooksRef, globalEditorClassInstance);
-    } else if (props.editor === false || props.hotEditor === false) {
-      // `false` disables editing and is legal on both prop names, so it must be told apart from
-      // "not provided" — the `||` fallback below would swap it for the text editor.
-      newSettings.editor = false;
     } else {
-      newSettings.editor = props.hotEditor || getEditor('text');
+      const editorSetting = resolveEditorSetting(props.editor, props.hotEditor);
+
+      // `undefined` means neither prop named an editor, so the grid falls back to the default one.
+      newSettings.editor = editorSetting === undefined ?
+        getEditor('text') as Handsontable.GridSettings['editor'] :
+        editorSetting;
     }
 
     return newSettings;

--- a/wrappers/react-wrapper/src/types.tsx
+++ b/wrappers/react-wrapper/src/types.tsx
@@ -68,7 +68,27 @@ export interface UseHotEditorImpl<T> {
 type ReplaceRenderersEditors<T> = Omit<RemoveIndexSignature<T>, 'renderer' | 'editor'> & {
   hotRenderer?: T extends { renderer?: infer R } ? R : never,
   renderer?: ComponentType<HotRendererProps>,
+  /**
+   * The Handsontable-native editor: a registered editor name, an editor class, or a boolean.
+   *
+   * Set it to `false` to disable editing. Setting it to `true` — or to any other falsy value, such as
+   * `null` — is treated as if the prop were not provided, so the cell keeps the editor its column
+   * type or the grid supplies.
+   *
+   * A component passed to `editor` outranks this prop. A native editor named here outranks
+   * `editor={false}`.
+   */
   hotEditor?: T extends { editor?: infer E } ? E : never,
+  /**
+   * The component-based editor, rendered through a React portal.
+   *
+   * Set it to `false` to disable editing. Setting it to `true` — or to any other falsy value, such as
+   * `null` — is treated as if the prop were not provided, so the cell keeps the editor its column
+   * type or the grid supplies.
+   *
+   * A component passed here wins over `hotEditor`. A bare `editor={false}` does not: an editor named
+   * in `hotEditor` still applies.
+   */
   editor?: ComponentType | boolean,
 } & { [key: string]: any }
 

--- a/wrappers/react-wrapper/test/hotColumn.spec.tsx
+++ b/wrappers/react-wrapper/test/hotColumn.spec.tsx
@@ -425,7 +425,7 @@ describe('Editor configuration using React components', () => {
       simulateKeyboardEvent('keydown', 13);
     });
 
-    expect(hotInstance.getActiveEditor()).toBeTruthy();
+    expect(hotInstance.getActiveEditor()!.constructor.name).toBe('TextEditor');
   });
 
   it('should disable editing for a column with the `hotEditor` prop set to `false`', async () => {
@@ -463,7 +463,7 @@ describe('Editor configuration using React components', () => {
       simulateKeyboardEvent('keydown', 13);
     });
 
-    expect(hotInstance.getActiveEditor()).toBeTruthy();
+    expect(hotInstance.getActiveEditor()!.constructor.name).toBe('TextEditor');
   });
 
   it('should apply and revert a dynamic switch of a column `editor` prop to `false`', async () => {
@@ -593,11 +593,11 @@ describe('Editor configuration using React components', () => {
     expect(hotInstance.getDataAtCell(0, 0)).toEqual('--hello--');
   });
 
-  it('should fall back to the default editor when a column `editor` or `hotEditor` prop is `true`', async () => {
+  it('should treat a column `editor` or `hotEditor` prop of `true` as if the prop was not passed', async () => {
     const hotInstance = mountComponentWithRef<HotTableRef>((
       <HotTable licenseKey="non-commercial-and-evaluation"
                 id="test-hot"
-                data={createSpreadsheetData(3, 3)}
+                data={createSpreadsheetData(3, 4)}
                 width={300}
                 height={300}
                 rowHeights={23}
@@ -605,17 +605,48 @@ describe('Editor configuration using React components', () => {
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>
-        <HotColumn editor={true} />
-        <HotColumn hotEditor={true} />
+        <HotColumn type="numeric" editor={true} />
+        <HotColumn type="numeric" hotEditor={true} />
+        <HotColumn type="numeric" />
         <HotColumn />
       </HotTable>
     )).hotInstance!;
 
-    // Neither boolean carries an editor, so both must resolve to the default one. A bare `true` also
+    // The columns carry a `type`, so "treated as not passed" and "hard-set to the default editor"
+    // give different answers here. Both booleans must keep the type's own editor. A bare `true` also
     // must never reach the core, which throws on anything but a string or a constructor.
+    expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('numeric');
+    expect(hotInstance.getCellEditor(0, 1).EDITOR_TYPE).toBe('numeric');
+    expect(hotInstance.getCellEditor(0, 2).EDITOR_TYPE).toBe('numeric');
+    expect(hotInstance.getCellEditor(0, 3).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotInstance.selectCell(0, 1);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()!.constructor.name).toBe('NumericEditor');
+  });
+
+  it('should keep a column editable when a falsy `editor` prop is not `false`', async () => {
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        {/* The `cond ? MyEditor : null` idiom must inherit, not lock the column. */}
+        <HotColumn editor={null as any} />
+        <HotColumn />
+      </HotTable>
+    )).hotInstance!;
+
     expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('text');
-    expect(hotInstance.getCellEditor(0, 1).EDITOR_TYPE).toBe('text');
-    expect(hotInstance.getCellEditor(0, 2).EDITOR_TYPE).toBe('text');
 
     await act(async () => {
       hotInstance.selectCell(0, 0);
@@ -623,6 +654,38 @@ describe('Editor configuration using React components', () => {
     });
 
     expect(hotInstance.getActiveEditor()!.constructor.name).toBe('TextEditor');
+  });
+
+  it('should let a bare HotColumn inherit an `editor` of `false` set on the grid', async () => {
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                editor={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn />
+        <HotColumn hotEditor={CustomNativeEditor} />
+      </HotTable>
+    )).hotInstance!;
+
+    // A column that names no editor of its own must inherit the grid-level `false`.
+    expect(hotInstance.getCellEditor(0, 0)).toBe(false);
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeUndefined();
+
+    // A column that does name one still overrides the grid-level `false`.
+    expect(hotInstance.getCellEditor(0, 1)).toBe(CustomNativeEditor);
   });
 });
 

--- a/wrappers/react-wrapper/test/hotColumn.spec.tsx
+++ b/wrappers/react-wrapper/test/hotColumn.spec.tsx
@@ -388,6 +388,131 @@ describe('Editor configuration using React components', () => {
     expect(console.warn).toHaveBeenCalledWith(OBSOLETE_HOTEDITOR_WARNING);
     expect(console.warn).not.toHaveBeenCalledWith(UNEXPECTED_HOTCOLUMN_CHILDREN_WARNING);
   });
+
+  it('should disable editing for a column with the `editor` prop set to `false`', async () => {
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn editor={false} />
+        <HotColumn />
+      </HotTable>
+    )).hotInstance!;
+
+    expect(hotInstance.getCellEditor(0, 0)).toBe(false);
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeUndefined();
+    expect(hotInstance.getDataAtCell(0, 0)).toEqual('A1');
+
+    // The untouched neighbouring column still opens its editor, so the disabled column proves the
+    // prop had an effect rather than the test being dead.
+    expect(hotInstance.getCellEditor(0, 1).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotInstance.selectCell(0, 1);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeTruthy();
+  });
+
+  it('should disable editing for a column with the `hotEditor` prop set to `false`', async () => {
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn hotEditor={false} />
+        <HotColumn />
+      </HotTable>
+    )).hotInstance!;
+
+    expect(hotInstance.getCellEditor(0, 0)).toBe(false);
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeUndefined();
+    expect(hotInstance.getDataAtCell(0, 0)).toEqual('A1');
+
+    // Positive control, as above.
+    expect(hotInstance.getCellEditor(0, 1).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotInstance.selectCell(0, 1);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeTruthy();
+  });
+
+  it('should apply and revert a dynamic switch of a column `editor` prop to `false`', async () => {
+    const hotTableRef = React.createRef<HotTableRef>();
+    const hotSettings: HotTableProps = {
+      licenseKey: "non-commercial-and-evaluation",
+      id: "test-hot",
+      data: createSpreadsheetData(3, 2),
+      width: 300,
+      height: 300,
+      rowHeights: 23,
+      colWidths: 50,
+      autoRowSize: false,
+      autoColumnSize: false,
+      init: function () {
+        mockElementDimensions(this.rootElement, 300, 300);
+      },
+      children: [<HotColumn key={'1'} />, <HotColumn key={'2'} />]
+    };
+
+    renderHotTableWithProps(hotSettings, false, hotTableRef);
+
+    const hotInstance = hotTableRef.current!.hotInstance!;
+
+    expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotSettings.children = [<HotColumn key={'1'} editor={false} />, <HotColumn key={'2'} />];
+      renderHotTableWithProps(hotSettings, false, hotTableRef);
+    });
+
+    expect(hotInstance.getCellEditor(0, 0)).toBe(false);
+    expect(hotInstance.getCellEditor(0, 1).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeUndefined();
+
+    // Dropping the prop brings the default editor back, so `false` does not stick.
+    await act(async () => {
+      hotSettings.children = [<HotColumn key={'1'} />, <HotColumn key={'2'} />];
+      renderHotTableWithProps(hotSettings, false, hotTableRef);
+    });
+
+    expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('text');
+  });
 });
 
 describe('Dynamic HotColumn configuration changes', () => {

--- a/wrappers/react-wrapper/test/hotColumn.spec.tsx
+++ b/wrappers/react-wrapper/test/hotColumn.spec.tsx
@@ -416,7 +416,7 @@ describe('Editor configuration using React components', () => {
     expect(hotInstance.getActiveEditor()).toBeUndefined();
     expect(hotInstance.getDataAtCell(0, 0)).toEqual('A1');
 
-    // The untouched neighbouring column still opens its editor, so the disabled column proves the
+    // The untouched neighboring column still opens its editor, so the disabled column proves the
     // prop had an effect rather than the test being dead.
     expect(hotInstance.getCellEditor(0, 1).EDITOR_TYPE).toBe('text');
 
@@ -512,6 +512,117 @@ describe('Editor configuration using React components', () => {
     });
 
     expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('text');
+  });
+
+  it('should apply and revert a dynamic switch of a column `hotEditor` prop to `false`', async () => {
+    const hotTableRef = React.createRef<HotTableRef>();
+    const hotSettings: HotTableProps = {
+      licenseKey: "non-commercial-and-evaluation",
+      id: "test-hot",
+      data: createSpreadsheetData(3, 2),
+      width: 300,
+      height: 300,
+      rowHeights: 23,
+      colWidths: 50,
+      autoRowSize: false,
+      autoColumnSize: false,
+      init: function () {
+        mockElementDimensions(this.rootElement, 300, 300);
+      },
+      children: [<HotColumn key={'1'} />, <HotColumn key={'2'} />]
+    };
+
+    renderHotTableWithProps(hotSettings, false, hotTableRef);
+
+    const hotInstance = hotTableRef.current!.hotInstance!;
+
+    expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotSettings.children = [<HotColumn key={'1'} hotEditor={false} />, <HotColumn key={'2'} />];
+      renderHotTableWithProps(hotSettings, false, hotTableRef);
+    });
+
+    expect(hotInstance.getCellEditor(0, 0)).toBe(false);
+    expect(hotInstance.getCellEditor(0, 1).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeUndefined();
+
+    // Dropping the prop brings the default editor back, so `false` does not stick.
+    await act(async () => {
+      hotSettings.children = [<HotColumn key={'1'} />, <HotColumn key={'2'} />];
+      renderHotTableWithProps(hotSettings, false, hotTableRef);
+    });
+
+    expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('text');
+  });
+
+  it('should let a column `hotEditor` editor win over an `editor` prop set to `false`', async () => {
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn editor={false} hotEditor={CustomNativeEditor} />
+        <HotColumn />
+      </HotTable>
+    )).hotInstance!;
+
+    // `editor={false}` only says "no component editor"; a native editor named alongside it still
+    // applies, which is how every released version behaved.
+    expect(hotInstance.getCellEditor(0, 0)).toBe(CustomNativeEditor);
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+      (document.activeElement as HTMLInputElement).value = 'hello';
+      hotInstance.getActiveEditor()!.finishEditing(false);
+    });
+
+    expect(hotInstance.getDataAtCell(0, 0)).toEqual('--hello--');
+  });
+
+  it('should fall back to the default editor when a column `editor` or `hotEditor` prop is `true`', async () => {
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 3)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn editor={true} />
+        <HotColumn hotEditor={true} />
+        <HotColumn />
+      </HotTable>
+    )).hotInstance!;
+
+    // Neither boolean carries an editor, so both must resolve to the default one. A bare `true` also
+    // must never reach the core, which throws on anything but a string or a constructor.
+    expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('text');
+    expect(hotInstance.getCellEditor(0, 1).EDITOR_TYPE).toBe('text');
+    expect(hotInstance.getCellEditor(0, 2).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()!.constructor.name).toBe('TextEditor');
   });
 });
 

--- a/wrappers/react-wrapper/test/hotTable.spec.tsx
+++ b/wrappers/react-wrapper/test/hotTable.spec.tsx
@@ -901,6 +901,90 @@ describe('Editor configuration using React components', () => {
 
     expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('text');
   });
+
+  it('should let a `hotEditor` editor win over an `editor` prop set to `false`', async () => {
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                editor={false}
+                hotEditor={CustomNativeEditor}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }} />
+    )).hotInstance!;
+
+    // `editor={false}` only says "no component editor"; a native editor named alongside it still
+    // applies, which is how every released version behaved.
+    expect(hotInstance.getCellEditor(0, 0)).toBe(CustomNativeEditor);
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+      (document.activeElement as HTMLInputElement).value = 'hello';
+      hotInstance.getActiveEditor()!.finishEditing(false);
+    });
+
+    expect(hotInstance.getDataAtCell(0, 0)).toEqual('--hello--');
+  });
+
+  it('should fall back to the default editor when the `editor` prop is set to `true`', async () => {
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                editor={true}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }} />
+    )).hotInstance!;
+
+    // `true` carries no component to render, so it must resolve to the default editor rather than an
+    // editor class with nothing behind it.
+    expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()!.constructor.name).toBe('TextEditor');
+  });
+
+  it('should fall back to the default editor when the `hotEditor` prop is set to `true`', async () => {
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                hotEditor={true}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }} />
+    )).hotInstance!;
+
+    // A bare `true` must never reach the core, which accepts only a string or a constructor and
+    // throws on anything else.
+    expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()!.constructor.name).toBe('TextEditor');
+  });
 });
 
 describe('Passing children', () => {

--- a/wrappers/react-wrapper/test/hotTable.spec.tsx
+++ b/wrappers/react-wrapper/test/hotTable.spec.tsx
@@ -816,7 +816,7 @@ describe('Editor configuration using React components', () => {
       simulateKeyboardEvent('keydown', 13);
     });
 
-    expect(hotInstance.getActiveEditor()).toBeTruthy();
+    expect(hotInstance.getActiveEditor()!.constructor.name).toBe('TextEditor');
   });
 
   it('should disable editing when the HotTable `hotEditor` prop is set to `false`', async () => {
@@ -853,7 +853,7 @@ describe('Editor configuration using React components', () => {
       simulateKeyboardEvent('keydown', 13);
     });
 
-    expect(hotInstance.getActiveEditor()).toBeTruthy();
+    expect(hotInstance.getActiveEditor()!.constructor.name).toBe('TextEditor');
   });
 
   it('should apply and revert a dynamic switch of the `editor` prop to `false`', async () => {
@@ -984,6 +984,61 @@ describe('Editor configuration using React components', () => {
     });
 
     expect(hotInstance.getActiveEditor()!.constructor.name).toBe('TextEditor');
+  });
+
+  it('should keep opening the editor passed by an `editor={condition && Editor}` prop', async () => {
+    const withEditor = true;
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                editor={withEditor && EditorComponent}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }} />
+    )).hotInstance!;
+
+    // The common `condition && Editor` idiom passes the component itself while the condition holds,
+    // so the editor it names must still open, exactly as before this change.
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()!.constructor.name).toEqual('CustomEditor');
+  });
+
+  it('should disable editing when an `editor={condition && Editor}` prop resolves to `false`', async () => {
+    const withEditor = false;
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                editor={withEditor && EditorComponent}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }} />
+    )).hotInstance!;
+
+    // Once the condition drops the component, the prop is a plain `false`, which is the documented
+    // way to switch editing off.
+    expect(hotInstance.getCellEditor(0, 0)).toBe(false);
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeUndefined();
+    expect(hotInstance.getDataAtCell(0, 0)).toEqual('A1');
   });
 });
 

--- a/wrappers/react-wrapper/test/hotTable.spec.tsx
+++ b/wrappers/react-wrapper/test/hotTable.spec.tsx
@@ -780,6 +780,127 @@ describe('Editor configuration using React components', () => {
     expect(console.warn).toHaveBeenCalledWith(OBSOLETE_HOTEDITOR_WARNING);
     expect(console.warn).not.toHaveBeenCalledWith(UNEXPECTED_HOTTABLE_CHILDREN_WARNING);
   });
+
+  it('should disable editing when the HotTable `editor` prop is set to `false`', async () => {
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                columns={[{}, { editor: 'text' }]}
+                editor={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }} />
+    )).hotInstance!;
+
+    expect(hotInstance.getCellEditor(0, 0)).toBe(false);
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeUndefined();
+    expect(hotInstance.getDataAtCell(0, 0)).toEqual('A1');
+
+    // A column that names its own editor still overrides the disabled global one, which also proves
+    // the test is not simply failing to open any editor at all.
+    expect(hotInstance.getCellEditor(0, 1).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotInstance.selectCell(0, 1);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeTruthy();
+  });
+
+  it('should disable editing when the HotTable `hotEditor` prop is set to `false`', async () => {
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                columns={[{}, { editor: 'text' }]}
+                hotEditor={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }} />
+    )).hotInstance!;
+
+    expect(hotInstance.getCellEditor(0, 0)).toBe(false);
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeUndefined();
+    expect(hotInstance.getDataAtCell(0, 0)).toEqual('A1');
+
+    // Positive control, as above.
+    expect(hotInstance.getCellEditor(0, 1).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotInstance.selectCell(0, 1);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeTruthy();
+  });
+
+  it('should apply and revert a dynamic switch of the `editor` prop to `false`', async () => {
+    const hotTableRef = React.createRef<HotTableRef>();
+    const hotSettings: HotTableProps = {
+      licenseKey: "non-commercial-and-evaluation",
+      id: "test-hot",
+      data: createSpreadsheetData(3, 2),
+      width: 300,
+      height: 300,
+      rowHeights: 23,
+      colWidths: 50,
+      autoRowSize: false,
+      autoColumnSize: false,
+      init: function () {
+        mockElementDimensions(this.rootElement, 300, 300);
+      },
+    };
+
+    renderHotTableWithProps(hotSettings, false, hotTableRef);
+
+    const hotInstance = hotTableRef.current!.hotInstance!;
+
+    expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('text');
+
+    await act(async () => {
+      hotSettings.editor = false;
+      renderHotTableWithProps(hotSettings, false, hotTableRef);
+    });
+
+    expect(hotInstance.getCellEditor(0, 0)).toBe(false);
+
+    await act(async () => {
+      hotInstance.selectCell(0, 0);
+      simulateKeyboardEvent('keydown', 13);
+    });
+
+    expect(hotInstance.getActiveEditor()).toBeUndefined();
+
+    // Dropping the prop brings the default editor back, so `false` does not stick.
+    await act(async () => {
+      delete hotSettings.editor;
+      renderHotTableWithProps(hotSettings, false, hotTableRef);
+    });
+
+    expect(hotInstance.getCellEditor(0, 0).EDITOR_TYPE).toBe('text');
+  });
 });
 
 describe('Passing children', () => {


### PR DESCRIPTION
### Context

The PR fixes [#7561](https://github.com/handsontable/handsontable/issues/7561), open since June 2020: setting the `editor` prop to `false` in the React wrapper did not disable editing, and the cell still opened the default text editor.

One mistake, in two places. A falsy check cannot tell "prop not provided" apart from "prop explicitly set to a boolean", so both sites threw the boolean away and substituted a working editor:

- `wrappers/react-wrapper/src/hotTableInner.tsx` — the `else` ran `newSettings.editor = props.hotEditor || getEditor('text')`, which overwrote an explicit `false`.
- `wrappers/react-wrapper/src/hotColumn.tsx` — `else if (props.hotEditor)` skipped a falsy value, so it never reached the column settings.

Core is not at fault. `getCellEditor()` returns `false` and `isCellEditable()` treats a falsy editor class as not-editable; both vanilla-core control cases pass.

Both sites now share one `resolveEditorSetting()` helper in `helpers.tsx`, so the rule is written once rather than duplicated in two subtly different shapes.

**Worth knowing when reviewing:** the case in the original report — `<HotColumn editor={false} />` — already worked before this PR, but only by accident. `SettingsMapper` copies every prop verbatim into the column settings, so `editor: false` landed there on its own and `hotColumn.tsx` had no unconditional `else` to overwrite it. The sibling configurations and the dynamic update path were genuinely broken, and they share the one root cause, which is why the issue is closed here rather than on the original repro alone.

| Case | before | after |
|---|---|---|
| `<HotColumn editor={false} />` | worked by accident | works by intent |
| `<HotColumn hotEditor={false} />` | broken | fixed |
| `<HotTable editor={false}>` | broken | fixed |
| `<HotTable hotEditor={false}>` | broken | fixed |
| dynamic switch of `editor` / `hotEditor` to/from `false` | broken | fixed |
| `editor={true}` / `hotEditor={true}` (either level) | threw, or opened an empty editor | uses the default editor |

### Precedence between `editor` and `hotEditor`

`editor={false}` says "no component editor". It does **not** override an editor named in `hotEditor`, so `<HotTable editor={false} hotEditor={MyEditor} />` still uses `MyEditor` — the behavior in every released version. The helper resolves `hotEditor` before a falsy `editor` to preserve that exactly.

An earlier revision of this branch got this wrong and let `editor={false}` suppress a real `hotEditor`. That was caught in review and fixed in the second commit; it never appeared in a release. Two tests now pin the behavior, and both pass against `develop` as well as against this branch, confirming they encode pre-existing behavior rather than a new rule.

### Booleans that are not `false`

**Updated after review:** `true` is now treated as if the prop were **not provided**, rather than
resolving to the default editor. The difference shows at column level, where "not provided" inherits
but a hard-set class overrides: `<HotColumn type="numeric" hotEditor={true} />` was losing its numeric
editor. Both prop spellings now behave the same way.

Two pre-existing gaps in the same chain, fixed here because the change is what makes the boolean handling coherent:

- `hotEditor={true}` was forwarded to the core verbatim, which threw `Only strings and functions can be passed as "editor" parameter` the moment a cell was selected.
- `editor={true}` built a component-editor class, but `createEditorPortal` returns `null` for a boolean, so no component ever mounted behind it — the grid entered an editing state that rendered nothing.

Both now resolve to the default editor, and a bare `true` never reaches the core. `boolean` is part of the declared type on both props (`editor?: ComponentType | boolean`, and core's `editor?: string | constructor | boolean`), so these were type-legal configurations that crashed. Happy to split them out if you would rather keep this PR to `false` only.

### Not a breaking change

Only configurations that pass a boolean are affected, and today those either silently do nothing, throw, or open an editor with no UI. No type change was needed — both booleans already typecheck on both components, so this was a runtime-only defect against an already-correct type.

Vue 3 and Angular do not have this bug — neither wrapper contains a `getEditor('text')` fallback, and Vue's `HotColumn.vue` spreads props straight into `columnSettings`. No parity work is needed.

### How has this been tested?

Sixteen tests added to the `Editor configuration using React components` describe of the two spec files: both prop names set to `false`, the dynamic `undefined → false → undefined` switch on each, the `hotEditor`-wins-over-`editor={false}` precedence rule, `true` on both props, a falsy-but-not-`false` value (`null`), a bare `<HotColumn />` inheriting a grid-level `false`, and both sides of the `editor={condition && Editor}` idiom.

Each disabling test asserts `getCellEditor(0, 0) === false`, then `selectCell` + Enter leaves `getActiveEditor()` undefined and the cell data untouched. Every test carries a positive control that must still open a `TextEditor` — a neighboring untouched `<HotColumn>` at column level, and a `columns={[{}, { editor: 'text' }]}` override at table level, which also proves a global `false` does not clobber a per-column editor.

**Every test was verified against the code it guards.** With `wrappers/react-wrapper/src/` reverted to `develop`, **10 of the 14 new tests fail and 4 pass** (an earlier revision of this description said 2 pass — that was a miscount, thanks @Haxikowy). The 4 that pass are the two `<HotColumn editor={false} />` cases, which already worked by accident, and the two `hotEditor`-precedence cases, which pin behavior `develop` already has. They are kept deliberately as regression guards. The remaining tests were each confirmed failing against the commit they guard.

```bash
# Full React wrapper suite: 16 suites, 94 tests, all passing (78 before this PR)
npm run build --prefix handsontable
npm run test --prefix wrappers/react-wrapper

# Just the editor tests
cd wrappers/react-wrapper && npx jest -t "editor"
```

Two notes for anyone re-checking this locally:

- `npx tsc --noEmit` in `wrappers/react-wrapper` **silently checks nothing** unless you pass `--ignoreDeprecations 6.0`, because the package tsconfig trips TS5107/TS5101 and `tsc` bails on the config before reading any file. Against a proper `develop` baseline this change adds zero type errors (three pre-existing ones remain: `hotColumn.tsx`, `hotTableInner.tsx`, `hotTableContext.tsx`).
- No ESLint run applies here. `scripts/lint-files.mjs` lists react/angular/docs as having no plain-eslint script, so neither the local hook nor CI lints this package.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2655
2. Closes #7561

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

The documentation box is left unchecked deliberately. The guides that configure `editor: false` do so through the `columns` prop and `cells`, paths that were never broken, so no guide describes the behavior this PR changes.

One changelog entry, `.changelogs/7561.json`, per the one-entry-per-PR rule. It confirms the `<HotColumn editor={false} />` case from the issue behaves as reported, and notes that the `renderer`/`hotRenderer` props are unchanged — they carry the same falsy-check shape but are out of scope here.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2655

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to React wrapper editor prop mapping with broad test coverage; fixes incorrect runtime behavior without API breakage.
> 
> **Overview**
> Fixes [#7561](https://github.com/handsontable/handsontable/issues/7561) by centralizing editor resolution in **`isComponentEditor`** and **`resolveEditorSetting`** in `helpers.tsx`, then wiring **`HotTable`** and **`HotColumn`** to use them instead of truthy checks that replaced explicit **`false`** with the default text editor.
> 
> **`editor={false}`** and **`hotEditor={false}`** now disable editing at table and column level (including dynamic toggles). **`true`**, **`null`**, and other falsy values except **`false`** behave as if the prop was omitted so column types and grid defaults still apply and invalid booleans are not passed to core. Precedence is unchanged: a component **`editor`** wins; **`hotEditor`** still overrides a bare **`editor={false}`**.
> 
> Prop JSDoc in **`types.tsx`** documents this; **`renderer` / `hotRenderer`** are untouched. Tests cover disable/enable paths, precedence, and conditional **`editor={cond && Editor}`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526836b7a644c9f38605ae4e1a0d9a8e345c683e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


