### PR TITLE
DEV-2653: Drop a late or superseded autocomplete source response

### DIFF
--- a/.changelogs/13273.json
+++ b/.changelogs/13273.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the autocomplete and dropdown editors re-showing a closed suggestion list and taking keyboard control back from the page when an asynchronous `source` answered after the editor had closed.",
+  "type": "fixed",
+  "issueOrPR": 13273,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13273.json
+++ b/.changelogs/13273.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed the autocomplete and dropdown editors re-showing a closed suggestion list and taking keyboard control back from the page when an asynchronous `source` answered after the editor had closed.",
+  "title": "Fixed the autocomplete and dropdown editors re-showing a closed suggestion list and taking keyboard control back from the page when an asynchronous `source` answered after the editor had closed. A `source` function is no longer called at all once the edit has finished, and `queryChoices()` is now a no-op while no edit is in progress.",
   "type": "fixed",
   "issueOrPR": 13273,
   "breaking": false,

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -150,7 +150,7 @@ In strict mode, the [`allowInvalid`](@/api/options.md#allowinvalid) option deter
 
 Autocomplete can also use asynchronous data sources. In the example below, suggestions for the "Car" column are loaded from the server with the Fetch API. To load data from a remote source, assign a function to the `source` option. The function receives the query string and the `process` callback. Call `process()` with the result array when the request completes.
 
-Handsontable ignores a response that arrives after the editor closed - including a close you may not notice, such as scrolling the edited cell out of view - and it ignores a response that a newer query has superseded, which happens on every keystroke. Call `process()` whenever the request completes, even late.
+Handsontable ignores a response that arrives after the editor closed - including a close you may not notice, such as scrolling the edited cell out of view - and it ignores a response that a newer query has superseded, which happens as you type. Call `process()` whenever the request completes, even late.
 
 ::: only-for javascript
 

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -150,7 +150,7 @@ In strict mode, the [`allowInvalid`](@/api/options.md#allowinvalid) option deter
 
 Autocomplete can also use asynchronous data sources. In the example below, suggestions for the "Car" column are loaded from the server with the Fetch API. To load data from a remote source, assign a function to the `source` option. The function receives the query string and the `process` callback. Call `process()` with the result array when the request completes.
 
-Call `process()` whenever the request completes, even late. Handsontable ignores a response that arrives after the editor closed, and it ignores a response that a newer query has already superseded. A slow request can never reopen the suggestion list over a cell you have stopped editing.
+Call `process()` whenever the request completes, even late. Handsontable ignores a response that arrives after the editor closed, and it ignores a response that a newer query has already superseded.
 
 ::: only-for javascript
 

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -150,6 +150,8 @@ In strict mode, the [`allowInvalid`](@/api/options.md#allowinvalid) option deter
 
 Autocomplete can also use asynchronous data sources. In the example below, suggestions for the "Car" column are loaded from the server with the Fetch API. To load data from a remote source, assign a function to the `source` option. The function receives the query string and the `process` callback. Call `process()` with the result array when the request completes.
 
+Call `process()` whenever the request completes, even late. Handsontable ignores a response that arrives after the editor closed, and it ignores a response that a newer query has already superseded. A slow request can never reopen the suggestion list over a cell you have stopped editing.
+
 ::: only-for javascript
 
 ::: example #example3 .docs-height-small --js 1 --ts 2

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -150,7 +150,7 @@ In strict mode, the [`allowInvalid`](@/api/options.md#allowinvalid) option deter
 
 Autocomplete can also use asynchronous data sources. In the example below, suggestions for the "Car" column are loaded from the server with the Fetch API. To load data from a remote source, assign a function to the `source` option. The function receives the query string and the `process` callback. Call `process()` with the result array when the request completes.
 
-Handsontable ignores a response that arrives after the editor closed, and it ignores a response that a newer query has already superseded. Call `process()` whenever the request completes, even late.
+Handsontable ignores a response that arrives after the editor closed - including a close you may not notice, such as scrolling the edited cell out of view - and it ignores a response that a newer query has superseded, which happens on every keystroke. Call `process()` whenever the request completes, even late.
 
 ::: only-for javascript
 

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -150,7 +150,7 @@ In strict mode, the [`allowInvalid`](@/api/options.md#allowinvalid) option deter
 
 Autocomplete can also use asynchronous data sources. In the example below, suggestions for the "Car" column are loaded from the server with the Fetch API. To load data from a remote source, assign a function to the `source` option. The function receives the query string and the `process` callback. Call `process()` with the result array when the request completes.
 
-Call `process()` whenever the request completes, even late. Handsontable ignores a response that arrives after the editor closed, and it ignores a response that a newer query has already superseded.
+Handsontable ignores a response that arrives after the editor closed, and it ignores a response that a newer query has already superseded. Call `process()` whenever the request completes, even late.
 
 ::: only-for javascript
 

--- a/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
+++ b/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
@@ -105,6 +105,8 @@ Internally, cell `{ type: 'dropdown' }` is equivalent to cell `{ type:'autocompl
 
 The `source` option can be provided in two formats:
 
+You can also assign a function to load the options from a remote source, as described in [Autocomplete strict mode with asynchronous data](@/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md#autocomplete-strict-mode-with-asynchronous-data). Handsontable ignores a response that arrives after the editor closed - including a close you may not notice, such as scrolling the edited cell out of view - and it ignores a response that a newer query has superseded, which happens on every keystroke. Call the callback whenever the request completes, even late.
+
 ### Array of values
 
 You can provide the `source` option as an array of values that will be used as the dropdown options.

--- a/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
+++ b/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
@@ -105,7 +105,7 @@ Internally, cell `{ type: 'dropdown' }` is equivalent to cell `{ type:'autocompl
 
 The `source` option can be provided in two formats:
 
-You can also assign a function to load the options from a remote source, as described in [Autocomplete strict mode with asynchronous data](@/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md#autocomplete-strict-mode-with-asynchronous-data). Handsontable ignores a response that arrives after the editor closed - including a close you may not notice, such as scrolling the edited cell out of view - and it ignores a response that a newer query has superseded, which happens on every keystroke. Call the callback whenever the request completes, even late.
+You can also assign a function to load the options from a remote source, as described in [Autocomplete strict mode with asynchronous data](@/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md#autocomplete-strict-mode-with-asynchronous-data). Handsontable ignores a response that arrives after the editor closed - including a close you may not notice, such as scrolling the edited cell out of view - and it ignores a response that a newer query has superseded, which happens as you type. Call the callback whenever the request completes, even late.
 
 ### Array of values
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -6102,6 +6102,10 @@ export default (): Record<string, unknown> => {
      * Note: When defining the `source` option as an array of objects with `key` and `value` properties, the data format for that cell
      * needs to be an object with `key` and `value` properties as well.
      *
+     * Note: When `source` is a function, Handsontable ignores a response that arrives after the editor closed - including
+     * a close you may not notice, such as scrolling the edited cell out of view - and it ignores a response that a newer
+     * query has superseded, which happens on every keystroke. Call the callback whenever the request completes, even late.
+     *
      * Read more:
      * - [Autocomplete cell type](@/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md)
      * - [Dropdown cell type](@/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md)

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -6104,7 +6104,7 @@ export default (): Record<string, unknown> => {
      *
      * Note: When `source` is a function, Handsontable ignores a response that arrives after the editor closed - including
      * a close you may not notice, such as scrolling the edited cell out of view - and it ignores a response that a newer
-     * query has superseded, which happens on every keystroke. Call the callback whenever the request completes, even late.
+     * query has superseded, which happens as you type. Call the callback whenever the request completes, even late.
      *
      * Read more:
      * - [Autocomplete cell type](@/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md)

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -340,6 +340,13 @@ export class AutocompleteEditor extends HandsontableEditor {
     //
     // Queries this editor deferred are cancelled outright; the token below is for the ones already
     // handed to user code, which cannot be.
+    //
+    // Known limitation: `refreshDimensions()` also calls `close()` as "hide for now" when the
+    // edited cell scrolls out of the rendered range, and there is no signal here to tell that apart
+    // from "the edit ended". So after the cell scrolls back the editor is visible again but its
+    // list can no longer populate. That path was already one-way before this change - the
+    // `removeHooksByKey` below means typing could not re-query after a scroll round trip either -
+    // and separating the two meanings belongs in `TextEditor`, not here.
     this.#queryTimeouts.forEach(timeoutId => clearTimeout(timeoutId));
     this.#queryTimeouts.clear();
 
@@ -376,20 +383,19 @@ export class AutocompleteEditor extends HandsontableEditor {
    * @param {string} query The query.
    */
   queryChoices(query: string): void {
-    // Both callers defer through `hot._registerTimeout()`, which has no cancel path - `close()`
-    // never clears the queue, so a timeout scheduled while the editor was open still fires after
-    // it closed. Bail rather than call the user's `source`, which is typically a network request.
+    // `close()` cancels the queries this editor deferred, so no internal caller reaches here once
+    // an edit has ended. This guard is for the public method: `queryChoices()` ships in the type
+    // declarations, and calling it while no edit is in progress must not invoke the user's
+    // `source`, which is typically a network request.
     //
-    // `state` rather than `isOpened()`: `_opened` is false for the whole of `open()`, and it stays
-    // false after `refreshDimensions()` closes an editor whose cell scrolled out of view and then
-    // shows it again on the way back, without ever restoring the flag. A guard on it would leave
-    // the suggestion list dead for the rest of such an edit. The close paths `state` cannot see are
-    // handled by the edit-session token instead, carried by each caller across its timeout.
-    //
-    // `WAITING` counts as open. `close()` is what unhooks `beforeKeyDown`, so keystrokes still
-    // schedule queries while an async validator runs, and under `allowInvalid: false` the editor
-    // stays open and returns to `EDITING`. Rejecting them here would stop the list refreshing for
+    // `WAITING` counts as in progress. `close()` is what unhooks `beforeKeyDown`, so keystrokes
+    // still schedule queries while an async validator runs, and under `allowInvalid: false` the
+    // editor stays open and returns to `EDITING`. Rejecting them would stop the list refreshing for
     // the length of every validation, which is a behavior change rather than a fix.
+    //
+    // `state` rather than `isOpened()`: `_opened` stays false after `refreshDimensions()` closes an
+    // editor whose cell scrolled out of view and then shows it again on the way back, without ever
+    // restoring the flag.
     if (this.state !== EDITOR_STATE.EDITING && this.state !== EDITOR_STATE.WAITING) {
       return;
     }

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -87,12 +87,21 @@ export class AutocompleteEditor extends HandsontableEditor {
    */
   #queryGeneration = 0;
   /**
-   * Edit-session token. Bumped on every `close()`, so work scheduled during one edit can tell that
-   * the edit has ended - which neither `state` nor `_opened` reports reliably.
+   * Edit-session token. Bumped on every `close()`, so a `source` response can tell that the edit it
+   * belongs to has ended - which neither `state` nor `_opened` reports reliably. Only the response
+   * needs a token: user code holds that callback and there is nothing to cancel, while the editor's
+   * own deferred queries are cancelled outright through `#queryTimeouts`.
    *
    * @type {number}
    */
   #editSession = 0;
+  /**
+   * Timer ids of the `queryChoices()` calls this editor has deferred and not yet run. Cleared on
+   * `close()`, so a query scheduled during an edit never runs after it.
+   *
+   * @type {Set}
+   */
+  #queryTimeouts: Set<ReturnType<typeof setTimeout>> = new Set();
 
   /**
    * Gets current value from editable element.
@@ -293,29 +302,47 @@ export class AutocompleteEditor extends HandsontableEditor {
       setAttribute(this.TEXTAREA, ...A11Y_EXPANDED('true'));
     }
 
-    // The editor can be closed again before this fires - `refreshDimensions()` does exactly that
-    // from inside `open()` when the cell is off-viewport - so carry the session and drop the query
-    // rather than reopening the list over a cell that is no longer being edited.
-    const editSession = this.#editSession;
+    this.#deferQuery();
+  }
 
-    this.hot._registerTimeout(() => {
-      if (editSession !== this.#editSession) {
-        return;
-      }
-
+  /**
+   * Defers a `queryChoices()` call and keeps its timer id so `close()` can cancel it.
+   *
+   * `hot._registerTimeout()` has no cancel path of its own - `_clearTimeouts()` runs only from
+   * `Core#destroy()` - so without this a query scheduled during an edit still fires after the
+   * editor closed, and starts a fresh request against a cell nobody is editing.
+   *
+   * @param {number} [delay] Delay in milliseconds.
+   */
+  #deferQuery(delay: number = 0): void {
+    const timeoutId = this.hot._registerTimeout(() => {
+      this.#queryTimeouts.delete(timeoutId);
       this.queryChoices(this.TEXTAREA.value);
-    });
+    }, delay);
+
+    this.#queryTimeouts.add(timeoutId);
   }
 
   /**
    * Closes the editor.
    */
   close(): void {
-    // Ends the edit session, which invalidates every query in flight and every query still waiting
-    // on a timeout. Closing is the one event that reliably means "no response is wanted any more":
-    // `state` stays `EDITING` when `refreshDimensions()` closes an editor whose cell scrolled out
-    // of the rendered range and when `afterSetTheme` closes one (`assignHooks`), and `_opened`
-    // stays false after that same cell scrolls back and the editor is shown again.
+    // The debounced refocus is armed by the inner grid's `afterScroll` and runs 100 ms later. It
+    // outlives the close by the same route the choices response used to, and `hideEditableElement()`
+    // only sets `opacity: 0`, so its `focus()` puts the caret back into a closed editor. The next
+    // scroll of a reopened list re-arms it, so cancelling here loses nothing.
+    this.#focusDebounced.cancel();
+
+    // Ends the edit session. Closing is the one event that reliably means "no response is wanted
+    // any more": `state` stays `EDITING` when `refreshDimensions()` closes an editor whose cell
+    // scrolled out of the rendered range and when `afterSetTheme` closes one (`assignHooks`), and
+    // `_opened` stays false after that same cell scrolls back and the editor is shown again.
+    //
+    // Queries this editor deferred are cancelled outright; the token below is for the ones already
+    // handed to user code, which cannot be.
+    this.#queryTimeouts.forEach(timeoutId => clearTimeout(timeoutId));
+    this.#queryTimeouts.clear();
+
     this.#editSession += 1;
 
     this.removeHooksByKey('beforeKeyDown');
@@ -358,7 +385,12 @@ export class AutocompleteEditor extends HandsontableEditor {
     // shows it again on the way back, without ever restoring the flag. A guard on it would leave
     // the suggestion list dead for the rest of such an edit. The close paths `state` cannot see are
     // handled by the edit-session token instead, carried by each caller across its timeout.
-    if (this.state !== EDITOR_STATE.EDITING) {
+    //
+    // `WAITING` counts as open. `close()` is what unhooks `beforeKeyDown`, so keystrokes still
+    // schedule queries while an async validator runs, and under `allowInvalid: false` the editor
+    // stays open and returns to `EDITING`. Rejecting them here would stop the list refreshing for
+    // the length of every validation, which is a behavior change rather than a fix.
+    if (this.state !== EDITOR_STATE.EDITING && this.state !== EDITOR_STATE.WAITING) {
       return;
     }
 
@@ -381,7 +413,12 @@ export class AutocompleteEditor extends HandsontableEditor {
         // state check - a response landing while an async validator holds the editor in `WAITING`
         // belongs to the still-open editor, and rejecting it would leave the list empty for the
         // rest of the edit when `allowInvalid: false` sends the state back to `EDITING`.
-        if (editSession !== this.#editSession || generation !== this.#queryGeneration) {
+        // `Core#destroy()` reaches neither token - it never closes the active editor - and
+        // `updateChoicesList()` would then touch an `htEditor` whose root element is gone. The
+        // guide tells people to answer late, and in a single-page app a torn-down grid is the
+        // usual way that happens.
+        if (this.hot.isDestroyed || editSession !== this.#editSession ||
+            generation !== this.#queryGeneration) {
           return;
         }
 
@@ -737,18 +774,7 @@ export class AutocompleteEditor extends HandsontableEditor {
         timeOffset += 10;
       }
 
-      // Carried across the delay for the same reason as in `open()`: a close landing inside the
-      // 10-20 ms window leaves `state` at `EDITING` on the scroll-out and theme paths, so without
-      // the session the timeout would start a fresh query against a closed editor.
-      const editSession = this.#editSession;
-
-      this.hot._registerTimeout(() => {
-        if (editSession !== this.#editSession) {
-          return;
-        }
-
-        this.queryChoices(this.TEXTAREA.value);
-      }, timeOffset);
+      this.#deferQuery(timeOffset);
     }
   }
 }

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -79,13 +79,20 @@ export class AutocompleteEditor extends HandsontableEditor {
    */
   #idPrefix = this.hot.guid.slice(0, 9);
   /**
-   * Generation token for the in-flight choices query. Bumped on every `queryChoices()` call and on
-   * every `close()`, so a response that no longer belongs to the edit in progress can be told apart
-   * from the one the editor is waiting for.
+   * Generation token for the in-flight choices query. Bumped on every `queryChoices()` call, so a
+   * response belonging to a superseded query can be told apart from the one the editor is waiting
+   * for.
    *
    * @type {number}
    */
   #queryGeneration = 0;
+  /**
+   * Edit-session token. Bumped on every `close()`, so work scheduled during one edit can tell that
+   * the edit has ended - which neither `state` nor `_opened` reports reliably.
+   *
+   * @type {number}
+   */
+  #editSession = 0;
 
   /**
    * Gets current value from editable element.
@@ -286,7 +293,16 @@ export class AutocompleteEditor extends HandsontableEditor {
       setAttribute(this.TEXTAREA, ...A11Y_EXPANDED('true'));
     }
 
+    // The editor can be closed again before this fires - `refreshDimensions()` does exactly that
+    // from inside `open()` when the cell is off-viewport - so carry the session and drop the query
+    // rather than reopening the list over a cell that is no longer being edited.
+    const editSession = this.#editSession;
+
     this.hot._registerTimeout(() => {
+      if (editSession !== this.#editSession) {
+        return;
+      }
+
       this.queryChoices(this.TEXTAREA.value);
     });
   }
@@ -295,15 +311,12 @@ export class AutocompleteEditor extends HandsontableEditor {
    * Closes the editor.
    */
   close(): void {
-    // Invalidates every query still in flight. Closing is the one event that reliably means "no
-    // response is wanted any more", and it is the only one: `state` stays `EDITING` when
-    // `refreshDimensions()` closes an editor whose cell scrolled out of the rendered range
-    // (`TextEditor.refreshDimensions`) and when `afterSetTheme` closes one (`assignHooks`), and
-    // `_opened` stays false after that same cell scrolls back and the editor is shown again.
-    // Bumping here also covers the gap between a close and the next `queryChoices()`: reopening at
-    // another cell only schedules its own query on a timeout, so without this a response for the
-    // previous cell could land first and still match.
-    this.#queryGeneration += 1;
+    // Ends the edit session, which invalidates every query in flight and every query still waiting
+    // on a timeout. Closing is the one event that reliably means "no response is wanted any more":
+    // `state` stays `EDITING` when `refreshDimensions()` closes an editor whose cell scrolled out
+    // of the rendered range and when `afterSetTheme` closes one (`assignHooks`), and `_opened`
+    // stays false after that same cell scrolls back and the editor is shown again.
+    this.#editSession += 1;
 
     this.removeHooksByKey('beforeKeyDown');
     super.close();
@@ -344,7 +357,7 @@ export class AutocompleteEditor extends HandsontableEditor {
     // false after `refreshDimensions()` closes an editor whose cell scrolled out of view and then
     // shows it again on the way back, without ever restoring the flag. A guard on it would leave
     // the suggestion list dead for the rest of such an edit. The close paths `state` cannot see are
-    // handled by the generation bump in `close()` instead.
+    // handled by the edit-session token instead, carried by each caller across its timeout.
     if (this.state !== EDITOR_STATE.EDITING) {
       return;
     }
@@ -352,6 +365,7 @@ export class AutocompleteEditor extends HandsontableEditor {
     type SourceValue = unknown[] | ((query: string, callback: (choices: unknown[]) => void) => void);
     const source = this.cellProperties.source as SourceValue | undefined;
     const generation = this.#queryGeneration + 1;
+    const editSession = this.#editSession;
 
     this.#queryGeneration = generation;
     this.query = query;
@@ -362,13 +376,12 @@ export class AutocompleteEditor extends HandsontableEditor {
       (source as SourceFn).call(this.cellProperties, query, (choices: unknown[]) => {
         // A user-supplied source answers whenever it likes, and `HandsontableEditor.close()` only
         // hides the nested grid, so a late response can still re-show the dropdown and pull focus
-        // back through `hot.listen()`. The generation carries the whole "is this still wanted"
-        // question: it moves on every close and on every newer query, and those are the only two
-        // ways a response stops being the one the editor is waiting for. Deliberately no state
-        // check here - a response landing while an async validator holds the editor in `WAITING`
+        // back through `hot.listen()`. Two ways a response stops being the one the editor waits
+        // for, one token each: the edit ended, or a newer query superseded it. Deliberately no
+        // state check - a response landing while an async validator holds the editor in `WAITING`
         // belongs to the still-open editor, and rejecting it would leave the list empty for the
         // rest of the edit when `allowInvalid: false` sends the state back to `EDITING`.
-        if (generation !== this.#queryGeneration) {
+        if (editSession !== this.#editSession || generation !== this.#queryGeneration) {
           return;
         }
 
@@ -724,11 +737,18 @@ export class AutocompleteEditor extends HandsontableEditor {
         timeOffset += 10;
       }
 
-      if (this.htEditor) {
-        this.hot._registerTimeout(() => {
-          this.queryChoices(this.TEXTAREA.value);
-        }, timeOffset);
-      }
+      // Carried across the delay for the same reason as in `open()`: a close landing inside the
+      // 10-20 ms window leaves `state` at `EDITING` on the scroll-out and theme paths, so without
+      // the session the timeout would start a fresh query against a closed editor.
+      const editSession = this.#editSession;
+
+      this.hot._registerTimeout(() => {
+        if (editSession !== this.#editSession) {
+          return;
+        }
+
+        this.queryChoices(this.TEXTAREA.value);
+      }, timeOffset);
     }
   }
 }

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -79,8 +79,9 @@ export class AutocompleteEditor extends HandsontableEditor {
    */
   #idPrefix = this.hot.guid.slice(0, 9);
   /**
-   * Generation token for the in-flight choices query. Bumped on every `queryChoices()` call so a
-   * response that belongs to a superseded query can be told apart from the current one.
+   * Generation token for the in-flight choices query. Bumped on every `queryChoices()` call and on
+   * every `close()`, so a response that no longer belongs to the edit in progress can be told apart
+   * from the one the editor is waiting for.
    *
    * @type {number}
    */
@@ -294,6 +295,16 @@ export class AutocompleteEditor extends HandsontableEditor {
    * Closes the editor.
    */
   close(): void {
+    // Invalidates every query still in flight. Closing is the one event that reliably means "no
+    // response is wanted any more", and it is the only one: `state` stays `EDITING` when
+    // `refreshDimensions()` closes an editor whose cell scrolled out of the rendered range
+    // (`TextEditor.refreshDimensions`) and when `afterSetTheme` closes one (`assignHooks`), and
+    // `_opened` stays false after that same cell scrolls back and the editor is shown again.
+    // Bumping here also covers the gap between a close and the next `queryChoices()`: reopening at
+    // another cell only schedules its own query on a timeout, so without this a response for the
+    // previous cell could land first and still match.
+    this.#queryGeneration += 1;
+
     this.removeHooksByKey('beforeKeyDown');
     super.close();
 
@@ -327,9 +338,13 @@ export class AutocompleteEditor extends HandsontableEditor {
   queryChoices(query: string): void {
     // Both callers defer through `hot._registerTimeout()`, which has no cancel path - `close()`
     // never clears the queue, so a timeout scheduled while the editor was open still fires after
-    // it closed. `state` is the signal to check rather than `isOpened()`: `beginEditing()` sets
-    // `state` to `EDITING` before calling `open()` and `_opened` only after it returns, so
-    // `isOpened()` is still false for a source that answers synchronously.
+    // it closed. Bail rather than call the user's `source`, which is typically a network request.
+    //
+    // `state` rather than `isOpened()`: `_opened` is false for the whole of `open()`, and it stays
+    // false after `refreshDimensions()` closes an editor whose cell scrolled out of view and then
+    // shows it again on the way back, without ever restoring the flag. A guard on it would leave
+    // the suggestion list dead for the rest of such an edit. The close paths `state` cannot see are
+    // handled by the generation bump in `close()` instead.
     if (this.state !== EDITOR_STATE.EDITING) {
       return;
     }
@@ -347,11 +362,13 @@ export class AutocompleteEditor extends HandsontableEditor {
       (source as SourceFn).call(this.cellProperties, query, (choices: unknown[]) => {
         // A user-supplied source answers whenever it likes, and `HandsontableEditor.close()` only
         // hides the nested grid, so a late response can still re-show the dropdown and pull focus
-        // back through `hot.listen()`. The state check rejects a response that outlived the edit.
-        // The generation check rejects one that belongs to a superseded query - including a query
-        // from an earlier open at a different cell, which the state check cannot see, because the
-        // editor is a per-instance singleton and is in the `EDITING` state again by then.
-        if (generation !== this.#queryGeneration || this.state !== EDITOR_STATE.EDITING) {
+        // back through `hot.listen()`. The generation carries the whole "is this still wanted"
+        // question: it moves on every close and on every newer query, and those are the only two
+        // ways a response stops being the one the editor is waiting for. Deliberately no state
+        // check here - a response landing while an async validator holds the editor in `WAITING`
+        // belongs to the still-open editor, and rejecting it would leave the list empty for the
+        // rest of the edit when `allowInvalid: false` sends the state back to `EDITING`.
+        if (generation !== this.#queryGeneration) {
           return;
         }
 

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -1,5 +1,6 @@
 import type { HotInstance } from '../../core/types';
 import type { CellProperties } from '../../settings';
+import { EDITOR_STATE } from '../baseEditor';
 import { HandsontableEditor } from '../handsontableEditor';
 import { pivot } from '../../helpers/array';
 import { isKeyValueObject, isObject } from '../../helpers/object';
@@ -77,6 +78,13 @@ export class AutocompleteEditor extends HandsontableEditor {
    * @type {string}
    */
   #idPrefix = this.hot.guid.slice(0, 9);
+  /**
+   * Generation token for the in-flight choices query. Bumped on every `queryChoices()` call so a
+   * response that belongs to a superseded query can be told apart from the current one.
+   *
+   * @type {number}
+   */
+  #queryGeneration = 0;
 
   /**
    * Gets current value from editable element.
@@ -311,17 +319,42 @@ export class AutocompleteEditor extends HandsontableEditor {
   /**
    * Prepares choices list based on applied argument.
    *
+   * Does nothing when the editor is not editing, and ignores a `source` response that arrives after
+   * the editor closed or after a newer query started.
+   *
    * @param {string} query The query.
    */
   queryChoices(query: string): void {
+    // Both callers defer through `hot._registerTimeout()`, which has no cancel path - `close()`
+    // never clears the queue, so a timeout scheduled while the editor was open still fires after
+    // it closed. `state` is the signal to check rather than `isOpened()`: `beginEditing()` sets
+    // `state` to `EDITING` before calling `open()` and `_opened` only after it returns, so
+    // `isOpened()` is still false for a source that answers synchronously.
+    if (this.state !== EDITOR_STATE.EDITING) {
+      return;
+    }
+
     type SourceValue = unknown[] | ((query: string, callback: (choices: unknown[]) => void) => void);
     const source = this.cellProperties.source as SourceValue | undefined;
+    const generation = this.#queryGeneration + 1;
 
+    this.#queryGeneration = generation;
     this.query = query;
 
     if (typeof source === 'function') {
       type SourceFn = (query: string, callback: (choices: unknown[]) => void) => void;
+
       (source as SourceFn).call(this.cellProperties, query, (choices: unknown[]) => {
+        // A user-supplied source answers whenever it likes, and `HandsontableEditor.close()` only
+        // hides the nested grid, so a late response can still re-show the dropdown and pull focus
+        // back through `hot.listen()`. The state check rejects a response that outlived the edit.
+        // The generation check rejects one that belongs to a superseded query - including a query
+        // from an earlier open at a different cell, which the state check cannot see, because the
+        // editor is a per-instance singleton and is in the `EDITING` state again by then.
+        if (generation !== this.#queryGeneration || this.state !== EDITOR_STATE.EDITING) {
+          return;
+        }
+
         this.rawChoices = choices;
         this.updateChoicesList(this.stripValuesIfNeeded(choices));
       });

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -34,6 +34,19 @@ Visual regression is a separate package (`visual-tests/`). Task workflow: the
   warning and silently stays off) and **no languages pack** (an i18n fixture
   loads `dist/languages/all.js` explicitly — the Puppeteer harness does that
   for you, this tier does not).
+- **Seed an editor fixture's cells with a non-empty value.** On an EMPTY cell,
+  `cell.click()` followed by `keyboard.press('Enter')` opens the editor and
+  closes it again on the same keypress. The trace is `afterBeginEditing`
+  (EDITING) → `beforeChange` (WAITING) → `afterChange` (VIRGIN). Nothing is
+  logged, so the spec just fails at "the editor never opened" with no pointer to
+  the cause. It is specific to click-then-Enter: `hot.selectCell()` then Enter
+  keeps an empty cell's editor open, and so does click-then-Enter as soon as the
+  cell has a value. Pre-existing and not root-caused (see the sibling case,
+  `dropdownEditor.spec.js`'s "empty-value focus"). For `autocomplete` /
+  `dropdown`, seed with a prefix the whole column's choice set shares (`'Al'` for
+  `Alpha/Alfa/Alto`) so `autocomplete`, which filters by the typed value, renders
+  the same list as `dropdown`, which forces `filter: false`, and one assertion
+  covers both. Reference: `fixtures/demo/autocomplete-async-source.html`.
 - A fixture-served library MUST be a dependency of THIS package, loaded from
   `/tests/node_modules/…` — CI installs only the filtered `handsontable-tests`
   workspace, so a path into any other package's `node_modules` does not exist

--- a/tests/e2e/autocomplete-async-source.spec.ts
+++ b/tests/e2e/autocomplete-async-source.spec.ts
@@ -53,7 +53,10 @@ EDITORS.forEach((editor) => {
 
       const listenCountBeforeResponse = await grid.listenCount();
 
-      // A zero here would mean nothing was ever in flight and the case proved nothing.
+      // Count the EDITOR's queries, not every query: `autocompleteValidator` calls the same user
+      // `source` on the strict save path, so a bare "something was in flight" guard can be met by
+      // the validator alone and prove nothing about the editor.
+      expect(await grid.editorQueryCount(0)).toBe(1);
       expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
 
       await expect.poll(() => grid.isDropdownShown()).toBe(false);
@@ -75,6 +78,7 @@ EDITORS.forEach((editor) => {
 
       const listenCountBeforeResponse = await grid.listenCount();
 
+      expect(await grid.editorQueryCount(0)).toBe(1);
       expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
 
       await expect.poll(() => grid.isDropdownShown()).toBe(false);
@@ -111,6 +115,158 @@ EDITORS.forEach((editor) => {
     });
   });
 
+  /**
+   * The guard has to tell "the edit ended" apart from "the edit is busy". `WAITING` is busy: an
+   * async validator is running, `close()` has not been called, so `beforeKeyDown` is still hooked
+   * and keystrokes still schedule queries. Under `allowInvalid: false` the editor then goes back to
+   * `EDITING` rather than closing. Rejecting those queries would stop the list refreshing for the
+   * length of every validation, which `develop` did not do.
+   */
+  test.describe(`${editor} editor with an async validator in flight`, () => {
+    let grid: AutocompleteAsyncSourcePage;
+
+    test.beforeEach(async({ page, theme, bundle }) => {
+      grid = new AutocompleteAsyncSourcePage(page, theme, bundle, { editor, validator: 'slowAsync' });
+      await grid.goto();
+    });
+
+    test('still refreshes the list while the editor waits on validation', async() => {
+      await grid.openEditor(0, 0);
+
+      expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
+      await expect.poll(() => grid.isDropdownShown()).toBe(true);
+
+      // Commit without settling the validator: the editor parks in `WAITING`, still open.
+      await grid.page.keyboard.press('Enter');
+      await expect.poll(() => grid.editorState()).toBe('STATE_WAITING');
+      expect(await grid.isEditorOpen()).toBe(true);
+
+      await grid.scheduleAnotherQuery();
+
+      // The query has to reach the `source` at all - that is the half the entry guard decides.
+      const states = await grid.queryStates(0);
+
+      expect(states.filter(state => state === 'STATE_WAITING').length).toBeGreaterThan(0);
+
+      expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
+
+      // And its answer has to render - that is the half the callback guard decides.
+      await expect.poll(() => grid.isDropdownShown()).toBe(true);
+      expect(sorted(await grid.dropdownChoices())).toEqual(sorted(await grid.choicesFor(0)));
+
+      await grid.settleValidation();
+    });
+
+    test('ignores a response from the validation window once the editor finally closes', async() => {
+      await grid.openEditor(0, 0);
+
+      await grid.page.keyboard.press('Enter');
+      await expect.poll(() => grid.editorState()).toBe('STATE_WAITING');
+
+      await grid.scheduleAnotherQuery();
+      await grid.settleValidation();
+
+      // A rejected value under `allowInvalid: false` keeps the editor open, so close it for real.
+      await grid.page.keyboard.press('Escape');
+      await expect.poll(() => grid.isEditorOpen()).toBe(false);
+      await expect.poll(() => grid.isDropdownShown()).toBe(false);
+
+      await grid.clickOutsideInput();
+
+      const listenCountBeforeResponse = await grid.listenCount();
+
+      expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
+
+      await expect.poll(() => grid.isDropdownShown()).toBe(false);
+      expect(await grid.listenCount()).toBe(listenCountBeforeResponse);
+    });
+  });
+
+  /**
+   * The choices response is not the only thing that outlives a close. `#focusDebounced` is armed by
+   * the inner grid's `afterScroll` and runs 100 ms later, outside `hot.timeouts` entirely, and
+   * `hideEditableElement()` only sets `opacity: 0` - so its `focus()` puts the caret back into a
+   * closed editor. Same symptom as the reported defect, different route, so the changelog's claim
+   * depends on this one too.
+   */
+  test.describe(`${editor} editor closed just after its list scrolled`, () => {
+    test('does not refocus itself after the close', async({ page, theme, bundle }) => {
+      const grid = new AutocompleteAsyncSourcePage(page, theme, bundle, { editor });
+
+      await grid.goto();
+      await grid.openEditor(0, 0);
+
+      expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
+      await expect.poll(() => grid.isDropdownShown()).toBe(true);
+
+      await grid.armRefocusThenClose();
+
+      expect(await grid.isEditorOpen()).toBe(false);
+      expect(await grid.refocusCountAfterClose()).toBe(0);
+    });
+  });
+
+  /**
+   * The guide tells people to answer late, and in a single-page app the usual way that happens is
+   * that the grid is gone. `Core#destroy()` never closes the active editor, so neither token moves
+   * and only the destroyed check stops the response from reaching a torn-down `htEditor`.
+   */
+  test.describe(`${editor} editor destroyed with a query in flight`, () => {
+    test('swallows a source response that arrives after the grid was destroyed', async({ page, theme, bundle }) => {
+      const errors: string[] = [];
+
+      page.on('pageerror', error => errors.push(error.message));
+
+      const grid = new AutocompleteAsyncSourcePage(page, theme, bundle, { editor });
+
+      await grid.goto();
+      await grid.openEditor(0, 0);
+
+      expect(await grid.editorQueryCount(0)).toBe(1);
+
+      await grid.destroyGrid();
+
+      expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
+      expect(errors).toEqual([]);
+    });
+  });
+
+  /**
+   * `#queryGeneration` exists for two queries inside ONE edit session, where `#editSession` never
+   * moves and cannot decide anything. Without a case like this the counter can be deleted and every
+   * other test still passes.
+   */
+  test.describe(`${editor} editor with two overlapping queries in one edit`, () => {
+    let grid: AutocompleteAsyncSourcePage;
+
+    test.beforeEach(async({ page, theme, bundle }) => {
+      grid = new AutocompleteAsyncSourcePage(page, theme, bundle, { editor, scenario: 'ordering' });
+      await grid.goto();
+    });
+
+    test('keeps the newest answer when an older one arrives after it', async() => {
+      await grid.openEditor(0, 0);
+      await grid.scheduleAnotherQuery();
+
+      // Two queries, same edit, neither answered yet.
+      expect(await grid.queryStates(0)).toEqual(['STATE_EDITING', 'STATE_EDITING']);
+      expect(await grid.pendingQueryCount(0)).toBe(2);
+
+      // Newest first, then the straggler. Each answer is tagged with its query's index, so the
+      // rendered list names which one won.
+      expect(await grid.resolveQueryAt(1)).toBe(true);
+      await expect.poll(async() => sorted(await grid.dropdownChoices()))
+        .toEqual(sorted((await grid.choicesFor(0)).map(choice => `${choice}-q1`)));
+
+      expect(await grid.resolveQueryAt(0)).toBe(true);
+
+      expect(sorted(await grid.dropdownChoices()))
+        .toEqual(sorted((await grid.choicesFor(0)).map(choice => `${choice}-q1`)));
+      expect(sorted(await grid.rawChoices() as string[]))
+        .toEqual(sorted((await grid.choicesFor(0)).map(choice => `${choice}-q1`)));
+    });
+  });
+
   test.describe(`${editor} editor closed by scrolling its cell out of view`, () => {
     let grid: AutocompleteAsyncSourcePage;
 
@@ -132,13 +288,20 @@ EDITORS.forEach((editor) => {
       expect(await grid.editorState()).toBe('STATE_EDITING');
       expect(await grid.isDropdownShown()).toBe(false);
 
+      // Hand keyboard control away before reading the baseline. `Core#listen()` runs `afterListen`
+      // only on a not-listening to listening transition, and a scroll never unlistens, so without
+      // this the count is pinned and the focus half of the assertion could not fail.
+      await grid.clickOutsideInput();
+
       const listenCountBeforeResponse = await grid.listenCount();
 
+      expect(await grid.editorQueryCount(0)).toBe(1);
       expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
 
       await expect.poll(() => grid.isDropdownShown()).toBe(false);
       expect(await grid.dropdownChoices()).toEqual([]);
       expect(await grid.listenCount()).toBe(listenCountBeforeResponse);
+      expect(await grid.isGridListening()).toBe(false);
     });
 
     test('starts no new query when a timeout scheduled before the close fires after it', async() => {
@@ -156,7 +319,7 @@ EDITORS.forEach((editor) => {
       expect(await grid.isEditorOpen()).toBe(false);
       expect(await grid.totalQueryCount()).toBe(queriesBefore);
 
-      await grid.resolveQueries(0);
+      expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
 
       expect(await grid.isDropdownShown()).toBe(false);
       expect(await grid.dropdownChoices()).toEqual([]);

--- a/tests/e2e/autocomplete-async-source.spec.ts
+++ b/tests/e2e/autocomplete-async-source.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '../fixtures/test';
+import { AutocompleteAsyncSourcePage } from '../fixtures/pages/AutocompleteAsyncSourcePage';
+
+const EDITORS = ['autocomplete', 'dropdown'] as const;
+
+const CHOICES = {
+  0: ['Alpha', 'Alfa', 'Alto'],
+  1: ['Bravo', 'Bruno', 'Brisk'],
+};
+
+/**
+ * Returns the list sorted, so a case pins WHICH choices are shown without also pinning the order
+ * `updateChoicesList()` happens to produce for them.
+ */
+function sorted(values: string[]): string[] {
+  return [...values].sort();
+}
+
+/**
+ * DEV-2653. `AutocompleteEditor` asks a user-supplied `source` for its choices and, until this was
+ * guarded, did nothing with the answer's timing. Two things made a late answer harmful rather than
+ * inert: `HandsontableEditor.close()` only hides the nested grid, so the object stays alive and
+ * willing to re-render, and `hot._registerTimeout()` has no cancel path, so the deferred
+ * `queryChoices()` calls survive a close too. A response arriving after the editor closed re-showed
+ * the suggestion list over a cell that was no longer being edited and called `hot.listen()`,
+ * handing keyboard control back to the grid.
+ *
+ * The fixture's `source` answers only when a case tells it to, so "the answer arrives late" is
+ * stated exactly instead of being raced against a timer.
+ *
+ * Both halves of the defect are asserted every time. `updateChoicesList()` sets `display` and calls
+ * `hot.listen()` independently, so a case that checked only the dropdown would pass on a fix that
+ * still stole focus.
+ */
+EDITORS.forEach((editor) => {
+  test.describe(`${editor} editor with an asynchronous source`, () => {
+    let grid: AutocompleteAsyncSourcePage;
+
+    test.beforeEach(async({ page, theme, bundle }) => {
+      grid = new AutocompleteAsyncSourcePage(page, theme, bundle, { editor });
+      await grid.goto();
+    });
+
+    test('ignores a source response that arrives after Escape closed the editor', async() => {
+      await grid.openEditor(0, 0);
+
+      await grid.page.keyboard.press('Escape');
+
+      await expect.poll(() => grid.isEditorOpen()).toBe(false);
+      await expect.poll(() => grid.isDropdownShown()).toBe(false);
+
+      await grid.clickOutsideInput();
+
+      const listenCountBeforeResponse = await grid.listenCount();
+
+      // A zero here would mean nothing was ever in flight and the case proved nothing.
+      expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
+
+      await expect.poll(() => grid.isDropdownShown()).toBe(false);
+      expect(await grid.dropdownChoices()).toEqual([]);
+      expect(await grid.listenCount()).toBe(listenCountBeforeResponse);
+      expect(await grid.isGridListening()).toBe(false);
+      expect(await grid.activeElementTestId()).toBe('outside-input');
+    });
+
+    test('ignores a source response that arrives after an outside click closed the editor', async() => {
+      await grid.openEditor(0, 0);
+
+      // A different close path from Escape: `DropdownEditor.finishEditing()` rewrites
+      // `restoreOriginalValue` from the active range, which Escape never reaches.
+      await grid.clickOutsideInput();
+
+      await expect.poll(() => grid.isEditorOpen()).toBe(false);
+      await expect.poll(() => grid.isDropdownShown()).toBe(false);
+
+      const listenCountBeforeResponse = await grid.listenCount();
+
+      expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
+
+      await expect.poll(() => grid.isDropdownShown()).toBe(false);
+      expect(await grid.dropdownChoices()).toEqual([]);
+      expect(await grid.listenCount()).toBe(listenCountBeforeResponse);
+      expect(await grid.isGridListening()).toBe(false);
+      expect(await grid.activeElementTestId()).toBe('outside-input');
+    });
+
+    test('ignores a source response from a previous edit after the editor reopened elsewhere', async() => {
+      await grid.openEditor(0, 0);
+
+      await grid.page.keyboard.press('Escape');
+
+      await expect.poll(() => grid.isEditorOpen()).toBe(false);
+
+      // The editor is a per-instance singleton, so this is the SAME object, now editing another
+      // column and back in the `EDITING` state. A guard that only reads the state cannot tell the
+      // stale response apart from the current one - the query generation is what does.
+      await grid.openEditor(0, 1);
+
+      expect(await grid.resolveQueries(1)).toBeGreaterThan(0);
+
+      await expect.poll(() => grid.isDropdownShown()).toBe(true);
+      await expect.poll(async() => sorted(await grid.dropdownChoices())).toEqual(sorted(CHOICES[1]));
+
+      expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
+
+      expect(sorted(await grid.dropdownChoices())).toEqual(sorted(CHOICES[1]));
+      expect(sorted(await grid.rawChoices() as string[])).toEqual(sorted(CHOICES[1]));
+      expect(await grid.isDropdownShown()).toBe(true);
+    });
+  });
+});

--- a/tests/e2e/autocomplete-async-source.spec.ts
+++ b/tests/e2e/autocomplete-async-source.spec.ts
@@ -140,5 +140,26 @@ EDITORS.forEach((editor) => {
       expect(await grid.dropdownChoices()).toEqual([]);
       expect(await grid.listenCount()).toBe(listenCountBeforeResponse);
     });
+
+    test('starts no new query when a timeout scheduled before the close fires after it', async() => {
+      await grid.openEditor(0, 0);
+
+      const queriesBefore = await grid.totalQueryCount();
+
+      // Invalidating the query already in flight is not enough on its own. A `queryChoices()`
+      // timeout scheduled in the 10-20 ms before the close still fires afterwards, and `state` is
+      // `EDITING` by then, so it would start a FRESH query - current by every other measure - and
+      // re-show the list over the closed editor once that one answered.
+      await grid.scheduleQueryThenClose();
+
+      expect(await grid.editorState()).toBe('STATE_EDITING');
+      expect(await grid.isEditorOpen()).toBe(false);
+      expect(await grid.totalQueryCount()).toBe(queriesBefore);
+
+      await grid.resolveQueries(0);
+
+      expect(await grid.isDropdownShown()).toBe(false);
+      expect(await grid.dropdownChoices()).toEqual([]);
+    });
   });
 });

--- a/tests/e2e/autocomplete-async-source.spec.ts
+++ b/tests/e2e/autocomplete-async-source.spec.ts
@@ -3,11 +3,6 @@ import { AutocompleteAsyncSourcePage } from '../fixtures/pages/AutocompleteAsync
 
 const EDITORS = ['autocomplete', 'dropdown'] as const;
 
-const CHOICES = {
-  0: ['Alpha', 'Alfa', 'Alto'],
-  1: ['Bravo', 'Bruno', 'Brisk'],
-};
-
 /**
  * Returns the list sorted, so a case pins WHICH choices are shown without also pinning the order
  * `updateChoicesList()` happens to produce for them.
@@ -24,6 +19,11 @@ function sorted(values: string[]): string[] {
  * `queryChoices()` calls survive a close too. A response arriving after the editor closed re-showed
  * the suggestion list over a cell that was no longer being edited and called `hot.listen()`,
  * handing keyboard control back to the grid.
+ *
+ * The guard is keyed on `close()`, which bumps a query generation, rather than on either state
+ * flag. Neither flag describes a closed editor on its own: `state` stays `EDITING` when
+ * `refreshDimensions()` closes an editor whose cell scrolled out of the rendered range, and
+ * `_opened` stays false after that same cell scrolls back and the editor is shown again.
  *
  * The fixture's `source` answers only when a case tells it to, so "the answer arrives late" is
  * stated exactly instead of being raced against a timer.
@@ -98,14 +98,47 @@ EDITORS.forEach((editor) => {
 
       expect(await grid.resolveQueries(1)).toBeGreaterThan(0);
 
+      const ownChoices = sorted(await grid.choicesFor(1));
+
       await expect.poll(() => grid.isDropdownShown()).toBe(true);
-      await expect.poll(async() => sorted(await grid.dropdownChoices())).toEqual(sorted(CHOICES[1]));
+      await expect.poll(async() => sorted(await grid.dropdownChoices())).toEqual(ownChoices);
 
       expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
 
-      expect(sorted(await grid.dropdownChoices())).toEqual(sorted(CHOICES[1]));
-      expect(sorted(await grid.rawChoices() as string[])).toEqual(sorted(CHOICES[1]));
+      expect(sorted(await grid.dropdownChoices())).toEqual(ownChoices);
+      expect(sorted(await grid.rawChoices() as string[])).toEqual(ownChoices);
       expect(await grid.isDropdownShown()).toBe(true);
+    });
+  });
+
+  test.describe(`${editor} editor closed by scrolling its cell out of view`, () => {
+    let grid: AutocompleteAsyncSourcePage;
+
+    test.beforeEach(async({ page, theme, bundle }) => {
+      grid = new AutocompleteAsyncSourcePage(page, theme, bundle, { editor, scenario: 'scroll' });
+      await grid.goto();
+    });
+
+    test('ignores a source response that arrives after the scroll closed the editor', async() => {
+      await grid.openEditor(0, 0);
+
+      await grid.scrollToRow(60);
+
+      // Pin the close AND the state it leaves behind before resolving anything. Without this the
+      // case would pass whenever the scroll left row 0 rendered, having proved nothing - and the
+      // `STATE_EDITING` half is the whole reason this case exists, since it is what a guard reading
+      // `state` alone would wave through.
+      await expect.poll(() => grid.isEditorOpen()).toBe(false);
+      expect(await grid.editorState()).toBe('STATE_EDITING');
+      expect(await grid.isDropdownShown()).toBe(false);
+
+      const listenCountBeforeResponse = await grid.listenCount();
+
+      expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
+
+      await expect.poll(() => grid.isDropdownShown()).toBe(false);
+      expect(await grid.dropdownChoices()).toEqual([]);
+      expect(await grid.listenCount()).toBe(listenCountBeforeResponse);
     });
   });
 });

--- a/tests/e2e/autocomplete-async-source.spec.ts
+++ b/tests/e2e/autocomplete-async-source.spec.ts
@@ -20,10 +20,11 @@ function sorted(values: string[]): string[] {
  * the suggestion list over a cell that was no longer being edited and called `hot.listen()`,
  * handing keyboard control back to the grid.
  *
- * The guard is keyed on `close()`, which bumps a query generation, rather than on either state
- * flag. Neither flag describes a closed editor on its own: `state` stays `EDITING` when
- * `refreshDimensions()` closes an editor whose cell scrolled out of the rendered range, and
- * `_opened` stays false after that same cell scrolls back and the editor is shown again.
+ * The fix keys on `close()` rather than on either state flag, because neither describes a closed
+ * editor on its own: `state` stays `EDITING` when `refreshDimensions()` closes an editor whose cell
+ * scrolled out of the rendered range, and `_opened` stays false after that same cell scrolls back
+ * and the editor is shown again. `close()` cancels the queries the editor deferred and ends the
+ * edit session that its `source` callbacks were issued under.
  *
  * The fixture's `source` answers only when a case tells it to, so "the answer arrives late" is
  * stated exactly instead of being raced against a timer.
@@ -126,7 +127,14 @@ EDITORS.forEach((editor) => {
     let grid: AutocompleteAsyncSourcePage;
 
     test.beforeEach(async({ page, theme, bundle }) => {
-      grid = new AutocompleteAsyncSourcePage(page, theme, bundle, { editor, validator: 'slowAsync' });
+      // `ordering` tags each answer with the index of the query it belongs to. Without that the
+      // second response is byte-identical to the first, the list never visibly changes, and the
+      // callback-guard half of this case would pass on the stale list.
+      grid = new AutocompleteAsyncSourcePage(page, theme, bundle, {
+        editor,
+        validator: 'slowAsync',
+        scenario: 'ordering',
+      });
       await grid.goto();
     });
 
@@ -150,9 +158,12 @@ EDITORS.forEach((editor) => {
 
       expect(await grid.resolveQueries(0)).toBeGreaterThan(0);
 
-      // And its answer has to render - that is the half the callback guard decides.
+      // And its answer has to REPLACE what the first one rendered - that is the half the callback
+      // guard decides, and only the tag can tell the two responses apart.
+      const secondAnswer = sorted((await grid.choicesFor(0)).map(choice => `${choice}-q1`));
+
       await expect.poll(() => grid.isDropdownShown()).toBe(true);
-      expect(sorted(await grid.dropdownChoices())).toEqual(sorted(await grid.choicesFor(0)));
+      await expect.poll(async() => sorted(await grid.dropdownChoices())).toEqual(secondAnswer);
 
       await grid.settleValidation();
     });
@@ -179,6 +190,28 @@ EDITORS.forEach((editor) => {
 
       await expect.poll(() => grid.isDropdownShown()).toBe(false);
       expect(await grid.listenCount()).toBe(listenCountBeforeResponse);
+    });
+  });
+
+  /**
+   * `queryChoices()` ships in the type declarations, and the changelog now states that it no-ops
+   * while no edit is in progress. With deferred queries cancelled on close, no internal caller can
+   * reach it outside an edit, so this contract is the entry guard's only remaining job - and
+   * removing that guard leaves every other case in this file green.
+   */
+  test.describe(`${editor} editor asked for choices with no edit in progress`, () => {
+    test('does not reach the source', async({ page, theme, bundle }) => {
+      const grid = new AutocompleteAsyncSourcePage(page, theme, bundle, { editor });
+
+      await grid.goto();
+      await grid.openEditor(0, 0);
+
+      await grid.page.keyboard.press('Escape');
+
+      await expect.poll(() => grid.isEditorOpen()).toBe(false);
+      expect(await grid.editorState()).toBe('STATE_VIRGIN');
+
+      expect(await grid.callQueryChoicesDirectly()).toBe(0);
     });
   });
 

--- a/tests/e2e/editor-hidden-cell.spec.ts
+++ b/tests/e2e/editor-hidden-cell.spec.ts
@@ -153,12 +153,12 @@ test.describe('non-text editors whose cell is hidden', () => {
 
     await grid.setPage(2);
 
-    // Assert only that the editor is gone. Whether a dropdown COMMITS or DISCARDS is decided by
-    // `DropdownEditor.finishEditing`, which rewrites the flag based on the active range, and by its
-    // own `queryChoices` timeout scheduled in `open()`. Both are pre-existing and race real typing,
-    // so the committed value is not a stable assertion here. The editor surviving a hidden cell is
-    // what this change fixes, and that is what this pins.
     await expect.poll(() => grid.isEditorOpen()).toBe(false);
+    // The committed value used to be unassertable here: `queryChoices()`, deferred in `open()` and
+    // again on every keystroke, could land after the page turn and re-highlight a choice that
+    // `HandsontableEditor.finishEditing` then read as the value. DEV-2653 made those deferred calls
+    // bail once the editor is no longer editing, which is what makes this stable.
+    await expect.poll(() => grid.sourceColumn(0)).toEqual(['A4', 'A2', 'A3', 'A4']);
   });
 });
 

--- a/tests/e2e/editor-hidden-cell.spec.ts
+++ b/tests/e2e/editor-hidden-cell.spec.ts
@@ -154,10 +154,12 @@ test.describe('non-text editors whose cell is hidden', () => {
     await grid.setPage(2);
 
     await expect.poll(() => grid.isEditorOpen()).toBe(false);
-    // The committed value used to be unassertable here: `queryChoices()`, deferred in `open()` and
-    // again on every keystroke, could land after the page turn and re-highlight a choice that
-    // `HandsontableEditor.finishEditing` then read as the value. DEV-2653 made those deferred calls
-    // bail once the editor is no longer editing, which is what makes this stable.
+    // Tightened opportunistically, not because anything here was fixed. The comment this replaced
+    // called the committed value unstable because a deferred `queryChoices()` could land after the
+    // page turn and re-highlight a choice that `HandsontableEditor.finishEditing` then read as the
+    // value. That race is not reachable with this fixture: `source` is a plain ARRAY, so
+    // `queryChoices()` runs synchronously, and every deferred call from the typing has already
+    // fired before `setPage`. Measured at 15/15 on `develop` as well as on the DEV-2653 branch.
     await expect.poll(() => grid.sourceColumn(0)).toEqual(['A4', 'A2', 'A3', 'A4']);
   });
 });

--- a/tests/e2e/editor-hidden-cell.spec.ts
+++ b/tests/e2e/editor-hidden-cell.spec.ts
@@ -154,13 +154,13 @@ test.describe('non-text editors whose cell is hidden', () => {
     await grid.setPage(2);
 
     await expect.poll(() => grid.isEditorOpen()).toBe(false);
-    // Tightened opportunistically, not because anything here was fixed. The comment this replaced
-    // called the committed value unstable because a deferred `queryChoices()` could land after the
-    // page turn and re-highlight a choice that `HandsontableEditor.finishEditing` then read as the
-    // value. That race is not reachable with this fixture: `source` is a plain ARRAY, so
-    // `queryChoices()` runs synchronously, and every deferred call from the typing has already
-    // fired before `setPage`. Measured at 15/15 on `develop` as well as on the DEV-2653 branch.
-    await expect.poll(() => grid.sourceColumn(0)).toEqual(['A4', 'A2', 'A3', 'A4']);
+    // Assert only that the editor is gone. Whether a dropdown COMMITS or DISCARDS is decided by
+    // `DropdownEditor.finishEditing`, which rewrites the flag from the active range, and that race
+    // is real: asserting `['A4', 'A2', 'A3', 'A4']` here held 15/15 locally on `e2e-main` and still
+    // failed on `e2e-classic` in CI (run 33069787284) with `A1`, the original value. It is not
+    // DEV-2653's timeout - this fixture's `source` is a plain ARRAY, so `queryChoices()` runs
+    // synchronously and nothing is deferred by the time the page turns. Pinning the value needs
+    // that discard path made deterministic first, which is its own task.
   });
 });
 

--- a/tests/fixtures/demo/autocomplete-async-source.html
+++ b/tests/fixtures/demo/autocomplete-async-source.html
@@ -84,6 +84,29 @@
       return pending.length;
     };
 
+    /**
+     * Schedules the editor's own deferred `queryChoices()` through a real keydown, then closes the
+     * editor synchronously - the same call `TextEditor.refreshDimensions()` makes when the edited
+     * cell scrolls out of the rendered range. Doing both in one turn is the only way to land a
+     * close inside the timeout's 10-20 ms window: no round trip from the spec is that fast, and
+     * `close()` unregisters the `beforeKeyDown` hook, so a later keystroke cannot schedule one.
+     *
+     * Resolves after 50 ms, which is strictly longer than the editor's own delay, so by then that
+     * timeout has provably either run or bailed. The wait is an ordering guarantee, not a guess.
+     */
+    window.htScheduleQueryThenClose = function() {
+      const editor = window.hot.getActiveEditor();
+
+      editor.TEXTAREA.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 65, bubbles: true }));
+      editor.close();
+
+      return new Promise(resolve => setTimeout(resolve, 50));
+    };
+
+    window.htQueryCount = function() {
+      return window.htPendingQueries.length;
+    };
+
     window.htPendingCount = function(col) {
       return window.htPendingQueries.filter(entry => entry.col === col && !entry.resolved).length;
     };

--- a/tests/fixtures/demo/autocomplete-async-source.html
+++ b/tests/fixtures/demo/autocomplete-async-source.html
@@ -19,9 +19,13 @@
     if (!window.htEditor) {
       throw new Error('Unknown ?editor= value: ' + JSON.stringify(htParams.get('editor')));
     }
-    window.htScenario = ({ plain: 'plain', scroll: 'scroll' })[htParams.get('scenario') ?? 'plain'];
+    window.htScenario = ({ plain: 'plain', scroll: 'scroll', ordering: 'ordering' })[htParams.get('scenario') ?? 'plain'];
     if (!window.htScenario) {
       throw new Error('Unknown ?scenario= value: ' + JSON.stringify(htParams.get('scenario')));
+    }
+    window.htValidator = ({ none: 'none', slowAsync: 'slowAsync' })[htParams.get('validator') ?? 'none'];
+    if (!window.htValidator) {
+      throw new Error('Unknown ?validator= value: ' + JSON.stringify(htParams.get('validator')));
     }
   </script>
 </head>
@@ -64,8 +68,37 @@
 
     function makeSource(col) {
       return function(query, process) {
-        window.htPendingQueries.push({ col, query, process, resolved: false });
+        const editor = window.hot.getActiveEditor();
+
+        // `state` is recorded, not a single "is this the editor asking" boolean, because no one
+        // boolean is right for every case. `autocompleteValidator` calls this same `source` on the
+        // strict path, so a save adds an entry too - that one arrives in `STATE_WAITING`, while an
+        // ordinary keystroke or open arrives in `STATE_EDITING`. A case that legitimately queries
+        // during validation is also `STATE_WAITING`, so each spec reads the shape it expects
+        // instead of trusting a label.
+        window.htPendingQueries.push({
+          col,
+          query,
+          process,
+          resolved: false,
+          state: editor ? editor.state : null,
+          opened: editor ? editor.isOpened() : false,
+        });
       };
+    }
+
+    /**
+     * Answers for one pending query. In the `ordering` scenario each answer is tagged with the
+     * index of the query it belongs to, which is the only way to see WHICH of two overlapping
+     * responses ended up rendered. The tag keeps the column's shared prefix, so it survives the
+     * `autocomplete` filter exactly as the untagged set does.
+     */
+    function answerFor(entry, index) {
+      if (window.htScenario !== 'ordering') {
+        return CHOICES[entry.col];
+      }
+
+      return CHOICES[entry.col].map(choice => `${choice}-q${index}`);
     }
 
     /**
@@ -78,11 +111,51 @@
 
       pending.forEach((entry) => {
         entry.resolved = true;
-        entry.process(CHOICES[entry.col]);
+        entry.process(answerFor(entry, window.htPendingQueries.indexOf(entry)));
       });
 
       return pending.length;
     };
+
+    /**
+     * Answers one specific query by its position in the call log, so a spec can resolve two
+     * overlapping queries newest-first. `htResolveQueries` always answers oldest-first and cannot
+     * express that ordering.
+     */
+    window.htResolveQueryAt = function(index) {
+      const entry = window.htPendingQueries[index];
+
+      if (!entry || entry.resolved) {
+        return false;
+      }
+
+      entry.resolved = true;
+      entry.process(answerFor(entry, index));
+
+      return true;
+    };
+
+    /**
+     * Returns the editor state captured for every query the column has received, in call order.
+     */
+    window.htQueryStates = function(col) {
+      return window.htPendingQueries.filter(entry => entry.col === col).map(entry => entry.state);
+    };
+
+    /**
+     * Resolves once a timer armed AFTER the editor's own deferred query would have fired.
+     *
+     * `onBeforeKeyDown` arms its `queryChoices()` timeout at 10 ms while the editor is open (20 ms
+     * when it is not). This sentinel is armed strictly later with the larger of the two delays, so
+     * its deadline is strictly later too and the editor's timer has either run or been cancelled by
+     * the time this resolves. That is an ordering fact about two timers, not a guess about how
+     * loaded the worker is - and unlike counting callbacks, it holds whether the editor's timeout
+     * ran or was cancelled, which is exactly what the cases here need to tell apart.
+     */
+    function afterEditorQueryTimeout() {
+      return new Promise(resolve => setTimeout(resolve, 20));
+    }
+
 
     /**
      * Schedules the editor's own deferred `queryChoices()` through a keyboard event, then closes the
@@ -91,20 +164,68 @@
      * close inside the timeout's 10-20 ms window: no round trip from the spec is that fast, and
      * `close()` unregisters the `beforeKeyDown` hook, so a later keystroke cannot schedule one.
      *
-     * Resolves after 50 ms, which is strictly longer than the editor's own delay, so by then that
-     * timeout has provably either run or bailed. The wait is an ordering guarantee, not a guess.
+     * Returns the run count captured BEFORE the keystroke, so the caller can wait for exactly one
+     * more rather than for a wall-clock delay.
      */
-    window.htScheduleQueryThenClose = function() {
-      const editor = window.hot.getActiveEditor();
+    function dispatchPrintableKey(editor) {
       const keydown = new KeyboardEvent('keydown', { key: 'a', code: 'KeyA', bubbles: true });
 
       // Chromium ignores the deprecated `keyCode` init dictionary member. The production handler
       // deliberately still reads it for browser compatibility, so define it on this test event.
       Object.defineProperty(keydown, 'keyCode', { value: 65 });
       editor.TEXTAREA.dispatchEvent(keydown);
+    }
+
+    window.htScheduleQuery = function() {
+      dispatchPrintableKey(window.hot.getActiveEditor());
+
+      return afterEditorQueryTimeout();
+    };
+
+    /**
+     * Arms the editor's debounced refocus the way a real dropdown scroll does, closes the editor
+     * inside the 100 ms window, and moves the caret out of the grid - all in one turn, because no
+     * round trip fits inside that window.
+     *
+     * The 200 ms marker is an ordering guarantee rather than a guess: the debounce timer was
+     * started first and is shorter, so it has fired or been cancelled by the time this resolves.
+     */
+    window.htFocusProbeDone = false;
+    window.htRefocusAfterClose = 0;
+
+    window.htArmRefocusThenClose = function() {
+      const editor = window.hot.getActiveEditor();
+      const originalFocus = editor.focus;
+
+      editor.htEditor.runHooks('afterScroll');
       editor.close();
 
-      return new Promise(resolve => setTimeout(resolve, 50));
+      // Wrapped AFTER the close, so it counts only what runs later - and `#focusDebounced` calls
+      // `this.focus()`, resolving the property at call time, so the wrapper still sees it. Counting
+      // the call itself rather than watching `document.activeElement` is what isolates this route:
+      // other machinery moves focus around a close too, and would mask or fake the result.
+      window.htRefocusAfterClose = 0;
+      window.htFocusProbeDone = false;
+
+      editor.focus = function(...args) {
+        window.htRefocusAfterClose += 1;
+
+        return originalFocus.apply(this, args);
+      };
+
+      setTimeout(() => {
+        editor.focus = originalFocus;
+        window.htFocusProbeDone = true;
+      }, 200);
+    };
+
+    window.htScheduleQueryThenClose = function() {
+      const editor = window.hot.getActiveEditor();
+
+      dispatchPrintableKey(editor);
+      editor.close();
+
+      return afterEditorQueryTimeout();
     };
 
     window.htQueryCount = function() {
@@ -135,12 +256,31 @@
       data: Array.from({ length: 4 }, () => SEEDS.slice()),
     };
 
+    // `allowInvalid: false` is what keeps the editor open and sends it back to `EDITING` once a
+    // rejected validation settles, which is the window the entry guard must not shut.
+    window.htPendingValidations = [];
+
+    const validatorColumn = window.htValidator === 'slowAsync' ? {
+      allowInvalid: false,
+      validator(value, callback) {
+        window.htPendingValidations.push(() => callback(false));
+      },
+    } : {};
+
+    window.htSettleValidation = function() {
+      const pending = window.htPendingValidations.splice(0);
+
+      pending.forEach(settle => settle());
+
+      return pending.length;
+    };
+
     window.hot = new Handsontable(container, Object.assign({
       colHeaders: true,
       rowHeaders: true,
       columns: [
-        { type: window.htEditor, source: makeSource(0) },
-        { type: window.htEditor, source: makeSource(1) },
+        Object.assign({ type: window.htEditor, source: makeSource(0) }, validatorColumn),
+        Object.assign({ type: window.htEditor, source: makeSource(1) }, validatorColumn),
       ],
       // Stamp test ids from `afterRenderer`, not from a grid-level `renderer`: a column `type`
       // installs its own renderer, which would override the grid-level one and leave the typed
@@ -156,6 +296,7 @@
       },
       licenseKey: 'non-commercial-and-evaluation',
     }, scenarioSettings));
+
   </script>
 </body>
 </html>

--- a/tests/fixtures/demo/autocomplete-async-source.html
+++ b/tests/fixtures/demo/autocomplete-async-source.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Autocomplete with an asynchronous source fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    const htParams = new URLSearchParams(location.search);
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+    window.htEditor = ({ autocomplete: 'autocomplete', dropdown: 'dropdown' })[htParams.get('editor') ?? 'autocomplete'];
+    if (!window.htEditor) {
+      throw new Error('Unknown ?editor= value: ' + JSON.stringify(htParams.get('editor')));
+    }
+  </script>
+</head>
+<body>
+  <div id="grid" data-testid="grid"></div>
+  <input type="text" data-testid="outside-input">
+
+  <script>
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    // One distinct choice set per column, so a response that belongs to column 0 is recognizable
+    // when it lands while column 1 is the one being edited.
+    const CHOICES = [
+      ['Alpha', 'Alfa', 'Alto'],
+      ['Bravo', 'Bruno', 'Brisk'],
+    ];
+
+    // Each column is seeded with the prefix its whole choice set shares. Two reasons, both load
+    // bearing. An EMPTY cell closes the editor again on the same Enter that opened it, so nothing
+    // would ever stay open to test. And a prefix keeps `autocomplete` (which filters by the typed
+    // value) showing the same three choices as `dropdown` (which forces `filter: false`), so one
+    // assertion covers both editors.
+    const SEEDS = ['Al', 'Br'];
+
+    // The source never answers on its own. A spec resolves a query by hand through
+    // `window.htResolveQueries(col)`, which is what makes "the response arrives after the editor
+    // closed" and "the response arrives after the editor reopened elsewhere" exact rather than a
+    // race against a timer. A `setTimeout`-based source would need the spec to out-wait it, which
+    // is the flake this whole fixture exists to avoid.
+    window.htPendingQueries = [];
+
+    function makeSource(col) {
+      return function(query, process) {
+        window.htPendingQueries.push({ col, query, process, resolved: false });
+      };
+    }
+
+    /**
+     * Resolves every query still pending for a column, oldest first, and returns how many were
+     * resolved. Returns 0 when the column has nothing in flight, which lets a spec poll for the
+     * query to exist rather than assume it does.
+     */
+    window.htResolveQueries = function(col) {
+      const pending = window.htPendingQueries.filter(entry => entry.col === col && !entry.resolved);
+
+      pending.forEach((entry) => {
+        entry.resolved = true;
+        entry.process(CHOICES[entry.col]);
+      });
+
+      return pending.length;
+    };
+
+    window.htPendingCount = function(col) {
+      return window.htPendingQueries.filter(entry => entry.col === col && !entry.resolved).length;
+    };
+
+    // `hot.listen()` moves no DOM focus - it makes the grid the keyboard listener again. Counting
+    // `afterListen` is therefore the precise probe for the focus-steal half of the defect, and it
+    // cannot be satisfied by an unrelated state that happens to leave `isListening()` true.
+    window.htListenCount = 0;
+
+    // Holds the editor object itself. It survives `close()` (which only hides the nested grid), so
+    // a spec can read the dropdown that a late response re-showed even with no active editor left.
+    window.htEditorRef = null;
+
+    window.hot = new Handsontable(container, {
+      data: Array.from({ length: 4 }, () => SEEDS.slice()),
+      colHeaders: true,
+      rowHeaders: true,
+      columns: [
+        { type: window.htEditor, source: makeSource(0) },
+        { type: window.htEditor, source: makeSource(1) },
+      ],
+      // Stamp test ids from `afterRenderer`, not from a grid-level `renderer`: a column `type`
+      // installs its own renderer, which would override the grid-level one and leave the typed
+      // columns with no test id at all.
+      afterRenderer(td, row, col) {
+        td.setAttribute('data-testid', `cell-${row}-${col}`);
+      },
+      afterBeginEditing() {
+        window.htEditorRef = window.hot.getActiveEditor();
+      },
+      afterListen() {
+        window.htListenCount += 1;
+      },
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/autocomplete-async-source.html
+++ b/tests/fixtures/demo/autocomplete-async-source.html
@@ -85,7 +85,7 @@
     };
 
     /**
-     * Schedules the editor's own deferred `queryChoices()` through a real keydown, then closes the
+     * Schedules the editor's own deferred `queryChoices()` through a keyboard event, then closes the
      * editor synchronously - the same call `TextEditor.refreshDimensions()` makes when the edited
      * cell scrolls out of the rendered range. Doing both in one turn is the only way to land a
      * close inside the timeout's 10-20 ms window: no round trip from the spec is that fast, and
@@ -96,8 +96,12 @@
      */
     window.htScheduleQueryThenClose = function() {
       const editor = window.hot.getActiveEditor();
+      const keydown = new KeyboardEvent('keydown', { key: 'a', code: 'KeyA', bubbles: true });
 
-      editor.TEXTAREA.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 65, bubbles: true }));
+      // Chromium ignores the deprecated `keyCode` init dictionary member. The production handler
+      // deliberately still reads it for browser compatibility, so define it on this test event.
+      Object.defineProperty(keydown, 'keyCode', { value: 65 });
+      editor.TEXTAREA.dispatchEvent(keydown);
       editor.close();
 
       return new Promise(resolve => setTimeout(resolve, 50));

--- a/tests/fixtures/demo/autocomplete-async-source.html
+++ b/tests/fixtures/demo/autocomplete-async-source.html
@@ -19,6 +19,10 @@
     if (!window.htEditor) {
       throw new Error('Unknown ?editor= value: ' + JSON.stringify(htParams.get('editor')));
     }
+    window.htScenario = ({ plain: 'plain', scroll: 'scroll' })[htParams.get('scenario') ?? 'plain'];
+    if (!window.htScenario) {
+      throw new Error('Unknown ?scenario= value: ' + JSON.stringify(htParams.get('scenario')));
+    }
   </script>
 </head>
 <body>
@@ -46,6 +50,10 @@
     // value) showing the same three choices as `dropdown` (which forces `filter: false`), so one
     // assertion covers both editors.
     const SEEDS = ['Al', 'Br'];
+
+    // Read by the page object, so the spec asserts against the fixture's own values instead of a
+    // second copy that could drift out of step with these.
+    window.htChoices = CHOICES;
 
     // The source never answers on its own. A spec resolves a query by hand through
     // `window.htResolveQueries(col)`, which is what makes "the response arrives after the editor
@@ -89,8 +97,18 @@
     // a spec can read the dropdown that a late response re-showed even with no active editor left.
     window.htEditorRef = null;
 
-    window.hot = new Handsontable(container, {
+    // `scroll` is the case where `TextEditor.refreshDimensions()` closes the editor on its own,
+    // through the `afterScrollVertically` hook, once the edited row leaves the rendered range. That
+    // close leaves `state` at `EDITING` and never restores `_opened` on the way back, so it is the
+    // close neither of those two flags describes.
+    const scenarioSettings = window.htScenario === 'scroll' ? {
+      data: Array.from({ length: 100 }, () => SEEDS.slice()),
+      height: 150,
+    } : {
       data: Array.from({ length: 4 }, () => SEEDS.slice()),
+    };
+
+    window.hot = new Handsontable(container, Object.assign({
       colHeaders: true,
       rowHeaders: true,
       columns: [
@@ -110,7 +128,7 @@
         window.htListenCount += 1;
       },
       licenseKey: 'non-commercial-and-evaluation',
-    });
+    }, scenarioSettings));
   </script>
 </body>
 </html>

--- a/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
+++ b/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
@@ -1,0 +1,193 @@
+import { type Locator, type Page, expect } from '@playwright/test';
+
+interface EditorFixture {
+  isOpened(): boolean;
+  state: string;
+  rawChoices: unknown[];
+  htEditor: { rootElement: HTMLElement };
+}
+
+interface HandsontableFixture {
+  getSelected(): number[][] | undefined;
+  getActiveEditor(): EditorFixture | undefined;
+  isListening(): boolean;
+}
+
+interface FixtureWindow extends Window {
+  hot: HandsontableFixture;
+  htEditorRef: EditorFixture | null;
+  htListenCount: number;
+  htResolveQueries(col: number): number;
+  htPendingCount(col: number): number;
+}
+
+interface PageOptions {
+  editor?: 'autocomplete' | 'dropdown';
+}
+
+/**
+ * Page Object for the fixture whose `source` answers only when a spec tells it to.
+ *
+ * Every probe that inspects the dropdown reads it through `window.htEditorRef` rather than a CSS
+ * locator. `HandsontableEditor.close()` only hides the nested grid, so the element a late response
+ * re-shows is still the same one, and Playwright's own visibility rules cannot be used to tell the
+ * two apart: the editor's parent is merely `opacity: 0` when closed, which counts as visible.
+ */
+export class AutocompleteAsyncSourcePage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly editor: string;
+  readonly outsideInput: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd', options: PageOptions = {}) {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.editor = options.editor ?? 'autocomplete';
+    this.outsideInput = page.getByTestId('outside-input');
+  }
+
+  /**
+   * Opens the fixture and waits for the first data cell to render.
+   */
+  async goto(): Promise<void> {
+    const query = `theme=${this.theme}&bundle=${this.bundle}&editor=${this.editor}`;
+
+    await this.page.goto(`/tests/fixtures/demo/autocomplete-async-source.html?${query}`);
+
+    // Wait for the bundle before the cell. The test id comes from the fixture's `afterRenderer`,
+    // so "cell not found" alone cannot tell a slow bundle apart from a grid that failed to render.
+    await this.page.waitForFunction(() => 'Handsontable' in window);
+
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /**
+   * Returns a data cell through its fixture-owned test id.
+   */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /**
+   * Selects a cell, opens its editor with Enter, and waits until the column's `source` has been
+   * asked for choices. Enter rather than typing: it leaves the query empty, so every choice matches
+   * the filter and the whole list is what the dropdown would show.
+   */
+  async openEditor(row: number, col: number): Promise<void> {
+    await this.cell(row, col).click();
+
+    await expect.poll(() => this.selected()).toEqual([[row, col, row, col]]);
+
+    await this.page.keyboard.press('Enter');
+
+    await expect.poll(() => this.isEditorOpen()).toBe(true);
+    await expect.poll(() => this.pendingQueryCount(col)).toBeGreaterThan(0);
+  }
+
+  /**
+   * Reports whether the cell editor is open.
+   */
+  async isEditorOpen(): Promise<boolean> {
+    return this.page.evaluate(() => (
+      (window as unknown as FixtureWindow).hot.getActiveEditor()?.isOpened() === true
+    ));
+  }
+
+  /**
+   * Returns how many queries the given column has in flight.
+   */
+  async pendingQueryCount(col: number): Promise<number> {
+    return this.page.evaluate(
+      target => (window as unknown as FixtureWindow).htPendingCount(target),
+      col,
+    );
+  }
+
+  /**
+   * Answers every query the given column has in flight and returns how many were answered.
+   * Assert on the return value: a zero means the case proved nothing, because no response landed.
+   */
+  async resolveQueries(col: number): Promise<number> {
+    return this.page.evaluate(
+      target => (window as unknown as FixtureWindow).htResolveQueries(target),
+      col,
+    );
+  }
+
+  /**
+   * Reports whether the suggestion list is currently shown. `updateChoicesList()` drives this by
+   * assigning `display` on the nested grid's root element, so it is the exact thing a late response
+   * would flip back on.
+   */
+  async isDropdownShown(): Promise<boolean> {
+    return this.page.evaluate(() => {
+      const editor = (window as unknown as FixtureWindow).htEditorRef;
+
+      return editor ? editor.htEditor.rootElement.style.display !== 'none' : false;
+    });
+  }
+
+  /**
+   * Returns the choices currently rendered in the suggestion list, read from its cells.
+   */
+  async dropdownChoices(): Promise<string[]> {
+    return this.page.evaluate(() => {
+      const editor = (window as unknown as FixtureWindow).htEditorRef;
+
+      if (!editor) {
+        return [];
+      }
+
+      return Array.from(editor.htEditor.rootElement.querySelectorAll('.ht_master td'))
+        .map(td => td.textContent ?? '');
+    });
+  }
+
+  /**
+   * Returns the choice set the editor last accepted from a `source` response.
+   */
+  async rawChoices(): Promise<unknown[]> {
+    return this.page.evaluate(() => (window as unknown as FixtureWindow).htEditorRef?.rawChoices ?? []);
+  }
+
+  /**
+   * Returns how many times the grid has become the keyboard listener. `updateChoicesList()` ends
+   * with `hot.listen()`, so a rise in this count after the editor closed IS the focus steal.
+   */
+  async listenCount(): Promise<number> {
+    return this.page.evaluate(() => (window as unknown as FixtureWindow).htListenCount);
+  }
+
+  /**
+   * Reports whether the grid is currently the keyboard listener.
+   */
+  async isGridListening(): Promise<boolean> {
+    return this.page.evaluate(() => (window as unknown as FixtureWindow).hot.isListening());
+  }
+
+  /**
+   * Returns the test id of the focused element, so a spec can pin focus to the outside input.
+   */
+  async activeElementTestId(): Promise<string | null> {
+    return this.page.evaluate(() => document.activeElement?.getAttribute('data-testid') ?? null);
+  }
+
+  /**
+   * Moves the caret to the plain input below the grid. `TableView` unlistens on a `mousedown` that
+   * lands on an outside input, so this is the user action that hands keyboard control away.
+   */
+  async clickOutsideInput(): Promise<void> {
+    await this.outsideInput.click();
+
+    await expect.poll(() => this.isGridListening()).toBe(false);
+  }
+
+  /**
+   * Returns the grid's current selection.
+   */
+  async selected(): Promise<number[][] | undefined> {
+    return this.page.evaluate(() => (window as unknown as FixtureWindow).hot.getSelected());
+  }
+}

--- a/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
+++ b/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
@@ -12,9 +12,13 @@ interface HandsontableFixture {
   getActiveEditor(): EditorFixture | undefined;
   isListening(): boolean;
   scrollViewportTo(options: { row: number, verticalSnap: string }): void;
+  destroy(): void;
 }
 
-interface FixtureWindow extends Window {
+// Deliberately not `extends Window`: `windowTypes.ts` already declares `hot` globally with the
+// full instance type, and narrowing it here to the handful of members these probes use would be a
+// TS2430 conflict. Every access goes through an explicit cast anyway.
+interface FixtureWindow {
   hot: HandsontableFixture;
   htEditorRef: EditorFixture | null;
   htListenCount: number;
@@ -22,12 +26,20 @@ interface FixtureWindow extends Window {
   htPendingCount(col: number): number;
   htChoices: string[][];
   htScheduleQueryThenClose(): Promise<void>;
+  htScheduleQuery(): Promise<void>;
   htQueryCount(): number;
+  htResolveQueryAt(index: number): boolean;
+  htQueryStates(col: number): (string | null)[];
+  htSettleValidation(): number;
+  htArmRefocusThenClose(): void;
+  htFocusProbeDone: boolean;
+  htRefocusAfterClose: number;
 }
 
 interface PageOptions {
   editor?: 'autocomplete' | 'dropdown';
-  scenario?: 'plain' | 'scroll';
+  scenario?: 'plain' | 'scroll' | 'ordering';
+  validator?: 'none' | 'slowAsync';
 }
 
 /**
@@ -44,6 +56,7 @@ export class AutocompleteAsyncSourcePage {
   readonly bundle: string;
   readonly editor: string;
   readonly scenario: string;
+  readonly validator: string;
   readonly outsideInput: Locator;
 
   constructor(page: Page, theme = 'main', bundle = 'umd', options: PageOptions = {}) {
@@ -52,6 +65,7 @@ export class AutocompleteAsyncSourcePage {
     this.bundle = bundle;
     this.editor = options.editor ?? 'autocomplete';
     this.scenario = options.scenario ?? 'plain';
+    this.validator = options.validator ?? 'none';
     this.outsideInput = page.getByTestId('outside-input');
   }
 
@@ -60,7 +74,7 @@ export class AutocompleteAsyncSourcePage {
    */
   async goto(): Promise<void> {
     const query = `theme=${this.theme}&bundle=${this.bundle}` +
-      `&editor=${this.editor}&scenario=${this.scenario}`;
+      `&editor=${this.editor}&scenario=${this.scenario}&validator=${this.validator}`;
 
     await this.page.goto(`/tests/fixtures/demo/autocomplete-async-source.html?${query}`);
 
@@ -224,7 +238,8 @@ export class AutocompleteAsyncSourcePage {
 
   /**
    * Lands a close inside the window of an already-scheduled `queryChoices()` timeout, then returns
-   * once that timeout has run or bailed. See the fixture for why both halves happen page-side.
+   * once that timeout has either run or been cancelled. See the fixture for why both halves happen
+   * page-side and how the wait is ordered against the editor's own timer.
    */
   async scheduleQueryThenClose(): Promise<void> {
     await this.page.evaluate(() => (window as unknown as FixtureWindow).htScheduleQueryThenClose());
@@ -235,6 +250,82 @@ export class AutocompleteAsyncSourcePage {
    */
   async totalQueryCount(): Promise<number> {
     return this.page.evaluate(() => (window as unknown as FixtureWindow).htQueryCount());
+  }
+
+  /**
+   * Returns how many of the column's queries came from the editor itself rather than from
+   * `autocompleteValidator`, which calls the same user `source` on the strict save path.
+   */
+  async editorQueryCount(col: number): Promise<number> {
+    const states = await this.page.evaluate(
+      target => (window as unknown as FixtureWindow).htQueryStates(target),
+      col,
+    );
+
+    return states.filter(state => state === 'STATE_EDITING').length;
+  }
+
+  /**
+   * Returns the editor state captured for each of the column's queries, in call order.
+   */
+  async queryStates(col: number): Promise<(string | null)[]> {
+    return this.page.evaluate(
+      target => (window as unknown as FixtureWindow).htQueryStates(target),
+      col,
+    );
+  }
+
+  /**
+   * Answers one specific query by its position in the call log, so two overlapping queries can be
+   * resolved newest-first.
+   */
+  async resolveQueryAt(index: number): Promise<boolean> {
+    return this.page.evaluate(
+      target => (window as unknown as FixtureWindow).htResolveQueryAt(target),
+      index,
+    );
+  }
+
+  /**
+   * Schedules another `queryChoices()` through a keystroke and returns once its timer has fired,
+   * leaving the editor open.
+   */
+  async scheduleAnotherQuery(): Promise<void> {
+    await this.page.evaluate(() => (window as unknown as FixtureWindow).htScheduleQuery());
+  }
+
+  /**
+   * Settles every pending async validation, rejecting the value. Returns how many settled.
+   */
+  async settleValidation(): Promise<number> {
+    return this.page.evaluate(() => (window as unknown as FixtureWindow).htSettleValidation());
+  }
+
+  /**
+   * Tears the grid down while a query is still in flight. `Core#destroy()` never closes the active
+   * editor, so neither token moves and only the destroyed check stops the response.
+   */
+  async destroyGrid(): Promise<void> {
+    await this.page.evaluate(() => (window as unknown as FixtureWindow).hot.destroy());
+  }
+
+  /**
+   * Arms the debounced refocus and closes the editor inside its window, returning once the debounce
+   * has provably fired or been cancelled.
+   */
+  async armRefocusThenClose(): Promise<void> {
+    await this.page.evaluate(() => (window as unknown as FixtureWindow).htArmRefocusThenClose());
+
+    await expect
+      .poll(() => this.page.evaluate(() => (window as unknown as FixtureWindow).htFocusProbeDone))
+      .toBe(true);
+  }
+
+  /**
+   * Returns how many times the editor refocused itself after that close.
+   */
+  async refocusCountAfterClose(): Promise<number> {
+    return this.page.evaluate(() => (window as unknown as FixtureWindow).htRefocusAfterClose);
   }
 
   /**

--- a/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
+++ b/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
@@ -5,6 +5,8 @@ interface EditorFixture {
   state: string;
   rawChoices: unknown[];
   htEditor: { rootElement: HTMLElement };
+  TEXTAREA: HTMLTextAreaElement;
+  queryChoices(query: string): void;
 }
 
 interface HandsontableFixture {
@@ -326,6 +328,25 @@ export class AutocompleteAsyncSourcePage {
    */
   async refocusCountAfterClose(): Promise<number> {
     return this.page.evaluate(() => (window as unknown as FixtureWindow).htRefocusAfterClose);
+  }
+
+  /**
+   * Calls the public `queryChoices()` and reports how many new queries reached the `source`.
+   *
+   * This is the only way to exercise the entry guard: with deferred queries cancelled on close, no
+   * internal caller can reach the method outside an edit, so the guard exists purely for the
+   * documented public contract - and that contract needs a test of its own.
+   */
+  async callQueryChoicesDirectly(): Promise<number> {
+    return this.page.evaluate(() => {
+      const fixture = window as unknown as FixtureWindow;
+      const editor = fixture.hot.getActiveEditor();
+      const before = fixture.htQueryCount();
+
+      editor?.queryChoices(editor.TEXTAREA.value);
+
+      return fixture.htQueryCount() - before;
+    });
   }
 
   /**

--- a/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
+++ b/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
@@ -11,6 +11,7 @@ interface HandsontableFixture {
   getSelected(): number[][] | undefined;
   getActiveEditor(): EditorFixture | undefined;
   isListening(): boolean;
+  scrollViewportTo(options: { row: number, verticalSnap: string }): void;
 }
 
 interface FixtureWindow extends Window {
@@ -19,10 +20,12 @@ interface FixtureWindow extends Window {
   htListenCount: number;
   htResolveQueries(col: number): number;
   htPendingCount(col: number): number;
+  htChoices: string[][];
 }
 
 interface PageOptions {
   editor?: 'autocomplete' | 'dropdown';
+  scenario?: 'plain' | 'scroll';
 }
 
 /**
@@ -38,6 +41,7 @@ export class AutocompleteAsyncSourcePage {
   readonly theme: string;
   readonly bundle: string;
   readonly editor: string;
+  readonly scenario: string;
   readonly outsideInput: Locator;
 
   constructor(page: Page, theme = 'main', bundle = 'umd', options: PageOptions = {}) {
@@ -45,6 +49,7 @@ export class AutocompleteAsyncSourcePage {
     this.theme = theme;
     this.bundle = bundle;
     this.editor = options.editor ?? 'autocomplete';
+    this.scenario = options.scenario ?? 'plain';
     this.outsideInput = page.getByTestId('outside-input');
   }
 
@@ -52,7 +57,8 @@ export class AutocompleteAsyncSourcePage {
    * Opens the fixture and waits for the first data cell to render.
    */
   async goto(): Promise<void> {
-    const query = `theme=${this.theme}&bundle=${this.bundle}&editor=${this.editor}`;
+    const query = `theme=${this.theme}&bundle=${this.bundle}` +
+      `&editor=${this.editor}&scenario=${this.scenario}`;
 
     await this.page.goto(`/tests/fixtures/demo/autocomplete-async-source.html?${query}`);
 
@@ -72,8 +78,8 @@ export class AutocompleteAsyncSourcePage {
 
   /**
    * Selects a cell, opens its editor with Enter, and waits until the column's `source` has been
-   * asked for choices. Enter rather than typing: it leaves the query empty, so every choice matches
-   * the filter and the whole list is what the dropdown would show.
+   * asked for choices. Enter rather than typing: full edit mode seeds the editor with the cell's
+   * own value, so the query is the column's shared choice prefix and the whole list matches.
    */
   async openEditor(row: number, col: number): Promise<void> {
     await this.cell(row, col).click();
@@ -182,6 +188,36 @@ export class AutocompleteAsyncSourcePage {
     await this.outsideInput.click();
 
     await expect.poll(() => this.isGridListening()).toBe(false);
+  }
+
+  /**
+   * Returns the choice set the fixture serves for a column, so a spec never carries a second copy.
+   */
+  async choicesFor(col: number): Promise<string[]> {
+    return this.page.evaluate(
+      target => (window as unknown as FixtureWindow).htChoices[target],
+      col,
+    );
+  }
+
+  /**
+   * Returns the editor's state machine value, or null when there is no active editor.
+   */
+  async editorState(): Promise<string | null> {
+    return this.page.evaluate(() => (
+      (window as unknown as FixtureWindow).hot.getActiveEditor()?.state ?? null
+    ));
+  }
+
+  /**
+   * Scrolls the viewport so the given row sits at the top. Past the rendered range this makes
+   * `TextEditor.refreshDimensions()` close the open editor through `afterScrollVertically`, without
+   * finishing the edit - the close that leaves `state` at `EDITING`.
+   */
+  async scrollToRow(row: number): Promise<void> {
+    await this.page.evaluate(target => {
+      (window as unknown as FixtureWindow).hot.scrollViewportTo({ row: target, verticalSnap: 'top' });
+    }, row);
   }
 
   /**

--- a/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
+++ b/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
@@ -21,6 +21,8 @@ interface FixtureWindow extends Window {
   htResolveQueries(col: number): number;
   htPendingCount(col: number): number;
   htChoices: string[][];
+  htScheduleQueryThenClose(): Promise<void>;
+  htQueryCount(): number;
 }
 
 interface PageOptions {
@@ -218,6 +220,21 @@ export class AutocompleteAsyncSourcePage {
     await this.page.evaluate(target => {
       (window as unknown as FixtureWindow).hot.scrollViewportTo({ row: target, verticalSnap: 'top' });
     }, row);
+  }
+
+  /**
+   * Lands a close inside the window of an already-scheduled `queryChoices()` timeout, then returns
+   * once that timeout has run or bailed. See the fixture for why both halves happen page-side.
+   */
+  async scheduleQueryThenClose(): Promise<void> {
+    await this.page.evaluate(() => (window as unknown as FixtureWindow).htScheduleQueryThenClose());
+  }
+
+  /**
+   * Returns how many queries the `source` has been asked for since the page loaded, answered or not.
+   */
+  async totalQueryCount(): Promise<number> {
+    return this.page.evaluate(() => (window as unknown as FixtureWindow).htQueryCount());
   }
 
   /**


### PR DESCRIPTION
### Context

The PR fixes the autocomplete and dropdown editors acting on a `source` response that arrives too late to be relevant.

`AutocompleteEditor` resolves its choices asynchronously and nothing on the resolution path checked whether the response was still wanted. Two facts made a late response harmful rather than inert:

- `HandsontableEditor.close()` only sets `htEditor.rootElement.style.display = 'none'`. The nested grid instance stays alive, so a late response re-renders instead of throwing.
- `hot._registerTimeout()` has no cancel path. `_clearTimeouts()` is called from exactly one place, `Core#destroy()`, and no editor `close()` clears the queue. So the `queryChoices()` calls deferred in `open()` and in `onBeforeKeyDown()` survive a close too.

The result: `updateChoicesList()` ran against a closed editor, re-showed the suggestion list over a cell the user was no longer editing, and called `hot.listen()`, handing keyboard control back to the grid.

Three paths reached this, and all three funnel through `queryChoices()`:

| Site | Why it lands late |
|---|---|
| `open()` tail | `_registerTimeout(..., 0)`, handle discarded |
| `onBeforeKeyDown()` | `_registerTimeout(..., 10-20)`, handle discarded |
| async `source` callback | user-supplied, arbitrarily late |

The `if (this.htEditor)` check at the third site was never a guard: the field is never nulled anywhere, so after the first open it can never be false, and it is a schedule-time check rather than a fire-time one.

#### The guard is keyed on `close()`, not on an editor flag

Neither state flag describes "the editor is closed", and this is the part worth reviewing closely.

- **`state` stays `EDITING` through a close.** `TextEditor.refreshDimensions()` calls `this.close()` when the edited cell leaves the rendered range, and its own early return proves it only gets there while `state === EDITING`. It runs from the permanently registered `afterScrollVertically` / `afterScrollHorizontally` hooks, so an ordinary scroll reaches it. `HandsontableEditor`'s `afterSetTheme` hook closes the same way.
- **`_opened` stays `false` after the cell scrolls back.** On the way back, `refreshDimensions()` calls `showEditableElement()` but never restores `_opened`. The editor is visibly open and editing with `isOpened() === false`, which is why `onBeforeKeyDown` already carries a pre-existing `if (!this.isOpened())` branch. A guard on that flag would leave the suggestion list dead for the rest of such an edit.

Measured, not argued:

```
after ed.close():                          state=STATE_EDITING  opened=false  display=none
after resolving the in-flight query:       display=""           choices rendered
after ed.close() then ed.refreshDimensions():
                                           state=STATE_EDITING  opened=false  parentOpacity=1
```

So the fix cancels rather than flags, and only falls back to a token where cancelling is impossible:

- **`#queryTimeouts`.** Both deferred `queryChoices()` calls keep their timer id, and `close()` clears them. `hot._registerTimeout()` has no cancel path of its own, so without this a query scheduled during an edit still fires afterwards and starts a fresh request against a cell nobody is editing. Cancelling says "this query is off" in the code rather than leaving every timer to wake up and compare two numbers.
- **`#editSession`, bumped in `close()`.** For the one thing that cannot be cancelled: the `source` callback, which user code holds. Closing is the reliable signal, `close()` is virtual, and every close path resolves to it.
- **`#queryGeneration`, bumped in `queryChoices()`.** Rejects a response superseded by a newer query inside the same edit, where `#editSession` never moves.

`queryChoices()` also returns early unless the editor is `EDITING` or `WAITING`, so a call that reaches it after a normal finish does not invoke the user's `source`, which is typically a network request. `WAITING` counts as open on purpose: `close()` is what unhooks `beforeKeyDown`, so keystrokes still schedule queries while an async validator runs, and under `allowInvalid: false` the editor stays open and returns to `EDITING`. Excluding it would stop the list refreshing for the length of every validation, which `develop` did not do.

#### A second staleness case the counters also cover

Editors are per-instance singletons (`_getEditorInstance`, "Returns instance (singleton) of editor class"), so one `AutocompleteEditor` object serves every autocomplete cell in a grid. Open A1 with a slow `source`, close it, open B2: without a token the A1 response lands while `state` is `EDITING` again and renders A1's choices into B2's dropdown. Keying on `close()` rather than only on the next query also closes the window in between, since reopening only *schedules* its own query on a timeout.

#### Deliberate non-choices

- **No state check inside the source callback.** The generation carries the whole question. Keeping one there dropped a response that lands while an async validator holds the editor in `WAITING`, which under `allowInvalid: false` left the list empty for the rest of the edit once the state returned to `EDITING`.
- **`updateChoicesList()` left unguarded.** It is documented public API and an existing spec calls it directly; all three reachable paths already pass through `queryChoices()`.
- **`HandsontableEditor.close()` still hides rather than destroys `htEditor`.** That is what keeps the object reachable, but changing it is a lifecycle and performance change with breaking surface (nested instance identity, re-init cost on every open) well outside this defect.

#### One more route to the same symptom, also fixed

`#focusDebounced` is armed by the inner grid's `afterScroll` and runs 100 ms later. It is created by `helpers/function.ts`'s `debounce()`, so it never enters `hot.timeouts` and `_clearTimeouts()` cannot reach it even on destroy, and its `cancel()` was never called. Since `hideEditableElement()` only sets `opacity: 0`, its `focus()` put the caret back into a closed editor. `close()` now cancels it, which is what makes the changelog's "taking keyboard control back from the page" true for every route rather than most of them.

#### Public surface

`queryChoices()` is in the shipped declarations. It is now a no-op while no edit is in progress, and a `source` with side effects is no longer called at all on a timeout that fires after the edit finished. `AutocompleteEditor` carries `@private` and the method is absent from the API reference, so `breaking` stays `false`, but the changelog entry states both.

#### Still open, no ticket

The `DropdownEditor.finishEditing()` discard race: with a page turn hiding the edited cell, a dropdown edit can discard where an equivalent select edit commits. Evidenced down to a CI run number in the comment on that case in `tests/e2e/editor-hidden-cell.spec.ts`. Out of scope here and worth its own task.

### How has this been tested?

New Playwright coverage in `tests/e2e/autocomplete-async-source.spec.ts`: ten cases, each run for both `autocomplete` and `dropdown`, so twenty in total.

1. A response arriving after Escape closed the editor.
2. A response arriving after an outside click closed the editor (a different close path: `DropdownEditor.finishEditing()` rewrites `restoreOriginalValue` from the active range, which Escape never reaches).
3. A response from a previous edit arriving after the editor reopened at another column.
4. A response arriving after a scroll closed the editor, asserting `isOpened() === false` **and** `state === 'STATE_EDITING'` first, so it cannot pass by having left the row rendered.
5. A `queryChoices()` timeout scheduled before a close and firing after it, asserting no new query starts.
6. The list still refreshing while an async validator holds the editor in `WAITING`.
7. A response from that validation window being ignored once the editor finally closes.
8. A response arriving after `Core#destroy()`, asserting no page error.
9. The editor not refocusing itself after a close that followed a list scroll.
10. Two overlapping queries in one edit resolved newest-first, asserting the older answer does not overwrite the newer.

Every case that can observe both symptoms asserts both. `updateChoicesList()` sets `display` and calls `hot.listen()` independently, so a case checking only the dropdown would pass on a fix that still stole focus. The focus half counts `afterListen`, and the scroll cases hand keyboard control away first, because `Core#listen()` fires that hook only on a not-listening to listening transition and would otherwise pin the count.

Queries are attributed to the editor rather than counted raw: `autocompleteValidator` calls the same user `source` on the strict save path, so a bare "something was in flight" guard could be satisfied by the validator alone.

The fixture's `source` answers only when the spec tells it to, so "the response arrives late" is stated rather than raced. Where a case has to prove a timer already fired, it waits on a sentinel timer armed later with a longer delay, which is an ordering fact about two timers rather than a guess about worker load.

**Which mechanism catches which case.** Each row is one build with a single mechanism removed, run against the same twenty tests, reporting failures:

| Build | Failures |
|---|---|
| Full fix | 0 / 20 |
| Without `#queryTimeouts` cancellation in `close()` | 2 / 20 (case 5) |
| Without `#editSession` | 10 / 20 (cases 1, 2, 4, 5, 7) |
| Without `#queryGeneration` | 2 / 20 (case 10) |
| Without `WAITING` in the entry guard | 2 / 20 (case 6) |
| Without the `isDestroyed` check | 2 / 20 (case 8) |
| Without the `#focusDebounced.cancel()` in `close()` | 2 / 20 (case 9) |

Every mechanism is load-bearing, and every one of them except the session token is pinned by exactly one case. `#editSession` is the broad one: it is the only thing standing between a `source` callback and a closed editor, so it covers the four close paths plus case 5, which the cancellation would otherwise have to catch alone.

```bash
# New spec, all six theme x bundle legs
cd tests && npx playwright test e2e/autocomplete-async-source.spec.ts

# Regression surface for a too-broad guard: the legacy suites that exercise these editors
npm --prefix handsontable run test:e2e -- --testPathPattern='editors/'
```

Full results, all green:

- Legacy Jasmine, whole suite: 9745 specs, 0 failures, 8 pending.
- Core unit: 3963 tests, 325 suites.
- Playwright, all six legs, whole suite: 2908 passed, 6 skipped.
- `npm --prefix handsontable run test:types`, `run eslint` (0 errors), and `npm --prefix tests run lint`.

**`tests/e2e/editor-hidden-cell.spec.ts` is unchanged except for its comment.** Its dropdown case asserts only that the editor closed, with a comment blaming this timeout for the committed value being unstable. Two things about that turned out to be worth recording. The blame was misplaced: the fixture's `source` is a plain array, so `queryChoices()` runs synchronously and nothing is deferred by the time the page turns. But the instability is real — tightening the case to assert the committed value held 15/15 locally on `e2e-main` and still failed on `e2e-classic` in CI (run 33069787284), committing `A1` instead of `A4`. That is `DropdownEditor.finishEditing()` rewriting `restoreOriginalValue` from the active range, and pinning the value needs that path made deterministic first. The comment now says so; the assertion stays loose.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2653

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

The autocomplete guide's asynchronous-source section stated the `process()` contract without saying anything about timing. It now says that a response arriving after the editor closed, or superseded by a newer query, is ignored. `tests/AGENTS.md` gained the fixture trap this work uncovered: on an empty cell, `click()` followed by `Enter` opens the editor and closes it again on the same keypress, silently, which makes an editor fixture fail at "the editor never opened" with nothing pointing at the cause.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2653

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core cell-editing and keyboard-focus behavior for autocomplete/dropdown with async sources, though the change is narrowly scoped to stale-response handling and is heavily regression-tested.
> 
> **Overview**
> Fixes autocomplete and dropdown editors **re-opening the suggestion list** and calling **`hot.listen()`** when an asynchronous `source` callback (or a deferred `queryChoices()` timer) finishes after the edit has ended.
> 
> **`AutocompleteEditor`** now tracks edit sessions and query generations, routes deferred lookups through **`#deferQuery()`** so **`close()`** can cancel pending timers, bumps **`#editSession`** on close, and drops stale **`source`** results when the grid is destroyed, the session changed, or a newer query superseded the request. **`queryChoices()`** is a no-op unless the editor is **`EDITING`** or **`WAITING`** (so async validation can still refresh the list). **`close()`** also cancels the debounced refocus that could steal focus after the list scrolled.
> 
> Docs and **`metaSchema`** describe that late or superseded async responses are ignored; callers can still invoke **`process()`** when the request completes. Adds changelog **13273**, Playwright coverage with a controllable async fixture, and a small **`tests/AGENTS.md`** note on seeding editor cells for e2e.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e16f486f98d32046c45be725e5014cebab437071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->