### PR TITLE
DEV-2661: Make one changelog entry per PR a hard rule

### DIFF
--- a/.changelogs/README.md
+++ b/.changelogs/README.md
@@ -18,6 +18,23 @@ Documentation-only, test-only, and CI/tooling PRs **pass automatically** — no 
 ...and re-run the failed **Changelog** check from the PR's checks tab (or push any new commit — `git commit --allow-empty` works). The check reads the PR body at run time; editing the description alone does not re-trigger it. The override is logged together with the source files it waves through, so reviewers can judge it.
 
 
+## One entry per pull request
+
+**A pull request adds exactly one entry to this directory. Never more than one.**
+
+This holds even when the PR fixes several issues, touches several packages, or makes several distinct
+user-facing changes — the single title describes the overall change. Two entries from one PR land as
+two overlapping lines in the same `CHANGELOG.md` section, and a reader cannot tell they came from one
+change. If one title cannot carry everything the PR does, split the PR, not the entry.
+
+Check before opening the PR:
+
+```bash
+git diff --name-only origin/develop...HEAD -- .changelogs/
+```
+
+Exactly one path must be listed.
+
 ## Entry format
 
 Every `.json` file in this directory holds a single entry with six required fields:

--- a/.claude/skills/changelog-creation/SKILL.md
+++ b/.claude/skills/changelog-creation/SKILL.md
@@ -100,7 +100,30 @@ This walks you through each field and writes the JSON file for you. You can also
 
 ## One Entry Per PR
 
-Create **one changelog entry per PR**, even if the PR fixes multiple issues. The title should describe the overall change, not list individual issues.
+**Exactly one changelog entry per PR. Never more than one.** This is a hard rule, not a preference.
+
+One PR adds **one** new `.json` file to `.changelogs/`, even when the PR fixes several issues, touches
+several packages, or makes several distinct user-facing changes. The title describes the overall
+change; it does not list individual issues.
+
+Do **not** add a second entry because:
+
+- the PR fixes a second bug that has no issue of its own — fold it into the one title;
+- one fix has a public issue number and another does not — pick the single `issuesOrigin` that fits
+  the PR's main subject and fold the rest in;
+- the changes feel unrelated — if they are genuinely unrelated, they belong in separate PRs.
+
+Two entries from one PR land as two lines in the same `CHANGELOG.md` section, usually overlapping in
+wording, and a reader cannot tell they came from one change. If a single title cannot carry everything
+the PR does, that is a sign the PR is too broad — split the PR, not the entry.
+
+Before you commit, check that the PR adds exactly one file:
+
+```bash
+git diff --name-only origin/develop...HEAD -- .changelogs/
+```
+
+Exactly one path must be listed. More than one means fold them together and delete the extras.
 
 ## Checklist
 
@@ -112,3 +135,4 @@ Create **one changelog entry per PR**, even if the PR fixes multiple issues. The
 6. Leave `issuesOrigin` as `"private"` unless the entry cites a real public GitHub issue number — see [Issue Origin](#issue-origin).
 7. Name the file `<PR-number>.json` and set `"issueOrPR"` to the same number. Do not guess or infer the number — read it from the created PR. Write to `<repo-root>/.changelogs/<PR-number>.json` — **not** inside any package subdirectory (e.g. `handsontable/.changelogs/` is wrong). With `"public"`, both the filename and `issueOrPR` use the **issue** number instead.
 8. Commit and push the new changelog file to the same feature branch so the open PR picks it up.
+9. Confirm the branch adds **exactly one** file under `.changelogs/` — see [One Entry Per PR](#one-entry-per-pr). More than one is always wrong.


### PR DESCRIPTION
### Context

The PR makes "one changelog entry per PR" a hard rule instead of a one-line preference.

The `changelog-creation` skill already said it, but in a single sentence with no reasoning and nothing to check against. That was not enough: [#13268](https://github.com/handsontable/handsontable/pull/13268) shipped two entries — one named after a public issue, one after the PR — and a reviewer had to catch it. Two entries from one PR land as two overlapping lines in the same `CHANGELOG.md` section, and a reader cannot tell they came from one change.

What changed:

- The skill's **One Entry Per PR** section now states the rule plainly and lists the three cases that tempt a second entry: a second bug with no issue of its own, one fix with a public issue number and another without, and changes that merely feel unrelated. Each says what to do instead — fold it in, or split the PR rather than the entry.
- The same rule is added to `.changelogs/README.md`, which is the in-repo spec the changelog CI gate is documented against. The skill is Claude-facing; the README is what a human contributor reads.
- Both places carry the one-line check that makes the rule testable, plus a new checklist step pointing at it:

```bash
git diff --name-only origin/develop...HEAD -- .changelogs/
```

Exactly one path must be listed.

### How has this been tested?

Documentation and tooling only — no source code, no behavior to test. Verified the command reports exactly one path on a correctly-formed branch, and more than one on `feature/DEV-2655_React-editor-false-not-honored` before that PR was corrected.

No changelog entry: this changes no shippable source, so the changelog gate passes automatically (`.changelogs/README.md`, "Mandatory PR check").

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2661
2. Came out of the review on #13268

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Repository tooling and documentation only.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2661
