### PR TITLE
DEV-2652: Keep an open editor bound to its record when rows are trimmed

### DIFF
--- a/.changelogs/13272.json
+++ b/.changelogs/13272.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed an in-progress cell edit landing on the wrong record, or appending rows to the source data, when rows were filtered, trimmed, sorted, or moved while the editor was open. The edit now follows its own record, and is discarded when that record can no longer be reached.",
+  "title": "Fixed an in-progress cell edit landing on the wrong record, or appending rows to the source data, when rows or columns were filtered, trimmed, sorted, moved, inserted, removed, or replaced while the editor was open. The edit now follows its own record, and is discarded when that record can no longer be reached.",
   "type": "fixed",
   "issueOrPR": 13272,
   "breaking": false,

--- a/.changelogs/13272.json
+++ b/.changelogs/13272.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed an in-progress cell edit landing on the wrong record, or appending rows to the source data, when a filter or `trimRows` removed rows while the editor was open.",
+  "title": "Fixed an in-progress cell edit landing on the wrong record, or appending rows to the source data, when rows were filtered, trimmed, sorted, or moved while the editor was open. The edit now follows its own record, and is discarded when that record can no longer be reached.",
   "type": "fixed",
   "issueOrPR": 13272,
   "breaking": false,

--- a/.changelogs/13272.json
+++ b/.changelogs/13272.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed an in-progress cell edit landing on the wrong record, or appending rows to the source data, when rows or columns were filtered, trimmed, sorted, moved, inserted, removed, or replaced while the editor was open. The edit now follows its own record, and is discarded when that record can no longer be reached.",
+  "title": "Fixed an in-progress cell edit landing on the wrong record, or appending rows to the source data, when rows or columns were filtered, trimmed, sorted, moved, inserted, removed, or replaced while the editor was open. The edit now follows its own record, and is discarded when a filter or trim takes that record out of view.",
   "type": "fixed",
   "issueOrPR": 13272,
   "breaking": false,

--- a/.changelogs/13272.json
+++ b/.changelogs/13272.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an in-progress cell edit landing on the wrong record, or appending rows to the source data, when a filter or `trimRows` removed rows while the editor was open.",
+  "type": "fixed",
+  "issueOrPR": 13272,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -86,10 +86,36 @@ class EditorManager {
    */
   #editedPhysicalColumn: number | null = null;
   /**
+   * Whether a structural change - a row or column being inserted or removed - is currently running.
+   *
+   * Such a change RENUMBERS the physical space, which invalidates `#editedPhysicalRow` while leaving
+   * the editor's visual coordinate correct. That is the opposite of what a trim or a permutation
+   * does, and the two are indistinguishable from the cache-update state alone, so the reconciliation
+   * stands down while this is set and the captured record is re-derived once the change lands.
+   *
+   * @type {boolean}
+   */
+  #structuralChangeInProgress = false;
+  /**
+   * Marks the start of a structural change, so the cache update it emits does not reconcile against
+   * a physical index that the change is in the middle of renumbering.
+   */
+  #onBeforeStructuralChange = (): void => {
+    this.#structuralChangeInProgress = true;
+  };
+  /**
+   * Marks the end of a structural change and re-derives the edited record from the editor's visual
+   * coordinate, which the change kept valid.
+   */
+  #onAfterStructuralChange = (): void => {
+    this.#structuralChangeInProgress = false;
+    this.#recaptureEditedRecord();
+  };
+  /**
    * Reacts to an index-map cache update on either axis.
    *
-   * The index-map reconciliation runs FIRST so that the hidden-cell guard tests `isHidden()` against
-   * rebound coordinates rather than the stale ones the index map just invalidated.
+   * The trimming reconciliation runs FIRST so that the hidden-cell guard tests `isHidden()` against
+   * rebound coordinates rather than the stale ones a trimming map just invalidated.
    *
    * @param {object} indexesChangesState The state object of the index mapper's cache update.
    * @param {boolean} indexesChangesState.indexesSequenceChanged Whether the indexes sequence changed.
@@ -118,6 +144,14 @@ class EditorManager {
     this.hot.addHook('beforeCompositionStart', (event: KeyboardEvent) => this.#onAfterDocumentKeyDown(event));
     this.hot.addHook('afterRowSequenceCacheUpdate', this.#onSequenceCacheUpdate);
     this.hot.addHook('afterColumnSequenceCacheUpdate', this.#onSequenceCacheUpdate);
+    this.hot.addHook('beforeCreateRow', this.#onBeforeStructuralChange);
+    this.hot.addHook('beforeRemoveRow', this.#onBeforeStructuralChange);
+    this.hot.addHook('beforeCreateCol', this.#onBeforeStructuralChange);
+    this.hot.addHook('beforeRemoveCol', this.#onBeforeStructuralChange);
+    this.hot.addHook('afterCreateRow', this.#onAfterStructuralChange);
+    this.hot.addHook('afterRemoveRow', this.#onAfterStructuralChange);
+    this.hot.addHook('afterCreateCol', this.#onAfterStructuralChange);
+    this.hot.addHook('afterRemoveCol', this.#onAfterStructuralChange);
     this.hot.view._wt.update(
       'onCellDblClick', (event: MouseEvent, coords: { isCell: () => boolean }, _elem: HTMLElement) =>
         this.#onCellDblClick(event, coords)
@@ -142,6 +176,10 @@ class EditorManager {
     // `beforeChange` that cancels the change, for instance) would disable the guard for the rest
     // of the instance's life rather than for that one edit.
     this.#hiddenCellCloseArmed = false;
+    // A vetoed `beforeCreateRow`/`beforeRemoveRow` never reaches its `after` counterpart, which
+    // would leave the latch set. Nothing changed in that case, so the only cost is the guard being
+    // inert for the rest of that edit - and a new edit cycle clears it.
+    this.#structuralChangeInProgress = false;
 
     if (this.activeEditor && this.activeEditor.isWaiting()) {
       this.closeEditor(false, false, (dataSaved: boolean) => {
@@ -384,24 +422,64 @@ class EditorManager {
   }
 
   /**
+   * Re-derives the edited record after a structural change has renumbered the physical space.
+   *
+   * Inserting or removing rows shifts the physical indexes of everything below, so the index captured
+   * in `prepareEditor()` now addresses a different record - but the editor's VISUAL coordinate came
+   * through intact, because the index mapper moved the visual space with it. So the visual side is
+   * the trustworthy one here, and it is what the record is read back from.
+   *
+   * A visual coordinate that no longer resolves means the change left the editor past the last row.
+   * There is nothing to commit to, so the edit is dropped rather than written through a coordinate
+   * that `applyChanges()` would satisfy by appending records.
+   */
+  #recaptureEditedRecord(): void {
+    const editor = this.activeEditor;
+
+    if (!editor || editor.state !== EDITOR_STATE.EDITING || editor.row === null || editor.col === null) {
+      return;
+    }
+
+    const physicalRow = this.hot.rowIndexMapper.getPhysicalFromVisualIndex(editor.row);
+    const physicalColumn = this.hot.columnIndexMapper.getPhysicalFromVisualIndex(editor.col);
+
+    if (physicalRow === null || physicalColumn === null) {
+      editor.cancelChanges();
+      this.clearActiveEditor();
+
+      return;
+    }
+
+    this.#editedPhysicalRow = physicalRow;
+    this.#editedPhysicalColumn = physicalColumn;
+  }
+
+  /**
    * Keeps an open editor bound to the RECORD it was opened on when an index map rearranges the
    * visual index space underneath it.
    *
    * Two kinds of change do that. A TRIMMING map (Filters, `trimRows`, `nestedRows`) COLLAPSES the
-   * visual space - the rows below a trimmed row shift up and the row count shrinks. A SEQUENCE
-   * change (`columnSorting`, `manualRowMove`) permutes it. Either way the editor is left holding the
-   * visual coordinates it captured in `prepare()`, and `BaseEditor#saveValue()` writes straight
-   * through them with no bounds check, so the pending edit lands on whichever record now occupies
-   * that visual slot - or, when a trim left the slot past the shortened row count, on rows that
-   * `applyChanges()` APPENDS to the source data to make room for it. Both are silent data corruption.
+   * visual space - the rows below a trimmed row shift up and the row count shrinks. A SEQUENCE change
+   * (`columnSorting`, `manualRowMove`, `manualColumnFreeze`) permutes it. Either way the editor is
+   * left holding the visual coordinates it captured in `prepare()`, and `BaseEditor#saveValue()`
+   * writes straight through them with no bounds check, so the pending edit lands on whichever record
+   * now occupies that visual slot - or, when a trim left the slot past the shortened row count, on
+   * rows that `applyChanges()` APPENDS to the source data to make room for it. Both are silent data
+   * corruption.
    *
    * Resolving the stored PHYSICAL index back to a visual one covers every shape with one test: the
-   * record is gone (no visual index - discard), the record moved (rebind - the edit still commits,
-   * to the right record), or nothing moved (no-op). The last branch is what keeps this from firing
-   * spuriously: a row insert churns both collections, and `BooleanMap#setValues()` emits a change
-   * even for a no-op write, so testing "something changed" alone would tear down unrelated edits.
-   * An insert or removal shifts the visual and physical spaces together, so the resolution returns
-   * the index the editor already held and the no-op branch takes it.
+   * record is gone (no visual index - discard), the record moved (rebind - the edit still commits, to
+   * the right record), or nothing moved (no-op). The last branch is what keeps this from firing
+   * spuriously: `BooleanMap#setValues()` emits a change even for a no-op write, so testing "something
+   * changed" alone would tear down unrelated edits.
+   *
+   * A structural change - an inserted or removed row or column - is the one case this reasoning does
+   * NOT cover, because it renumbers the physical space and invalidates the captured index while
+   * leaving the visual coordinate correct. It raises the same flags and cannot be told apart from the
+   * state object, so `#onBeforeStructuralChange()` stands this method down for the duration and
+   * `#recaptureEditedRecord()` re-derives the record afterwards. Without that, a grid with any
+   * trimming map registered would discard a valid edit on `alter('remove_row', ...)` and, with a sort
+   * active, rebind onto the wrong record on `alter('insert_row_above', ...)`.
    *
    * Runs SYNCHRONOUSLY, unlike `#closeEditorWhenCellHidden()`. `Filters#filter()` re-selects the
    * highlighted column immediately after writing its map, which commits the open editor before any
@@ -414,16 +492,21 @@ class EditorManager {
    * rewrites the restore flag - which is harmless here because a discard is what that override would
    * decide anyway once the edited record is gone from the visual space.
    *
-   * The editor keeps its on-screen position until the next render. That is cosmetic and, on the
-   * Filters path, invisible: `filter()` renders before yielding.
+   * A rebind moves the editor's coordinates, NOT its pixel position or the selection - neither
+   * `render()` nor `view.render()` repositions an open editor, so it stays drawn over the row it
+   * started on for the rest of the edit. On the Filters path that is invisible because `filter()`
+   * closes the editor outright, but on the `trimRows` path the editor is left painted over a
+   * neighbouring row. The commit still lands on the right record; only the position is wrong.
    *
-   * Three limits, all deliberate. A trimming change does NOT adjust the selection - `core.ts` calls
+   * Three limits, all deliberate. An index-map change does NOT adjust the selection - `core.ts` calls
    * `selection.commit()` only for `hiddenIndexesChanged` - so the highlight can be left past the last
    * row, and typing into it grows the data set. That is reachable with no editor involved at all and
-   * is a separate defect; this method does not paper over it. An editor parked in `WAITING` is not
-   * reconciled either, because `finishEditing()` has already run `saveValue()` by then and there is
-   * nothing left to redirect. And no core plugin registers a trimming map on the COLUMN axis - only
-   * `rowIndexMapper` - so the column half runs for user-registered maps only.
+   * is a separate defect; this method does not paper over it. No core plugin registers a TRIMMING map
+   * on the column axis, so the column half of that case runs for user-registered maps only, though
+   * core plugins do permute the column sequence (`manualColumnMove`, `manualColumnFreeze`).
+   *
+   * And an editor parked in `WAITING` is not reconciled: `finishEditing()` has already run
+   * `saveValue()` by then, so there is nothing left to redirect.
    *
    * @param {object} indexesChangesState The state object of the index mapper's cache update.
    * @param {boolean} indexesChangesState.indexesSequenceChanged Whether the indexes sequence changed.
@@ -436,7 +519,7 @@ class EditorManager {
     const editor = this.activeEditor;
 
     if ((!indexesChangesState.trimmedIndexesChanged && !indexesChangesState.indexesSequenceChanged) ||
-        !editor ||
+        this.#structuralChangeInProgress || !editor ||
         editor.state !== EDITOR_STATE.EDITING ||
         this.#editedPhysicalRow === null || this.#editedPhysicalColumn === null) {
       return;

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -120,13 +120,17 @@ class EditorManager {
    * each suspend and resume the mapper themselves, so even inside `hot.batch()` every `alter()`
    * flushes its own update and the two counts are observed separately.
    *
-   * @param {object} indexesChangesState The state object of the index mapper's cache update.
+   * `afterRowSequenceCacheUpdate` is a PUBLIC hook, so `hot.runHooks()` can fire it with no payload
+   * at all. The state defaults to all-false for that case, which reduces the repair to the structural
+   * one and keeps the hidden-cell guard behind it running.
+   *
+   * @param {object} [indexesChangesState] The state object of the index mapper's cache update.
    * @param {boolean} indexesChangesState.indexesSequenceChanged Whether the indexes sequence changed.
    * @param {boolean} indexesChangesState.trimmedIndexesChanged Whether the trimmed indexes changed.
    */
   #onRowSequenceCacheUpdate = (indexesChangesState: {
     indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean;
-  }): void => {
+  } = { indexesSequenceChanged: false, trimmedIndexesChanged: false }): void => {
     const indexCount = this.hot.rowIndexMapper.getNumberOfIndexes();
 
     this.#repairEditor(indexCount !== this.#lastRowIndexCount, indexesChangesState);
@@ -138,13 +142,13 @@ class EditorManager {
    * Kept separate from the row handler so a structural change on one axis cannot route the other
    * axis's rearrangement into the wrong repair.
    *
-   * @param {object} indexesChangesState The state object of the index mapper's cache update.
+   * @param {object} [indexesChangesState] The state object of the index mapper's cache update.
    * @param {boolean} indexesChangesState.indexesSequenceChanged Whether the indexes sequence changed.
    * @param {boolean} indexesChangesState.trimmedIndexesChanged Whether the trimmed indexes changed.
    */
   #onColumnSequenceCacheUpdate = (indexesChangesState: {
     indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean;
-  }): void => {
+  } = { indexesSequenceChanged: false, trimmedIndexesChanged: false }): void => {
     const indexCount = this.hot.columnIndexMapper.getNumberOfIndexes();
 
     this.#repairEditor(indexCount !== this.#lastColumnIndexCount, indexesChangesState);
@@ -480,7 +484,8 @@ class EditorManager {
   #recaptureEditedRecord(): void {
     const editor = this.activeEditor;
 
-    if (!editor || editor.state !== EDITOR_STATE.EDITING || editor.row === null || editor.col === null) {
+    if (!editor || (editor.state !== EDITOR_STATE.EDITING && editor.state !== EDITOR_STATE.VIRGIN) ||
+        editor.row === null || editor.col === null) {
       return;
     }
 
@@ -577,10 +582,14 @@ class EditorManager {
     indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean;
   }): void {
     const editor = this.activeEditor;
+    const isEditing = editor?.state === EDITOR_STATE.EDITING;
+    // A prepared-but-untyped editor is just as stale as an editing one, and more quietly so: nothing
+    // re-prepares it, `openEditor()` skips `prepareEditor()` while a reference exists, and the first
+    // keystroke then calls `beginEditing()` on the pre-change coordinates.
+    const isPrepared = editor?.state === EDITOR_STATE.VIRGIN;
 
     if ((!indexesChangesState.trimmedIndexesChanged && !indexesChangesState.indexesSequenceChanged) ||
-        !editor ||
-        editor.state !== EDITOR_STATE.EDITING ||
+        !editor || (!isEditing && !isPrepared) ||
         this.#editedPhysicalRow === null || this.#editedPhysicalColumn === null) {
       return;
     }
@@ -588,14 +597,23 @@ class EditorManager {
     const visualRow = this.hot.rowIndexMapper.getVisualFromPhysicalIndex(this.#editedPhysicalRow);
     const visualColumn = this.hot.columnIndexMapper.getVisualFromPhysicalIndex(this.#editedPhysicalColumn);
 
+    if (isPrepared) {
+      // Nothing has been typed, so there is no value to carry and no reason to rebind. Dropping the
+      // reference is the whole repair: the next keystroke finds no active editor and goes back
+      // through `prepareEditor()`, which reads the coordinates, `TD`, `prop`, `originalValue` and
+      // cell meta from the post-change state.
+      if (visualRow !== editor.row || visualColumn !== editor.col) {
+        this.clearActiveEditor();
+      }
+
+      return;
+    }
+
     // No visual index means the record itself is trimmed. There is nowhere to commit to, so the edit
     // is dropped rather than written through coordinates that now address a different record.
     if (visualRow === null || visualColumn === null) {
       editor.cancelChanges();
-      // Drop the reference too. `openEditor()` re-prepares only when there is no active editor, so a
-      // lingering one would let the next keystroke reuse this editor's pre-trim `TD`, `prop`,
-      // `originalValue` and cell meta. Clearing sends the next edit back through `prepareEditor()`,
-      // which reads them from the post-trim state.
+      // Drop the reference too, for the same reason as the prepared case above.
       this.clearActiveEditor();
 
       return;

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -574,6 +574,11 @@ class EditorManager {
    * before it – but the value does not survive. Making it survive means moving the selection with the
    * record, which is a larger change than this repair.
    *
+   * An editor a structural change stranded past the last row is discarded here rather than rebound:
+   * its captured record was cleared as unresolvable, and its own coordinates address nothing, so
+   * there is no record left to follow. Discarding is what keeps a following `Filters#filter()` from
+   * committing through those coordinates and appending records.
+   *
    * Two further limits. An index-map change does NOT adjust the selection – `core.ts` calls
    * `selection.commit()` only for `hiddenIndexesChanged` – so the highlight can be left past the last
    * row, and typing into it grows the data set. That is reachable with no editor involved at all and
@@ -600,8 +605,28 @@ class EditorManager {
     const isPrepared = editor?.state === EDITOR_STATE.VIRGIN;
 
     if ((!indexesChangesState.trimmedIndexesChanged && !indexesChangesState.indexesSequenceChanged) ||
-        !editor || (!isEditing && !isPrepared) ||
-        this.#editedPhysicalRow === null || this.#editedPhysicalColumn === null) {
+        !editor || (!isEditing && !isPrepared)) {
+      return;
+    }
+
+    // No captured record means an earlier structural change renumbered it away. The editor's own
+    // coordinates are then the only thing left, so check whether they still address anything: if
+    // they do not, that change stranded the editor past the last row and nothing re-prepared it. A
+    // commit through those coordinates is what `applyChanges()` satisfies by APPENDING records, so
+    // the edit is dropped here rather than at the next keystroke.
+    //
+    // Only reached with no captured record. While one exists it is the better guide - it survives a
+    // trim that leaves the editor's own stale coordinates unresolvable, which is the ordinary rebind.
+    if (this.#editedPhysicalRow === null || this.#editedPhysicalColumn === null) {
+      if (this.hot.rowIndexMapper.getPhysicalFromVisualIndex(editor.row!) === null ||
+          this.hot.columnIndexMapper.getPhysicalFromVisualIndex(editor.col!) === null) {
+        if (isEditing) {
+          editor.cancelChanges();
+        }
+
+        this.clearActiveEditor();
+      }
+
       return;
     }
 

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -70,6 +70,21 @@ class EditorManager {
    * @type {boolean}
    */
   #hiddenCellCloseArmed = false;
+  /**
+   * The PHYSICAL row index of the record the active editor was prepared for, or `null` when no
+   * editor is prepared. Captured because the editor itself stores only VISUAL coordinates, which a
+   * trimming index map invalidates without notice.
+   *
+   * @type {number|null}
+   */
+  #editedPhysicalRow: number | null = null;
+  /**
+   * The PHYSICAL column index of the record the active editor was prepared for, or `null` when no
+   * editor is prepared. The column counterpart of `#editedPhysicalRow`.
+   *
+   * @type {number|null}
+   */
+  #editedPhysicalColumn: number | null = null;
 
   /**
    * @param {Core} hotInstance The Handsontable instance.
@@ -84,8 +99,14 @@ class EditorManager {
 
     this.hot.addHook('afterDocumentKeyDown', (event: KeyboardEvent) => this.#onAfterDocumentKeyDown(event));
     this.hot.addHook('beforeCompositionStart', (event: KeyboardEvent) => this.#onAfterDocumentKeyDown(event));
-    this.hot.addHook('afterRowSequenceCacheUpdate', () => this.#closeEditorWhenCellHidden());
-    this.hot.addHook('afterColumnSequenceCacheUpdate', () => this.#closeEditorWhenCellHidden());
+    this.hot.addHook('afterRowSequenceCacheUpdate', (indexesChangesState) => {
+      this.#reconcileEditorWithTrimmedIndexes(indexesChangesState);
+      this.#closeEditorWhenCellHidden();
+    });
+    this.hot.addHook('afterColumnSequenceCacheUpdate', (indexesChangesState) => {
+      this.#reconcileEditorWithTrimmedIndexes(indexesChangesState);
+      this.#closeEditorWhenCellHidden();
+    });
     this.hot.view._wt.update(
       'onCellDblClick', (event: MouseEvent, coords: { isCell: () => boolean }, _elem: HTMLElement) =>
         this.#onCellDblClick(event, coords)
@@ -163,6 +184,10 @@ class EditorManager {
       // Using not modified coordinates, as we need to get the table element using selection coordinates.
       // There is an extra translation in the editor for saving value.
       this.activeEditor.prepare(row, col, prop, td, originalValue, this.cellProperties);
+      // Remember which RECORD this edit belongs to. The editor keeps visual coordinates only, and a
+      // trimming map rebinds those to a different record; see `#reconcileEditorWithTrimmedIndexes()`.
+      this.#editedPhysicalRow = this.hot.rowIndexMapper.getPhysicalFromVisualIndex(row);
+      this.#editedPhysicalColumn = this.hot.columnIndexMapper.getPhysicalFromVisualIndex(col);
     }
   }
 
@@ -268,6 +293,8 @@ class EditorManager {
    */
   clearActiveEditor() {
     this.activeEditor = undefined;
+    this.#editedPhysicalRow = null;
+    this.#editedPhysicalColumn = null;
   }
 
   /**
@@ -346,6 +373,69 @@ class EditorManager {
   }
 
   /**
+   * Keeps an open editor bound to the RECORD it was opened on when a TRIMMING index map changes the
+   * visual index space underneath it.
+   *
+   * Filters, `trimRows` and `nestedRows` all register a `trimming` map. Unlike a hiding map, a
+   * trimming map COLLAPSES the visual index space: the rows below a trimmed row shift up. The editor
+   * stores visual coordinates captured in `prepare()`, and `BaseEditor#saveValue()` writes straight
+   * through them with no bounds check, so after a trim the pending edit lands on whichever record now
+   * occupies that visual slot - or, when the slot is past the shortened row count, on rows that
+   * `applyChanges()` APPENDS to the source data to make room for it. Both are silent data corruption.
+   *
+   * Resolving the stored PHYSICAL index back to a visual one covers all three shapes with one test:
+   * the record was trimmed away (no visual index - discard), the record survived but moved because
+   * rows above it were trimmed (rebind - the edit still commits, to the right record), or nothing
+   * moved (no-op). The last branch is what keeps this from firing spuriously: any row insert churns
+   * the trimming collection, and `BooleanMap#setValues()` emits a change even for a no-op write, so
+   * testing "the trimmed set changed" alone would tear down unrelated edits.
+   *
+   * Runs SYNCHRONOUSLY, unlike `#closeEditorWhenCellHidden()`. `Filters#filter()` re-selects the
+   * highlighted column immediately after writing its map, which commits the open editor before any
+   * deferred handler could run. Deferring here would let the corrupting write happen first. Nothing
+   * re-enters the manager as a result: the rebind writes no data, and the discard goes through
+   * `cancelChanges()` rather than `finishEditing(true)` to skip the render the latter appends, so
+   * neither branch reaches `setDataAtCell()` inside a cache update that is still unwinding.
+   *
+   * `cancelChanges()` also bypasses editor-level discard policy - `DropdownEditor#finishEditing()`
+   * rewrites the restore flag - which is harmless here because a discard is what that override would
+   * decide anyway once the edited record is gone from the visual space.
+   *
+   * The editor keeps its on-screen position until the next render. That is cosmetic and, on the
+   * Filters path, invisible: `filter()` renders before yielding.
+   *
+   * @param {object} indexesChangesState The state object of the index mapper's cache update.
+   * @param {boolean} indexesChangesState.indexesSequenceChanged Whether the indexes sequence changed.
+   * @param {boolean} indexesChangesState.trimmedIndexesChanged Whether the trimmed indexes changed.
+   * @param {boolean} indexesChangesState.hiddenIndexesChanged Whether the hidden indexes changed.
+   */
+  #reconcileEditorWithTrimmedIndexes(indexesChangesState: {
+    indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean; hiddenIndexesChanged: boolean;
+  }): void {
+    const editor = this.activeEditor;
+
+    if (!indexesChangesState.trimmedIndexesChanged || !editor ||
+        editor.state !== EDITOR_STATE.EDITING ||
+        this.#editedPhysicalRow === null || this.#editedPhysicalColumn === null) {
+      return;
+    }
+
+    const visualRow = this.hot.rowIndexMapper.getVisualFromPhysicalIndex(this.#editedPhysicalRow);
+    const visualColumn = this.hot.columnIndexMapper.getVisualFromPhysicalIndex(this.#editedPhysicalColumn);
+
+    // No visual index means the record itself is trimmed. There is nowhere to commit to, so the edit
+    // is dropped rather than written through coordinates that now address a different record.
+    if (visualRow === null || visualColumn === null) {
+      editor.cancelChanges();
+
+      return;
+    }
+
+    editor.row = visualRow;
+    editor.col = visualColumn;
+  }
+
+  /**
    * Ends an edit when a HIDING index map removes the edited cell from the DOM while the editor is
    * still open.
    *
@@ -365,9 +455,10 @@ class EditorManager {
    * itself on scroll but keeps `state` at `EDITING`, so the edit survives until the user scrolls
    * back. These hooks never fire on scroll, so that case cannot reach here at all.
    *
-   * A TRIMMING map (Filters, `trimRows`) is deliberately out of scope. It collapses the visual
-   * index space instead of preserving it, so the edited coordinates silently rebind to a different
-   * row that is still rendered and `isHidden()` reads `false`. That defect predates this method.
+   * A TRIMMING map (Filters, `trimRows`) needs the opposite treatment and is handled separately by
+   * `#reconcileEditorWithTrimmedIndexes()`, which runs first on the same two hooks. It collapses the
+   * visual index space instead of preserving it, so `isHidden()` reads `false` for a trimmed row and
+   * this method never fires for one.
    *
    * The edit is finished rather than cancelled, which for most editors means it is COMMITTED - the
    * same outcome clicking the pager already produces, since that is an outside click and therefore

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -86,36 +86,41 @@ class EditorManager {
    */
   #editedPhysicalColumn: number | null = null;
   /**
-   * Whether a structural change - a row or column being inserted or removed - is currently running.
+   * The size of each PHYSICAL index space as of the last cache update.
    *
-   * Such a change RENUMBERS the physical space, which invalidates `#editedPhysicalRow` while leaving
-   * the editor's visual coordinate correct. That is the opposite of what a trim or a permutation
-   * does, and the two are indistinguishable from the cache-update state alone, so the reconciliation
-   * stands down while this is set and the captured record is re-derived once the change lands.
+   * Only a structural change - an inserted or removed row or column - changes these. A trim, a
+   * permutation and a hide all leave the physical space the same size, so a difference here is the
+   * signal that `#editedPhysicalRow` has just been renumbered out from under the editor.
    *
-   * @type {boolean}
+   * Seeded in the constructor rather than from a sentinel: the manager is built after the index
+   * mappers are initialized, so the first cache update it ever sees is a real one, and a sentinel
+   * would make that update look structural.
+   *
+   * @type {number}
    */
-  #structuralChangeInProgress = false;
+  #lastRowIndexCount = 0;
   /**
-   * Marks the start of a structural change, so the cache update it emits does not reconcile against
-   * a physical index that the change is in the middle of renumbering.
+   * The column counterpart of `#lastRowIndexCount`.
+   *
+   * @type {number}
    */
-  #onBeforeStructuralChange = (): void => {
-    this.#structuralChangeInProgress = true;
-  };
-  /**
-   * Marks the end of a structural change and re-derives the edited record from the editor's visual
-   * coordinate, which the change kept valid.
-   */
-  #onAfterStructuralChange = (): void => {
-    this.#structuralChangeInProgress = false;
-    this.#recaptureEditedRecord();
-  };
+  #lastColumnIndexCount = 0;
   /**
    * Reacts to an index-map cache update on either axis.
    *
-   * The trimming reconciliation runs FIRST so that the hidden-cell guard tests `isHidden()` against
-   * rebound coordinates rather than the stale ones a trimming map just invalidated.
+   * A structural change and a rearrangement need opposite repairs - one invalidates the captured
+   * PHYSICAL index and keeps the visual coordinate, the other does the reverse - and the state object
+   * cannot tell them apart, because `insertIndexes()`/`removeIndexes()` raise the same flags a filter
+   * does. The SIZE of the physical space can: only an insert or a remove changes it. Comparing it
+   * against the previous update picks the right repair without relying on hook ordering, and nothing
+   * a plugin vetoes can strand it - a cancelled `beforeCreateRow` never changes the count either.
+   *
+   * The one shape this misses is a structural change that leaves the count where it started - an
+   * insert and a removal batched into a single cache update. `alter()` performs one operation per
+   * call, so nothing in core produces it.
+   *
+   * The chosen repair runs BEFORE the hidden-cell guard, so that guard tests `isHidden()` against
+   * corrected coordinates rather than the stale ones the index map just invalidated.
    *
    * @param {object} indexesChangesState The state object of the index mapper's cache update.
    * @param {boolean} indexesChangesState.indexesSequenceChanged Whether the indexes sequence changed.
@@ -125,7 +130,20 @@ class EditorManager {
   #onSequenceCacheUpdate = (indexesChangesState: {
     indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean; hiddenIndexesChanged: boolean;
   }): void => {
-    this.#reconcileEditorWithIndexMaps(indexesChangesState);
+    const rowIndexCount = this.hot.rowIndexMapper.getNumberOfIndexes();
+    const columnIndexCount = this.hot.columnIndexMapper.getNumberOfIndexes();
+    const isStructuralChange = rowIndexCount !== this.#lastRowIndexCount ||
+      columnIndexCount !== this.#lastColumnIndexCount;
+
+    this.#lastRowIndexCount = rowIndexCount;
+    this.#lastColumnIndexCount = columnIndexCount;
+
+    if (isStructuralChange) {
+      this.#recaptureEditedRecord();
+    } else {
+      this.#reconcileEditorWithIndexMaps(indexesChangesState);
+    }
+
     this.#closeEditorWhenCellHidden();
   };
 
@@ -139,19 +157,13 @@ class EditorManager {
     this.tableMeta = tableMeta;
     this.selection = selection;
     this.eventManager = new EventManager(hotInstance);
+    this.#lastRowIndexCount = hotInstance.rowIndexMapper.getNumberOfIndexes();
+    this.#lastColumnIndexCount = hotInstance.columnIndexMapper.getNumberOfIndexes();
 
     this.hot.addHook('afterDocumentKeyDown', (event: KeyboardEvent) => this.#onAfterDocumentKeyDown(event));
     this.hot.addHook('beforeCompositionStart', (event: KeyboardEvent) => this.#onAfterDocumentKeyDown(event));
     this.hot.addHook('afterRowSequenceCacheUpdate', this.#onSequenceCacheUpdate);
     this.hot.addHook('afterColumnSequenceCacheUpdate', this.#onSequenceCacheUpdate);
-    this.hot.addHook('beforeCreateRow', this.#onBeforeStructuralChange);
-    this.hot.addHook('beforeRemoveRow', this.#onBeforeStructuralChange);
-    this.hot.addHook('beforeCreateCol', this.#onBeforeStructuralChange);
-    this.hot.addHook('beforeRemoveCol', this.#onBeforeStructuralChange);
-    this.hot.addHook('afterCreateRow', this.#onAfterStructuralChange);
-    this.hot.addHook('afterRemoveRow', this.#onAfterStructuralChange);
-    this.hot.addHook('afterCreateCol', this.#onAfterStructuralChange);
-    this.hot.addHook('afterRemoveCol', this.#onAfterStructuralChange);
     this.hot.view._wt.update(
       'onCellDblClick', (event: MouseEvent, coords: { isCell: () => boolean }, _elem: HTMLElement) =>
         this.#onCellDblClick(event, coords)
@@ -176,10 +188,6 @@ class EditorManager {
     // `beforeChange` that cancels the change, for instance) would disable the guard for the rest
     // of the instance's life rather than for that one edit.
     this.#hiddenCellCloseArmed = false;
-    // A vetoed `beforeCreateRow`/`beforeRemoveRow` never reaches its `after` counterpart, which
-    // would leave the latch set. Nothing changed in that case, so the only cost is the guard being
-    // inert for the rest of that edit - and a new edit cycle clears it.
-    this.#structuralChangeInProgress = false;
 
     if (this.activeEditor && this.activeEditor.isWaiting()) {
       this.closeEditor(false, false, (dataSaved: boolean) => {
@@ -424,6 +432,8 @@ class EditorManager {
   /**
    * Re-derives the edited record after a structural change has renumbered the physical space.
    *
+   * Runs INSTEAD of the reconciliation, never after it, so the stale captured index is never acted on.
+   *
    * Inserting or removing rows shifts the physical indexes of everything below, so the index captured
    * in `prepareEditor()` now addresses a different record - but the editor's VISUAL coordinate came
    * through intact, because the index mapper moved the visual space with it. So the visual side is
@@ -476,10 +486,10 @@ class EditorManager {
    * A structural change - an inserted or removed row or column - is the one case this reasoning does
    * NOT cover, because it renumbers the physical space and invalidates the captured index while
    * leaving the visual coordinate correct. It raises the same flags and cannot be told apart from the
-   * state object, so `#onBeforeStructuralChange()` stands this method down for the duration and
-   * `#recaptureEditedRecord()` re-derives the record afterwards. Without that, a grid with any
-   * trimming map registered would discard a valid edit on `alter('remove_row', ...)` and, with a sort
-   * active, rebind onto the wrong record on `alter('insert_row_above', ...)`.
+   * state object, so `#onSequenceCacheUpdate()` routes those to `#recaptureEditedRecord()` instead,
+   * discriminating on the physical index count. Without that split, a grid with any trimming map
+   * registered would discard a valid edit on `alter('remove_row', ...)` and, with a sort active,
+   * rebind onto the wrong record on `alter('insert_row_above', ...)`.
    *
    * Runs SYNCHRONOUSLY, unlike `#closeEditorWhenCellHidden()`. `Filters#filter()` re-selects the
    * highlighted column immediately after writing its map, which commits the open editor before any
@@ -519,7 +529,7 @@ class EditorManager {
     const editor = this.activeEditor;
 
     if ((!indexesChangesState.trimmedIndexesChanged && !indexesChangesState.indexesSequenceChanged) ||
-        this.#structuralChangeInProgress || !editor ||
+        !editor ||
         editor.state !== EDITOR_STATE.EDITING ||
         this.#editedPhysicalRow === null || this.#editedPhysicalColumn === null) {
       return;

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -88,7 +88,7 @@ class EditorManager {
   /**
    * The size of each PHYSICAL index space as of the last cache update.
    *
-   * Only a structural change - an inserted or removed row or column - changes these. A trim, a
+   * Only a structural change – an inserted or removed row or column – changes these. A trim, a
    * permutation and a hide all leave the physical space the same size, so a difference here is the
    * signal that `#editedPhysicalRow` has just been renumbered out from under the editor.
    *
@@ -108,14 +108,14 @@ class EditorManager {
   /**
    * Reacts to a ROW index-map cache update.
    *
-   * A structural change and a rearrangement need opposite repairs - one invalidates the captured
-   * PHYSICAL index and keeps the visual coordinate, the other does the reverse - and the state object
+   * A structural change and a rearrangement need opposite repairs – one invalidates the captured
+   * PHYSICAL index and keeps the visual coordinate, the other does the reverse – and the state object
    * cannot tell them apart, because `insertIndexes()`/`removeIndexes()` raise the same flags a filter
    * does. The SIZE of the physical space can: only an insert or a remove changes it. Comparing it
    * against the previous update picks the right repair without relying on hook ordering, and nothing
-   * a plugin vetoes can strand it - a cancelled `beforeCreateRow` never changes the count either.
+   * a plugin vetoes can strand it – a cancelled `beforeCreateRow` never changes the count either.
    *
-   * The one shape this misses is a structural change that leaves the count where it started - an
+   * The one shape this misses is a structural change that leaves the count where it started – an
    * insert and a removal collapsing into a single cache update. `insertIndexes()`/`removeIndexes()`
    * each suspend and resume the mapper themselves, so even inside `hot.batch()` every `alter()`
    * flushes its own update and the two counts are observed separately.
@@ -471,14 +471,14 @@ class EditorManager {
    * Runs INSTEAD of the reconciliation, never after it, so the stale captured index is never acted on.
    *
    * Inserting or removing rows shifts the physical indexes of everything below, so the index captured
-   * in `prepareEditor()` now addresses a different record - but the editor's VISUAL coordinate came
+   * in `prepareEditor()` now addresses a different record – but the editor's VISUAL coordinate came
    * through intact, because the index mapper moved the visual space with it. So the visual side is
    * the trustworthy one here, and it is what the record is read back from.
    *
    * This never discards. Core already carries an edit across a structural change: `alter()` runs
    * `selection.shiftRows()` after the cache update, and the `prepareEditor()` behind it re-derives
    * the editor's coordinates and the captured record together. All this method does is keep the
-   * captured record correct for the changes core does NOT re-prepare after - a removal entirely below
+   * captured record correct for the changes core does NOT re-prepare after – a removal entirely below
    * the edited cell leaves the selection alone, so nothing else would notice the renumbering.
    */
   #recaptureEditedRecord(): void {
@@ -510,21 +510,21 @@ class EditorManager {
    * visual index space underneath it.
    *
    * Two kinds of change do that. A TRIMMING map (Filters, `trimRows`, `nestedRows`) COLLAPSES the
-   * visual space - the rows below a trimmed row shift up and the row count shrinks. A SEQUENCE change
+   * visual space – the rows below a trimmed row shift up and the row count shrinks. A SEQUENCE change
    * (`columnSorting`, `manualRowMove`, `manualColumnFreeze`) permutes it. Either way the editor is
    * left holding the visual coordinates it captured in `prepare()`, and `BaseEditor#saveValue()`
    * writes straight through them with no bounds check, so the pending edit lands on whichever record
-   * now occupies that visual slot - or, when a trim left the slot past the shortened row count, on
+   * now occupies that visual slot – or, when a trim left the slot past the shortened row count, on
    * rows that `applyChanges()` APPENDS to the source data to make room for it. Both are silent data
    * corruption.
    *
    * Resolving the stored PHYSICAL index back to a visual one covers every shape with one test: the
-   * record is gone (no visual index - discard), the record moved (rebind - the edit still commits, to
+   * record is gone (no visual index – discard), the record moved (rebind – the edit still commits, to
    * the right record), or nothing moved (no-op). The last branch is what keeps this from firing
    * spuriously: `BooleanMap#setValues()` emits a change even for a no-op write, so testing "something
    * changed" alone would tear down unrelated edits.
    *
-   * A structural change - an inserted or removed row or column - is the one case this reasoning does
+   * A structural change – an inserted or removed row or column – is the one case this reasoning does
    * NOT cover, because it renumbers the physical space and invalidates the captured index while
    * leaving the visual coordinate correct. It raises the same flags, so the state object cannot tell
    * it apart; `#onRowSequenceCacheUpdate()` and its column twin discriminate on the physical index
@@ -538,16 +538,16 @@ class EditorManager {
    * branch writes data, so nothing reaches `setDataAtCell()` inside a cache update still unwinding.
    *
    * The discard goes through `cancelChanges()` rather than `finishEditing(true)`, which skips the
-   * render `finishEditing()` appends - but NOT every render: `AutocompleteEditor#discardEditor()`
+   * render `finishEditing()` appends – but NOT every render: `AutocompleteEditor#discardEditor()`
    * calls `view.render()` unconditionally, so for the autocomplete family this repaints from inside
    * `IndexMapper#updateCache()`. That is the same nested repaint the pre-existing `outsideClick`
    * teardown already performs, and the render reads the caches this update has already rebuilt.
    *
-   * `cancelChanges()` also bypasses editor-level discard policy - `DropdownEditor#finishEditing()`
-   * rewrites the restore flag - which is harmless here because a discard is what that override would
+   * `cancelChanges()` also bypasses editor-level discard policy – `DropdownEditor#finishEditing()`
+   * rewrites the restore flag – which is harmless here because a discard is what that override would
    * decide anyway once the edited record is gone from the visual space.
    *
-   * A rebind moves the editor's coordinates and NOTHING else - not its pixel position, not the
+   * A rebind moves the editor's coordinates and NOTHING else – not its pixel position, not the
    * selection. Neither `render()` nor `view.render()` repositions an open editor, so it stays drawn
    * over the row it started on for the rest of the edit; on the Filters path that is invisible
    * because `filter()` closes the editor outright, but on the `trimRows` path it is left painted
@@ -558,13 +558,13 @@ class EditorManager {
    * Two paths do not: an editor whose `finishEditing()` vetoes on a moved range rewrites the commit
    * into a discard (`DropdownEditor`, and the `date`, `autocomplete` and `handsontable` types built
    * on it), and a Ctrl+Enter commit reads the SELECTION corners rather than the editor's coordinates
-   * (`BaseEditor#saveValue()`). On both the edit is lost rather than misplaced - which is what this
+   * (`BaseEditor#saveValue()`). On both the edit is lost rather than misplaced – which is what this
    * method exists to guarantee, and strictly better than the row-appending corruption they produced
-   * before it - but the value does not survive. Making it survive means moving the selection with the
+   * before it – but the value does not survive. Making it survive means moving the selection with the
    * record, which is a larger change than this repair.
    *
-   * Two further limits. An index-map change does NOT adjust the selection - `core.ts` calls
-   * `selection.commit()` only for `hiddenIndexesChanged` - so the highlight can be left past the last
+   * Two further limits. An index-map change does NOT adjust the selection – `core.ts` calls
+   * `selection.commit()` only for `hiddenIndexesChanged` – so the highlight can be left past the last
    * row, and typing into it grows the data set. That is reachable with no editor involved at all and
    * is a separate defect; this method does not paper over it. And an editor parked in `WAITING` is
    * not reconciled: `finishEditing()` has already run `saveValue()` by then, so there is nothing

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -106,7 +106,7 @@ class EditorManager {
    */
   #lastColumnIndexCount = 0;
   /**
-   * Reacts to an index-map cache update on either axis.
+   * Reacts to a ROW index-map cache update.
    *
    * A structural change and a rearrangement need opposite repairs - one invalidates the captured
    * PHYSICAL index and keeps the visual coordinate, the other does the reverse - and the state object
@@ -116,27 +116,59 @@ class EditorManager {
    * a plugin vetoes can strand it - a cancelled `beforeCreateRow` never changes the count either.
    *
    * The one shape this misses is a structural change that leaves the count where it started - an
-   * insert and a removal batched into a single cache update. `alter()` performs one operation per
-   * call, so nothing in core produces it.
-   *
-   * The chosen repair runs BEFORE the hidden-cell guard, so that guard tests `isHidden()` against
-   * corrected coordinates rather than the stale ones the index map just invalidated.
+   * insert and a removal collapsing into a single cache update. `insertIndexes()`/`removeIndexes()`
+   * each suspend and resume the mapper themselves, so even inside `hot.batch()` every `alter()`
+   * flushes its own update and the two counts are observed separately.
    *
    * @param {object} indexesChangesState The state object of the index mapper's cache update.
    * @param {boolean} indexesChangesState.indexesSequenceChanged Whether the indexes sequence changed.
    * @param {boolean} indexesChangesState.trimmedIndexesChanged Whether the trimmed indexes changed.
-   * @param {boolean} indexesChangesState.hiddenIndexesChanged Whether the hidden indexes changed.
    */
-  #onSequenceCacheUpdate = (indexesChangesState: {
-    indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean; hiddenIndexesChanged: boolean;
+  #onRowSequenceCacheUpdate = (indexesChangesState: {
+    indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean;
   }): void => {
-    const rowIndexCount = this.hot.rowIndexMapper.getNumberOfIndexes();
-    const columnIndexCount = this.hot.columnIndexMapper.getNumberOfIndexes();
-    const isStructuralChange = rowIndexCount !== this.#lastRowIndexCount ||
-      columnIndexCount !== this.#lastColumnIndexCount;
+    const indexCount = this.hot.rowIndexMapper.getNumberOfIndexes();
 
-    this.#lastRowIndexCount = rowIndexCount;
-    this.#lastColumnIndexCount = columnIndexCount;
+    this.#repairEditor(indexCount !== this.#lastRowIndexCount, indexesChangesState);
+    this.#lastRowIndexCount = indexCount;
+  };
+  /**
+   * Reacts to a COLUMN index-map cache update.
+   *
+   * Kept separate from the row handler so a structural change on one axis cannot route the other
+   * axis's rearrangement into the wrong repair.
+   *
+   * @param {object} indexesChangesState The state object of the index mapper's cache update.
+   * @param {boolean} indexesChangesState.indexesSequenceChanged Whether the indexes sequence changed.
+   * @param {boolean} indexesChangesState.trimmedIndexesChanged Whether the trimmed indexes changed.
+   */
+  #onColumnSequenceCacheUpdate = (indexesChangesState: {
+    indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean;
+  }): void => {
+    const indexCount = this.hot.columnIndexMapper.getNumberOfIndexes();
+
+    this.#repairEditor(indexCount !== this.#lastColumnIndexCount, indexesChangesState);
+    this.#lastColumnIndexCount = indexCount;
+  };
+  /**
+   * Applies the repair one axis's cache update calls for, then lets the hidden-cell guard run.
+   *
+   * The repair runs BEFORE that guard, so it tests `isHidden()` against corrected coordinates rather
+   * than the stale ones the index map just invalidated.
+   *
+   * @param {boolean} isStructuralChange Whether that axis's physical index count just changed.
+   * @param {object} indexesChangesState The state object of the index mapper's cache update.
+   * @param {boolean} indexesChangesState.indexesSequenceChanged Whether the indexes sequence changed.
+   * @param {boolean} indexesChangesState.trimmedIndexesChanged Whether the trimmed indexes changed.
+   */
+  #repairEditor(isStructuralChange: boolean, indexesChangesState: {
+    indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean;
+  }): void {
+    // `core.destroy()` tears the manager down and only then force-flushes both mappers, so this is
+    // still reachable afterwards. Every other path in this file guards the same way.
+    if (this.destroyed) {
+      return;
+    }
 
     if (isStructuralChange) {
       this.#recaptureEditedRecord();
@@ -145,7 +177,7 @@ class EditorManager {
     }
 
     this.#closeEditorWhenCellHidden();
-  };
+  }
 
   /**
    * @param {Core} hotInstance The Handsontable instance.
@@ -162,8 +194,8 @@ class EditorManager {
 
     this.hot.addHook('afterDocumentKeyDown', (event: KeyboardEvent) => this.#onAfterDocumentKeyDown(event));
     this.hot.addHook('beforeCompositionStart', (event: KeyboardEvent) => this.#onAfterDocumentKeyDown(event));
-    this.hot.addHook('afterRowSequenceCacheUpdate', this.#onSequenceCacheUpdate);
-    this.hot.addHook('afterColumnSequenceCacheUpdate', this.#onSequenceCacheUpdate);
+    this.hot.addHook('afterRowSequenceCacheUpdate', this.#onRowSequenceCacheUpdate);
+    this.hot.addHook('afterColumnSequenceCacheUpdate', this.#onColumnSequenceCacheUpdate);
     this.hot.view._wt.update(
       'onCellDblClick', (event: MouseEvent, coords: { isCell: () => boolean }, _elem: HTMLElement) =>
         this.#onCellDblClick(event, coords)
@@ -439,9 +471,11 @@ class EditorManager {
    * through intact, because the index mapper moved the visual space with it. So the visual side is
    * the trustworthy one here, and it is what the record is read back from.
    *
-   * A visual coordinate that no longer resolves means the change left the editor past the last row.
-   * There is nothing to commit to, so the edit is dropped rather than written through a coordinate
-   * that `applyChanges()` would satisfy by appending records.
+   * This never discards. Core already carries an edit across a structural change: `alter()` runs
+   * `selection.shiftRows()` after the cache update, and the `prepareEditor()` behind it re-derives
+   * the editor's coordinates and the captured record together. All this method does is keep the
+   * captured record correct for the changes core does NOT re-prepare after - a removal entirely below
+   * the edited cell leaves the selection alone, so nothing else would notice the renumbering.
    */
   #recaptureEditedRecord(): void {
     const editor = this.activeEditor;
@@ -453,10 +487,12 @@ class EditorManager {
     const physicalRow = this.hot.rowIndexMapper.getPhysicalFromVisualIndex(editor.row);
     const physicalColumn = this.hot.columnIndexMapper.getPhysicalFromVisualIndex(editor.col);
 
+    // A coordinate that no longer resolves means the removal was at or above the edited cell, and
+    // the selection shift that follows has not run yet. Leave everything alone: `shiftRows()` moves
+    // the highlight and the `prepareEditor()` behind it re-derives BOTH the editor's coordinates and
+    // the captured record from the post-change state. Discarding here instead would throw away an
+    // edit that core was about to carry across correctly.
     if (physicalRow === null || physicalColumn === null) {
-      editor.cancelChanges();
-      this.clearActiveEditor();
-
       return;
     }
 
@@ -485,46 +521,60 @@ class EditorManager {
    *
    * A structural change - an inserted or removed row or column - is the one case this reasoning does
    * NOT cover, because it renumbers the physical space and invalidates the captured index while
-   * leaving the visual coordinate correct. It raises the same flags and cannot be told apart from the
-   * state object, so `#onSequenceCacheUpdate()` routes those to `#recaptureEditedRecord()` instead,
-   * discriminating on the physical index count. Without that split, a grid with any trimming map
-   * registered would discard a valid edit on `alter('remove_row', ...)` and, with a sort active,
-   * rebind onto the wrong record on `alter('insert_row_above', ...)`.
+   * leaving the visual coordinate correct. It raises the same flags, so the state object cannot tell
+   * it apart; `#onRowSequenceCacheUpdate()` and its column twin discriminate on the physical index
+   * count and route those to `#recaptureEditedRecord()` instead. Without that split, a grid with any
+   * trimming map registered would, with a sort active, rebind onto the wrong record on
+   * `alter('insert_row_above', ...)`.
    *
    * Runs SYNCHRONOUSLY, unlike `#closeEditorWhenCellHidden()`. `Filters#filter()` re-selects the
    * highlighted column immediately after writing its map, which commits the open editor before any
-   * deferred handler could run. Deferring here would let the corrupting write happen first. Nothing
-   * re-enters the manager as a result: the rebind writes no data, and the discard goes through
-   * `cancelChanges()` rather than `finishEditing(true)` to skip the render the latter appends, so
-   * neither branch reaches `setDataAtCell()` inside a cache update that is still unwinding.
+   * deferred handler could run. Deferring here would let the corrupting write happen first. Neither
+   * branch writes data, so nothing reaches `setDataAtCell()` inside a cache update still unwinding.
+   *
+   * The discard goes through `cancelChanges()` rather than `finishEditing(true)`, which skips the
+   * render `finishEditing()` appends - but NOT every render: `AutocompleteEditor#discardEditor()`
+   * calls `view.render()` unconditionally, so for the autocomplete family this repaints from inside
+   * `IndexMapper#updateCache()`. That is the same nested repaint the pre-existing `outsideClick`
+   * teardown already performs, and the render reads the caches this update has already rebuilt.
    *
    * `cancelChanges()` also bypasses editor-level discard policy - `DropdownEditor#finishEditing()`
    * rewrites the restore flag - which is harmless here because a discard is what that override would
    * decide anyway once the edited record is gone from the visual space.
    *
-   * A rebind moves the editor's coordinates, NOT its pixel position or the selection - neither
-   * `render()` nor `view.render()` repositions an open editor, so it stays drawn over the row it
-   * started on for the rest of the edit. On the Filters path that is invisible because `filter()`
-   * closes the editor outright, but on the `trimRows` path the editor is left painted over a
-   * neighbouring row. The commit still lands on the right record; only the position is wrong.
+   * A rebind moves the editor's coordinates and NOTHING else - not its pixel position, not the
+   * selection. Neither `render()` nor `view.render()` repositions an open editor, so it stays drawn
+   * over the row it started on for the rest of the edit; on the Filters path that is invisible
+   * because `filter()` closes the editor outright, but on the `trimRows` path it is left painted
+   * over a neighboring row.
    *
-   * Three limits, all deliberate. An index-map change does NOT adjust the selection - `core.ts` calls
+   * That the selection does not follow bounds what the rebind can promise, and the boundary is worth
+   * stating precisely. A plain text commit reads `this.row`/`this.col` and lands on the right record.
+   * Two paths do not: an editor whose `finishEditing()` vetoes on a moved range rewrites the commit
+   * into a discard (`DropdownEditor`, and the `date`, `autocomplete` and `handsontable` types built
+   * on it), and a Ctrl+Enter commit reads the SELECTION corners rather than the editor's coordinates
+   * (`BaseEditor#saveValue()`). On both the edit is lost rather than misplaced - which is what this
+   * method exists to guarantee, and strictly better than the row-appending corruption they produced
+   * before it - but the value does not survive. Making it survive means moving the selection with the
+   * record, which is a larger change than this repair.
+   *
+   * Two further limits. An index-map change does NOT adjust the selection - `core.ts` calls
    * `selection.commit()` only for `hiddenIndexesChanged` - so the highlight can be left past the last
    * row, and typing into it grows the data set. That is reachable with no editor involved at all and
-   * is a separate defect; this method does not paper over it. No core plugin registers a TRIMMING map
-   * on the column axis, so the column half of that case runs for user-registered maps only, though
-   * core plugins do permute the column sequence (`manualColumnMove`, `manualColumnFreeze`).
+   * is a separate defect; this method does not paper over it. And an editor parked in `WAITING` is
+   * not reconciled: `finishEditing()` has already run `saveValue()` by then, so there is nothing
+   * left to redirect.
    *
-   * And an editor parked in `WAITING` is not reconciled: `finishEditing()` has already run
-   * `saveValue()` by then, so there is nothing left to redirect.
+   * No core plugin registers a TRIMMING map on the column axis, so that half runs for user-registered
+   * maps only; core plugins do permute the column sequence (`manualColumnMove`, `manualColumnFreeze`)
+   * and the reconciliation follows those.
    *
    * @param {object} indexesChangesState The state object of the index mapper's cache update.
    * @param {boolean} indexesChangesState.indexesSequenceChanged Whether the indexes sequence changed.
    * @param {boolean} indexesChangesState.trimmedIndexesChanged Whether the trimmed indexes changed.
-   * @param {boolean} indexesChangesState.hiddenIndexesChanged Whether the hidden indexes changed.
    */
   #reconcileEditorWithIndexMaps(indexesChangesState: {
-    indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean; hiddenIndexesChanged: boolean;
+    indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean;
   }): void {
     const editor = this.activeEditor;
 
@@ -576,7 +626,7 @@ class EditorManager {
    * back. These hooks never fire on scroll, so that case cannot reach here at all.
    *
    * A TRIMMING map (Filters, `trimRows`) needs the opposite treatment and is handled separately by
-   * `#reconcileEditorWithIndexMaps()`, which runs first on the same two hooks. It collapses the
+   * the repair dispatched before this method on the same two hooks. A trimming map collapses the
    * visual index space instead of preserving it, so `isHidden()` reads `false` for a trimmed row and
    * this method never fires for one.
    *

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -475,11 +475,18 @@ class EditorManager {
    * through intact, because the index mapper moved the visual space with it. So the visual side is
    * the trustworthy one here, and it is what the record is read back from.
    *
-   * This never discards. Core already carries an edit across a structural change: `alter()` runs
+   * This never discards. USUALLY core carries the edit across on its own: `alter()` runs
    * `selection.shiftRows()` after the cache update, and the `prepareEditor()` behind it re-derives
-   * the editor's coordinates and the captured record together. All this method does is keep the
-   * captured record correct for the changes core does NOT re-prepare after – a removal entirely below
-   * the edited cell leaves the selection alone, so nothing else would notice the renumbering.
+   * the editor's coordinates and the captured record together. Where that happens, discarding here
+   * would throw away an edit that was about to commit correctly.
+   *
+   * It does not always happen. `shiftRows()` only shifts a range whose outer top-start corner is at
+   * or below the removed row, so a focus moved below that corner – Enter or Tab inside a multi-cell
+   * selection – is left where it was, and `core.ts` only closes the editor when the removed range
+   * covers the HIGHLIGHT. The editor is then stranded past the last row and the commit appends, the
+   * same as it does without this repair. What this method still guarantees in that case is that it
+   * does not make things worse: the captured record is cleared rather than left pointing at whatever
+   * record inherited its index, so no later trim can resolve a lie and rebind onto a live record.
    */
   #recaptureEditedRecord(): void {
     const editor = this.activeEditor;
@@ -492,12 +499,16 @@ class EditorManager {
     const physicalRow = this.hot.rowIndexMapper.getPhysicalFromVisualIndex(editor.row);
     const physicalColumn = this.hot.columnIndexMapper.getPhysicalFromVisualIndex(editor.col);
 
-    // A coordinate that no longer resolves means the removal was at or above the edited cell, and
-    // the selection shift that follows has not run yet. Leave everything alone: `shiftRows()` moves
-    // the highlight and the `prepareEditor()` behind it re-derives BOTH the editor's coordinates and
-    // the captured record from the post-change state. Discarding here instead would throw away an
-    // edit that core was about to carry across correctly.
+    // A coordinate that no longer resolves means the removal was at or above the edited cell. Leave
+    // the EDITOR alone – `shiftRows()` normally moves the highlight and the `prepareEditor()` behind
+    // it re-derives everything, and discarding here would throw away an edit about to commit
+    // correctly – but drop the captured record, which the renumbering has just invalidated. Where the
+    // re-prepare does happen it re-captures anyway; where it does not, the reconciliation early-exits
+    // on `null` instead of resolving a stale index onto whatever record inherited it.
     if (physicalRow === null || physicalColumn === null) {
+      this.#editedPhysicalRow = null;
+      this.#editedPhysicalColumn = null;
+
       return;
     }
 

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -135,6 +135,12 @@ class EditorManager {
    * each suspend and resume the mapper themselves, so even inside `hot.batch()` every `alter()`
    * flushes its own update and the two counts are observed separately.
    *
+   * The comparison is PROVISIONAL, not the considered design. `IndexMapper` already tracks the real
+   * answer in `indexesChangeSource` (`'insert'`/`'remove'`/`'move'`/`'init'`/`'update'`), which
+   * `nestedHeaders` reads for the same question; it is simply not on the `cacheUpdated` payload yet,
+   * because `insertIndexes()`/`removeIndexes()` clear it before the hook fires. Putting it there
+   * removes both counters, their constructor seeding and the blind spot above – DEV-2681.
+   *
    * `afterRowSequenceCacheUpdate` is a PUBLIC hook, so `hot.runHooks()` can fire it with no payload
    * at all. The state defaults to all-false for that case, which reduces the repair to the structural
    * one and keeps the hidden-cell guard behind it running.
@@ -594,7 +600,12 @@ class EditorManager {
    * (`BaseEditor#saveValue()`). On both the edit is lost rather than misplaced – which is what this
    * method exists to guarantee, and strictly better than the row-appending corruption they produced
    * before it – but the value does not survive. Making it survive means moving the selection with the
-   * record, which is a larger change than this repair.
+   * record, which is a larger change than this repair: DEV-2680.
+   *
+   * Both exceptions are pinned by cases in `tests/e2e/editor-trimmed-row.spec.ts` under `commit paths
+   * the rebind cannot reach`. Those cases assert the LOSS on purpose, so a regression back to a write
+   * fails – they are not a statement that losing the edit is the desired end state. DEV-2680 inverts
+   * them.
    *
    * An editor a structural change stranded past the last row is discarded here rather than rebound:
    * its captured record was cleared as unresolvable, and its own coordinates address nothing, so

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -85,6 +85,23 @@ class EditorManager {
    * @type {number|null}
    */
   #editedPhysicalColumn: number | null = null;
+  /**
+   * Reacts to an index-map cache update on either axis.
+   *
+   * The index-map reconciliation runs FIRST so that the hidden-cell guard tests `isHidden()` against
+   * rebound coordinates rather than the stale ones the index map just invalidated.
+   *
+   * @param {object} indexesChangesState The state object of the index mapper's cache update.
+   * @param {boolean} indexesChangesState.indexesSequenceChanged Whether the indexes sequence changed.
+   * @param {boolean} indexesChangesState.trimmedIndexesChanged Whether the trimmed indexes changed.
+   * @param {boolean} indexesChangesState.hiddenIndexesChanged Whether the hidden indexes changed.
+   */
+  #onSequenceCacheUpdate = (indexesChangesState: {
+    indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean; hiddenIndexesChanged: boolean;
+  }): void => {
+    this.#reconcileEditorWithIndexMaps(indexesChangesState);
+    this.#closeEditorWhenCellHidden();
+  };
 
   /**
    * @param {Core} hotInstance The Handsontable instance.
@@ -99,14 +116,8 @@ class EditorManager {
 
     this.hot.addHook('afterDocumentKeyDown', (event: KeyboardEvent) => this.#onAfterDocumentKeyDown(event));
     this.hot.addHook('beforeCompositionStart', (event: KeyboardEvent) => this.#onAfterDocumentKeyDown(event));
-    this.hot.addHook('afterRowSequenceCacheUpdate', (indexesChangesState) => {
-      this.#reconcileEditorWithTrimmedIndexes(indexesChangesState);
-      this.#closeEditorWhenCellHidden();
-    });
-    this.hot.addHook('afterColumnSequenceCacheUpdate', (indexesChangesState) => {
-      this.#reconcileEditorWithTrimmedIndexes(indexesChangesState);
-      this.#closeEditorWhenCellHidden();
-    });
+    this.hot.addHook('afterRowSequenceCacheUpdate', this.#onSequenceCacheUpdate);
+    this.hot.addHook('afterColumnSequenceCacheUpdate', this.#onSequenceCacheUpdate);
     this.hot.view._wt.update(
       'onCellDblClick', (event: MouseEvent, coords: { isCell: () => boolean }, _elem: HTMLElement) =>
         this.#onCellDblClick(event, coords)
@@ -185,7 +196,7 @@ class EditorManager {
       // There is an extra translation in the editor for saving value.
       this.activeEditor.prepare(row, col, prop, td, originalValue, this.cellProperties);
       // Remember which RECORD this edit belongs to. The editor keeps visual coordinates only, and a
-      // trimming map rebinds those to a different record; see `#reconcileEditorWithTrimmedIndexes()`.
+      // trimming map rebinds those to a different record; see `#reconcileEditorWithIndexMaps()`.
       this.#editedPhysicalRow = this.hot.rowIndexMapper.getPhysicalFromVisualIndex(row);
       this.#editedPhysicalColumn = this.hot.columnIndexMapper.getPhysicalFromVisualIndex(col);
     }
@@ -373,22 +384,24 @@ class EditorManager {
   }
 
   /**
-   * Keeps an open editor bound to the RECORD it was opened on when a TRIMMING index map changes the
+   * Keeps an open editor bound to the RECORD it was opened on when an index map rearranges the
    * visual index space underneath it.
    *
-   * Filters, `trimRows` and `nestedRows` all register a `trimming` map. Unlike a hiding map, a
-   * trimming map COLLAPSES the visual index space: the rows below a trimmed row shift up. The editor
-   * stores visual coordinates captured in `prepare()`, and `BaseEditor#saveValue()` writes straight
-   * through them with no bounds check, so after a trim the pending edit lands on whichever record now
-   * occupies that visual slot - or, when the slot is past the shortened row count, on rows that
+   * Two kinds of change do that. A TRIMMING map (Filters, `trimRows`, `nestedRows`) COLLAPSES the
+   * visual space - the rows below a trimmed row shift up and the row count shrinks. A SEQUENCE
+   * change (`columnSorting`, `manualRowMove`) permutes it. Either way the editor is left holding the
+   * visual coordinates it captured in `prepare()`, and `BaseEditor#saveValue()` writes straight
+   * through them with no bounds check, so the pending edit lands on whichever record now occupies
+   * that visual slot - or, when a trim left the slot past the shortened row count, on rows that
    * `applyChanges()` APPENDS to the source data to make room for it. Both are silent data corruption.
    *
-   * Resolving the stored PHYSICAL index back to a visual one covers all three shapes with one test:
-   * the record was trimmed away (no visual index - discard), the record survived but moved because
-   * rows above it were trimmed (rebind - the edit still commits, to the right record), or nothing
-   * moved (no-op). The last branch is what keeps this from firing spuriously: any row insert churns
-   * the trimming collection, and `BooleanMap#setValues()` emits a change even for a no-op write, so
-   * testing "the trimmed set changed" alone would tear down unrelated edits.
+   * Resolving the stored PHYSICAL index back to a visual one covers every shape with one test: the
+   * record is gone (no visual index - discard), the record moved (rebind - the edit still commits,
+   * to the right record), or nothing moved (no-op). The last branch is what keeps this from firing
+   * spuriously: a row insert churns both collections, and `BooleanMap#setValues()` emits a change
+   * even for a no-op write, so testing "something changed" alone would tear down unrelated edits.
+   * An insert or removal shifts the visual and physical spaces together, so the resolution returns
+   * the index the editor already held and the no-op branch takes it.
    *
    * Runs SYNCHRONOUSLY, unlike `#closeEditorWhenCellHidden()`. `Filters#filter()` re-selects the
    * highlighted column immediately after writing its map, which commits the open editor before any
@@ -404,17 +417,26 @@ class EditorManager {
    * The editor keeps its on-screen position until the next render. That is cosmetic and, on the
    * Filters path, invisible: `filter()` renders before yielding.
    *
+   * Three limits, all deliberate. A trimming change does NOT adjust the selection - `core.ts` calls
+   * `selection.commit()` only for `hiddenIndexesChanged` - so the highlight can be left past the last
+   * row, and typing into it grows the data set. That is reachable with no editor involved at all and
+   * is a separate defect; this method does not paper over it. An editor parked in `WAITING` is not
+   * reconciled either, because `finishEditing()` has already run `saveValue()` by then and there is
+   * nothing left to redirect. And no core plugin registers a trimming map on the COLUMN axis - only
+   * `rowIndexMapper` - so the column half runs for user-registered maps only.
+   *
    * @param {object} indexesChangesState The state object of the index mapper's cache update.
    * @param {boolean} indexesChangesState.indexesSequenceChanged Whether the indexes sequence changed.
    * @param {boolean} indexesChangesState.trimmedIndexesChanged Whether the trimmed indexes changed.
    * @param {boolean} indexesChangesState.hiddenIndexesChanged Whether the hidden indexes changed.
    */
-  #reconcileEditorWithTrimmedIndexes(indexesChangesState: {
+  #reconcileEditorWithIndexMaps(indexesChangesState: {
     indexesSequenceChanged: boolean; trimmedIndexesChanged: boolean; hiddenIndexesChanged: boolean;
   }): void {
     const editor = this.activeEditor;
 
-    if (!indexesChangesState.trimmedIndexesChanged || !editor ||
+    if ((!indexesChangesState.trimmedIndexesChanged && !indexesChangesState.indexesSequenceChanged) ||
+        !editor ||
         editor.state !== EDITOR_STATE.EDITING ||
         this.#editedPhysicalRow === null || this.#editedPhysicalColumn === null) {
       return;
@@ -427,6 +449,11 @@ class EditorManager {
     // is dropped rather than written through coordinates that now address a different record.
     if (visualRow === null || visualColumn === null) {
       editor.cancelChanges();
+      // Drop the reference too. `openEditor()` re-prepares only when there is no active editor, so a
+      // lingering one would let the next keystroke reuse this editor's pre-trim `TD`, `prop`,
+      // `originalValue` and cell meta. Clearing sends the next edit back through `prepareEditor()`,
+      // which reads them from the post-trim state.
+      this.clearActiveEditor();
 
       return;
     }
@@ -456,7 +483,7 @@ class EditorManager {
    * back. These hooks never fire on scroll, so that case cannot reach here at all.
    *
    * A TRIMMING map (Filters, `trimRows`) needs the opposite treatment and is handled separately by
-   * `#reconcileEditorWithTrimmedIndexes()`, which runs first on the same two hooks. It collapses the
+   * `#reconcileEditorWithIndexMaps()`, which runs first on the same two hooks. It collapses the
    * visual index space instead of preserving it, so `isHidden()` reads `false` for a trimmed row and
    * this method never fires for one.
    *

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -86,6 +86,21 @@ class EditorManager {
    */
   #editedPhysicalColumn: number | null = null;
   /**
+   * Whether a structural change stranded the editor during the CURRENT task.
+   *
+   * `alter()` emits its cache update before `selection.shiftRows()`, so between the two the editor
+   * legitimately sits on a coordinate that resolves to nothing while a `prepareEditor()` is still
+   * coming. Anything that reconciles inside that window – a plugin trimming from `afterRemoveRow`,
+   * say – would otherwise read the editor as unusable and discard an edit that was about to commit.
+   *
+   * Cleared on a timeout rather than on a paired hook, so nothing a plugin cancels can strand it:
+   * the window closes when the task that opened it ends, which is where `alter()` has finished all
+   * its synchronous work.
+   *
+   * @type {boolean}
+   */
+  #strandedInCurrentTask = false;
+  /**
    * The size of each PHYSICAL index space as of the last cache update.
    *
    * Only a structural change – an inserted or removed row or column – changes these. A trim, a
@@ -224,6 +239,8 @@ class EditorManager {
     // `beforeChange` that cancels the change, for instance) would disable the guard for the rest
     // of the instance's life rather than for that one edit.
     this.#hiddenCellCloseArmed = false;
+    // A successful re-prepare is the end of any strand window.
+    this.#strandedInCurrentTask = false;
 
     if (this.activeEditor && this.activeEditor.isWaiting()) {
       this.closeEditor(false, false, (dataSaved: boolean) => {
@@ -508,6 +525,11 @@ class EditorManager {
     if (physicalRow === null || physicalColumn === null) {
       this.#editedPhysicalRow = null;
       this.#editedPhysicalColumn = null;
+      this.#strandedInCurrentTask = true;
+
+      this.hot._registerTimeout(() => {
+        this.#strandedInCurrentTask = false;
+      }, 0);
 
       return;
     }
@@ -615,11 +637,16 @@ class EditorManager {
     // commit through those coordinates is what `applyChanges()` satisfies by APPENDING records, so
     // the edit is dropped here rather than at the next keystroke.
     //
+    // Not while `#strandedInCurrentTask` is set: inside the `alter()` that stranded it the editor
+    // reads as unusable only because `selection.shiftRows()` has not run yet, and the re-prepare
+    // behind it is about to make the coordinates good again.
+    //
     // Only reached with no captured record. While one exists it is the better guide - it survives a
     // trim that leaves the editor's own stale coordinates unresolvable, which is the ordinary rebind.
     if (this.#editedPhysicalRow === null || this.#editedPhysicalColumn === null) {
-      if (this.hot.rowIndexMapper.getPhysicalFromVisualIndex(editor.row!) === null ||
-          this.hot.columnIndexMapper.getPhysicalFromVisualIndex(editor.col!) === null) {
+      if (!this.#strandedInCurrentTask &&
+          (this.hot.rowIndexMapper.getPhysicalFromVisualIndex(editor.row!) === null ||
+           this.hot.columnIndexMapper.getPhysicalFromVisualIndex(editor.col!) === null)) {
         if (isEditing) {
           editor.cancelChanges();
         }

--- a/tests/e2e/editor-trimmed-row.spec.ts
+++ b/tests/e2e/editor-trimmed-row.spec.ts
@@ -610,6 +610,10 @@ test.describe('an index-map change on the column axis', () => {
  * and both now lose the edit instead. They are recorded here because "the edit lands on the right
  * record" is the guarantee in `#reconcileEditorWithIndexMaps()`'s JSDoc, and these are its two
  * documented exceptions. A future change that turns either back into a write must fail here.
+ *
+ * Losing the edit is NOT the desired end state - it is where this repair stops. Making the value
+ * survive means moving the selection with the record, tracked as DEV-2680, which inverts both of
+ * these cases into asserting the value lands on the edited record.
  */
 test.describe('commit paths the rebind cannot reach', () => {
   /**

--- a/tests/e2e/editor-trimmed-row.spec.ts
+++ b/tests/e2e/editor-trimmed-row.spec.ts
@@ -685,3 +685,75 @@ test.describe('a data swap under an open editor', () => {
     expect(await grid.sourceRowCount()).toBe(3);
   });
 });
+
+/**
+ * Two states around the edges of the repair: an editor that exists but has not been typed into, and
+ * the public hook being fired by hand.
+ */
+test.describe('edges of the repair', () => {
+  /**
+   * Clicking a cell runs `prepareEditor()`, so an editor exists in `VIRGIN` holding that cell's
+   * coordinates, `TD`, `prop`, `originalValue` and cell meta - and nothing re-prepares it when a trim
+   * moves the visual space underneath. `openEditor()` skips `prepareEditor()` while a reference
+   * exists, so the first keystroke would otherwise begin editing against the trimmed-away record's
+   * state.
+   *
+   * `originalValue` is the read that shows it: visual row 3 displays `'A4'` after row 0 is trimmed,
+   * so a correctly re-prepared editor reports `'A4'`. Reporting `'A3'` means the stale meta survived,
+   * and with it that record's `readOnly`, `validator` and `type`.
+   *
+   * The target record is NOT what changes here. The selection never moved, so the write goes to the
+   * row the user can see highlighted either way - this is about the editor agreeing with it.
+   */
+  test('re-prepares a prepared-but-untyped editor when a trim moves its cell',
+    async({ page, theme, bundle }) => {
+      const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+      await grid.goto();
+
+      await grid.cell(3, 0).click();
+      await grid.trimRows([0]);
+
+      await grid.typeOnSelection('EDITED');
+
+      expect(await grid.editorOriginalValue()).toBe('A4');
+
+      await grid.commitWithEnter();
+
+      await expect.poll(() => grid.sourceData()).toEqual([
+        ['A0', 'B0'],
+        ['A1', 'B1'],
+        ['A2', 'B2'],
+        ['A3', 'B3'],
+        ['EDITED', 'B4'],
+      ]);
+      expect(await grid.sourceRowCount()).toBe(5);
+    });
+
+  /**
+   * `afterRowSequenceCacheUpdate` is public, so anyone can fire it through `runHooks()` with no
+   * payload. The handler reads two flags off that payload, and an unguarded read throws - which also
+   * skips the hidden-cell guard that runs behind it.
+   */
+  test('survives the public hook being fired without a payload', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.openEditorAndType(1, 0, 'EDITED');
+
+    expect(await grid.fireCacheUpdateHookWithoutPayload()).toBeNull();
+
+    // The edit is untouched, and still commits where it was typed.
+    await expect.poll(() => grid.editorState()).toBe('STATE_EDITING');
+
+    await grid.commitWithEnter();
+
+    await expect.poll(() => grid.sourceData()).toEqual([
+      ['A0', 'B0'],
+      ['EDITED', 'B1'],
+      ['A2', 'B2'],
+      ['A3', 'B3'],
+      ['A4', 'B4'],
+    ]);
+  });
+});

--- a/tests/e2e/editor-trimmed-row.spec.ts
+++ b/tests/e2e/editor-trimmed-row.spec.ts
@@ -1,0 +1,278 @@
+import { test, expect } from '../fixtures/test';
+import { EditorTrimmedRowPage } from '../fixtures/pages/EditorTrimmedRowPage';
+
+const UNTOUCHED = [
+  ['A0', 'B0'],
+  ['A1', 'B1'],
+  ['A2', 'B2'],
+  ['A3', 'B3'],
+  ['A4', 'B4'],
+];
+
+/**
+ * A TRIMMING index map collapses the visual index space: rows below a trimmed row shift up, and the
+ * row count shrinks. An open editor holds the VISUAL coordinates it captured when it was prepared,
+ * and `BaseEditor#saveValue()` writes through them with no bounds check, so before the fix a trim
+ * under an open editor produced silent data corruption in one of three shapes - a write to the
+ * wrong record, a write to a record the grid APPENDED to reach the stale coordinate, or a write to
+ * the wrong record after the edited row merely moved.
+ *
+ * Every case here asserts the whole source data set AND the record count. Checking one cell is not
+ * enough: a commit that lands on the right record while growing the dataset is still the bug.
+ */
+test.describe('Filters trims the edited record away', () => {
+  /**
+   * The append shape, and the severe one: the edited visual row sits past the post-filter row
+   * count, so `applyChanges()` creates the missing rows to reach it. Before the fix this produced
+   * `['A0','A1','A2','A3','A4', null, null, 'EDITED']` - eight records where there were five, with
+   * the typed value on a record that did not exist a moment earlier.
+   */
+  test('discards the edit instead of appending rows to reach a stale coordinate', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.openEditorAndType(3, 0, 'EDITED');
+
+    await grid.filterToValues(0, ['A2']);
+
+    await expect.poll(() => grid.sawTrimmingCacheUpdate('row')).toBe(true);
+
+    await expect.poll(() => grid.sourceRowCount()).toBe(5);
+    await expect.poll(() => grid.sourceData()).toEqual(UNTOUCHED);
+    expect(await grid.committedChangeCount()).toBe(0);
+
+    // Pins that this case really is the append shape: the editor's visual row (3) is past the last
+    // visible row. Without this the case would silently degrade into the wrong-record shape below.
+    expect(await grid.visibleRowCount()).toBe(1);
+  });
+
+  /**
+   * The same cause with the row count intact, which is the shape a fix aimed only at the append
+   * would leave behind. The edited visual row (0) still resolves after the filter, but to a
+   * different record: before the fix `'A2'` was overwritten with the value typed into `'A0'`.
+   */
+  test('discards the edit instead of writing it onto the record that took the slot',
+    async({ page, theme, bundle }) => {
+      const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+      await grid.goto();
+      await grid.openEditorAndType(0, 0, 'EDITED');
+
+      await grid.filterToValues(0, ['A2']);
+
+      // The surviving record moved into the edited row's visual slot. That coincidence is the whole
+      // case, so assert it rather than assuming the filter produced it.
+      await expect.poll(() => grid.toPhysicalRow(0)).toBe(2);
+      await expect.poll(() => grid.sawTrimmingCacheUpdate('row')).toBe(true);
+
+      await expect.poll(() => grid.sourceRowCount()).toBe(5);
+      await expect.poll(() => grid.sourceData()).toEqual(UNTOUCHED);
+      expect(await grid.committedChangeCount()).toBe(0);
+    });
+});
+
+/**
+ * The edited record survives the filter and only MOVES, because rows above it were trimmed. Nothing
+ * about the row count betrays this one, and a guard that only reacts to "the edited row became
+ * invisible" misses it entirely - which is why the fix resolves the editor's physical record on
+ * every trimming change rather than testing for disappearance.
+ */
+test.describe('Filters keeps the edited record but moves it', () => {
+  /**
+   * `filter()` re-selects the highlighted column before it returns, and that selection change is
+   * what commits the edit - synchronously, inside `filter()`. So the edit does land, and it must
+   * land on `'A4'`. Before the fix the stale visual row 4 was past the two remaining rows, which
+   * appended three records and put `'EDITED'` on the last of them.
+   */
+  test('commits the edit to the record it was typed into', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.openEditorAndType(4, 0, 'EDITED');
+
+    await grid.filterToValues(0, ['A3', 'A4']);
+
+    await expect.poll(() => grid.sawTrimmingCacheUpdate('row')).toBe(true);
+
+    await expect.poll(() => grid.sourceRowCount()).toBe(5);
+    await expect.poll(() => grid.sourceData()).toEqual([
+      ['A0', 'B0'],
+      ['A1', 'B1'],
+      ['A2', 'B2'],
+      ['A3', 'B3'],
+      ['EDITED', 'B4'],
+    ]);
+
+    // Pins that the edited record really did move: had the filter left it at visual row 4, the
+    // stale coordinate would have been in range and this case would prove nothing.
+    expect(await grid.visibleRowCount()).toBe(2);
+  });
+});
+
+/**
+ * `trimRows()` reaches the editor by a different route from `filter()`: it touches neither the
+ * selection nor the render, so nothing commits the edit as a side effect. The stale editor is left
+ * armed and corrupts on whatever the user does next. These cases therefore end with a real commit
+ * trigger rather than reading the data straight after the trim.
+ */
+test.describe('trimRows removes or moves the edited record', () => {
+  /**
+   * With the record gone the edit is dropped, and it must be dropped THERE - not left pending on a
+   * stale coordinate. Before the fix the editor stayed open and the next click committed `'EDITED'`
+   * onto `'A4'`, the record that had taken over visual row 3.
+   */
+  test('closes the editor and leaves a later click unable to commit', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.openEditorAndType(3, 0, 'EDITED');
+
+    await grid.trimRows([3]);
+
+    await expect.poll(() => grid.sawTrimmingCacheUpdate('row')).toBe(true);
+    await expect.poll(() => grid.isEditorOpen()).toBe(false);
+    // `trimRows()` issues no render of its own, so the editor has to take itself off screen. The
+    // textarea wrapper lives in the DOM permanently; its hidden class is the real signal.
+    await expect(grid.editorHolder).toHaveClass(/ht_editor_hidden/);
+
+    await grid.cell(0, 0).click();
+
+    await expect.poll(() => grid.sourceRowCount()).toBe(5);
+    await expect.poll(() => grid.sourceData()).toEqual(UNTOUCHED);
+    expect(await grid.committedChangeCount()).toBe(0);
+  });
+
+  /**
+   * The record survives two rows above it being trimmed, so the editor stays open and rebinds. The
+   * direct read is `editorRow()`: 4 before the trim, 2 after. Before the fix it stayed at 4, which
+   * is past the three remaining rows - Enter then appended two records and wrote `'EDITED'` onto
+   * the last one.
+   */
+  test('rebinds the open editor so Enter commits to the record it was typed into',
+    async({ page, theme, bundle }) => {
+      const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+      await grid.goto();
+      await grid.openEditorAndType(4, 0, 'EDITED');
+
+      await grid.trimRows([0, 1]);
+
+      await expect.poll(() => grid.sawTrimmingCacheUpdate('row')).toBe(true);
+      await expect.poll(() => grid.editorState()).toBe('STATE_EDITING');
+      await expect.poll(() => grid.editorRow()).toBe(2);
+      await expect.poll(() => grid.editorText()).toBe('EDITED');
+
+      await grid.commitWithEnter();
+
+      await expect.poll(() => grid.sourceRowCount()).toBe(5);
+      await expect.poll(() => grid.sourceData()).toEqual([
+        ['A0', 'B0'],
+        ['A1', 'B1'],
+        ['A2', 'B2'],
+        ['A3', 'B3'],
+        ['EDITED', 'B4'],
+      ]);
+    });
+});
+
+/**
+ * The guard reacts to a trimming-map write, and trimming maps are written far more often than they
+ * actually move anything - `BooleanMap#setValues()` emits its change event even when every value it
+ * writes is the one already there. Tearing an edit down on that churn would be a regression worse
+ * than the bug, so the fix compares the edited record's resolved visual index instead of trusting
+ * the change event.
+ */
+test.describe('a trimming-map write that moves nothing', () => {
+  test('leaves the open edit untouched', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.openEditorAndType(2, 0, 'EDITED');
+
+    // Untrimming a row that was never trimmed: the map is rewritten, the change event fires, and
+    // not one index moves.
+    await grid.untrimRows([1]);
+
+    await expect.poll(() => grid.sawTrimmingCacheUpdate('row')).toBe(true);
+    await expect.poll(() => grid.editorState()).toBe('STATE_EDITING');
+    await expect.poll(() => grid.editorRow()).toBe(2);
+    expect(await grid.committedChangeCount()).toBe(0);
+
+    await grid.commitWithEnter();
+
+    await expect.poll(() => grid.sourceRowCount()).toBe(5);
+    await expect.poll(() => grid.sourceData()).toEqual([
+      ['A0', 'B0'],
+      ['A1', 'B1'],
+      ['EDITED', 'B2'],
+      ['A3', 'B3'],
+      ['A4', 'B4'],
+    ]);
+  });
+});
+
+/**
+ * Two states that reach the guard by a route none of the cases above take, and that the fix has to
+ * survive rather than improve: the editor's cell has no rendered `TD` at all, and a physical index
+ * shift that no trimming map performed.
+ */
+test.describe('states the captured record has to survive', () => {
+  /**
+   * `EditorManager#prepareEditor()` does its work only when the edited cell has a rendered `TD`, so
+   * a cell scrolled out of the viewport leaves the editor open on coordinates the manager will not
+   * refresh. Filtering from there still has to resolve the right record. Before the fix the stale
+   * visual row 0 pointed at the single surviving record and overwrote `'A50'`.
+   */
+  test('discards an edit whose cell was scrolled out of view before the filter ran',
+    async({ page, theme, bundle }) => {
+      const grid = new EditorTrimmedRowPage(page, theme, bundle, { scenario: 'tall' });
+
+      await grid.goto();
+      await grid.openEditorAndType(0, 0, 'EDITED');
+
+      await grid.scrollToRow(60);
+
+      // The edit survives a scroll - that is deliberate, long-standing behavior - so this is the
+      // state the filter has to be applied from, not an incidental one.
+      await expect.poll(() => grid.isRowRendered(0)).toBe(false);
+      await expect.poll(() => grid.editorState()).toBe('STATE_EDITING');
+
+      await grid.filterToValues(0, ['A50']);
+
+      await expect.poll(() => grid.sawTrimmingCacheUpdate('row')).toBe(true);
+
+      await expect.poll(() => grid.sourceRowCount()).toBe(100);
+      await expect.poll(() => grid.sourceCell(0, 0)).toBe('A0');
+      await expect.poll(() => grid.sourceCell(50, 0)).toBe('A50');
+      expect(await grid.committedChangeCount()).toBe(0);
+    });
+
+  /**
+   * `alter('remove_row')` shifts PHYSICAL indexes and emits a trimming-map change on the way, so the
+   * captured record index can go stale in a way no resolution can detect. Core closes the editor
+   * only when the removed range covers the highlighted row, so editing row 4 while row 1 is removed
+   * leaves the editor open with a coordinate that is now past the end - which before the fix
+   * appended a record on the next commit. The edit is dropped instead; nothing is invented.
+   */
+  test('never grows the data set when a row removal strands the editor past the last row',
+    async({ page, theme, bundle }) => {
+      const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+      await grid.goto();
+      await grid.openEditorAndType(4, 0, 'EDITED');
+
+      await grid.removeRow(1);
+
+      await expect.poll(() => grid.sawTrimmingCacheUpdate('row')).toBe(true);
+
+      await grid.cell(0, 0).click();
+
+      await expect.poll(() => grid.sourceRowCount()).toBe(4);
+      await expect.poll(() => grid.sourceData()).toEqual([
+        ['A0', 'B0'],
+        ['A2', 'B2'],
+        ['A3', 'B3'],
+        ['A4', 'B4'],
+      ]);
+    });
+});

--- a/tests/e2e/editor-trimmed-row.spec.ts
+++ b/tests/e2e/editor-trimmed-row.spec.ts
@@ -831,3 +831,37 @@ test.describe('a removal that strands the editor', () => {
       ]);
     });
 });
+
+/**
+ * An index-map change fired from INSIDE the `alter()` that is still running.
+ *
+ * `alter()` emits its cache update before `selection.shiftRows()`, so in between the editor sits on
+ * a coordinate that resolves to nothing while a `prepareEditor()` is still coming. A plugin trimming
+ * from `afterRemoveRow` lands exactly there. Reading the editor as unusable at that moment and
+ * discarding would throw away an edit that was about to commit correctly – `develop` commits it, so
+ * doing anything else here is a regression rather than a gap.
+ */
+test.describe('an index-map change nested inside a removal', () => {
+  test('keeps an edit that the pending re-prepare is about to rescue',
+    async({ page, theme, bundle }) => {
+      const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+      await grid.goto();
+      await grid.openEditorAndType(4, 0, 'EDITED');
+
+      // Removes `'A0'`, and trims what is then physical row 0 (`'A1'`) from inside `afterRemoveRow`.
+      await grid.removeRowTrimmingFrom(0, 0);
+
+      await expect.poll(() => grid.editorState()).toBe('STATE_EDITING');
+
+      await grid.commitWithEnter();
+
+      await expect.poll(() => grid.sourceData()).toEqual([
+        ['A1', 'B1'],
+        ['A2', 'B2'],
+        ['A3', 'B3'],
+        ['EDITED', 'B4'],
+      ]);
+      expect(await grid.sourceRowCount()).toBe(4);
+    });
+});

--- a/tests/e2e/editor-trimmed-row.spec.ts
+++ b/tests/e2e/editor-trimmed-row.spec.ts
@@ -385,7 +385,7 @@ test.describe('a sequence change under an open editor', () => {
 
     await grid.sortFirstColumnDescending();
 
-    // Sorting trims nothing - this is the flag that the trimming-only gate did not react to.
+    // Sorting trims nothing - this is the flag that a trimming-only gate does not react to.
     await expect.poll(() => grid.sawSequenceCacheUpdate('row')).toBe(true);
     expect(await grid.sawTrimmingCacheUpdate('row')).toBe(false);
     await expect.poll(() => grid.editorRow()).toBe(0);
@@ -415,6 +415,9 @@ test.describe('a sequence change under an open editor', () => {
     await grid.moveRow(0, 3);
 
     await expect.poll(() => grid.sawSequenceCacheUpdate('row')).toBe(true);
+    // Same negative assertion as the sort case, so this cannot silently start passing for the
+    // trimming reason instead of the sequence one.
+    expect(await grid.sawTrimmingCacheUpdate('row')).toBe(false);
     await expect.poll(() => grid.editorRow()).toBe(3);
 
     await grid.commitWithEnter();
@@ -427,5 +430,76 @@ test.describe('a sequence change under an open editor', () => {
       ['A4', 'B4'],
     ]);
     expect(await grid.sourceRowCount()).toBe(5);
+  });
+});
+
+/**
+ * A structural change - `alter()` inserting or removing rows - is the case the physical-index
+ * approach gets backwards. It RENUMBERS the physical space, so the captured index goes stale while
+ * the editor's visual coordinate stays correct; reconciling against the captured index then discards
+ * a valid edit or rebinds onto the wrong record. Both cases below need a permutation active, because
+ * unsorted the two index spaces shift together and the error cancels out.
+ *
+ * Core only closes the editor when the removed range covers the highlighted row (`core.ts`), so an
+ * `alter()` elsewhere in the grid leaves the edit open and live.
+ */
+test.describe('a structural change while an editor is open', () => {
+  /**
+   * Sorted descending, visual 0 is physical 4 (`'A4'`). Removing visual row 4 removes `'A0'` - a
+   * different record entirely - and `'A4'` is still at visual 0, so the edit must still commit onto
+   * it. Reconciling against the captured index instead saw physical 4 fall out of range and dropped
+   * the edit: `['A1','A2','A3','A4']` with the typing lost.
+   */
+  test('keeps a valid edit when an unrelated row is removed', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle, { sorting: true });
+
+    await grid.goto();
+    await grid.sortFirstColumnDescending();
+
+    await expect.poll(() => grid.toPhysicalRow(0)).toBe(4);
+
+    await grid.openEditorAndType(0, 0, 'EDITED');
+    await grid.removeRow(4, 1);
+
+    await expect.poll(() => grid.editorState()).toBe('STATE_EDITING');
+
+    await grid.commitWithEnter();
+
+    await expect.poll(() => grid.sourceData()).toEqual([
+      ['A1', 'B1'],
+      ['A2', 'B2'],
+      ['A3', 'B3'],
+      ['EDITED', 'B4'],
+    ]);
+    expect(await grid.sourceRowCount()).toBe(4);
+  });
+
+  /**
+   * The insert half. `'A4'` is at visual 0 and stays there, but every physical index at or above the
+   * insertion point shifts up by one, so the captured index 4 now addresses `'A3'`. Reconciling
+   * against it rebound the editor to visual 1 and committed onto `'A3'` - the exact corruption shape
+   * this whole change exists to prevent.
+   */
+  test('commits to the right record when a row is inserted', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle, { sorting: true });
+
+    await grid.goto();
+    await grid.sortFirstColumnDescending();
+    await grid.openEditorAndType(0, 0, 'EDITED');
+
+    await grid.insertRowAbove(4, 1);
+
+    await expect.poll(() => grid.editorRow()).toBe(0);
+
+    await grid.commitWithEnter();
+
+    await expect.poll(() => grid.sourceData()).toEqual([
+      [null, null],
+      ['A0', 'B0'],
+      ['A1', 'B1'],
+      ['A2', 'B2'],
+      ['A3', 'B3'],
+      ['EDITED', 'B4'],
+    ]);
   });
 });

--- a/tests/e2e/editor-trimmed-row.spec.ts
+++ b/tests/e2e/editor-trimmed-row.spec.ts
@@ -37,9 +37,11 @@ test.describe('Filters trims the edited record away', () => {
 
     await expect.poll(() => grid.sawTrimmingCacheUpdate('row')).toBe(true);
 
-    await expect.poll(() => grid.sourceRowCount()).toBe(5);
-    await expect.poll(() => grid.sourceData()).toEqual(UNTOUCHED);
+    // The change count is what rules out a commit landing a tick later; `expect.poll` would pass on
+    // its first sample and prove nothing about persistence. Read the data plainly, after it.
     expect(await grid.committedChangeCount()).toBe(0);
+    expect(await grid.sourceRowCount()).toBe(5);
+    expect(await grid.sourceData()).toEqual(UNTOUCHED);
 
     // Pins that this case really is the append shape: the editor's visual row (3) is past the last
     // visible row. Without this the case would silently degrade into the wrong-record shape below.
@@ -65,9 +67,9 @@ test.describe('Filters trims the edited record away', () => {
       await expect.poll(() => grid.toPhysicalRow(0)).toBe(2);
       await expect.poll(() => grid.sawTrimmingCacheUpdate('row')).toBe(true);
 
-      await expect.poll(() => grid.sourceRowCount()).toBe(5);
-      await expect.poll(() => grid.sourceData()).toEqual(UNTOUCHED);
       expect(await grid.committedChangeCount()).toBe(0);
+      expect(await grid.sourceRowCount()).toBe(5);
+      expect(await grid.sourceData()).toEqual(UNTOUCHED);
     });
 });
 
@@ -137,10 +139,51 @@ test.describe('trimRows removes or moves the edited record', () => {
 
     await grid.cell(0, 0).click();
 
-    await expect.poll(() => grid.sourceRowCount()).toBe(5);
-    await expect.poll(() => grid.sourceData()).toEqual(UNTOUCHED);
     expect(await grid.committedChangeCount()).toBe(0);
+    expect(await grid.sourceRowCount()).toBe(5);
+    expect(await grid.sourceData()).toEqual(UNTOUCHED);
   });
+
+  /**
+   * The discard has to release the editor, not just its value. `openEditor()` re-prepares only when
+   * there is no active editor, so a lingering reference would let the next keystroke reuse the
+   * pre-trim `TD`, `prop`, `originalValue` and cell meta of a record that is no longer on screen.
+   *
+   * `originalValue` is the discriminating read, not the write. The selection is not adjusted by a
+   * trim, so the coordinates a save goes through are the same either way and the value lands on
+   * `'A4'` regardless - what a stale reference changes is the record the editor was SET UP for:
+   * `'A3'`'s cell meta, `prop`, `TD` and original value, for a record no longer on screen. A stale
+   * `readOnly` or `validator` from that meta would decide the next edit.
+   */
+  test('re-prepares from post-trim state when the user keeps typing after the discard',
+    async({ page, theme, bundle }) => {
+      const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+      await grid.goto();
+      await grid.openEditorAndType(3, 0, 'EDITED');
+
+      // Physical row 3 is trimmed, so visual row 3 - still the selected one - now shows `'A4'`.
+      await grid.trimRows([3]);
+
+      await expect.poll(() => grid.isEditorOpen()).toBe(false);
+
+      await grid.typeOnSelection('X');
+
+      await expect.poll(() => grid.isEditorOpen()).toBe(true);
+      // `'A3'` here would mean the discarded editor was reused with the trimmed record's state.
+      expect(await grid.editorOriginalValue()).toBe('A4');
+
+      await grid.commitWithEnter();
+
+      await expect.poll(() => grid.sourceData()).toEqual([
+        ['A0', 'B0'],
+        ['A1', 'B1'],
+        ['A2', 'B2'],
+        ['A3', 'B3'],
+        ['X', 'B4'],
+      ]);
+      expect(await grid.sourceRowCount()).toBe(5);
+    });
 
   /**
    * The record survives two rows above it being trimmed, so the editor stays open and rebinds. The
@@ -249,10 +292,13 @@ test.describe('states the captured record has to survive', () => {
 
   /**
    * `alter('remove_row')` shifts PHYSICAL indexes and emits a trimming-map change on the way, so the
-   * captured record index can go stale in a way no resolution can detect. Core closes the editor
-   * only when the removed range covers the highlighted row, so editing row 4 while row 1 is removed
-   * leaves the editor open with a coordinate that is now past the end - which before the fix
-   * appended a record on the next commit. The edit is dropped instead; nothing is invented.
+   * captured record index can go stale. Core closes the editor only when the removed range covers
+   * the highlighted row, so editing row 4 while row 1 is removed leaves the editor open with a
+   * coordinate that is now past the end - which before the fix appended a record on the next commit.
+   *
+   * This pins the past-the-end shape only: the captured index no longer resolves, so the edit is
+   * dropped and nothing is invented. The other stale shape - the captured index still resolves, but
+   * to a different surviving record - is not covered here, and the fix does not claim to repair it.
    */
   test('never grows the data set when a row removal strands the editor past the last row',
     async({ page, theme, bundle }) => {
@@ -275,4 +321,111 @@ test.describe('states the captured record has to survive', () => {
         ['A4', 'B4'],
       ]);
     });
+});
+
+/**
+ * With `columnSorting` active a visual row index no longer equals its physical one, so a fix that
+ * accidentally captured or resolved a VISUAL index still passes every case above. This case is the
+ * one that separates the two: the record being edited sits at a visual index that belongs to a
+ * different physical row, and the assertion is which physical record the value lands on.
+ */
+test.describe('a sorted index mapping under the trim', () => {
+  /**
+   * Sorted descending, visual 1 is physical 3 (`'A3'`). The filter then trims physical 0, 1 and 4,
+   * leaving `'A3'` and `'A2'` at visual 0 and 1 - so the edited record moves up one slot and the
+   * editor has to follow it. Before the fix the stale visual row 1 was still in range and the value
+   * landed on `'A2'`, with no row-count change to betray it.
+   */
+  test('commits to the record being edited, not the one at the same visual index',
+    async({ page, theme, bundle }) => {
+      const grid = new EditorTrimmedRowPage(page, theme, bundle, { sorting: true });
+
+      await grid.goto();
+      await grid.sortFirstColumnDescending();
+
+      // The two index spaces genuinely differ here. Without this the case degrades into a plain
+      // repeat of the unsorted moved-record case.
+      await expect.poll(() => grid.toPhysicalRow(1)).toBe(3);
+
+      await grid.openEditorAndType(1, 0, 'EDITED');
+
+      await grid.filterToValues(0, ['A3', 'A2']);
+
+      await expect.poll(() => grid.sawTrimmingCacheUpdate('row')).toBe(true);
+
+      await expect.poll(() => grid.sourceRowCount()).toBe(5);
+      await expect.poll(() => grid.sourceData()).toEqual([
+        ['A0', 'B0'],
+        ['A1', 'B1'],
+        ['A2', 'B2'],
+        ['EDITED', 'B3'],
+        ['A4', 'B4'],
+      ]);
+    });
+});
+
+/**
+ * A SEQUENCE change permutes the visual space without trimming anything: `columnSorting` and
+ * `manualRowMove` report `indexesSequenceChanged` and leave `trimmedIndexesChanged` false. The
+ * editor is stranded exactly as a trim strands it - it holds a visual index that now belongs to a
+ * different record - so the same reconciliation has to cover both, and the row count never betrays
+ * these because no record is added or removed.
+ */
+test.describe('a sequence change under an open editor', () => {
+  /**
+   * Sorting descending while `'A4'` is being edited moves that record from visual 4 to visual 0.
+   * Before the gate covered sequence changes, the stale visual row 4 addressed `'A0'` and the edit
+   * landed there - `['EDITED','A1','A2','A3','A4']`.
+   */
+  test('follows the record through a sort', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle, { sorting: true });
+
+    await grid.goto();
+    await grid.openEditorAndType(4, 0, 'EDITED');
+
+    await grid.sortFirstColumnDescending();
+
+    // Sorting trims nothing - this is the flag that the trimming-only gate did not react to.
+    await expect.poll(() => grid.sawSequenceCacheUpdate('row')).toBe(true);
+    expect(await grid.sawTrimmingCacheUpdate('row')).toBe(false);
+    await expect.poll(() => grid.editorRow()).toBe(0);
+
+    await grid.commitWithEnter();
+
+    await expect.poll(() => grid.sourceData()).toEqual([
+      ['A0', 'B0'],
+      ['A1', 'B1'],
+      ['A2', 'B2'],
+      ['A3', 'B3'],
+      ['EDITED', 'B4'],
+    ]);
+    expect(await grid.sourceRowCount()).toBe(5);
+  });
+
+  /**
+   * `manualRowMove` reaches the same state by a different plugin. Moving the edited record `'A0'`
+   * down to index 3 leaves `'A1'` occupying visual 0, which is where the stale coordinate pointed.
+   */
+  test('follows the record through a row move', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.openEditorAndType(0, 0, 'EDITED');
+
+    await grid.moveRow(0, 3);
+
+    await expect.poll(() => grid.sawSequenceCacheUpdate('row')).toBe(true);
+    await expect.poll(() => grid.editorRow()).toBe(3);
+
+    await grid.commitWithEnter();
+
+    await expect.poll(() => grid.sourceData()).toEqual([
+      ['EDITED', 'B0'],
+      ['A1', 'B1'],
+      ['A2', 'B2'],
+      ['A3', 'B3'],
+      ['A4', 'B4'],
+    ]);
+    expect(await grid.sourceRowCount()).toBe(5);
+  });
 });

--- a/tests/e2e/editor-trimmed-row.spec.ts
+++ b/tests/e2e/editor-trimmed-row.spec.ts
@@ -291,36 +291,40 @@ test.describe('states the captured record has to survive', () => {
     });
 
   /**
-   * `alter('remove_row')` shifts PHYSICAL indexes and emits a trimming-map change on the way, so the
-   * captured record index can go stale. Core closes the editor only when the removed range covers
-   * the highlighted row, so editing row 4 while row 1 is removed leaves the editor open with a
-   * coordinate that is now past the end - which before the fix appended a record on the next commit.
+   * Removing a row ABOVE the edited one is the case the reconciliation must keep its hands off.
    *
-   * This pins the past-the-end shape only: the captured index no longer resolves, so the edit is
-   * dropped and nothing is invented. The other stale shape - the captured index still resolves, but
-   * to a different surviving record - is not covered here, and the fix does not claim to repair it.
+   * `dataMap.removeRow()` fires the cache update synchronously and `selection.shiftRows()` runs only
+   * afterwards, so at handler time the editor still holds its pre-removal coordinate - which is now
+   * past the last row and resolves to nothing. Treating that as "the record is gone" and discarding
+   * would destroy a live edit, because the selection shift immediately behind it re-prepares the
+   * editor on the right row and the value commits correctly. Core carries this across on its own;
+   * the reconciliation's job here is to not get in the way.
+   *
+   * `'A4'` is being edited when row 1 disappears, so it lands at visual 3 and the edit belongs to it.
    */
-  test('never grows the data set when a row removal strands the editor past the last row',
-    async({ page, theme, bundle }) => {
-      const grid = new EditorTrimmedRowPage(page, theme, bundle);
+  test('leaves an edit alone when a row above it is removed', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle);
 
-      await grid.goto();
-      await grid.openEditorAndType(4, 0, 'EDITED');
+    await grid.goto();
+    await grid.openEditorAndType(4, 0, 'EDITED');
 
-      await grid.removeRow(1);
+    await grid.removeRow(1);
 
-      await expect.poll(() => grid.sawTrimmingCacheUpdate('row')).toBe(true);
+    // Still live, and re-prepared onto the shifted row rather than discarded.
+    await expect.poll(() => grid.editorState()).toBe('STATE_EDITING');
+    await expect.poll(() => grid.editorRow()).toBe(3);
+    await expect.poll(() => grid.editorText()).toBe('EDITED');
 
-      await grid.cell(0, 0).click();
+    await grid.cell(0, 0).click();
 
-      await expect.poll(() => grid.sourceRowCount()).toBe(4);
-      await expect.poll(() => grid.sourceData()).toEqual([
-        ['A0', 'B0'],
-        ['A2', 'B2'],
-        ['A3', 'B3'],
-        ['A4', 'B4'],
-      ]);
-    });
+    await expect.poll(() => grid.sourceRowCount()).toBe(4);
+    await expect.poll(() => grid.sourceData()).toEqual([
+      ['A0', 'B0'],
+      ['A2', 'B2'],
+      ['A3', 'B3'],
+      ['EDITED', 'B4'],
+    ]);
+  });
 });
 
 /**
@@ -542,5 +546,142 @@ test.describe('a structural change that gets vetoed', () => {
     expect(await grid.committedChangeCount()).toBe(0);
     expect(await grid.sourceRowCount()).toBe(5);
     expect(await grid.sourceData()).toEqual(UNTOUCHED);
+  });
+});
+
+/**
+ * The COLUMN axis. No core plugin trims columns, so the trimming half of the repair is unreachable
+ * there - but `manualColumnMove` permutes the column sequence and `alter('remove_col')` restructures
+ * it, which are the two shapes the column arm of the repair exists for. Without these the captured
+ * physical column, the column half of the recapture, and the column index count are all dead code.
+ */
+test.describe('an index-map change on the column axis', () => {
+  /**
+   * Moving column 0 to index 1 puts the edited cell at visual column 1. The editor has to follow it,
+   * or the commit lands in column `'B'`.
+   */
+  test('follows the record through a column move', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.openEditorAndType(2, 0, 'EDITED');
+
+    await grid.moveColumn(0, 1);
+
+    await expect.poll(() => grid.sawSequenceCacheUpdate('column')).toBe(true);
+    await expect.poll(() => grid.editorCol()).toBe(1);
+
+    await grid.commitWithEnter();
+
+    // Physical column 0 is still the one that was edited, wherever it now sits on screen.
+    await expect.poll(() => grid.sourceData()).toEqual([
+      ['A0', 'B0'],
+      ['A1', 'B1'],
+      ['EDITED', 'B2'],
+      ['A3', 'B3'],
+      ['A4', 'B4'],
+    ]);
+  });
+
+  /**
+   * Removing the OTHER column restructures the column space while the edited cell survives at the
+   * same visual index. The edit must come through untouched - the column mirror of the row case.
+   */
+  test('keeps a valid edit when another column is removed', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.openEditorAndType(2, 0, 'EDITED');
+
+    await grid.removeColumn(1);
+
+    await expect.poll(() => grid.editorState()).toBe('STATE_EDITING');
+
+    await grid.commitWithEnter();
+
+    await expect.poll(() => grid.sourceData()).toEqual([['A0'], ['A1'], ['EDITED'], ['A3'], ['A4']]);
+  });
+});
+
+/**
+ * The two commit paths the rebind cannot reach, pinned so they stay merely lossy.
+ *
+ * Neither is a defect this change introduced - both produced the row-appending corruption before it,
+ * and both now lose the edit instead. They are recorded here because "the edit lands on the right
+ * record" is the guarantee in `#reconcileEditorWithIndexMaps()`'s JSDoc, and these are its two
+ * documented exceptions. A future change that turns either back into a write must fail here.
+ */
+test.describe('commit paths the rebind cannot reach', () => {
+  /**
+   * `DropdownEditor#finishEditing()` rewrites the commit into a discard when the active range no
+   * longer contains `(this.row, this.col)`. The rebind moves those coordinates and nothing moves the
+   * selection, so `Enter` discards. On develop this appended two records and wrote `'EDITED'` onto
+   * the second of them.
+   */
+  test('a dropdown edit is lost, not misplaced, after a trim moves its record',
+    async({ page, theme, bundle }) => {
+      const grid = new EditorTrimmedRowPage(page, theme, bundle, { editor: 'dropdown' });
+
+      await grid.goto();
+
+      await grid.cell(4, 0).click();
+      await grid.typeOnSelection('EDITED');
+
+      await grid.trimRows([0, 1]);
+
+      await expect.poll(() => grid.editorRow()).toBe(2);
+
+      await grid.commitWithEnter();
+
+      expect(await grid.sourceRowCount()).toBe(5);
+      expect(await grid.sourceData()).toEqual(UNTOUCHED);
+    });
+
+  /**
+   * `BaseEditor#saveValue()` reads the SELECTION corners under `ctrlDown`, never the editor's own
+   * coordinates, so the rebind is invisible to it. The selection was left past the last visible row
+   * by the trim, so nothing is written at all.
+   */
+  test('a Ctrl+Enter commit is lost, not misplaced, after a trim',
+    async({ page, theme, bundle }) => {
+      const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+      await grid.goto();
+      await grid.openEditorAndType(4, 0, 'EDITED');
+
+      await grid.trimRows([0, 1]);
+
+      await grid.commitWithCtrlEnter();
+
+      expect(await grid.sourceRowCount()).toBe(5);
+      expect(await grid.sourceData()).toEqual(UNTOUCHED);
+    });
+});
+
+/**
+ * `updateData()` swaps the whole physical space without closing an open editor - `core.ts` excludes
+ * it from the teardown list on purpose - and it is the path every wrapper takes when its `data` prop
+ * changes. The count moves, so the repair routes structural and re-derives from the visual
+ * coordinate, which keeps the edit alive against the NEW data set rather than discarding it.
+ */
+test.describe('a data swap under an open editor', () => {
+  test('keeps the edit against the new data set', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.openEditorAndType(1, 0, 'EDITED');
+
+    await grid.updateData([['N0', 'M0'], ['N1', 'M1'], ['N2', 'M2']]);
+
+    await expect.poll(() => grid.editorState()).toBe('STATE_EDITING');
+
+    await grid.commitWithEnter();
+
+    await expect.poll(() => grid.sourceData()).toEqual([
+      ['N0', 'M0'],
+      ['EDITED', 'M1'],
+      ['N2', 'M2'],
+    ]);
+    expect(await grid.sourceRowCount()).toBe(3);
   });
 });

--- a/tests/e2e/editor-trimmed-row.spec.ts
+++ b/tests/e2e/editor-trimmed-row.spec.ts
@@ -503,3 +503,44 @@ test.describe('a structural change while an editor is open', () => {
     ]);
   });
 });
+
+/**
+ * An invariant guard, not a reproduction: a structural change that gets CANCELLED must leave the
+ * reconciliation working for the rest of the edit.
+ *
+ * `Formulas` returns `false` from `beforeCreateRow` and `beforeRemoveRow` whenever HyperFormula
+ * rejects the operation, and a cancelled insert fires `beforeCreateRow` with no `afterCreateRow` and
+ * no cache update behind it (verified). Any design that armed on the `before` hook and disarmed on
+ * the `after` one is therefore one re-prepare away from latching permanently, which would silently
+ * stop reconciling and put the original corruption back.
+ *
+ * Discriminating on the physical index count sidesteps that entirely - a cancelled insert changes no
+ * counts, so there is nothing to arm and nothing to strand. This case pins the invariant rather than
+ * a failure: it also passes against the earlier hook-pair implementation, because an `alter()` is
+ * followed by a re-prepare that happened to clear the latch. It exists so a future refactor back to
+ * a hook-armed design has to prove the same property.
+ */
+test.describe('a structural change that gets vetoed', () => {
+  test('leaves the reconciliation working for the rest of the edit', async({ page, theme, bundle }) => {
+    const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+    await grid.goto();
+    await grid.vetoRowCreation();
+
+    await grid.openEditorAndType(0, 0, 'EDITED');
+
+    await grid.insertRowAbove(0, 1);
+
+    // The veto held, so nothing about the data changed - but `beforeCreateRow` did fire.
+    expect(await grid.sourceRowCount()).toBe(5);
+    await expect.poll(() => grid.editorState()).toBe('STATE_EDITING');
+
+    // The edited record is trimmed away here, so the edit must be discarded rather than written
+    // through a coordinate that now addresses `'A2'`.
+    await grid.filterToValues(0, ['A2']);
+
+    expect(await grid.committedChangeCount()).toBe(0);
+    expect(await grid.sourceRowCount()).toBe(5);
+    expect(await grid.sourceData()).toEqual(UNTOUCHED);
+  });
+});

--- a/tests/e2e/editor-trimmed-row.spec.ts
+++ b/tests/e2e/editor-trimmed-row.spec.ts
@@ -665,6 +665,38 @@ test.describe('commit paths the rebind cannot reach', () => {
  * coordinate, which keeps the edit alive against the NEW data set rather than discarding it.
  */
 test.describe('a data swap under an open editor', () => {
+  /**
+   * The same swap at the SAME length takes the other branch. The physical count does not move, so
+   * this routes to the rearrangement repair, which resolves the captured index against a data set
+   * that shares nothing with the one the edit was typed into. A replaced `data` prop of unchanged
+   * length is the dominant wrapper shape, so the two branches both need pinning.
+   */
+  test('keeps the edit when the swap does not change the row count',
+    async({ page, theme, bundle }) => {
+      const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+      await grid.goto();
+      await grid.openEditorAndType(1, 0, 'EDITED');
+
+      await grid.updateData([
+        ['N0', 'M0'], ['N1', 'M1'], ['N2', 'M2'], ['N3', 'M3'], ['N4', 'M4'],
+      ]);
+
+      await expect.poll(() => grid.editorState()).toBe('STATE_EDITING');
+      await expect.poll(() => grid.editorRow()).toBe(1);
+
+      await grid.commitWithEnter();
+
+      await expect.poll(() => grid.sourceData()).toEqual([
+        ['N0', 'M0'],
+        ['EDITED', 'M1'],
+        ['N2', 'M2'],
+        ['N3', 'M3'],
+        ['N4', 'M4'],
+      ]);
+      expect(await grid.sourceRowCount()).toBe(5);
+    });
+
   test('keeps the edit against the new data set', async({ page, theme, bundle }) => {
     const grid = new EditorTrimmedRowPage(page, theme, bundle);
 

--- a/tests/e2e/editor-trimmed-row.spec.ts
+++ b/tests/e2e/editor-trimmed-row.spec.ts
@@ -789,3 +789,45 @@ test.describe('edges of the repair', () => {
     ]);
   });
 });
+
+/**
+ * A removal that `Selection#shiftRows()` declines to shift. It only shifts a range whose outer
+ * top-start corner is at or below the removed row, and `core.ts` only closes the editor when the
+ * removed range covers the HIGHLIGHT - so a focus moved below that corner (Enter or Tab inside a
+ * multi-cell selection) leaves the editor sitting past the last row with nothing re-preparing it.
+ *
+ * The commit through those coordinates is the row-appending corruption. This is the one shape where
+ * the repair cannot recover the record: the renumbering invalidated the captured index and the
+ * editor's own coordinates address nothing, so there is nothing left to follow. What it can do is
+ * refuse to write, which is what the next index-map change does.
+ */
+test.describe('a removal that strands the editor', () => {
+  test('discards rather than appending when a later filter would commit through it',
+    async({ page, theme, bundle }) => {
+      const grid = new EditorTrimmedRowPage(page, theme, bundle);
+
+      await grid.goto();
+
+      await grid.selectRangeWithFocusAt([0, 0, 4, 0], 4, 0);
+      await grid.typeOnSelection('EDITED');
+
+      // Row 1 goes; the highlight is not inside the removed range and the range's top-start corner
+      // is above it, so neither `closeEditor()` nor `shiftRows()` touches the editor.
+      await grid.removeRow(1);
+
+      await expect.poll(() => grid.editorRow()).toBe(4);
+      expect(await grid.sourceRowCount()).toBe(4);
+
+      // On develop this filter commits through visual row 4 and appends four records.
+      await grid.filterToValues(0, ['A2']);
+
+      expect(await grid.committedChangeCount()).toBe(0);
+      expect(await grid.sourceRowCount()).toBe(4);
+      expect(await grid.sourceData()).toEqual([
+        ['A0', 'B0'],
+        ['A2', 'B2'],
+        ['A3', 'B3'],
+        ['A4', 'B4'],
+      ]);
+    });
+});

--- a/tests/fixtures/demo/editor-trimmed-row.html
+++ b/tests/fixtures/demo/editor-trimmed-row.html
@@ -23,6 +23,10 @@
     if (!window.htScenario) {
       throw new Error('Unknown ?scenario= value: ' + JSON.stringify(htParams.get('scenario')));
     }
+    window.htEditor = ({ text: 'text', dropdown: 'dropdown' })[htParams.get('editor') ?? 'text'];
+    if (!window.htEditor) {
+      throw new Error('Unknown ?editor= value: ' + JSON.stringify(htParams.get('editor')));
+    }
   </script>
 </head>
 <body>
@@ -79,6 +83,15 @@
       // `indexesSequenceChanged`, not `trimmedIndexesChanged`. Enabled unconditionally; inert until
       // a case drives them.
       manualRowMove: true,
+      // The column axis has its own permutation producers, and no core plugin trims columns - so
+      // this is the only way to exercise the column half of the repair.
+      manualColumnMove: true,
+      // `dropdown` extends `autocomplete`, whose `finishEditing()` rewrites a commit into a discard
+      // when the active range no longer contains the editor's coordinates. That is the shape the
+      // rebind cannot rescue, and a case pins it rather than leaving it to a JSDoc claim.
+      columns: window.htEditor === 'dropdown'
+        ? [{ type: 'dropdown', source: ['A0', 'A1', 'A2', 'A3', 'A4', 'EDITED'] }, {}]
+        : undefined,
       // Stamp test ids from `afterRenderer` rather than a grid-level `renderer`, so a column `type`
       // cannot override it and leave the typed column with no test id.
       afterRenderer(td, row, col) {

--- a/tests/fixtures/demo/editor-trimmed-row.html
+++ b/tests/fixtures/demo/editor-trimmed-row.html
@@ -75,6 +75,10 @@
       dropdownMenu: true,
       trimRows: [],
       columnSorting: window.htSorting,
+      // Sorting and row moving rearrange the visual space without trimming anything - they report
+      // `indexesSequenceChanged`, not `trimmedIndexesChanged`. Enabled unconditionally; inert until
+      // a case drives them.
+      manualRowMove: true,
       // Stamp test ids from `afterRenderer` rather than a grid-level `renderer`, so a column `type`
       // cannot override it and leave the typed column with no test id.
       afterRenderer(td, row, col) {

--- a/tests/fixtures/demo/editor-trimmed-row.html
+++ b/tests/fixtures/demo/editor-trimmed-row.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Editor with a trimmed row fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    const htParams = new URLSearchParams(location.search);
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+    window.htSorting = ({ true: true, false: false })[htParams.get('sorting') ?? 'false'];
+    if (window.htSorting === undefined) {
+      throw new Error('Unknown ?sorting= value: ' + JSON.stringify(htParams.get('sorting')));
+    }
+    window.htScenario = ({ small: 'small', tall: 'tall' })[htParams.get('scenario') ?? 'small'];
+    if (!window.htScenario) {
+      throw new Error('Unknown ?scenario= value: ' + JSON.stringify(htParams.get('scenario')));
+    }
+  </script>
+</head>
+<body>
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    // Two columns, so a case can pin that the untouched column survives a filter run intact. Every
+    // value is distinct: these assertions are all about WHICH record a write landed on, and a
+    // repeated value would hide a write that went to the wrong one.
+    const DATA = [
+      ['A0', 'B0'],
+      ['A1', 'B1'],
+      ['A2', 'B2'],
+      ['A3', 'B3'],
+      ['A4', 'B4'],
+    ];
+
+    // Records every committed change so a spec can assert that NO commit happened, which a poll on
+    // the data alone cannot do: expect.poll passes on its first sample and would race a commit.
+    window.htChanges = [];
+
+    // Records the index-map cache updates so a spec can assert the guard's TRIGGER actually fired.
+    // A trimming change reports `trimmedIndexesChanged` and never `hiddenIndexesChanged`, which is
+    // exactly why the hiding-map guard cannot see any of these cases.
+    window.htCacheUpdates = { row: [], column: [] };
+
+    // `tall` exists only so a cell can be scrolled out of the rendered viewport while its editor
+    // stays open. `EditorManager#prepareEditor()` skips its work when the cell has no rendered `TD`,
+    // so that state is the one place the captured record and the active editor could drift apart.
+    const scenarioSettings = window.htScenario === 'tall' ? {
+      data: Array.from({ length: 100 }, (unused, row) => [`A${row}`, `B${row}`]),
+      height: 150,
+    } : {
+      data: DATA,
+    };
+
+    window.hot = new Handsontable(container, Object.assign({
+      colHeaders: ['A', 'B'],
+      rowHeaders: true,
+      // Both plugins register a TRIMMING index map, and they reach the editor by different routes:
+      // `filter()` re-selects and renders before it returns, `trimRows()` does neither.
+      filters: true,
+      dropdownMenu: true,
+      trimRows: [],
+      columnSorting: window.htSorting,
+      // Stamp test ids from `afterRenderer` rather than a grid-level `renderer`, so a column `type`
+      // cannot override it and leave the typed column with no test id.
+      afterRenderer(td, row, col) {
+        td.setAttribute('data-testid', `cell-${row}-${col}`);
+      },
+      afterChange(changes, source) {
+        if (changes) {
+          window.htChanges.push(...changes.map(change => change.concat(source)));
+        }
+      },
+      afterRowSequenceCacheUpdate(state) {
+        window.htCacheUpdates.row.push(state);
+      },
+      afterColumnSequenceCacheUpdate(state) {
+        window.htCacheUpdates.column.push(state);
+      },
+      licenseKey: 'non-commercial-and-evaluation',
+    }, scenarioSettings));
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/EditorTrimmedRowPage.ts
+++ b/tests/fixtures/pages/EditorTrimmedRowPage.ts
@@ -1,0 +1,301 @@
+import { type Locator, type Page, expect } from '@playwright/test';
+
+interface FiltersPlugin {
+  addCondition(column: number, name: string, args: unknown[]): void;
+  filter(): void;
+}
+
+interface TrimRowsPlugin {
+  trimRows(rows: number[]): void;
+  untrimRows(rows: number[]): void;
+}
+
+interface HandsontableFixture {
+  getSelected(): number[][] | undefined;
+  getActiveEditor(): {
+    isOpened(): boolean;
+    state: string;
+    row: number | null;
+    col: number | null;
+    TEXTAREA?: HTMLTextAreaElement;
+  } | undefined;
+  getSourceData(): unknown[][];
+  countSourceRows(): number;
+  countRows(): number;
+  getPlugin(name: string): FiltersPlugin & TrimRowsPlugin;
+  toPhysicalRow(row: number): number;
+  alter(action: string, index: number, amount?: number): void;
+  scrollViewportTo(options: { row: number; verticalSnap: string }): void;
+  getCell(row: number, col: number, topmost?: boolean): HTMLElement | null;
+}
+
+interface CacheUpdateState {
+  indexesSequenceChanged: boolean;
+  trimmedIndexesChanged: boolean;
+  hiddenIndexesChanged: boolean;
+}
+
+interface RecordingWindow extends Window {
+  htChanges: unknown[][];
+  htCacheUpdates: { row: CacheUpdateState[]; column: CacheUpdateState[] };
+}
+
+interface PageOptions {
+  sorting?: boolean;
+  scenario?: 'small' | 'tall';
+}
+
+/**
+ * Page Object for the fixture that exercises an open editor whose record is removed or moved by a
+ * trimming index map (Filters, `trimRows`).
+ */
+export class EditorTrimmedRowPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly sorting: boolean;
+  readonly scenario: string;
+  readonly editorHolder: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd', options: PageOptions = {}) {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.sorting = options.sorting ?? false;
+    this.scenario = options.scenario ?? 'small';
+    // The text editor's textarea wrapper. It stays in the DOM permanently and is merely hidden, so
+    // its `ht_editor_hidden` class is the only reliable DOM-level "the editor is not on screen".
+    this.editorHolder = page.locator('.handsontableInputHolder');
+  }
+
+  /**
+   * Opens the fixture and waits for the first data cell to render.
+   */
+  async goto(): Promise<void> {
+    const query = `theme=${this.theme}&bundle=${this.bundle}` +
+      `&sorting=${this.sorting}&scenario=${this.scenario}`;
+
+    await this.page.goto(`/tests/fixtures/demo/editor-trimmed-row.html?${query}`);
+
+    // Wait for the bundle before the cell. The test id comes from the fixture's `afterRenderer`, so
+    // "cell not found" alone cannot tell a slow bundle apart from a grid that failed to render.
+    await this.page.waitForFunction(() => 'Handsontable' in window);
+
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /**
+   * Returns a data cell through its fixture-owned test id.
+   */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /**
+   * Selects a cell, opens its text editor by typing, and leaves the value uncommitted.
+   *
+   * Typing straight onto a selected cell opens the editor and REPLACES its content. Opening with
+   * `Enter` would keep the old value and put the caret after it.
+   */
+  async openEditorAndType(row: number, col: number, value: string): Promise<void> {
+    await this.cell(row, col).click();
+
+    await expect.poll(() => this.selected()).toEqual([[row, col, row, col]]);
+
+    await this.page.keyboard.type(value);
+
+    await expect.poll(() => this.isEditorOpen()).toBe(true);
+    await expect.poll(() => this.editorText()).toBe(value);
+  }
+
+  /**
+   * Filters the given column down to the listed values, exactly as picking them in the dropdown
+   * menu's value list would. Driven through the plugin API rather than the menu, because opening
+   * the menu is an outside click that closes the editor before the filter ever runs.
+   */
+  async filterToValues(column: number, values: string[]): Promise<void> {
+    await this.page.evaluate(([targetColumn, targetValues]) => {
+      const filters = (window as Window & { hot: HandsontableFixture }).hot.getPlugin('filters');
+
+      filters.addCondition(targetColumn as number, 'by_value', [targetValues]);
+      filters.filter();
+    }, [column, values] as [number, string[]]);
+  }
+
+  /**
+   * Trims rows through the `trimRows` plugin. Unlike `filter()`, this touches neither the selection
+   * nor the render, so nothing commits the open editor as a side effect.
+   */
+  async trimRows(rows: number[]): Promise<void> {
+    await this.page.evaluate((targetRows) => {
+      (window as Window & { hot: HandsontableFixture }).hot.getPlugin('trimRows').trimRows(targetRows);
+    }, rows);
+  }
+
+  /**
+   * Untrims rows through the `trimRows` plugin. Called with rows that are not trimmed, this writes
+   * the trimming map without changing a single index - the no-op churn that must NOT close an
+   * editor. `BooleanMap#setValues()` emits its change event regardless, so the guard's trigger
+   * still fires.
+   */
+  async untrimRows(rows: number[]): Promise<void> {
+    await this.page.evaluate((targetRows) => {
+      (window as Window & { hot: HandsontableFixture }).hot.getPlugin('trimRows').untrimRows(targetRows);
+    }, rows);
+  }
+
+  /**
+   * Removes rows through `alter()`. This shifts PHYSICAL indexes, unlike a trimming map, and still
+   * emits a trimming-map change - the one way the captured record can go stale without the guard
+   * being able to tell.
+   */
+  async removeRow(row: number, amount = 1): Promise<void> {
+    await this.page.evaluate(([target, count]) => {
+      (window as Window & { hot: HandsontableFixture }).hot.alter('remove_row', target, count);
+    }, [row, amount] as [number, number]);
+  }
+
+  /**
+   * Scrolls the viewport so the given row is at the top, which un-renders the rows left behind
+   * without touching any index map.
+   */
+  async scrollToRow(row: number): Promise<void> {
+    await this.page.evaluate((target) => {
+      (window as Window & { hot: HandsontableFixture }).hot
+        .scrollViewportTo({ row: target, verticalSnap: 'top' });
+    }, row);
+  }
+
+  /**
+   * Reports whether a visual row still has a rendered `TD`. A row scrolled out of the viewport has
+   * none, which is the state `prepareEditor()` refuses to work in.
+   */
+  async isRowRendered(row: number): Promise<boolean> {
+    return this.page.evaluate(
+      target => (window as Window & { hot: HandsontableFixture }).hot.getCell(target, 0, true) !== null,
+      row,
+    );
+  }
+
+  /**
+   * Returns one value straight from the source data, by PHYSICAL row index. Used where the data set
+   * is too large to assert whole.
+   */
+  async sourceCell(physicalRow: number, col: number): Promise<unknown> {
+    return this.page.evaluate(
+      ([targetRow, targetCol]) => (window as Window & { hot: HandsontableFixture })
+        .hot.getSourceData()[targetRow][targetCol],
+      [physicalRow, col] as [number, number],
+    );
+  }
+
+  /**
+   * Commits the open edit with Enter, the way a user ends an edit.
+   */
+  async commitWithEnter(): Promise<void> {
+    await this.page.keyboard.press('Enter');
+  }
+
+  /**
+   * Reports whether the cell editor is open.
+   *
+   * Read through `getActiveEditor().isOpened()` rather than DOM visibility: `.handsontableInput` is
+   * always in the DOM and a closed text editor is merely `opacity: 0`, which Playwright still
+   * counts as visible.
+   */
+  async isEditorOpen(): Promise<boolean> {
+    return this.page.evaluate(() => (
+      (window as Window & { hot: HandsontableFixture }).hot.getActiveEditor()?.isOpened() === true
+    ));
+  }
+
+  /**
+   * Returns the editor's state machine value, or null when there is no active editor.
+   */
+  async editorState(): Promise<string | null> {
+    return this.page.evaluate(() => (
+      (window as Window & { hot: HandsontableFixture }).hot.getActiveEditor()?.state ?? null
+    ));
+  }
+
+  /**
+   * Returns the text held by the editor, whether or not it is currently shown.
+   */
+  async editorText(): Promise<string | null> {
+    return this.page.evaluate(() => (
+      (window as Window & { hot: HandsontableFixture }).hot.getActiveEditor()?.TEXTAREA?.value ?? null
+    ));
+  }
+
+  /**
+   * Returns the VISUAL row the active editor is currently bound to. This is the coordinate the save
+   * writes through, so it is the direct read of whether a rebind happened.
+   */
+  async editorRow(): Promise<number | null> {
+    return this.page.evaluate(() => (
+      (window as Window & { hot: HandsontableFixture }).hot.getActiveEditor()?.row ?? null
+    ));
+  }
+
+  /**
+   * Returns the whole source data set, in physical row order. Stronger than probing single cells:
+   * it pins the row count and every untouched record in one assertion.
+   */
+  async sourceData(): Promise<unknown[][]> {
+    return this.page.evaluate(() => (window as Window & { hot: HandsontableFixture }).hot.getSourceData());
+  }
+
+  /**
+   * Returns the number of records in the source data. The severity of this bug is the growth here:
+   * it survives into everything that reads the source data afterwards.
+   */
+  async sourceRowCount(): Promise<number> {
+    return this.page.evaluate(() => (window as Window & { hot: HandsontableFixture }).hot.countSourceRows());
+  }
+
+  /**
+   * Returns the number of VISIBLE rows, which a trimming map collapses. The append only happens
+   * when the editor's visual row is past this count, so a case that means to exercise the append
+   * has to pin it.
+   */
+  async visibleRowCount(): Promise<number> {
+    return this.page.evaluate(() => (window as Window & { hot: HandsontableFixture }).hot.countRows());
+  }
+
+  /**
+   * Returns the physical row a visual row currently maps to.
+   */
+  async toPhysicalRow(row: number): Promise<number> {
+    return this.page.evaluate(
+      target => (window as Window & { hot: HandsontableFixture }).hot.toPhysicalRow(target),
+      row,
+    );
+  }
+
+  /**
+   * Returns how many changes the grid has committed since it was created.
+   */
+  async committedChangeCount(): Promise<number> {
+    return this.page.evaluate(() => (window as unknown as RecordingWindow).htChanges.length);
+  }
+
+  /**
+   * Reports whether an index-map cache update that changed TRIMMED indexes has been recorded on the
+   * given axis. Assert this before concluding anything from "the data is intact": without it, a
+   * case passes when the guard's trigger never fired at all.
+   */
+  async sawTrimmingCacheUpdate(axis: 'row' | 'column'): Promise<boolean> {
+    return this.page.evaluate(
+      target => (window as unknown as RecordingWindow).htCacheUpdates[target]
+        .some(state => state.trimmedIndexesChanged),
+      axis,
+    );
+  }
+
+  /**
+   * Returns the grid's current selection.
+   */
+  async selected(): Promise<number[][] | undefined> {
+    return this.page.evaluate(() => (window as Window & { hot: HandsontableFixture }).hot.getSelected());
+  }
+}

--- a/tests/fixtures/pages/EditorTrimmedRowPage.ts
+++ b/tests/fixtures/pages/EditorTrimmedRowPage.ts
@@ -25,6 +25,8 @@ interface ManualColumnMovePlugin {
 interface HandsontableFixture {
   addHook(name: string, callback: () => boolean): void;
   getSelected(): number[][] | undefined;
+  selectCells(ranges: number[][]): void;
+  selection: { transformFocus(row: number, col: number): void };
   getActiveEditor(): {
     isOpened(): boolean;
     state: string;
@@ -214,6 +216,23 @@ export class EditorTrimmedRowPage {
     await this.page.evaluate(() => {
       (window as Window & { hot: HandsontableFixture }).hot.addHook('beforeCreateRow', () => false);
     });
+  }
+
+  /**
+   * Selects a range and then moves the FOCUS below its top-start corner, the state Enter or Tab
+   * produces inside a multi-cell selection.
+   *
+   * `Selection#shiftRows()` only shifts a range whose outer top-start corner is at or below the
+   * removed row, so a focus parked below that corner is left where it was when rows above it are
+   * removed - which is how an editor ends up stranded past the last row with nothing re-preparing it.
+   */
+  async selectRangeWithFocusAt(range: number[], focusRow: number, focusColumn: number): Promise<void> {
+    await this.page.evaluate(([targetRange, row, column]) => {
+      const hot = (window as Window & { hot: HandsontableFixture }).hot;
+
+      hot.selectCells([targetRange as number[]]);
+      hot.selection.transformFocus(row as number, column as number);
+    }, [range, focusRow, focusColumn] as [number[], number, number]);
   }
 
   /**

--- a/tests/fixtures/pages/EditorTrimmedRowPage.ts
+++ b/tests/fixtures/pages/EditorTrimmedRowPage.ts
@@ -39,6 +39,7 @@ interface HandsontableFixture {
   getPlugin(name: string): FiltersPlugin & TrimRowsPlugin & ColumnSortingPlugin & ManualRowMovePlugin
     & ManualColumnMovePlugin;
   updateData(data: unknown[][]): void;
+  runHooks(name: string): void;
   toPhysicalRow(row: number): number;
   alter(action: string, index: number, amount?: number): void;
   scrollViewportTo(options: { row: number; verticalSnap: string }): void;
@@ -244,6 +245,22 @@ export class EditorTrimmedRowPage {
     await this.page.evaluate((next) => {
       (window as Window & { hot: HandsontableFixture }).hot.updateData(next);
     }, data);
+  }
+
+  /**
+   * Fires the public cache-update hook with NO payload, the way any integration calling
+   * `hot.runHooks('afterRowSequenceCacheUpdate')` would. Returns the thrown error, or null.
+   */
+  async fireCacheUpdateHookWithoutPayload(): Promise<string | null> {
+    return this.page.evaluate(() => {
+      try {
+        (window as Window & { hot: HandsontableFixture }).hot.runHooks('afterRowSequenceCacheUpdate');
+
+        return null;
+      } catch (error) {
+        return String(error);
+      }
+    });
   }
 
   /**

--- a/tests/fixtures/pages/EditorTrimmedRowPage.ts
+++ b/tests/fixtures/pages/EditorTrimmedRowPage.ts
@@ -18,6 +18,10 @@ interface ManualRowMovePlugin {
   moveRow(row: number, finalIndex: number): void;
 }
 
+interface ManualColumnMovePlugin {
+  moveColumn(column: number, finalIndex: number): void;
+}
+
 interface HandsontableFixture {
   addHook(name: string, callback: () => boolean): void;
   getSelected(): number[][] | undefined;
@@ -32,7 +36,9 @@ interface HandsontableFixture {
   getSourceData(): unknown[][];
   countSourceRows(): number;
   countRows(): number;
-  getPlugin(name: string): FiltersPlugin & TrimRowsPlugin & ColumnSortingPlugin & ManualRowMovePlugin;
+  getPlugin(name: string): FiltersPlugin & TrimRowsPlugin & ColumnSortingPlugin & ManualRowMovePlugin
+    & ManualColumnMovePlugin;
+  updateData(data: unknown[][]): void;
   toPhysicalRow(row: number): number;
   alter(action: string, index: number, amount?: number): void;
   scrollViewportTo(options: { row: number; verticalSnap: string }): void;
@@ -53,6 +59,7 @@ interface RecordingWindow extends Window {
 interface PageOptions {
   sorting?: boolean;
   scenario?: 'small' | 'tall';
+  editor?: 'text' | 'dropdown';
 }
 
 /**
@@ -65,6 +72,7 @@ export class EditorTrimmedRowPage {
   readonly bundle: string;
   readonly sorting: boolean;
   readonly scenario: string;
+  readonly editor: string;
   readonly editorHolder: Locator;
 
   constructor(page: Page, theme = 'main', bundle = 'umd', options: PageOptions = {}) {
@@ -73,6 +81,7 @@ export class EditorTrimmedRowPage {
     this.bundle = bundle;
     this.sorting = options.sorting ?? false;
     this.scenario = options.scenario ?? 'small';
+    this.editor = options.editor ?? 'text';
     // The text editor's textarea wrapper. It stays in the DOM permanently and is merely hidden, so
     // its `ht_editor_hidden` class is the only reliable DOM-level "the editor is not on screen".
     this.editorHolder = page.locator('.handsontableInputHolder');
@@ -83,7 +92,7 @@ export class EditorTrimmedRowPage {
    */
   async goto(): Promise<void> {
     const query = `theme=${this.theme}&bundle=${this.bundle}` +
-      `&sorting=${this.sorting}&scenario=${this.scenario}`;
+      `&sorting=${this.sorting}&scenario=${this.scenario}&editor=${this.editor}`;
 
     await this.page.goto(`/tests/fixtures/demo/editor-trimmed-row.html?${query}`);
 
@@ -204,6 +213,53 @@ export class EditorTrimmedRowPage {
     await this.page.evaluate(() => {
       (window as Window & { hot: HandsontableFixture }).hot.addHook('beforeCreateRow', () => false);
     });
+  }
+
+  /**
+   * Moves one column through `manualColumnMove`, permuting the COLUMN sequence.
+   */
+  async moveColumn(column: number, finalIndex: number): Promise<void> {
+    await this.page.evaluate(([target, destination]) => {
+      const hot = (window as Window & { hot: HandsontableFixture }).hot;
+
+      hot.getPlugin('manualColumnMove').moveColumn(target, destination);
+      (hot as unknown as { render(): void }).render();
+    }, [column, finalIndex] as [number, number]);
+  }
+
+  /**
+   * Removes columns through `alter()` - the column axis's structural change.
+   */
+  async removeColumn(column: number, amount = 1): Promise<void> {
+    await this.page.evaluate(([target, count]) => {
+      (window as Window & { hot: HandsontableFixture }).hot.alter('remove_col', target, count);
+    }, [column, amount] as [number, number]);
+  }
+
+  /**
+   * Replaces the whole data set through `updateData()`, which swaps the physical space without
+   * closing an open editor - the path every wrapper takes when its `data` prop changes.
+   */
+  async updateData(data: unknown[][]): Promise<void> {
+    await this.page.evaluate((next) => {
+      (window as Window & { hot: HandsontableFixture }).hot.updateData(next);
+    }, data);
+  }
+
+  /**
+   * Commits with Ctrl+Enter, which reads the SELECTION corners rather than the editor's coordinates.
+   */
+  async commitWithCtrlEnter(): Promise<void> {
+    await this.page.keyboard.press('Control+Enter');
+  }
+
+  /**
+   * Returns the VISUAL column the active editor is currently bound to.
+   */
+  async editorCol(): Promise<number | null> {
+    return this.page.evaluate(() => (
+      (window as Window & { hot: HandsontableFixture }).hot.getActiveEditor()?.col ?? null
+    ));
   }
 
   /**

--- a/tests/fixtures/pages/EditorTrimmedRowPage.ts
+++ b/tests/fixtures/pages/EditorTrimmedRowPage.ts
@@ -196,6 +196,16 @@ export class EditorTrimmedRowPage {
   }
 
   /**
+   * Inserts rows through `alter()`. A structural change: it renumbers the PHYSICAL space while
+   * leaving the editor's visual coordinate valid, which is the opposite of what a trim does.
+   */
+  async insertRowAbove(row: number, amount = 1): Promise<void> {
+    await this.page.evaluate(([target, count]) => {
+      (window as Window & { hot: HandsontableFixture }).hot.alter('insert_row_above', target, count);
+    }, [row, amount] as [number, number]);
+  }
+
+  /**
    * Removes rows through `alter()`. This shifts PHYSICAL indexes, unlike a trimming map, and still
    * emits a trimming-map change - the one way the captured record can go stale without the guard
    * being able to tell.

--- a/tests/fixtures/pages/EditorTrimmedRowPage.ts
+++ b/tests/fixtures/pages/EditorTrimmedRowPage.ts
@@ -19,6 +19,7 @@ interface ManualRowMovePlugin {
 }
 
 interface HandsontableFixture {
+  addHook(name: string, callback: () => boolean): void;
   getSelected(): number[][] | undefined;
   getActiveEditor(): {
     isOpened(): boolean;
@@ -193,6 +194,16 @@ export class EditorTrimmedRowPage {
       hot.getPlugin('manualRowMove').moveRow(target, destination);
       (hot as unknown as { render(): void }).render();
     }, [row, finalIndex] as [number, number]);
+  }
+
+  /**
+   * Makes every subsequent row insertion fail its `beforeCreateRow` veto, the way Formulas does when
+   * HyperFormula rejects the change. The hook fires, nothing is created, and no cache update follows.
+   */
+  async vetoRowCreation(): Promise<void> {
+    await this.page.evaluate(() => {
+      (window as Window & { hot: HandsontableFixture }).hot.addHook('beforeCreateRow', () => false);
+    });
   }
 
   /**

--- a/tests/fixtures/pages/EditorTrimmedRowPage.ts
+++ b/tests/fixtures/pages/EditorTrimmedRowPage.ts
@@ -10,6 +10,14 @@ interface TrimRowsPlugin {
   untrimRows(rows: number[]): void;
 }
 
+interface ColumnSortingPlugin {
+  sort(config: { column: number; sortOrder: string }): void;
+}
+
+interface ManualRowMovePlugin {
+  moveRow(row: number, finalIndex: number): void;
+}
+
 interface HandsontableFixture {
   getSelected(): number[][] | undefined;
   getActiveEditor(): {
@@ -18,11 +26,12 @@ interface HandsontableFixture {
     row: number | null;
     col: number | null;
     TEXTAREA?: HTMLTextAreaElement;
+    originalValue: unknown;
   } | undefined;
   getSourceData(): unknown[][];
   countSourceRows(): number;
   countRows(): number;
-  getPlugin(name: string): FiltersPlugin & TrimRowsPlugin;
+  getPlugin(name: string): FiltersPlugin & TrimRowsPlugin & ColumnSortingPlugin & ManualRowMovePlugin;
   toPhysicalRow(row: number): number;
   alter(action: string, index: number, amount?: number): void;
   scrollViewportTo(options: { row: number; verticalSnap: string }): void;
@@ -82,6 +91,24 @@ export class EditorTrimmedRowPage {
     await this.page.waitForFunction(() => 'Handsontable' in window);
 
     await expect(this.cell(0, 0)).toBeVisible();
+
+    // Building the grid already emits a trimming cache update - `loadData` initializes the trimming
+    // map, and the fixture's hooks are attached before that. Leaving it in the log would make every
+    // `sawTrimmingCacheUpdate()` assertion pass without the case's own trigger ever firing.
+    await this.resetCacheUpdateLog();
+  }
+
+  /**
+   * Empties the recorded index-map cache updates, so what a case asserts afterwards can only have
+   * come from that case's own trigger.
+   */
+  async resetCacheUpdateLog(): Promise<void> {
+    await this.page.evaluate(() => {
+      const recorder = (window as unknown as RecordingWindow).htCacheUpdates;
+
+      recorder.row.length = 0;
+      recorder.column.length = 0;
+    });
   }
 
   /**
@@ -145,6 +172,30 @@ export class EditorTrimmedRowPage {
   }
 
   /**
+   * Sorts the first column descending, so a visual row index stops equalling its physical one. This
+   * is what makes the physical-index resolution in the fix non-vacuous.
+   */
+  async sortFirstColumnDescending(): Promise<void> {
+    await this.page.evaluate(() => {
+      (window as Window & { hot: HandsontableFixture }).hot
+        .getPlugin('columnSorting').sort({ column: 0, sortOrder: 'desc' });
+    });
+  }
+
+  /**
+   * Moves one row through `manualRowMove`. Like sorting, this permutes the visual space and reports
+   * `indexesSequenceChanged` - it trims nothing.
+   */
+  async moveRow(row: number, finalIndex: number): Promise<void> {
+    await this.page.evaluate(([target, destination]) => {
+      const hot = (window as Window & { hot: HandsontableFixture }).hot;
+
+      hot.getPlugin('manualRowMove').moveRow(target, destination);
+      (hot as unknown as { render(): void }).render();
+    }, [row, finalIndex] as [number, number]);
+  }
+
+  /**
    * Removes rows through `alter()`. This shifts PHYSICAL indexes, unlike a trimming map, and still
    * emits a trimming-map change - the one way the captured record can go stale without the guard
    * being able to tell.
@@ -187,6 +238,25 @@ export class EditorTrimmedRowPage {
         .hot.getSourceData()[targetRow][targetCol],
       [physicalRow, col] as [number, number],
     );
+  }
+
+  /**
+   * Types onto the current selection, which opens an editor if none is open, and leaves the value
+   * uncommitted.
+   */
+  async typeOnSelection(value: string): Promise<void> {
+    await this.page.keyboard.type(value);
+  }
+
+  /**
+   * Returns the value the active editor believes it is replacing. `prepareEditor()` reads it from
+   * the source data at prepare time, so it reports which record the editor was set up for -
+   * independently of where a save would land.
+   */
+  async editorOriginalValue(): Promise<unknown> {
+    return this.page.evaluate(() => (
+      (window as Window & { hot: HandsontableFixture }).hot.getActiveEditor()?.originalValue ?? null
+    ));
   }
 
   /**
@@ -288,6 +358,19 @@ export class EditorTrimmedRowPage {
     return this.page.evaluate(
       target => (window as unknown as RecordingWindow).htCacheUpdates[target]
         .some(state => state.trimmedIndexesChanged),
+      axis,
+    );
+  }
+
+  /**
+   * Reports whether an index-map cache update that changed the index SEQUENCE has been recorded on
+   * the given axis. This is the flag a sort or a row move raises, and it is separate from the
+   * trimming one.
+   */
+  async sawSequenceCacheUpdate(axis: 'row' | 'column'): Promise<boolean> {
+    return this.page.evaluate(
+      target => (window as unknown as RecordingWindow).htCacheUpdates[target]
+        .some(state => state.indexesSequenceChanged),
       axis,
     );
   }

--- a/tests/fixtures/pages/EditorTrimmedRowPage.ts
+++ b/tests/fixtures/pages/EditorTrimmedRowPage.ts
@@ -23,7 +23,7 @@ interface ManualColumnMovePlugin {
 }
 
 interface HandsontableFixture {
-  addHook(name: string, callback: () => boolean): void;
+  addHook(name: string, callback: () => unknown): void;
   getSelected(): number[][] | undefined;
   selectCells(ranges: number[][]): void;
   selection: { transformFocus(row: number, col: number): void };
@@ -306,6 +306,21 @@ export class EditorTrimmedRowPage {
     await this.page.evaluate(([target, count]) => {
       (window as Window & { hot: HandsontableFixture }).hot.alter('insert_row_above', target, count);
     }, [row, amount] as [number, number]);
+  }
+
+  /**
+   * Trims a row from inside `afterRemoveRow`, then removes a row - the nesting that puts an index-map
+   * change into the window between `alter()`'s cache update and the selection shift behind it.
+   */
+  async removeRowTrimmingFrom(removeIndex: number, trimRow: number): Promise<void> {
+    await this.page.evaluate(([target, trimmed]) => {
+      const hot = (window as Window & { hot: HandsontableFixture }).hot;
+
+      hot.addHook('afterRemoveRow', () => {
+        hot.getPlugin('trimRows').trimRows([trimmed as number]);
+      });
+      hot.alter('remove_row', target as number, 1);
+    }, [removeIndex, trimRow] as [number, number]);
   }
 
   /**


### PR DESCRIPTION
### Context

The PR fixes silent source-data corruption when an index map rearranges rows while a cell editor is open.

The editor holds the visual coordinates captured in `prepare()`, and `BaseEditor#saveValue()` writes through them with no bounds check. Two kinds of index-map change invalidate them:

- a **trimming** map (Filters, `trimRows`, `nestedRows`) *collapses* the visual space — rows below a trimmed row shift up and the row count shrinks;
- a **sequence** change (`columnSorting`, `manualRowMove`) *permutes* it.

Either way the pending edit lands on whichever record now occupies that visual slot. Three shapes, all silent:

| Case | Condition | Result |
|---|---|---|
| Wrong record | edited visual row `<=` post-change `countRows() - 1` | the typed value overwrites a different physical record |
| Appended rows | edited visual row `>` post-trim `countRows() - 1` | `applyChanges()` **appends records** to reach the stale coordinate |
| Shifted record | the edited row survives but moves | the edit lands on a different surviving record, with no row-count change |

Traced path, for a filter:

1. `Filters#filter()` bulk-writes its trimming map (`filters.ts:1020`). The visual row space collapses here, and the flush fires `afterRowSequenceCacheUpdate` with `{ trimmedIndexesChanged: true }` synchronously.
2. Still inside `filter()`, `filters.ts:1045` re-selects the highlighted column. That selection change reaches `editorManager.closeEditor()` through `core.ts:802-804` and commits the edit — which is why the editor is already `STATE_VIRGIN` before the render, and why `afterViewRender` cannot catch this.
3. `BaseEditor#saveValue()` passes the stale `this.row` into `populateFromArray(..., 'edit')` with `endRow: null` (`baseEditor.ts:271`). `null` is not `typeof 'number'`, so `end` is `undefined` in `grid.populateFromArray` and the row loop's only clamp is dead at default settings.
4. `applyChanges()` grows the dataset (`core.ts:2032`):

```js
while (changes[i][0] > instance.countRows() - 1) {
  const missingRows = changes[i][0] - (instance.countRows() - 1);
  datamap.createRow(undefined, missingRows, { source: 'auto' });  // undefined index => append
}
```

Worked example matching the reported output: 5 rows, filter keeps only `A2`, editor on visual row 3. Post-trim `countRows() === 1`, so `missingRows = 3 - 0 = 3`; the source data becomes 8 records; the visible rows are then physical `2, 5, 6, 7`, so visual row 3 resolves to physical 7 — `["A0","A1","A2","A3","A4", null, null, "EDITED"]`.

`trimRows()` and a sort reach the same broken state by a different route: neither touches the selection nor renders, so nothing commits at the time — the stale editor is simply left armed for whatever the user does next.

#### The fix

Entirely in `EditorManager`, keyed on the row/column mapper's own change signal so it covers every producer at once:

- `prepareEditor()` captures the **physical** row/column of the record being edited; `clearActiveEditor()` clears it.
- `#reconcileEditorWithIndexMaps()` runs on `afterRowSequenceCacheUpdate` / `afterColumnSequenceCacheUpdate` when either `trimmedIndexesChanged` or `indexesSequenceChanged` is set, and resolves that physical index back to a visual one:
  - no visual index (record gone) — discard via `cancelChanges()` and release the editor, writing nothing;
  - a different visual index (record moved) — rebind, so the pending commit still lands on the right record;
  - the same visual index — no-op.
- It runs **synchronously**, unlike `#closeEditorWhenCellHidden()`, because `filters.ts:1045` would beat a deferred handler. Neither branch writes data or renders, so nothing re-enters a cache update that is still unwinding.
- The now-false "a TRIMMING map is deliberately out of scope" paragraph in `#closeEditorWhenCellHidden()`'s JSDoc (added by #13245) is corrected.

Comparing the *resolved visual index* rather than testing a flag is what keeps this from firing spuriously: `BooleanMap#setValues()` emits a change even for a no-op write, so a flag test alone would tear down unrelated edits.

`core.ts:2032` is deliberately left alone. Growth past the last row is load-bearing for pasting below the last row, and narrowing it would be a breaking change. It is the amplifier here, not the cause.

A **structural** change — `alter()` inserting or removing rows — is the one case this reasoning gets backwards: it renumbers the physical space, so the captured index goes stale while the editor's *visual* coordinate stays correct. It raises the same flags as a filter, so the state object cannot tell them apart. The **size of the physical space** can: only an insert or a remove changes it. `#onSequenceCacheUpdate()` compares it against the previous update and routes structural changes to `#recaptureEditedRecord()`, which re-derives the record from the visual coordinate and discards only when that coordinate no longer resolves.

Without that split, any grid with a trimming map registered discarded a valid edit on `alter('remove_row', ...)` and, with a sort active, rebound onto the wrong record on `alter('insert_row_above', ...)`. Both are covered by cases.

Discriminating on the count rather than on `beforeCreateRow`/`afterCreateRow` pairing also means nothing a plugin cancels can strand it — `Formulas` returns `false` from those hooks whenever HyperFormula rejects the change, and a cancelled insert fires the `before` hook with no `after` hook and no cache update behind it. A cancelled insert changes no counts, so there is nothing to arm and nothing to leave armed.

#### Known limits, stated in the JSDoc

- An index-map change does **not** adjust the selection (`core.ts` calls `selection.commit()` only for `hiddenIndexesChanged`), so the highlight can be left past the last row and typing into it grows the data set. That is reachable **with no editor involved at all** — verified with a probe that never opens an editor — and is a separate pre-existing defect this PR does not paper over. Worth its own ticket.
- An editor parked in `WAITING` is not reconciled: `finishEditing()` has already run `saveValue()` by then, so there is nothing left to redirect.
- No core plugin registers a *trimming* map on the **column** axis, so that half runs for user-registered maps only. Core plugins do permute the column sequence (`manualColumnMove`, `manualColumnFreeze`), which the reconciliation now follows.
- A rebind moves the editor's coordinates and nothing else — not its pixel position, not the selection. Neither `render()` nor `view.render()` repositions an open editor, so on the `trimRows` path it stays drawn over the row it started on.
- Because the selection does not follow, two commit paths do not deliver the guarantee: an editor whose `finishEditing()` vetoes on a moved range (`DropdownEditor`, and the `date` / `autocomplete` / `handsontable` types built on it), and a Ctrl+Enter commit, which reads the selection corners rather than the editor's coordinates. On both the edit is **lost rather than misplaced** — `develop` appended rows in the dropdown case — but the value does not survive. Making it survive means moving the selection with the record, which is a larger change than this repair. Both are pinned by cases.
- `getActiveEditor()` now returns a `STATE_VIRGIN` editor at points where it previously returned an editing one, and a discarded edit fires no `beforeChange`/`afterChange`.

### How has this been tested?

New Playwright suite, `tests/e2e/editor-trimmed-row.spec.ts` (20 cases) with `tests/fixtures/pages/EditorTrimmedRowPage.ts` and `tests/fixtures/demo/editor-trimmed-row.html`. There was no existing test anywhere that opens an editor and then trims its row.

Cases: the append shape; the wrong-record shape; the shifted-record shape; both `trimRows` routes; a trimming-map write that moves nothing; an editor whose cell was scrolled out of view before the filter ran; `alter('remove_row')` stranding the editor past the last row; a sorted index mapping under a trim (so visual and physical genuinely differ); re-preparation from post-trim state when the user keeps typing after a discard; a sort and a `manualRowMove` under an open editor; and two structural-change cases (`alter()` removing an unrelated row, and inserting one) that only fail with a permutation active. Every case asserts the whole source data set **and** `countSourceRows()`, plus recorders proving the trigger actually fired and that no commit happened where none should.

13 of the 20 cases fail against `develop`. The other 7 are **regression guards, not proofs** — they pin behavior `develop` already gets right (a removal above the edit, a removal below it, an insert, a no-op trimming write, a Ctrl+Enter commit, a `updateData()` swap, a column removal) and exist because earlier revisions of this change broke several of them. They are labelled as such in their own comments.

```bash
# the new suite, plus the hiding-map suite from #13245 to prove it still holds
cd tests && npx playwright test --project=e2e-main \
  e2e/editor-trimmed-row.spec.ts e2e/editor-hidden-cell.spec.ts    # 33 passed

# core regression sweep - the guard now runs on every index-map change
npm --prefix handsontable run test:unit    # 3963 passed
npm --prefix handsontable run test:e2e     # 9745 specs, 0 failures
npm --prefix handsontable run eslint
npm --prefix handsontable run stylelint
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2652

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2652

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core edit/commit path in `EditorManager` now runs synchronously on every row/column index-map update; behavior is heavily tested but regressions could affect any grid with filters, trimming, or sorting during inline edit.
> 
> **Overview**
> Fixes **silent source-data corruption** when Filters, `trimRows`, sorting, row/column moves, or structural `alter()` run while a cell editor is open. The editor only kept **visual** coordinates, so commits could hit the wrong row, **append rows**, or write past a trimmed record.
> 
> **`EditorManager`** now stores the edited cell’s **physical** row/column in `prepareEditor()`, clears it when the editor is cleared, and on `afterRowSequenceCacheUpdate` / `afterColumnSequenceCacheUpdate` runs **`#repairEditor`** before the existing hidden-cell close logic. **Rearrangements** (trim/sequence) go through **`#reconcileEditorWithIndexMaps`**: drop the edit if the record left the visual grid, **rebind** `editor.row`/`col` if it moved, no-op if nothing changed (so no-op trimming-map writes do not kill edits). **Structural** insert/remove is detected by a change in physical index count and handled by **`#recaptureEditedRecord`** instead, so row insert/remove does not mis-reconcile against a stale physical index; a short **`#strandedInCurrentTask`** window avoids discarding edits during the gap between `alter()`’s cache update and `selection.shiftRows()`.
> 
> Adds changelog entry **#13272** and a large Playwright suite (`editor-trimmed-row.spec.ts` plus fixture/page object) covering filters, `trimRows`, sorts, moves, structural changes, column axis, `updateData`, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d85906ab9194ff5965d798a9022dc5b9a5352378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->