### PR TITLE
DEV-2662: Make one changelog entry per section a hard rule

### DIFF
--- a/.changelogs/README.md
+++ b/.changelogs/README.md
@@ -18,6 +18,23 @@ Documentation-only, test-only, and CI/tooling PRs **pass automatically** — no 
 ...and re-run the failed **Changelog** check from the PR's checks tab (or push any new commit — `git commit --allow-empty` works). The check reads the PR body at run time; editing the description alone does not re-trigger it. The override is logged together with the source files it waves through, so reviewers can judge it.
 
 
+## One entry per pull request
+
+**A pull request adds exactly one entry to this directory. Never more than one.**
+
+This holds even when the PR fixes several issues, touches several packages, or makes several distinct
+user-facing changes — the single title describes the overall change. Two entries from one PR land as
+two overlapping lines in the same `CHANGELOG.md` section, and a reader cannot tell they came from one
+change. If one title cannot carry everything the PR does, split the PR, not the entry.
+
+Check before opening the PR:
+
+```bash
+git diff --name-only origin/develop...HEAD -- .changelogs/
+```
+
+Exactly one path must be listed.
+
 ## Entry format
 
 Every `.json` file in this directory holds a single entry with six required fields:

--- a/.changelogs/README.md
+++ b/.changelogs/README.md
@@ -18,22 +18,25 @@ Documentation-only, test-only, and CI/tooling PRs **pass automatically** — no 
 ...and re-run the failed **Changelog** check from the PR's checks tab (or push any new commit — `git commit --allow-empty` works). The check reads the PR body at run time; editing the description alone does not re-trigger it. The override is logged together with the source files it waves through, so reviewers can judge it.
 
 
-## One entry per pull request
+## One entry per changelog section
 
-**A pull request adds exactly one entry to this directory. Never more than one.**
+**A PR never adds two entries that land in the same `CHANGELOG.md` section for the same package.** One entry per PR is the norm.
 
-This holds even when the PR fixes several issues, touches several packages, or makes several distinct
-user-facing changes — the single title describes the overall change. Two entries from one PR land as
-two overlapping lines in the same `CHANGELOG.md` section, and a reader cannot tell they came from one
-change. If one title cannot carry everything the PR does, split the PR, not the entry.
+One entry stays the norm even when the PR fixes several issues, touches several packages, or makes several distinct user-facing changes — the single title describes the overall change. Two entries that share a `type` and a `framework` land as two overlapping lines in the same section, and a reader cannot tell they came from one change. If one title cannot carry everything the PR does, split the PR, not the entry.
 
-Check before opening the PR:
+A second entry is correct only when it lands somewhere else — a different `type`, or a different `framework`. The common case is a public issue fixed alongside a private behavior change: `fixed` plus `changed`. Those two cannot fold into one file, because a file carries one `type` and `type` picks the section.
+
+The CI gate does not count entries. It only asserts that a source change adds at least one, so this rule rests on the author and the reviewer.
+
+Check before you commit the entry:
 
 ```bash
-git diff --name-only origin/develop...HEAD -- .changelogs/
+git fetch origin develop
+git diff --name-only --diff-filter=A origin/develop...HEAD -- '.changelogs/*.json'
 ```
 
-Exactly one path must be listed.
+Read the `type` and `framework` of every path it lists. Two paths that share both are wrong — fold them together and delete the extra. Swap `develop` for the PR's base branch when you target a release branch.
+
 
 ## Entry format
 

--- a/.claude/skills/changelog-creation/SKILL.md
+++ b/.claude/skills/changelog-creation/SKILL.md
@@ -98,32 +98,27 @@ node bin/changelog entry
 
 This walks you through each field and writes the JSON file for you. You can also create the file manually -- the format is simple enough.
 
-## One Entry Per PR
+## One Entry Per Changelog Section
 
-**Exactly one changelog entry per PR. Never more than one.** This is a hard rule, not a preference.
+**Never add two entries that land in the same `CHANGELOG.md` section for the same package.** One entry per PR is the norm. The authoritative rule lives in [`.changelogs/README.md`](../../../.changelogs/README.md); this section is the short form.
 
-One PR adds **one** new `.json` file to `.changelogs/`, even when the PR fixes several issues, touches
-several packages, or makes several distinct user-facing changes. The title describes the overall
-change; it does not list individual issues.
+That holds even when the PR fixes several issues or makes several distinct user-facing changes. The title describes the overall change; it does not list individual issues.
 
-Do **not** add a second entry because:
+Do **not** add a second entry with the same `type` and `framework` because:
 
 - the PR fixes a second bug that has no issue of its own — fold it into the one title;
-- one fix has a public issue number and another does not — pick the single `issuesOrigin` that fits
-  the PR's main subject and fold the rest in;
 - the changes feel unrelated — if they are genuinely unrelated, they belong in separate PRs.
 
-Two entries from one PR land as two lines in the same `CHANGELOG.md` section, usually overlapping in
-wording, and a reader cannot tell they came from one change. If a single title cannot carry everything
-the PR does, that is a sign the PR is too broad — split the PR, not the entry.
+A second entry **is** correct when it lands elsewhere — a different `type`, or a different `framework`. A public issue fixed alongside a private behavior change is the common case: `fixed` plus `changed`. Those cannot fold into one file, because a file carries one `type` and `type` picks the section.
 
-Before you commit, check that the PR adds exactly one file:
+Before you commit, list what the branch adds:
 
 ```bash
-git diff --name-only origin/develop...HEAD -- .changelogs/
+git fetch origin develop
+git diff --name-only --diff-filter=A origin/develop...HEAD -- '.changelogs/*.json'
 ```
 
-Exactly one path must be listed. More than one means fold them together and delete the extras.
+Read the `type` and `framework` of every path it lists. Two paths that share both are wrong — fold them together and delete the extra. Swap `develop` for the PR's base branch when you target a release branch.
 
 ## Checklist
 
@@ -135,4 +130,4 @@ Exactly one path must be listed. More than one means fold them together and dele
 6. Leave `issuesOrigin` as `"private"` unless the entry cites a real public GitHub issue number — see [Issue Origin](#issue-origin).
 7. Name the file `<PR-number>.json` and set `"issueOrPR"` to the same number. Do not guess or infer the number — read it from the created PR. Write to `<repo-root>/.changelogs/<PR-number>.json` — **not** inside any package subdirectory (e.g. `handsontable/.changelogs/` is wrong). With `"public"`, both the filename and `issueOrPR` use the **issue** number instead.
 8. Commit and push the new changelog file to the same feature branch so the open PR picks it up.
-9. Confirm the branch adds **exactly one** file under `.changelogs/` — see [One Entry Per PR](#one-entry-per-pr). More than one is always wrong.
+9. Confirm no two files the branch adds under `.changelogs/` share the same `type` and `framework` — see [One Entry Per Changelog Section](#one-entry-per-changelog-section).

--- a/.claude/skills/changelog-creation/SKILL.md
+++ b/.claude/skills/changelog-creation/SKILL.md
@@ -100,7 +100,30 @@ This walks you through each field and writes the JSON file for you. You can also
 
 ## One Entry Per PR
 
-Create **one changelog entry per PR**, even if the PR fixes multiple issues. The title should describe the overall change, not list individual issues.
+**Exactly one changelog entry per PR. Never more than one.** This is a hard rule, not a preference.
+
+One PR adds **one** new `.json` file to `.changelogs/`, even when the PR fixes several issues, touches
+several packages, or makes several distinct user-facing changes. The title describes the overall
+change; it does not list individual issues.
+
+Do **not** add a second entry because:
+
+- the PR fixes a second bug that has no issue of its own — fold it into the one title;
+- one fix has a public issue number and another does not — pick the single `issuesOrigin` that fits
+  the PR's main subject and fold the rest in;
+- the changes feel unrelated — if they are genuinely unrelated, they belong in separate PRs.
+
+Two entries from one PR land as two lines in the same `CHANGELOG.md` section, usually overlapping in
+wording, and a reader cannot tell they came from one change. If a single title cannot carry everything
+the PR does, that is a sign the PR is too broad — split the PR, not the entry.
+
+Before you commit, check that the PR adds exactly one file:
+
+```bash
+git diff --name-only origin/develop...HEAD -- .changelogs/
+```
+
+Exactly one path must be listed. More than one means fold them together and delete the extras.
 
 ## Checklist
 
@@ -112,3 +135,4 @@ Create **one changelog entry per PR**, even if the PR fixes multiple issues. The
 6. Leave `issuesOrigin` as `"private"` unless the entry cites a real public GitHub issue number — see [Issue Origin](#issue-origin).
 7. Name the file `<PR-number>.json` and set `"issueOrPR"` to the same number. Do not guess or infer the number — read it from the created PR. Write to `<repo-root>/.changelogs/<PR-number>.json` — **not** inside any package subdirectory (e.g. `handsontable/.changelogs/` is wrong). With `"public"`, both the filename and `issueOrPR` use the **issue** number instead.
 8. Commit and push the new changelog file to the same feature branch so the open PR picks it up.
+9. Confirm the branch adds **exactly one** file under `.changelogs/` — see [One Entry Per PR](#one-entry-per-pr). More than one is always wrong.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -12,7 +12,7 @@ Read and apply the review checklists from these files:
 
 ## Repository-level checks
 
-- **Changelog**: If package source code changes, require a new `/.changelogs/*.json` file. Skip if the PR description contains `[skip changelog]`. In that file, `issuesOrigin` must be `private` with `issueOrPR` equal to the PR number and the file named `<PR-number>.json` — **unless** the entry cites a real public GitHub issue, in which case `public` is correct and both `issueOrPR` and the filename use the issue number. See `/.changelogs/README.md`.
+- **Changelog**: If package source code changes, require a new `/.changelogs/*.json` file. Skip if the PR description contains `[skip changelog]`. In that file, `issuesOrigin` must be `private` with `issueOrPR` equal to the PR number and the file named `<PR-number>.json` — **unless** the entry cites a real public GitHub issue, in which case `public` is correct and both `issueOrPR` and the filename use the issue number. Flag two added entries that share the same `type` and `framework` — they land as two overlapping lines in one `CHANGELOG.md` section and must be folded into one. Two entries with a different `type` or `framework` are fine. See `/.changelogs/README.md`.
 - **Breaking change**: If a PR introduces a breaking change, require the `Breaking change` label and migration guide updates in `/docs/content/guides/upgrade-and-migration/`.
 - **Docs**: For user-facing behavior or UX changes, require matching docs updates in `/docs/content/`.
 - **Agent guidance**: If a PR introduces new conventions, constraints, or gotchas, require an `/AGENTS.md` update.


### PR DESCRIPTION
### Context

The PR turns the "one changelog entry" guidance into a hard, checkable rule instead of a one-line preference.

The `changelog-creation` skill already said "one entry per PR", but in a single sentence with no reasoning and nothing to check against. That was not enough. On [#13268](https://github.com/handsontable/handsontable/pull/13268) the branch carried two entries for a while — `13268.json` and `7561.json`, both `fixed` + `react`, so both would have landed as two overlapping lines in the same `CHANGELOG.md` section. A reviewer caught it, and the extra file was deleted in `526836b7a` before the merge, so the PR shipped only `7561.json`.

"One entry per PR" turned out to be too strong as written. Recent PRs merge two entries on purpose when the two land in different sections: [#13239](https://github.com/handsontable/handsontable/pull/13239) (`added` + `removed`), [#13237](https://github.com/handsontable/handsontable/pull/13237) (`fixed` + `changed`), [#13224](https://github.com/handsontable/handsontable/pull/13224) (`fixed` + `changed`). Each pairs a public issue with a private behavior change, and a file carries one `type`, so folding them would file half the change under the wrong heading. The rule is therefore scoped to the section, not to the PR.

What changed:

- `.changelogs/README.md` gets a **One entry per changelog section** section. One entry per PR stays the norm; two entries are wrong only when they share a `type` and a `framework`. It also says plainly that the CI gate does not count entries — it asserts only that a source change adds at least one.
- The skill's section is trimmed to the short form and links to the README, which `AGENTS.md` names as the authoritative spec.
- `.cursor/BUGBOT.md` carries the same rule, so the bot flags a same-section pair and leaves a legitimate cross-section pair alone.
- Both docs carry the check command, and the skill checklist gains a step pointing at it:

```bash
git fetch origin develop
git diff --name-only --diff-filter=A origin/develop...HEAD -- '.changelogs/*.json'
```

Read the `type` and `framework` of every path it lists.

### How has this been tested?

Documentation and tooling only — no source code, no behavior to test.

The command was checked against both states of #13268. That branch is deleted, but the commits are still reachable through `refs/pull/13268/head`:

- at `da52d9a2e`, the two-entry state, it lists `.changelogs/13268.json` and `.changelogs/7561.json` — both `fixed` + `react`, which the rule flags;
- at `526836b7a`, after the extra file was deleted, it lists `.changelogs/7561.json` alone.

Checked against a legitimate pair too: #13239 lists `7147.json` (`added`) and `13239.json` (`removed`), which the rule allows.

The earlier version of the command (`git diff --name-only origin/develop...HEAD -- .changelogs/`) was wrong and is replaced. On this branch it listed `.changelogs/README.md` — one path, reported as OK, for a branch that adds no entry at all. `--diff-filter=A` and the `*.json` filter close that hole; the `git fetch` line stops a stale `origin/develop` from collapsing the three-dot range and listing every entry merged upstream since the last fetch.

Not enforced in CI: `evaluateChangelogGate` receives only `{status, filename}` per changed file, so it cannot read `type` or `framework`. A section-aware gate needs entry contents, and is left as a follow-up.

No changelog entry: this changes no shippable source, so the changelog gate passes automatically (`.changelogs/README.md`, "Mandatory PR check").

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2662
2. Came out of the review on #13268

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Repository tooling and documentation only.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2662

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and review-guidance only; no runtime or CI behavior changes beyond what reviewers/agents are told to flag.
> 
> **Overview**
> Turns the soft “one changelog entry per PR” preference into an explicit **one entry per `CHANGELOG.md` section (same package)** rule, documented for humans, agents, and automated review.
> 
> **`.changelogs/README.md`** adds a full section: one title per PR is the norm; duplicate `type` + `framework` pairs create overlapping lines in the same section and should be merged (or the PR split). A second file is only valid when `type` or `framework` differs (e.g. `fixed` + `changed`). CI still only requires *at least* one entry, so authors/reviewers own this check. Includes a `git diff` command listing newly added `.changelogs/*.json` files to verify `type`/`framework` uniqueness.
> 
> The **changelog-creation** skill renames and expands the same guidance, links to the README as authoritative, and adds checklist step 9. **BUGBOT** changelog checks now flag two added entries with the same `type` and `framework`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cf028d30cc7fa4b04c345cd5149a942ca37ae65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

