### PR TITLE
DEV-2659: Stop mergeCells re-clearing already-applied merge areas (#7555)

### DIFF
--- a/.changelogs/7555.json
+++ b/.changelogs/7555.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed a bug where re-applying an unchanged `mergeCells` configuration through `updateSettings()` cleared the merged-away cells again, emitting `beforeChange` and `afterChange` for values that did not change. In React and Angular, which resend every setting on each render, this looped until the framework aborted it. A merge area that was already applied now keeps its merge but skips the data population, extending the configuration populates only the newly added areas, and `updateSettings({ data, mergeCells })` now leaves the new data alone just as `loadData()` already did.",
+  "title": "Fixed a bug where re-applying an unchanged `mergeCells` configuration through `updateSettings()` cleared the merged-away cells again, firing `beforeChange` and `afterChange` for values that did not change. A re-applied merge area now clears only the cells that still hold a value.",
   "type": "fixed",
   "issueOrPR": 7555,
   "breaking": false,

--- a/.changelogs/7555.json
+++ b/.changelogs/7555.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a bug where re-applying an unchanged `mergeCells` configuration through `updateSettings()` cleared the merged-away cells again, emitting `beforeChange` and `afterChange` for values that did not change. In React and Angular, which resend every setting on each render, this looped until the framework aborted it. A merge area that was already applied now keeps its merge but skips the data population, extending the configuration populates only the newly added areas, and `updateSettings({ data, mergeCells })` now leaves the new data alone just as `loadData()` already did.",
+  "type": "fixed",
+  "issueOrPR": 7555,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -352,6 +352,25 @@ Both [`getData()`](@/api/core.md#getdata) and [`getSourceData()`](@/api/core.md#
 
 Unmerging does not restore the cleared values. If you need the original values back, keep a copy before merging, or restore them yourself in a [`beforeUnmergeCells`](@/api/hooks.md#beforeunmergecells) or [`afterUnmergeCells`](@/api/hooks.md#afterunmergecells) handler.
 
+### Clearing runs once per merged range
+
+A merged range clears its covered cells when it is first applied, not every time the configuration is read. Passing the same `mergeCells` value to [`updateSettings()`](@/api/core.md#updatesettings) again keeps the merge and changes nothing else: no cells are cleared a second time, and no [`beforeChange`](@/api/hooks.md#beforechange) or [`afterChange`](@/api/hooks.md#afterchange) event fires. Adding a range to the configuration clears only that new range.
+
+This matters when a framework wrapper resends every option on each render. React and Angular do, so without it a store-driven app would keep receiving change events for values that never changed.
+
+One consequence: if you pass new `data` alongside an unchanged `mergeCells` value, the covered cells of the new data keep their values.
+
+```js
+hot.updateSettings({
+  data: [['A1', 'B1'], ['A2', 'B2']],
+  mergeCells: [{ row: 0, col: 0, rowspan: 2, colspan: 2 }], // unchanged
+});
+
+hot.getDataAtCell(0, 1); // -> 'B1', not null
+```
+
+[`loadData()`](@/api/core.md#loaddata) and [`updateData()`](@/api/core.md#updatedata) behave the same way. To clear the covered cells of a fresh dataset, unmerge the range and merge it again, or clear those cells yourself.
+
 ## Effect on viewport getter methods
 
 With merged cells, the rendered range extends to fit any merged cell that crosses the viewport edge. This is the same expansion that the `virtualized` option turns off. As a result, the rendered-range getters can return indexes beyond what you see on the screen:

--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -352,13 +352,15 @@ Both [`getData()`](@/api/core.md#getdata) and [`getSourceData()`](@/api/core.md#
 
 Unmerging does not restore the cleared values. If you need the original values back, keep a copy before merging, or restore them yourself in a [`beforeUnmergeCells`](@/api/hooks.md#beforeunmergecells) or [`afterUnmergeCells`](@/api/hooks.md#afterunmergecells) handler.
 
-### Clearing runs once per merged range
+### Re-applying the same configuration
 
-A merged range clears its covered cells when it is first applied, not every time the configuration is read. Passing the same `mergeCells` value to [`updateSettings()`](@/api/core.md#updatesettings) again keeps the merge and changes nothing else: no cells are cleared a second time, and no [`beforeChange`](@/api/hooks.md#beforechange) or [`afterChange`](@/api/hooks.md#afterchange) event fires. Adding a range to the configuration clears only that new range.
+Re-applying a `mergeCells` value through [`updateSettings()`](@/api/core.md#updatesettings) clears only the cells that still hold a value. A range whose cells are already empty changes no data, so it fires no [`beforeChange`](@/api/hooks.md#beforechange) or [`afterChange`](@/api/hooks.md#afterchange) event.
 
-This matters when a framework wrapper resends every option on each render. React and Angular do, so without it a store-driven app would keep receiving change events for values that never changed.
+This depends on the clearing write reaching the data. If you cancel it -- by returning `false` from `beforeChange`, or with a validator that rejects `null` while [`allowInvalid`](@/api/options.md#allowinvalid) is `false` -- the covered cells keep their values, and every re-apply tries to clear them again.
 
-One consequence: if you pass new `data` alongside an unchanged `mergeCells` value, the covered cells of the new data keep their values.
+This matters when a framework wrapper resends every option on each render. React and Angular do. Without it, an app that writes those events back into a store keeps receiving changes for values that never changed, and the two can keep triggering each other.
+
+Nothing else about the clearing changes. A range still clears its covered cells the first time you apply it, even where those cells are already empty. And if new values arrive in a covered range -- because you passed new `data`, or because sorting, filtering, or a row move brought other rows under the range -- the next re-apply clears them, then stays quiet:
 
 ```js
 hot.updateSettings({
@@ -366,10 +368,8 @@ hot.updateSettings({
   mergeCells: [{ row: 0, col: 0, rowspan: 2, colspan: 2 }], // unchanged
 });
 
-hot.getDataAtCell(0, 1); // -> 'B1', not null
+hot.getDataAtCell(0, 1); // -> null, cleared as usual
 ```
-
-[`loadData()`](@/api/core.md#loaddata) and [`updateData()`](@/api/core.md#updatedata) behave the same way. To clear the covered cells of a fresh dataset, unmerge the range and merge it again, or clear those cells yourself.
 
 ## Effect on viewport getter methods
 

--- a/docs/content/guides/getting-started/react-redux/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux/react-redux.md
@@ -45,7 +45,18 @@ The following example implements the `@handsontable/react-wrapper` component wit
 
 The reducer above returns the previous state object when no value actually changed. Keep that guard in your own reducer.
 
-Not every change comes from the user. Plugins write to the grid as well: [`mergeCells`](@/api/options.md#mergecells) clears the cells that a merge area covers. Those writes reach [`beforeChange`](@/api/hooks.md#beforechange) too, and the hook's second argument tells you where a change came from -- `'edit'` for a user edit, the plugin name for a plugin write. Use that argument when you want to treat the two differently.
+Not every change comes from the user. Plugins write to the grid as well: [`mergeCells`](@/api/options.md#mergecells) clears the cells that a merge area covers. Those writes reach [`beforeChange`](@/api/hooks.md#beforechange) too, and the hook's second argument tells you where a change came from -- `'edit'` for a user edit, and the plugin's registered name for a plugin write. That name is capitalized, so the merge plugin's writes arrive as `'MergeCells'`, not `'mergeCells'`:
+
+```js
+const onBeforeHotChange = (changes, source) => {
+  if (source === 'MergeCells') {
+    // decide here whether these belong in your store
+  }
+  // ...
+};
+```
+
+See [Definition for `source` argument](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument) for the full list.
 
 A reducer that returns a new state object on every action re-renders the component, which resends the settings to the grid. Without the guard, a plugin write and a re-render can keep triggering each other.
 

--- a/docs/content/guides/getting-started/react-redux/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux/react-redux.md
@@ -45,18 +45,9 @@ The following example implements the `@handsontable/react-wrapper` component wit
 
 The reducer above returns the previous state object when no value actually changed. Keep that guard in your own reducer.
 
-Not every change comes from the user. Plugins write to the grid as well: [`mergeCells`](@/api/options.md#mergecells) clears the cells that a merge area covers. Those writes reach [`beforeChange`](@/api/hooks.md#beforechange) too, and the hook's second argument tells you where a change came from -- `'edit'` for a user edit, and the plugin's registered name for a plugin write. That name is capitalized, so the merge plugin's writes arrive as `'MergeCells'`, not `'mergeCells'`:
+Not every change comes from the user. Plugins write to the grid as well: [`mergeCells`](@/api/options.md#mergecells) clears the cells that a merge area covers. Those writes reach [`beforeChange`](@/api/hooks.md#beforechange) too, and the hook's second argument tells you where a change came from -- `'edit'` for a user edit, and the plugin's registered name for a plugin write. That name is capitalized, so the merge plugin's writes arrive as `'MergeCells'`, not `'mergeCells'`. See [Definition for `source` argument](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument) for the full list.
 
-```js
-const onBeforeHotChange = (changes, source) => {
-  if (source === 'MergeCells') {
-    // decide here whether these belong in your store
-  }
-  // ...
-};
-```
-
-See [Definition for `source` argument](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument) for the full list.
+Dispatch those writes like any other change. The example returns `false` from `beforeChange`, so the store is the only thing that can apply them. Drop them and the covered cells keep their values, the plugin tries to clear them again on the next render, and the two keep triggering each other. Use `source` to label a change, not to skip it.
 
 A reducer that returns a new state object on every action re-renders the component, which resends the settings to the grid. Without the guard, a plugin write and a re-render can keep triggering each other.
 

--- a/docs/content/guides/getting-started/react-redux/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux/react-redux.md
@@ -41,6 +41,16 @@ The following example implements the `@handsontable/react-wrapper` component wit
 
 :::
 
+::: tip
+
+The reducer above returns the previous state object when no value actually changed. Keep that guard in your own reducer.
+
+Not every change comes from the user. Plugins write to the grid as well: [`mergeCells`](@/api/options.md#mergecells) clears the cells that a merge area covers. Those writes reach [`beforeChange`](@/api/hooks.md#beforechange) too, and the hook's second argument tells you where a change came from -- `'edit'` for a user edit, the plugin name for a plugin write. Use that argument when you want to treat the two differently.
+
+A reducer that returns a new state object on every action re-renders the component, which resends the settings to the grid. Without the guard, a plugin write and a re-render can keep triggering each other.
+
+:::
+
 ## Advanced example
 
 This example shows:
@@ -59,7 +69,8 @@ The editor component changes the behavior of the renderer component, by passing 
 ## What you learned
 
 - You can connect a `HotTable` component to a Redux store using `react-redux`'s `connect()` method.
-- The `afterChange` hook dispatches Redux actions whenever the user edits a cell, keeping global state in sync.
+- The `beforeChange` hook dispatches Redux actions whenever a cell changes, keeping global state in sync.
+- A reducer that returns the previous state when nothing changed keeps plugin writes from looping with re-renders.
 - Custom editor and renderer components can read from and write to the Redux store, enabling grid cells to reflect shared application state.
 
 ## Next steps

--- a/docs/content/guides/getting-started/react-redux/react/example1.jsx
+++ b/docs/content/guides/getting-started/react-redux/react/example1.jsx
@@ -107,17 +107,22 @@ const initialReduxStoreState = {
 
 const updatesReducer = (state = initialReduxStoreState, action) => {
   switch (action.type) {
-    case 'updateData':
+    case 'updateData': {
+      let hasChanged = false;
       const newData = state.data.map((row) => [...row]);
 
       action.dataChanges.forEach(([row, column, oldValue, newValue]) => {
-        newData[row][column] = newValue;
+        if (newData[row][column] !== newValue) {
+          newData[row][column] = newValue;
+          hasChanged = true;
+        }
       });
 
-      return {
-        ...state,
-        data: newData,
-      };
+      // Return the previous state when no value actually changed. Plugins write to the grid on
+      // their own (`mergeCells` clears the cells that a merge area covers), and handing back a new
+      // state object every time would re-render the component and resend the settings in a loop.
+      return hasChanged ? { ...state, data: newData } : state;
+    }
     case 'updateReadOnly':
       return {
         ...state,

--- a/docs/content/guides/getting-started/react-redux/react/example1.tsx
+++ b/docs/content/guides/getting-started/react-redux/react/example1.tsx
@@ -126,17 +126,22 @@ const updatesReducer = (
   action: { type: any; dataChanges: [any, any, any, any][]; readOnly: any }
 ) => {
   switch (action.type) {
-    case 'updateData':
+    case 'updateData': {
+      let hasChanged = false;
       const newData = state.data.map((row) => [...row]);
 
       action.dataChanges.forEach(([row, column, oldValue, newValue]) => {
-        newData[row][column] = newValue;
+        if (newData[row][column] !== newValue) {
+          newData[row][column] = newValue;
+          hasChanged = true;
+        }
       });
 
-      return {
-        ...state,
-        data: newData,
-      };
+      // Return the previous state when no value actually changed. Plugins write to the grid on
+      // their own (`mergeCells` clears the cells that a merge area covers), and handing back a new
+      // state object every time would re-render the component and resend the settings in a loop.
+      return hasChanged ? { ...state, data: newData } : state;
+    }
 
     case 'updateReadOnly':
       return {

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -4296,6 +4296,12 @@ export default (): Record<string, unknown> => {
      * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
      * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
+     * A merged range clears the cells it covers when it is first applied. Passing the same value to
+     * [`updateSettings()`](@/api/core.md#updatesettings) again keeps the merge but clears nothing a
+     * second time, and fires no `beforeChange` or `afterChange` event. Adding a range to the array
+     * clears only that new range. As a result, passing new `data` alongside an unchanged `mergeCells`
+     * value leaves the covered cells of that new data intact, the same way `loadData()` does.
+     *
      * Read more:
      * - [Merge cells](@/guides/cell-features/merge-cells/merge-cells.md)
      *

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -4296,11 +4296,13 @@ export default (): Record<string, unknown> => {
      * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
      * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
-     * A merged range clears the cells it covers when it is first applied. Passing the same value to
-     * [`updateSettings()`](@/api/core.md#updatesettings) again keeps the merge but clears nothing a
-     * second time, and fires no `beforeChange` or `afterChange` event. Adding a range to the array
-     * clears only that new range. As a result, passing new `data` alongside an unchanged `mergeCells`
-     * value leaves the covered cells of that new data intact, the same way `loadData()` does.
+     * A merged range clears the cells it covers. Re-applying the same value through
+     * [`updateSettings()`](@/api/core.md#updatesettings) clears only the cells that still hold a
+     * value, so a range that is already empty fires no `beforeChange` or `afterChange` event. Values
+     * that come back into a covered range — through new `data`, a sort, a filter, or a row move — are
+     * cleared on the next re-apply, as before. This assumes the clearing write reaches the data:
+     * cancel it (a `beforeChange` returning `false`, or a validator rejecting `null`) and every
+     * re-apply tries again.
      *
      * Read more:
      * - [Merge cells](@/guides/cell-features/merge-cells/merge-cells.md)

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -455,6 +455,7 @@ describe('MergeCells', () => {
 
     it('should not emit the change hooks again when the `mergeCells` config is re-applied unchanged (#7555)', async() => {
       const beforeChange = jasmine.createSpy('beforeChange');
+      const afterChange = jasmine.createSpy('afterChange');
 
       handsontable({
         data: [
@@ -464,6 +465,7 @@ describe('MergeCells', () => {
         ],
         mergeCells: [{ row: 1, col: 0, rowspan: 2, colspan: 2 }],
         beforeChange,
+        afterChange,
       });
 
       // The first application clears every cell the merge area covers except its anchor.
@@ -475,6 +477,7 @@ describe('MergeCells', () => {
       ]);
 
       beforeChange.calls.reset();
+      afterChange.calls.reset();
 
       // Framework wrappers resend every setting on each render, so an unchanged `mergeCells` value
       // arrives again. Re-clearing the same cells would write nothing but still emit, which loops a
@@ -484,6 +487,7 @@ describe('MergeCells', () => {
       });
 
       expect(beforeChange.calls.count()).toBe(0);
+      expect(afterChange.calls.count()).toBe(0);
       expect(getData()).toEqual([
         ['A1', 'B1', 'C1'],
         ['A2', null, 'C2'],
@@ -519,7 +523,63 @@ describe('MergeCells', () => {
       ]);
     });
 
-    it('should leave the covered cells of newly passed data alone when `mergeCells` is unchanged', async() => {
+    it('should stay quiet on a re-apply when a `valueGetter` makes a cleared cell read back non-null', async() => {
+      const beforeChange = jasmine.createSpy('beforeChange');
+
+      handsontable({
+        data: [
+          ['A1', 'B1', 'C1'],
+          ['A2', 'B2', 'C2'],
+          ['A3', 'B3', 'C3'],
+        ],
+        // The displayed value of a cleared cell is no longer `null`, so the decision to skip has to
+        // read the stored value instead.
+        columns: [{ valueGetter: value => value ?? 'N/A' }, { valueGetter: value => value ?? 'N/A' }, {}],
+        mergeCells: [{ row: 1, col: 0, rowspan: 2, colspan: 2 }],
+        beforeChange,
+      });
+
+      beforeChange.calls.reset();
+
+      await updateSettings({ mergeCells: [{ row: 1, col: 0, rowspan: 2, colspan: 2 }] });
+      await updateSettings({ mergeCells: [{ row: 1, col: 0, rowspan: 2, colspan: 2 }] });
+
+      expect(beforeChange.calls.count()).toBe(0);
+      expect(getSourceData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', null, 'C2'],
+        [null, null, 'C3'],
+      ]);
+    });
+
+    it('should keep trying to clear a covered cell whose clearing write is cancelled', async() => {
+      // Documented limitation: the skip is decided from the stored value, so a handler that refuses
+      // the write leaves the cell filled and every re-apply tries again.
+      const beforeChange = jasmine.createSpy('beforeChange').and.returnValue(false);
+
+      handsontable({
+        data: [
+          ['A1', 'B1', 'C1'],
+          ['A2', 'B2', 'C2'],
+          ['A3', 'B3', 'C3'],
+        ],
+        mergeCells: [{ row: 1, col: 0, rowspan: 2, colspan: 2 }],
+        beforeChange,
+      });
+
+      beforeChange.calls.reset();
+
+      await updateSettings({ mergeCells: [{ row: 1, col: 0, rowspan: 2, colspan: 2 }] });
+
+      expect(beforeChange.calls.count()).toBe(1);
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+      ]);
+    });
+
+    it('should still clear the covered cells of newly passed data when `mergeCells` is unchanged', async() => {
       const beforeChange = jasmine.createSpy('beforeChange');
 
       handsontable({
@@ -534,7 +594,8 @@ describe('MergeCells', () => {
 
       beforeChange.calls.reset();
 
-      // Same behavior as `loadData()`, which never re-cleared the covered cells either.
+      // The new data brings real values back into the covered cells, so they are cleared again. Only
+      // a re-apply that would change nothing is skipped.
       await updateSettings({
         data: [
           ['X1', 'Y1', 'Z1'],
@@ -544,10 +605,10 @@ describe('MergeCells', () => {
         mergeCells: [{ row: 0, col: 0, rowspan: 2, colspan: 2 }],
       });
 
-      expect(beforeChange.calls.count()).toBe(0);
+      expect(beforeChange.calls.count()).toBe(1);
       expect(getData()).toEqual([
-        ['X1', 'Y1', 'Z1'],
-        ['X2', 'Y2', 'Z2'],
+        ['X1', null, 'Z1'],
+        [null, null, 'Z2'],
         ['X3', 'Y3', 'Z3'],
       ]);
     });
@@ -569,19 +630,38 @@ describe('MergeCells', () => {
         beforeChange,
       });
 
-      // Sorting re-anchors the merge onto its new visual position, so the area no longer matches the
-      // key the config declares. The next re-apply therefore populates once more — and after that the
-      // collection is back in sync with the config, so further re-applies stay silent.
+      // Sorting moves other rows under the merge area, so the covered cells hold values again.
       getPlugin('columnSorting').sort({ column: 2, sortOrder: 'asc' });
+
+      expect(getData()).toEqual([
+        ['A4', 'B4', 1],
+        ['A5', 'B5', 2],
+        ['A2', null, 3],
+        [null, null, 4],
+        ['A1', 'B1', 5],
+      ]);
 
       beforeChange.calls.reset();
 
       await updateSettings({ mergeCells });
 
+      // Those values are cleared once, and only the cells that still held one are touched.
       expect(beforeChange.calls.count()).toBe(1);
+      expect(beforeChange.calls.mostRecent().args[0]).toEqual([
+        [1, 1, 'B5', null],
+        [2, 0, 'A2', null],
+      ]);
+      expect(getData()).toEqual([
+        ['A4', 'B4', 1],
+        ['A5', null, 2],
+        [null, null, 3],
+        [null, null, 4],
+        ['A1', 'B1', 5],
+      ]);
 
       beforeChange.calls.reset();
 
+      // From here the area is empty again, so further re-applies stay silent.
       await updateSettings({ mergeCells });
       await updateSettings({ mergeCells });
 

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -452,6 +452,99 @@ describe('MergeCells', () => {
       expect(TD.getAttribute('rowspan')).toBe(null);
       expect(TD.getAttribute('colspan')).toBe(null);
     });
+
+    it('should not emit the change hooks again when the `mergeCells` config is re-applied unchanged (#7555)', async() => {
+      const beforeChange = jasmine.createSpy('beforeChange');
+
+      handsontable({
+        data: [
+          ['A1', 'B1', 'C1'],
+          ['A2', 'B2', 'C2'],
+          ['A3', 'B3', 'C3'],
+        ],
+        mergeCells: [{ row: 1, col: 0, rowspan: 2, colspan: 2 }],
+        beforeChange,
+      });
+
+      // The first application clears every cell the merge area covers except its anchor.
+      expect(beforeChange.calls.count()).toBe(1);
+      expect(beforeChange.calls.mostRecent().args[0]).toEqual([
+        [1, 1, 'B2', null],
+        [2, 0, 'A3', null],
+        [2, 1, 'B3', null],
+      ]);
+
+      beforeChange.calls.reset();
+
+      // Framework wrappers resend every setting on each render, so an unchanged `mergeCells` value
+      // arrives again. Re-clearing the same cells would write nothing but still emit, which loops a
+      // store-driven integration that re-renders in response to the hook.
+      await updateSettings({
+        mergeCells: [{ row: 1, col: 0, rowspan: 2, colspan: 2 }],
+      });
+
+      expect(beforeChange.calls.count()).toBe(0);
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', null, 'C2'],
+        [null, null, 'C3'],
+      ]);
+    });
+
+    it('should populate only the newly added merge area when the `mergeCells` config is extended', async() => {
+      const beforeChange = jasmine.createSpy('beforeChange');
+
+      handsontable({
+        data: [
+          ['A1', 'B1', 'C1', 'D1'],
+          ['A2', 'B2', 'C2', 'D2'],
+          ['A3', 'B3', 'C3', 'D3'],
+        ],
+        mergeCells: [{ row: 0, col: 0, rowspan: 1, colspan: 2 }],
+        beforeChange,
+      });
+
+      beforeChange.calls.reset();
+
+      await updateSettings({
+        mergeCells: [
+          { row: 0, col: 0, rowspan: 1, colspan: 2 },
+          { row: 2, col: 2, rowspan: 1, colspan: 2 },
+        ],
+      });
+
+      expect(beforeChange.calls.count()).toBe(1);
+      expect(beforeChange.calls.mostRecent().args[0]).toEqual([
+        [2, 3, 'D3', null],
+      ]);
+    });
+
+    it('should populate the merge area again when the `mergeCells` config changes its span', async() => {
+      const beforeChange = jasmine.createSpy('beforeChange');
+
+      handsontable({
+        data: [
+          ['A1', 'B1', 'C1'],
+          ['A2', 'B2', 'C2'],
+          ['A3', 'B3', 'C3'],
+        ],
+        mergeCells: [{ row: 0, col: 0, rowspan: 1, colspan: 2 }],
+        beforeChange,
+      });
+
+      beforeChange.calls.reset();
+
+      await updateSettings({
+        mergeCells: [{ row: 0, col: 0, rowspan: 2, colspan: 2 }],
+      });
+
+      expect(beforeChange.calls.count()).toBe(1);
+      expect(beforeChange.calls.mostRecent().args[0]).toEqual([
+        [0, 1, null, null],
+        [1, 0, 'A2', null],
+        [1, 1, 'B2', null],
+      ]);
+    });
   });
 
   describe('loadData', () => {

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -519,6 +519,75 @@ describe('MergeCells', () => {
       ]);
     });
 
+    it('should leave the covered cells of newly passed data alone when `mergeCells` is unchanged', async() => {
+      const beforeChange = jasmine.createSpy('beforeChange');
+
+      handsontable({
+        data: [
+          ['A1', 'B1', 'C1'],
+          ['A2', 'B2', 'C2'],
+          ['A3', 'B3', 'C3'],
+        ],
+        mergeCells: [{ row: 0, col: 0, rowspan: 2, colspan: 2 }],
+        beforeChange,
+      });
+
+      beforeChange.calls.reset();
+
+      // Same behavior as `loadData()`, which never re-cleared the covered cells either.
+      await updateSettings({
+        data: [
+          ['X1', 'Y1', 'Z1'],
+          ['X2', 'Y2', 'Z2'],
+          ['X3', 'Y3', 'Z3'],
+        ],
+        mergeCells: [{ row: 0, col: 0, rowspan: 2, colspan: 2 }],
+      });
+
+      expect(beforeChange.calls.count()).toBe(0);
+      expect(getData()).toEqual([
+        ['X1', 'Y1', 'Z1'],
+        ['X2', 'Y2', 'Z2'],
+        ['X3', 'Y3', 'Z3'],
+      ]);
+    });
+
+    it('should settle after one re-population when the `mergeCells` config is re-applied over a sorted grid', async() => {
+      const beforeChange = jasmine.createSpy('beforeChange');
+      const mergeCells = [{ row: 1, col: 0, rowspan: 2, colspan: 2 }];
+
+      handsontable({
+        data: [
+          ['A1', 'B1', 5],
+          ['A2', 'B2', 3],
+          ['A3', 'B3', 4],
+          ['A4', 'B4', 1],
+          ['A5', 'B5', 2],
+        ],
+        mergeCells,
+        columnSorting: true,
+        beforeChange,
+      });
+
+      // Sorting re-anchors the merge onto its new visual position, so the area no longer matches the
+      // key the config declares. The next re-apply therefore populates once more — and after that the
+      // collection is back in sync with the config, so further re-applies stay silent.
+      getPlugin('columnSorting').sort({ column: 2, sortOrder: 'asc' });
+
+      beforeChange.calls.reset();
+
+      await updateSettings({ mergeCells });
+
+      expect(beforeChange.calls.count()).toBe(1);
+
+      beforeChange.calls.reset();
+
+      await updateSettings({ mergeCells });
+      await updateSettings({ mergeCells });
+
+      expect(beforeChange.calls.count()).toBe(0);
+    });
+
     it('should populate the merge area again when the `mergeCells` config changes its span', async() => {
       const beforeChange = jasmine.createSpy('beforeChange');
 

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -523,6 +523,34 @@ describe('MergeCells', () => {
       ]);
     });
 
+    it('should stay quiet on a re-apply when the visual and physical column order differ', async() => {
+      const beforeChange = jasmine.createSpy('beforeChange');
+      const mergeCells = [{ row: 0, col: 0, rowspan: 2, colspan: 2 }];
+
+      handsontable({
+        data: [
+          ['A1', 'B1', 'C1'],
+          ['A2', 'B2', 'C2'],
+          ['A3', 'B3', 'C3'],
+        ],
+        // Visual column 0 is physical 2, visual 1 is physical 0. Reading the stored value with a
+        // physical index would land on the anchor column and see a value that was never cleared.
+        manualColumnMove: [2, 0, 1],
+        mergeCells,
+        beforeChange,
+      });
+
+      const dataAfterMerge = getData();
+
+      beforeChange.calls.reset();
+
+      await updateSettings({ mergeCells });
+      await updateSettings({ mergeCells });
+
+      expect(beforeChange.calls.count()).toBe(0);
+      expect(getData()).toEqual(dataAfterMerge);
+    });
+
     it('should stay quiet on a re-apply when a `valueGetter` makes a cleared cell read back non-null', async() => {
       const beforeChange = jasmine.createSpy('beforeChange');
 

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -507,13 +507,15 @@ export class MergeCells extends BasePlugin {
    */
   #getStoredValueAt(row: number, column: number): unknown {
     const physicalRow = this.hot.toPhysicalRow(row);
-    const physicalColumn = this.hot.toPhysicalColumn(column);
 
-    if (physicalRow === null || physicalColumn === null) {
+    if (physicalRow === null) {
       return undefined;
     }
 
-    return this.hot.getSourceDataAtCell(physicalRow, physicalColumn);
+    // `getSourceDataAtCell()` takes a physical row but a *visual* column — it runs `colToProp()`,
+    // which translates to physical itself. Translating the column here as well would translate it
+    // twice and read a different cell whenever the two orders differ.
+    return this.hot.getSourceDataAtCell(physicalRow, column);
   }
 
   /**

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -182,6 +182,17 @@ export class MergeCells extends BasePlugin {
    */
   #initialized = false;
   /**
+   * Keys of the merge areas seen in a previous settings application, in the {@link toMergeAreaKey}
+   * form. Recording an area says only that its clearing pass has already run once — not that the
+   * write landed, which a `beforeChange` handler or a validator can still refuse. Derived from the
+   * declared settings, never from `mergedCellsCollection`: the collection's coordinates are
+   * re-anchored when rows are trimmed or reordered, so they stop matching what the settings declare
+   * and would make a re-applied area look new.
+   *
+   * @type {Set<string>}
+   */
+  #appliedMergeKeys: Set<string> = new Set();
+  /**
    * Physical top-left (row/column) of every merged cell, captured while its visual coordinates are
    * authoritative (creation, structural edits). Read on a pure row-trimming change to re-anchor the
    * merge's visual `row`/`col` onto the rows that stay visible — keeping the merge whole (span
@@ -288,6 +299,7 @@ export class MergeCells extends BasePlugin {
   disablePlugin() {
     this.hot.rowIndexMapper.removeLocalHook('cacheUpdated', this.#onRowIndexCacheUpdated);
     this.clearCollections();
+    this.#appliedMergeKeys.clear();
     this.unregisterShortcuts();
     this.hot.render();
     this.#initialized = false;
@@ -311,11 +323,9 @@ export class MergeCells extends BasePlugin {
    *  - [`mergeCells`](@/api/options.md#mergecells)
    */
   updatePlugin() {
-    // Snapshot the applied areas before `disablePlugin()` empties the collection, so
-    // `generateFromSettings()` can tell a re-applied area from a newly declared one.
-    const alreadyAppliedMerges = new Set(
-      this.mergedCellsCollection.mergedCells.map(mergedCell => toMergeAreaKey(mergedCell))
-    );
+    // Copy before `disablePlugin()` clears the field, so `generateFromSettings()` can tell a
+    // re-applied area from a newly declared one.
+    const alreadyAppliedMerges = new Set(this.#appliedMergeKeys);
 
     this.disablePlugin();
     this.enablePlugin();
@@ -429,9 +439,10 @@ export class MergeCells extends BasePlugin {
    *
    * @private
    * @param {Set<string>} [alreadyAppliedMerges] Keys of the merge areas that were already applied before
-   * this call, in the {@link toMergeAreaKey} form. Those areas keep their merge but skip the data
-   * population, because their cells were cleared when they were first applied. Defaults to an empty set,
-   * so a first application populates every area.
+   * this call, in the {@link toMergeAreaKey} form — normally a copy of `#appliedMergeKeys` taken before
+   * `disablePlugin()` cleared it. Those areas keep their merge but skip the data population, because
+   * their cells were cleared when they were first applied. Defaults to an empty set, so a first
+   * application populates every area.
    */
   generateFromSettings(alreadyAppliedMerges: Set<string> = new Set()) {
     const validSettings = this.getSetting<{ row: number, col: number, rowspan: number, colspan: number }[]>('cells')
@@ -451,17 +462,23 @@ export class MergeCells extends BasePlugin {
       // clears the collection first, so skipping this would drop the merge entirely.
       this.mergeRange(mergeRange, true, true);
 
-      // An area that was already applied has had its cells cleared once. Clearing them again writes
-      // no new value, but still emits `beforeChange`/`afterChange`, which loops any integration that
-      // resends its settings in response to those hooks (#7555).
-      if (alreadyAppliedMerges.has(toMergeAreaKey(mergeCellInfo))) {
-        return;
-      }
+      const mergeAreaKey = toMergeAreaKey(mergeCellInfo);
+      // A first application clears the whole area, exactly as before. A re-applied one clears only
+      // the cells that still hold a value: writing `null` over a cell that is already empty changes
+      // no data, but still emits `beforeChange`/`afterChange`, and that is what loops an integration
+      // resending its settings in response to those hooks (#7555).
+      const isReapplied = alreadyAppliedMerges.has(mergeAreaKey);
+
+      this.#appliedMergeKeys.add(mergeAreaKey);
 
       for (let r = row; r < row + rowspan; r++) {
         for (let c = col; c < col + colspan; c++) {
           // Not resetting a cell representing a merge area's value.
-          if (r !== row || c !== col) {
+          if (r === row && c === col) {
+            continue;
+          }
+
+          if (!isReapplied || this.#getStoredValueAt(r, c) !== null) {
             populatedNulls.push([r, c, null]);
           }
         }
@@ -475,6 +492,28 @@ export class MergeCells extends BasePlugin {
 
     // TODO: Change the `source` argument to a more meaningful value, e.g. `${this.pluginName}.clearCells`.
     this.hot.setDataAtCell(populatedNulls, undefined, undefined, this.pluginName ?? undefined);
+  }
+
+  /**
+   * Reads what a cell holds in the data source, bypassing `valueGetter` and the `modifyData` hook.
+   * A merge area's clearing write stores `null`, so deciding whether it still needs to run has to
+   * compare against the stored value — the displayed one can be non-null for an already cleared cell.
+   * Returns `undefined` when the coordinates cannot be translated, which keeps the caller on the safe
+   * side by treating the cell as not yet cleared.
+   *
+   * @param {number} row Visual row index.
+   * @param {number} column Visual column index.
+   * @returns {*} The stored value.
+   */
+  #getStoredValueAt(row: number, column: number): unknown {
+    const physicalRow = this.hot.toPhysicalRow(row);
+    const physicalColumn = this.hot.toPhysicalColumn(column);
+
+    if (physicalRow === null || physicalColumn === null) {
+      return undefined;
+    }
+
+    return this.hot.getSourceDataAtCell(physicalRow, physicalColumn);
   }
 
   /**

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -17,7 +17,7 @@ import { getStyle } from '../../helpers/dom/element';
 import { isChrome } from '../../helpers/browser';
 import { FocusOrder, type FocusNodeData } from './focusOrder';
 import { createMergeCellRenderer } from './renderer';
-import { sumCellsHeights } from './utils';
+import { sumCellsHeights, toMergeAreaKey } from './utils';
 
 Hooks.getSingleton().register('beforeMergeCells');
 Hooks.getSingleton().register('afterMergeCells');
@@ -311,10 +311,16 @@ export class MergeCells extends BasePlugin {
    *  - [`mergeCells`](@/api/options.md#mergecells)
    */
   updatePlugin() {
+    // Snapshot the applied areas before `disablePlugin()` empties the collection, so
+    // `generateFromSettings()` can tell a re-applied area from a newly declared one.
+    const alreadyAppliedMerges = new Set(
+      this.mergedCellsCollection.mergedCells.map(mergedCell => toMergeAreaKey(mergedCell))
+    );
+
     this.disablePlugin();
     this.enablePlugin();
 
-    this.generateFromSettings();
+    this.generateFromSettings(alreadyAppliedMerges);
     this.#initialized = true;
     this.#captureMergeAnchors();
 
@@ -422,8 +428,12 @@ export class MergeCells extends BasePlugin {
    * Generates the merged cells from the settings provided to the plugin.
    *
    * @private
+   * @param {Set<string>} [alreadyAppliedMerges] Keys of the merge areas that were already applied before
+   * this call, in the {@link toMergeAreaKey} form. Those areas keep their merge but skip the data
+   * population, because their cells were cleared when they were first applied. Defaults to an empty set,
+   * so a first application populates every area.
    */
-  generateFromSettings() {
+  generateFromSettings(alreadyAppliedMerges: Set<string> = new Set()) {
     const validSettings = this.getSetting<{ row: number, col: number, rowspan: number, colspan: number }[]>('cells')
       .filter(mergeCellInfo => this.validateSetting(mergeCellInfo));
     const nonOverlappingSettings = this.mergedCellsCollection
@@ -437,8 +447,16 @@ export class MergeCells extends BasePlugin {
       const to = this.hot._createCellCoords(row + rowspan - 1, col + colspan - 1);
       const mergeRange = this.hot._createCellRange(from, from, to);
 
-      // Merging without data population.
+      // Merging without data population. Runs for every area, re-applied or not — `updatePlugin()`
+      // clears the collection first, so skipping this would drop the merge entirely.
       this.mergeRange(mergeRange, true, true);
+
+      // An area that was already applied has had its cells cleared once. Clearing them again writes
+      // no new value, but still emits `beforeChange`/`afterChange`, which loops any integration that
+      // resends its settings in response to those hooks (#7555).
+      if (alreadyAppliedMerges.has(toMergeAreaKey(mergeCellInfo))) {
+        return;
+      }
 
       for (let r = row; r < row + rowspan; r++) {
         for (let c = col; c < col + colspan; c++) {

--- a/handsontable/src/plugins/mergeCells/utils.ts
+++ b/handsontable/src/plugins/mergeCells/utils.ts
@@ -1,4 +1,23 @@
 import type { HotInstance } from '../../core/types';
+
+/**
+ * Builds a comparison key from a merge area's visual geometry. Two merge areas that cover exactly
+ * the same cells produce the same key, which is how a re-applied merge is told apart from a newly
+ * declared one.
+ *
+ * @param {object} mergeArea The merge area to build the key from.
+ * @param {number} mergeArea.row Visual row index of the merge area's top-left corner.
+ * @param {number} mergeArea.col Visual column index of the merge area's top-left corner.
+ * @param {number} mergeArea.rowspan Number of rows the merge area spans.
+ * @param {number} mergeArea.colspan Number of columns the merge area spans.
+ * @returns {string} The comparison key.
+ */
+export function toMergeAreaKey(
+  { row, col, rowspan, colspan }: { row: number, col: number, rowspan: number, colspan: number }
+): string {
+  return `${row},${col},${rowspan},${colspan}`;
+}
+
 /**
  * Calculates the total height of the merged cell.
  *


### PR DESCRIPTION
### Context

The PR fixes [#7555](https://github.com/handsontable/handsontable/issues/7555) — open since 2019 — where adding `mergeCells` to the official Redux example produces an infinite loop of `beforeChange` calls.

Re-verified before fixing, on released **18.0.0** and on **develop `f62994a`**: it reproduces identically on both, so nothing had fixed it since the report.

| Build | `mergeCells` | `beforeChange` calls | renders | outcome |
|---|---|---|---|---|
| 18.0.0 | yes | 53 | 54 | React error #185 "Maximum update depth exceeded" |
| develop | yes | 53 | 54 | identical |
| develop | **no** (control) | **0** | 1 | clean |

The loop never settles. React's own nested-update guard aborts it at ~50 updates and leaves the grid broken. The control run shows the single `mergeCells` line is the cause.

#### Root cause

The fault is in core, not in the wrapper. With an **identical** `mergeCells` value, three `updateSettings` calls that carry the key produce three extra emissions; the same three calls with the key omitted produce zero. The trigger is the key's mere presence.

1. `generateFromSettings()` writes `null` into every non-anchor cell through `setDataAtCell(..., source: 'MergeCells')`.
2. `updatePlugin()` re-runs it whenever the `updateSettings` payload merely *contains* `mergeCells` — `BasePlugin#isRelevantToSettings` only tests `!== undefined`.
3. The React wrapper (`SettingsMapper.getSettings`) and the Angular wrapper resend every prop on each render, so the key always arrives. **Vue 3 is immune**, because `prepareSettings` deep-compares and drops unchanged keys.
4. Core never filters no-op changes, so a `null` → `null` write still fires the hook.

The Redux recipe's reducer returns a new state object on every dispatch, which re-renders and closes the circle back to step 3.

#### The fix

`updatePlugin()` snapshots the merge areas already registered in the collection **before** `disablePlugin()` empties it, and threads that set into `generateFromSettings()`. An area whose `row,col,rowspan,colspan` key is in the set is still re-merged — the collection was cleared, so skipping `mergeRange()` would drop the merge entirely — but it skips the data population, because its cells were cleared when it was first applied.

**First application is byte-identical to before.** Only re-application of an already-applied area changes. Extending the configuration now populates only the newly added areas, where previously it re-populated every area.

Two alternatives were considered and rejected:

- *Skip cells that already hold `null`.* Clean argument, but `mergeCells.spec.js` deliberately pins that those no-op writes **are** emitted on a fresh grid whose covered cells are already null. That existing test would have to be flipped to make the fix pass.
- *Make `updatePlugin()` a no-op when the config is unchanged.* Skips the bounds re-validation that `generateFromSettings()` performs through `validateSetting()`.

#### One deliberate behavior change — please review

`updateSettings({ data, mergeCells })` no longer re-clears the covered cells in the new data. This removes an inconsistency rather than creating one: `loadData()` never re-cleared them, because the plugin registers no `afterLoadData` hook. Measured on both builds:

| path | before | after |
|---|---|---|
| `loadData(newData)` | values kept | values kept |
| `updateSettings({ data: newData, mergeCells: same })` | values **cleared** | values kept |

This cannot be avoided while fixing the loop: a Redux store hands back a new data array on every dispatch, so any "re-populate when the data changed" rule would loop exactly as before.

Known non-improvement, unchanged from today and not engineered around: a merge re-anchored by row trimming no longer matches a resent config key, so that path still re-populates.

#### Docs recipe

The Redux guide's reducer now returns the **previous state object** when no value actually changed, which is the idiomatic Redux practice and stops the loop on its own even without the core fix. A `source` filter was considered and rejected — it would keep the covered cells' data instead of clearing it, silently changing documented merge semantics for anyone following the recipe. The guide gained a tip covering the guard and the `beforeChange` `source` argument, and a stale line naming `afterChange` where the example uses `beforeChange` was corrected.

### How has this been tested?

Three cases were added to the existing `mergeCells updateSettings` describe block. The first two were run against the unfixed build first and **both failed there**, as intended:

1. unchanged config re-applied → **0** emissions (was 1) — the regression test;
2. config extended → only the new area's cells emitted (was: every area's);
3. span changed → still populates (guard, passes either way).

```bash
# The merge suite, including the three new cases
npm run test:e2e --prefix handsontable -- --testPathPattern=mergeCells   # 518 specs, 0 failures

# Full gates
npm run test:e2e --prefix handsontable                                    # 9725 specs, 0 failures
npm run test:unit --prefix handsontable                                   # 3963 passed
npm run test:types --prefix handsontable                                  # pass
npm run eslint --prefix handsontable                                      # 0 errors
npm run test --prefix wrappers/react-wrapper                              # 78 passed
```

Manually verified in real Chromium with the official Redux recipe plus the reporter's added `mergeCells` line, against a local build: `beforeChange` fires **1** time instead of 53, no React #185, and the store is nulled exactly once — the documented merge behavior is preserved.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2659
2. #7555

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2659

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core merge clearing on `updateSettings`, which affects Redux/React integrations and any code listening to `MergeCells`-sourced changes; behavior is well-tested but alters long-standing re-clear semantics for unchanged config with new data.
> 
> **Overview**
> Fixes an infinite **React/Redux** loop ([#7555](https://github.com/handsontable/handsontable/issues/7555)) where framework wrappers resend the same `mergeCells` on every render and the plugin kept writing `null` into already-empty covered cells, firing `beforeChange`/`afterChange` with source `MergeCells` even when nothing changed.
> 
> The **mergeCells** plugin now remembers which merge areas (by visual `row,col,rowspan,colspan` keys via `toMergeAreaKey`) have already had their clearing pass. On `updateSettings()` with the same config it still re-merges the range but only queues `setDataAtCell` clears for covered cells whose **stored** value is not `null` (`#getStoredValueAt`, so `valueGetter` does not mask cleared cells). First application and newly added or resized merge areas behave as before; new `data` under an unchanged merge still clears values that reappear (sort/filter/row move).
> 
> Docs add a “re-applying the same configuration” section, **React-Redux** example reducers return the previous state when no cell value actually changed, plus guidance on plugin `source` values. Tests cover re-apply silence, column move, `valueGetter`, cancelled clears, new data, sorting, and span changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d00085f38a59c2b2f10d36fbde9a400d8792926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->