### PR TITLE
DEV-2664: Stop an Angular editor of true throwing on cell select

### DIFF
--- a/.changelogs/13277.json
+++ b/.changelogs/13277.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the Angular wrapper throwing an error on cell select when a cell's `editor` setting was `true`.",
+  "type": "fixed",
+  "issueOrPR": 13277,
+  "breaking": false,
+  "framework": "angular"
+}

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA, NgZone, SimpleChange, SimpleChanges } from '@angular/core';
 import Handsontable from 'handsontable';
 import { registerPlugin, CopyPaste } from 'handsontable/plugins';
+import { NumericEditor, TextEditor } from 'handsontable/editors';
+import { registerCellType, NumericCellType } from 'handsontable/cellTypes';
 import { HotTableModule } from './hot-table.module';
 import { HOT_DESTROYED_WARNING, HotTableComponent } from './hot-table.component';
 import { GridSettings } from './models/grid-settings';
@@ -11,6 +13,8 @@ import { HOT_GLOBAL_CONFIG, HotGlobalConfigService, NON_COMMERCIAL_LICENSE } fro
 import { DynamicComponentService } from './renderer/hot-dynamic-renderer-component.service';
 
 registerPlugin(CopyPaste);
+// The `boolean \`editor\` setting` suite needs a cell type that brings its own editor along.
+registerCellType(NumericCellType);
 
 describe('HotTableComponent', () => {
   let fixture: ComponentFixture<HotTableComponent>;
@@ -620,6 +624,68 @@ describe('HotTableComponent', () => {
       });
 
       expect(capturedZoneState).toBe(true);
+    });
+  });
+
+  describe('boolean `editor` setting', () => {
+    // Core accepts only a string or a constructor as `editor`. A bare `true` used to reach it
+    // untouched and throw `Only strings and functions can be passed as "editor" parameter` the
+    // moment a cell was selected, because selecting a cell prepares its editor.
+    const selectFirstCell = () => fixture.componentInstance.hotInstance.selectCell(0, 0);
+
+    const createTable = (extraSettings: GridSettings) => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { ...settings, ...extraSettings };
+      fixture.componentInstance.data = createSpreadsheetData(3, 3);
+      fixture.detectChanges();
+    };
+
+    it('should fall back to the default editor for a grid-level `editor` of `true`', () => {
+      createTable({ editor: true } as GridSettings);
+
+      expect(selectFirstCell).not.toThrow();
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(TextEditor);
+    });
+
+    it('should fall back to the default editor for a column-level `editor` of `true`', () => {
+      createTable({ columns: [{ editor: true }, {}, {}] } as GridSettings);
+
+      expect(selectFirstCell).not.toThrow();
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(TextEditor);
+      // The control column, which sets no editor, resolves the same way it always did.
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 1)).toBe(TextEditor);
+    });
+
+    it('should keep the editor a column `type` supplies when `editor` is `true`', () => {
+      createTable({ columns: [{ type: 'numeric', editor: true }, {}, {}] } as GridSettings);
+
+      expect(selectFirstCell).not.toThrow();
+      // `true` means "no editor named", not "use the default one" — resolving it to the text
+      // editor here would silently strip the numeric editor the `type` brings in.
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(NumericEditor);
+    });
+
+    it('should still disable editing for an `editor` of `false`', () => {
+      createTable({ columns: [{ editor: false }, {}, {}] } as GridSettings);
+
+      expect(selectFirstCell).not.toThrow();
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(false);
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 1)).toBe(TextEditor);
+    });
+
+    it('should normalize an `editor` of `true` arriving through a settings update', () => {
+      createTable({});
+
+      fixture.componentInstance.ngOnChanges({
+        settings: new SimpleChange(
+          fixture.componentInstance.settings,
+          { ...settings, columns: [{ editor: true }, {}, {}] } as GridSettings,
+          false
+        ),
+      } as SimpleChanges);
+
+      expect(selectFirstCell).not.toThrow();
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(TextEditor);
     });
   });
 });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.spec.ts
@@ -495,4 +495,80 @@ describe('HotSettingsResolver', () => {
       expect(wrappedTwice).toBe(wrappedOnce);
     });
   });
+
+  describe('boolean `editor` setting', () => {
+    it('should drop a grid-level `editor` of `true` so the cell falls back to the default editor', () => {
+      const inputSettings = { editor: true } as GridSettings;
+
+      const result = service.applyCustomSettings(inputSettings);
+
+      // `true` names no editor. Core takes only a string or a constructor and throws on the first
+      // edit when a bare boolean reaches it, so the key must be gone, not set to `undefined`.
+      expect('editor' in result).toBe(false);
+      // The caller's own object stays untouched, as with every other resolved setting.
+      expect(inputSettings.editor).toBe(true);
+    });
+
+    it('should drop a column-level `editor` of `true`', () => {
+      const inputSettings: GridSettings = {
+        columns: [{ editor: true } as ColumnSettings, { data: 'name' } as ColumnSettings],
+      };
+
+      const result = service.applyCustomSettings(inputSettings);
+
+      expect('editor' in result.columns[0]).toBe(false);
+      // The control column is left exactly as it was.
+      expect('editor' in result.columns[1]).toBe(false);
+      expect((inputSettings.columns[0] as ColumnSettings).editor).toBe(true);
+    });
+
+    it('should keep a column `type` when its `editor` of `true` is dropped', () => {
+      const result = service.applyCustomSettings({
+        columns: [{ type: 'numeric', editor: true } as ColumnSettings],
+      });
+
+      // Resolving `true` to the default text editor would silently throw away the editor the
+      // column's `type` supplies, so it has to be dropped instead of rewritten.
+      expect('editor' in result.columns[0]).toBe(false);
+      expect((result.columns[0] as ColumnSettingsInternal).type).toBe('numeric');
+    });
+
+    it('should leave an `editor` of `false` alone at both levels', () => {
+      const result = service.applyCustomSettings({
+        editor: false,
+        columns: [{ editor: false } as ColumnSettings],
+      } as GridSettings);
+
+      // Core reads `false` as "editing disabled" — it is a real setting, not a missing one.
+      expect(result.editor).toBe(false);
+      expect((result.columns[0] as ColumnSettings).editor).toBe(false);
+    });
+
+    it('should leave an `editor` of `null` alone, so it keeps locking the cell', () => {
+      const result = service.applyCustomSettings({
+        columns: [{ editor: null } as unknown as ColumnSettings],
+      });
+
+      // `null` sits outside the declared `string | ctor | boolean` type. Passing it straight
+      // through keeps the wrapper aligned with vanilla Handsontable, which locks the cell.
+      expect((result.columns[0] as ColumnSettings).editor).toBeNull();
+    });
+
+    it('should not touch a component editor while normalizing booleans', () => {
+      const result = service.applyCustomSettings({
+        columns: [{ editor: TestEditorComponent } as ColumnSettings],
+      });
+
+      expect((result.columns[0] as ColumnSettingsInternal)._editorComponentReference).toBeDefined();
+    });
+
+    it('should tolerate a `columns` function alongside a grid-level `editor` of `true`', () => {
+      const columnsFn = () => ({ data: 'name' }) as ColumnSettings;
+
+      const result = service.applyCustomSettings({ editor: true, columns: columnsFn } as GridSettings);
+
+      expect('editor' in result).toBe(false);
+      expect(result.columns).toBe(columnsFn);
+    });
+  });
 });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.ts
@@ -44,6 +44,7 @@ export class HotSettingsResolver {
       mergedSettings.columns = mergedSettings.columns.map((column) => ({ ...column }));
     }
 
+    this.normalizeEditorSetting(mergedSettings);
     this.updateColumnRendererForGivenCustomRenderer(mergedSettings);
     this.updateColumnEditorForGivenCustomEditor(mergedSettings, previousColumns);
     this.updateColumnValidatorForGivenCustomValidator(mergedSettings);
@@ -74,6 +75,37 @@ export class HotSettingsResolver {
         };
         (wrapped as any)[HOT_ZONE_WRAPPED] = true;
         settings[key] = wrapped;
+      }
+    });
+  }
+
+  /**
+   * Drops an `editor` setting of `true`, on the grid and on every column.
+   *
+   * Core takes only a string or a constructor and throws `Only strings and functions can be passed
+   * as "editor" parameter` on the first edit when a bare `true` reaches it. `true` names no editor,
+   * so it is treated as if the setting were never provided, and the cell keeps whatever editor its
+   * `type`, the grid, or the default supplies. Resolving it to the default editor instead would
+   * silently drop the editor a column's `type` brings in, turning `{ type: 'numeric', editor: true }`
+   * into a plain text cell.
+   *
+   * `false` is left alone — core reads it as "editing disabled" — and so is `null`, which keeps
+   * locking the cell exactly as it does in vanilla Handsontable.
+   *
+   * @param mergedSettings The merged grid settings.
+   */
+  private normalizeEditorSetting(mergedSettings: GridSettings): void {
+    if (mergedSettings.editor === true) {
+      delete mergedSettings.editor;
+    }
+
+    if (!Array.isArray(mergedSettings.columns)) {
+      return;
+    }
+
+    (mergedSettings.columns as ColumnSettings[]).forEach((cellSettings) => {
+      if (cellSettings.editor === true) {
+        delete cellSettings.editor;
       }
     });
   }


### PR DESCRIPTION
### Context

The PR fixes the Angular wrapper throwing `Only strings and functions can be passed as "editor" parameter` as soon as a cell is selected, whenever the `editor` setting is `true`.

Core declares `editor?: string | ctor | boolean`, so `editor: true` type-checks. At runtime core accepts only a string or a constructor, so a bare `true` reaches `getEditorInstance()` and throws on the first editor preparation — which happens on cell select, not on first edit.

The wrapper's `HotSettingsResolver.updateColumnEditorForGivenCustomEditor()` only rewrites `editor` when it holds an Angular editor component type. A boolean matches neither check, so the method returns early and the value reaches core untouched. A grid-level `editor` was never inspected at all.

`applyCustomSettings()` now drops an `editor` of `true` from the grid settings and from every column, before any other resolution runs. It is the single funnel for both the initial settings and `ngOnChanges`, so the update path is covered too.

**`true` is treated as "no editor named", not as "use the default editor".** Resolving it to the text editor would silently discard the editor a column's `type` supplies, turning `columns: [{ type: 'numeric', editor: true }]` into a plain text cell. Dropping the key instead lets the cell inherit from its `type`, the grid, or the default. This matches the semantic the React wrapper uses in #13268.

`editor: false` is untouched — core reads it as "editing disabled" — and this half of the problem never affected the Angular wrapper.

**On `editor: null`:** left as-is, so it keeps locking the cell exactly as vanilla Handsontable does. `null` sits outside the declared `string | ctor | boolean` type, so this is a lenience choice rather than a correctness one. The React wrapper inherits instead, but that comes from its prop layer, which the Angular wrapper does not have. Worth aligning with the Vue 3 wrapper's call on the same question (DEV-2663).

**Relationship to DEV-2661:** this is a standalone wrapper fix. DEV-2661 proposes normalizing `editor: true` in core, which would fix vanilla, Vue and Angular at once. That has not landed. If it does, this wrapper-side normalization becomes redundant rather than conflicting — it would simply never find a `true` left to drop.

No documentation change here: `metaSchema` documents only `false`, and updating it is DEV-2661's scope.

### How has this been tested?

Added 12 tests across two existing specs. Verified they are meaningful by reverting the source change and re-running: 8 of the 12 fail without the fix, including the discriminating `type: 'numeric'` case and the settings-update path. The other 4 are regression guards for `false`, `null` and component editors, which pass either way by design.

`projects/hot-table/src/lib/services/hot-settings-resolver.service.spec.ts` — resolver level:

- drops a grid-level `editor: true`
- drops a column-level `editor: true`, leaving a control column untouched
- keeps a column's `type` when its `editor: true` is dropped
- leaves `editor: false` alone at both levels
- leaves `editor: null` alone
- does not disturb a component editor
- tolerates a `columns` function alongside a grid-level `editor: true`

`projects/hot-table/src/lib/hot-table.component.spec.ts` — real `Handsontable.Core` instance through `TestBed`:

- grid-level `editor: true` no longer throws on `selectCell`, and `getCellEditor(0, 0)` is `TextEditor`
- column-level `editor: true` behaves the same, and the control column is unchanged
- `{ type: 'numeric', editor: true }` keeps `NumericEditor`
- `editor: false` still disables editing
- `editor: true` arriving through `ngOnChanges` is normalized on the update path too

```bash
npm --prefix handsontable run build
npm --prefix wrappers/angular-wrapper run test
npm --prefix wrappers/angular-wrapper run lint
```

Full Angular wrapper suite: 303 tests, 13 suites, all passing. Lint clean.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2664
2. DEV-2661 — proposed core-level normalization that would make this wrapper change redundant
3. DEV-2663 — the same gap in the Vue 3 wrapper
4. #13268 — the React wrapper fix this mirrors

### Affected project(s):

- [ ] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2664

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Angular settings normalization for `editor: true`; other editor values and core Handsontable behavior are explicitly preserved by tests.
> 
> **Overview**
> Fixes the Angular wrapper throwing **"Only strings and functions can be passed as editor parameter"** when a cell is selected with **`editor: true`** on the grid or a column.
> 
> **`HotSettingsResolver`** now runs **`normalizeEditorSetting`** early in **`applyCustomSettings`**, **removing** `editor` when it is exactly **`true`** (grid-level and per column). That treats `true` as “no editor named” so cells inherit from column **`type`**, grid defaults, or the default text editor—**not** by forcing the text editor, which would break cases like **`{ type: 'numeric', editor: true }`**.
> 
> **`editor: false`**, **`null`**, string/constructor/component editors are unchanged. The same path covers initial settings and **`ngOnChanges`** updates.
> 
> Adds resolver and **`HotTableComponent`** tests plus an Angular changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1aafda88502ca239a9bb0e93d476b83327a2c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->