### PR TITLE
DEV-2663: Normalize an editor setting of true instead of throwing

### DIFF
--- a/.changelogs/13278.json
+++ b/.changelogs/13278.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an `editor` option of `true` throwing an error instead of using the default editor.",
+  "type": "fixed",
+  "issueOrPR": 13278,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/getCellEditor.spec.js
+++ b/handsontable/src/__tests__/core/getCellEditor.spec.js
@@ -277,6 +277,46 @@ describe('Core.getCellEditor', () => {
       expect(getCellEditor(1, 1)).toBe(getCellType('text').editor);
     });
 
+    it('should return the `type` editor when passed through the `cell` option', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        cell: [
+          { row: 1, col: 1, type: 'numeric', editor: true },
+        ],
+      });
+
+      // The `cell` option does not go through the layer `updateMeta` calls - it lands in
+      // `CellMeta#setMeta`, which used to store the raw `true` as an own property and so blocked
+      // the `type` expansion from supplying the numeric editor.
+      expect(getCellEditor(1, 1)).toBe(getCellType('numeric').editor);
+      expect(getCellMeta(1, 1).editor).not.toBe(true);
+    });
+
+    it('should keep the inherited editor when `setCellMeta` writes an `editor` of `true`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        editor: 'password',
+      });
+
+      setCellMeta(1, 1, 'editor', true);
+
+      expect(getCellEditor(1, 1)).toBe(getCellType('password').editor);
+      expect(getCellMeta(1, 1).editor).not.toBe(true);
+    });
+
+    it('should not drop a grid-level editor when `updateSettings` passes an `editor` of `true`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        editor: 'password',
+      });
+
+      await updateSettings({ editor: true });
+
+      // "Not passed" means the previous value stands, exactly as `updateSettings({})` would leave it.
+      expect(getCellEditor(1, 1)).toBe(getCellType('password').editor);
+      expect(getCellMeta(1, 1).editor).not.toBe(true);
+    });
+
     it('should return the `type` editor when passed through the `cells` option', async() => {
       handsontable({
         data: createSpreadsheetData(5, 5),

--- a/handsontable/src/__tests__/core/getCellEditor.spec.js
+++ b/handsontable/src/__tests__/core/getCellEditor.spec.js
@@ -223,4 +223,93 @@ describe('Core.getCellEditor', () => {
     expect(getCellEditor(1, 5)).toBe(getCellType('numeric').editor);
     expect(getCellEditor(100, 100)).toBe(getCellType('numeric').editor);
   });
+
+  describe('`editor` set to `true`', () => {
+    // `true` names no editor, so it has to read as "not passed" - the cell keeps the editor its
+    // `type` (or a higher configuration level) provides. Returning the raw `true` made
+    // `getEditorInstance()` throw on the first edit (GH #7561 follow-up).
+    it('should return the default text editor when only `editor: true` is defined', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        editor: true,
+      });
+
+      expect(getCellEditor(1, 1)).toBe(getCellType('text').editor);
+    });
+
+    it('should return the `type` editor when `editor: true` is defined next to a `type`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        columns: [
+          { type: 'numeric', editor: true },
+          { type: 'password', editor: true },
+          {},
+        ],
+      });
+
+      expect(getCellEditor(1, 0)).toBe(getCellType('numeric').editor);
+      expect(getCellEditor(1, 1)).toBe(getCellType('password').editor);
+      // control column - proves the harness resolves editors at all
+      expect(getCellEditor(1, 2)).toBe(getCellType('text').editor);
+    });
+
+    it('should return the editor inherited from the grid level', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        editor: 'password',
+        columns: [
+          { editor: true },
+          {},
+        ],
+      });
+
+      expect(getCellEditor(1, 0)).toBe(getCellType('password').editor);
+    });
+
+    it('should return the default text editor when passed through the `cell` option', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        cell: [
+          { row: 1, col: 1, editor: true },
+        ],
+      });
+
+      expect(getCellEditor(1, 1)).toBe(getCellType('text').editor);
+    });
+
+    it('should return the `type` editor when passed through the `cells` option', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        cells(row, column) {
+          return column === 0 ? { type: 'numeric', editor: true } : {};
+        },
+      });
+
+      expect(getCellEditor(1, 0)).toBe(getCellType('numeric').editor);
+      expect(getCellEditor(1, 1)).toBe(getCellType('text').editor);
+    });
+
+    it('should return the default text editor after `updateSettings`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await updateSettings({ editor: true });
+
+      expect(getCellEditor(1, 1)).toBe(getCellType('text').editor);
+    });
+
+    it('should still disable editing for `editor: false`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        columns: [
+          { type: 'numeric', editor: false },
+          {},
+        ],
+      });
+
+      expect(getCellEditor(1, 0)).toBe(false);
+      expect(getCellEditor(1, 1)).toBe(getCellType('text').editor);
+    });
+  });
 });

--- a/handsontable/src/__tests__/settings/editor.spec.js
+++ b/handsontable/src/__tests__/settings/editor.spec.js
@@ -224,5 +224,80 @@ describe('settings', () => {
         await selectCell(0, 0);
       });
     });
+
+    describe('set to `true`', () => {
+      // `true` names no editor. It used to reach `getEditorInstance()` untouched, which threw
+      // 'Only strings and functions can be passed as "editor" parameter' on the first edit.
+      it('should open the default text editor instead of throwing', async() => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+          editor: true,
+        });
+
+        await selectCell(0, 0);
+        await keyDownUp('enter');
+
+        expect(getActiveEditor() instanceof Handsontable.editors.TextEditor).toBe(true);
+        expect(isEditorVisible()).toBe(true);
+
+        getActiveEditor().setValue('edited');
+
+        await keyDownUp('enter');
+
+        expect(getDataAtCell(0, 0)).toBe('edited');
+      });
+
+      it('should open the `type` editor of the column instead of the text editor', async() => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+          columns: [
+            { type: 'numeric', editor: true },
+            {},
+          ],
+        });
+
+        await selectCell(0, 0);
+        await keyDownUp('enter');
+
+        expect(getActiveEditor() instanceof Handsontable.editors.NumericEditor).toBe(true);
+
+        await keyDownUp('escape');
+
+        // control column - proves the harness opens editors at all
+        await selectCell(0, 1);
+        await keyDownUp('enter');
+
+        expect(getActiveEditor() instanceof Handsontable.editors.TextEditor).toBe(true);
+      });
+
+      it('should open the default text editor when set through the `cell` option', async() => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+          cell: [
+            { row: 0, col: 0, editor: true },
+          ],
+        });
+
+        await selectCell(0, 0);
+        await keyDownUp('enter');
+
+        expect(getActiveEditor() instanceof Handsontable.editors.TextEditor).toBe(true);
+        expect(isEditorVisible()).toBe(true);
+      });
+
+      it('should open the default text editor when set through `updateSettings`', async() => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+        });
+
+        await updateSettings({ editor: true });
+
+        await selectCell(0, 0);
+        await keyDownUp('enter');
+
+        expect(getActiveEditor() instanceof Handsontable.editors.TextEditor).toBe(true);
+        expect(isEditorVisible()).toBe(true);
+      });
+    });
   });
 });

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -4778,7 +4778,12 @@ export default function Core(
 
     type EditorConstructor = (new (hotInstance: HotInstance) => unknown) & { EDITOR_TYPE?: string };
 
-    return (isUndefined(cellEditor) ? getEditor('text') : cellEditor) as EditorConstructor;
+    // An `editor` of `true` names no editor. The meta layers already drop it on the way in, so
+    // reaching this branch means it was written straight onto the cell meta (for example by a
+    // `beforeGetCellMeta` hook). Fall back to the default editor rather than returning the bare
+    // boolean, which `getEditorInstance()` cannot resolve and would throw on.
+    return ((isUndefined(cellEditor) || cellEditor === true) ?
+      getEditor('text') : cellEditor) as EditorConstructor;
   };
 
   /**

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -3423,7 +3423,13 @@ export default function Core(
         }
 
       } else if (!init && hasOwnProperty(settings, i)) { // Update settings
-        globalMeta[i] = settings[i];
+        // An `editor` of `true` names no editor, so it reads as "the setting was not passed" — and a
+        // setting that is not passed leaves the previous value alone. Writing the boolean here would
+        // bypass `normalizeEditorSetting()`, which only runs on the layer `updateMeta` calls, and
+        // park a bare `true` on the global meta for every cell to inherit.
+        if (i !== 'editor' || settings[i] !== true) {
+          globalMeta[i] = settings[i];
+        }
       }
     }
 

--- a/handsontable/src/dataMap/metaManager/__tests__/metaManager.unit.ts
+++ b/handsontable/src/dataMap/metaManager/__tests__/metaManager.unit.ts
@@ -3,7 +3,7 @@ import GlobalMeta from '../metaLayers/globalMeta';
 import TableMeta from '../metaLayers/tableMeta';
 import ColumnMeta from '../metaLayers/columnMeta';
 import CellMeta from '../metaLayers/cellMeta';
-import { registerAllCellTypes } from '../../../cellTypes';
+import { registerAllCellTypes, getCellType } from '../../../cellTypes';
 
 registerAllCellTypes();
 
@@ -509,6 +509,113 @@ describe('MetaManager', () => {
 
       expect(meta.className).toBe('htCenter');
       expect(metaManager.cellMeta.getMetaIfExists(10, 4)).toBeUndefined();
+    });
+  });
+
+  describe('an "editor" setting of `true`', () => {
+    // `true` names no editor, so it has to read as "not passed" - the cell keeps the editor its
+    // "type" (or a higher meta layer) provides. Without normalization the raw `true` reaches
+    // `getEditorInstance()`, which throws on the first edit (GH #7561 follow-up).
+    const textEditor = () => getCellType('text').editor;
+    const numericEditor = () => getCellType('numeric').editor;
+
+    it('should fall back to the default editor when passed to the global meta layer', () => {
+      const metaManager = new MetaManager();
+
+      metaManager.updateGlobalMeta({ editor: true });
+
+      expect(metaManager.getGlobalMeta().editor).toBe(textEditor());
+    });
+
+    it('should fall back to the default editor when passed to the table meta layer', () => {
+      const metaManager = new MetaManager();
+
+      metaManager.updateTableMeta({ editor: true });
+
+      expect(metaManager.getTableMeta().editor).toBe(textEditor());
+    });
+
+    it('should fall back to the default editor when passed to the column meta layer', () => {
+      const metaManager = new MetaManager();
+
+      metaManager.updateColumnMeta(2, { editor: true });
+
+      const meta = metaManager.getCellMeta(0, 2, { visualRow: 0, visualColumn: 2 });
+
+      expect(meta.editor).toBe(textEditor());
+    });
+
+    it('should fall back to the default editor when passed to the cell meta layer', () => {
+      const metaManager = new MetaManager();
+
+      metaManager.updateCellMeta(1, 1, { editor: true });
+
+      const meta = metaManager.getCellMeta(1, 1, { visualRow: 1, visualColumn: 1 });
+
+      expect(meta.editor).toBe(textEditor());
+    });
+
+    it('should keep the editor supplied by the cell "type" of the same column', () => {
+      const metaManager = new MetaManager();
+
+      metaManager.updateColumnMeta(3, { type: 'numeric', editor: true });
+
+      const meta = metaManager.getCellMeta(0, 3, { visualRow: 0, visualColumn: 3 });
+
+      expect(meta.editor).toBe(numericEditor());
+      expect(meta.renderer).toBe(getCellType('numeric').renderer);
+    });
+
+    it('should keep the editor supplied by the cell "type" of the same cell', () => {
+      const metaManager = new MetaManager();
+
+      metaManager.updateCellMeta(2, 2, { type: 'numeric', editor: true });
+
+      const meta = metaManager.getCellMeta(2, 2, { visualRow: 2, visualColumn: 2 });
+
+      expect(meta.editor).toBe(numericEditor());
+    });
+
+    it('should keep the editor inherited from a higher meta layer', () => {
+      const metaManager = new MetaManager();
+
+      metaManager.updateGlobalMeta({ editor: 'password' });
+      metaManager.updateColumnMeta(1, { editor: true });
+
+      const meta = metaManager.getCellMeta(0, 1, { visualRow: 0, visualColumn: 1 });
+
+      expect(meta.editor).toBe('password');
+    });
+
+    it('should not leave the raw `true` on the meta object', () => {
+      const metaManager = new MetaManager();
+
+      metaManager.updateColumnMeta(0, { type: 'numeric', editor: true });
+
+      const meta = metaManager.getCellMeta(0, 0, { visualRow: 0, visualColumn: 0 });
+
+      expect(meta.editor).not.toBe(true);
+      expect(metaManager.getColumnMeta(0).editor).not.toBe(true);
+    });
+
+    it('should not affect an "editor" setting of `false`, which still disables editing', () => {
+      const metaManager = new MetaManager();
+
+      metaManager.updateColumnMeta(0, { type: 'numeric', editor: false });
+
+      const meta = metaManager.getCellMeta(0, 0, { visualRow: 0, visualColumn: 0 });
+
+      expect(meta.editor).toBe(false);
+    });
+
+    it('should not affect a named editor, which still wins over the cell "type"', () => {
+      const metaManager = new MetaManager();
+
+      metaManager.updateColumnMeta(0, { type: 'numeric', editor: 'password' });
+
+      const meta = metaManager.getCellMeta(0, 0, { visualRow: 0, visualColumn: 0 });
+
+      expect(meta.editor).toBe('password');
     });
   });
 });

--- a/handsontable/src/dataMap/metaManager/__tests__/utils.unit.ts
+++ b/handsontable/src/dataMap/metaManager/__tests__/utils.unit.ts
@@ -3,6 +3,7 @@ import {
   columnFactory,
   assert,
   isNullish,
+  normalizeEditorSetting,
 } from '../utils';
 import { registerAllCellTypes, getCellType } from '../../../cellTypes';
 
@@ -264,6 +265,45 @@ describe('MetaManager utils', () => {
       expect(isNullish(NaN)).toBe(false);
       expect(isNullish({})).toBe(false);
       expect(isNullish([])).toBe(false);
+    });
+  });
+
+  describe('normalizeEditorSetting', () => {
+    it('should drop an "editor" property of `true`, so it reads as "not passed"', () => {
+      const settings = { editor: true, type: 'numeric' };
+      const normalizedSettings = normalizeEditorSetting(settings);
+
+      expect(normalizedSettings).not.toBe(settings);
+      expect('editor' in normalizedSettings).toBe(false);
+      expect(normalizedSettings.type).toBe('numeric');
+    });
+
+    it('should not mutate the passed settings object', () => {
+      const settings = { editor: true };
+
+      normalizeEditorSetting(settings);
+
+      expect(settings.editor).toBe(true);
+    });
+
+    it('should return the very same object when the "editor" property needs no normalization', () => {
+      const namedEditor = { editor: 'numeric' };
+      const disabledEditor = { editor: false };
+      const nullEditor = { editor: null };
+      const noEditor = { type: 'numeric' };
+
+      expect(normalizeEditorSetting(namedEditor)).toBe(namedEditor);
+      expect(normalizeEditorSetting(disabledEditor)).toBe(disabledEditor);
+      expect(normalizeEditorSetting(nullEditor)).toBe(nullEditor);
+      expect(normalizeEditorSetting(noEditor)).toBe(noEditor);
+    });
+
+    it('should keep an "editor" property that is a truthy non-boolean value', () => {
+      class CustomEditor {}
+
+      const settings = { editor: CustomEditor };
+
+      expect(normalizeEditorSetting(settings).editor).toBe(CustomEditor);
     });
   });
 });

--- a/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
@@ -1,4 +1,4 @@
-import { extendByMetaType, assert } from '../utils';
+import { extendByMetaType, assert, normalizeEditorSetting } from '../utils';
 import LazyFactoryMap from '../lazyFactoryMap';
 import { extend, hasOwnProperty } from '../../../helpers/object';
 import { isDefined } from '../../../helpers/mixed';
@@ -98,9 +98,10 @@ export default class CellMeta {
    */
   updateMeta(physicalRow: number, physicalColumn: number, settings: Record<string, unknown>) {
     const meta = this.getMeta(physicalRow, physicalColumn);
+    const normalizedSettings = normalizeEditorSetting(settings);
 
-    extend(meta, settings);
-    extendByMetaType(meta, settings);
+    extend(meta, normalizedSettings);
+    extendByMetaType(meta, normalizedSettings);
   }
 
   /**

--- a/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
@@ -231,6 +231,20 @@ export default class CellMeta {
   setMeta(physicalRow: number, physicalColumn: number, key: string, value: unknown) {
     const cellMeta = this.metas.obtain(physicalRow).obtain(physicalColumn);
 
+    // An `editor` of `true` names no editor, so it reads as "the setting was not passed". Dropping
+    // the own property lets the cell keep the editor its `type` expands to, or the one inherited
+    // from the column and grid layers. Storing the boolean instead would hand a bare `true` to
+    // `getEditorInstance()` and, by clearing the key from `_automaticallyAssignedMetaProps`, would
+    // also stop `extendByMetaType()` from supplying the type's editor. The bookkeeping entries are
+    // cleared too, so an earlier real write does not keep the cell pinned against meta eviction.
+    if (key === 'editor' && value === true) {
+      delete cellMeta[key];
+      (cellMeta._persistedMetaProps as Set<string> | undefined)?.delete(key);
+      (cellMeta._userDefinedMetaProps as Set<string> | undefined)?.delete(key);
+
+      return;
+    }
+
     (cellMeta._automaticallyAssignedMetaProps as Set<string> | undefined)?.delete(key);
     cellMeta[key] = value;
 

--- a/handsontable/src/dataMap/metaManager/metaLayers/columnMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/columnMeta.ts
@@ -1,5 +1,5 @@
 import { extend } from '../../../helpers/object';
-import { columnFactory, extendByMetaType } from '../utils';
+import { columnFactory, extendByMetaType, normalizeEditorSetting } from '../utils';
 import LazyFactoryMap from '../lazyFactoryMap';
 
 /**
@@ -68,9 +68,10 @@ export default class ColumnMeta {
    */
   updateMeta(physicalColumn: number, settings: Record<string, unknown>) {
     const meta = this.getMeta(physicalColumn);
+    const normalizedSettings = normalizeEditorSetting(settings);
 
-    extend(meta, settings);
-    extendByMetaType(meta, settings);
+    extend(meta, normalizedSettings);
+    extendByMetaType(meta, normalizedSettings);
   }
 
   /**

--- a/handsontable/src/dataMap/metaManager/metaLayers/globalMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/globalMeta.ts
@@ -1,5 +1,5 @@
 import { extend } from '../../../helpers/object';
-import { extendByMetaType } from '../utils';
+import { extendByMetaType, normalizeEditorSetting } from '../utils';
 import metaSchemaFactory from '../metaSchema';
 
 /**
@@ -85,10 +85,12 @@ export default class GlobalMeta {
    * @param {object} settings An object to merge with.
    */
   updateMeta(settings: Record<string, unknown>) {
-    extend(this.meta, settings);
+    const normalizedSettings = normalizeEditorSetting(settings);
+
+    extend(this.meta, normalizedSettings);
     extendByMetaType(this.meta, {
-      ...settings,
-      type: settings.type ?? this.meta.type,
-    }, settings);
+      ...normalizedSettings,
+      type: normalizedSettings.type ?? this.meta.type,
+    }, normalizedSettings);
   }
 }

--- a/handsontable/src/dataMap/metaManager/metaLayers/tableMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/tableMeta.ts
@@ -1,5 +1,5 @@
 import { extend } from '../../../helpers/object';
-import { extendByMetaType } from '../utils';
+import { extendByMetaType, normalizeEditorSetting } from '../utils';
 
 /**
  * The table meta object is a layer that keeps all settings of the Handsontable that was passed in
@@ -58,7 +58,9 @@ export default class TableMeta {
    * @param {object} settings An object to merge with.
    */
   updateMeta(settings: Record<string, unknown>) {
-    extend(this.meta, settings);
-    extendByMetaType(this.meta, settings, settings);
+    const normalizedSettings = normalizeEditorSetting(settings);
+
+    extend(this.meta, normalizedSettings);
+    extendByMetaType(this.meta, normalizedSettings, normalizedSettings);
   }
 }

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -2474,6 +2474,10 @@ export default (): Record<string, unknown> => {
      * | `Delete` / `Backspace`                  | Clear the contents of the selected cells                    |
      * | `Ctrl` + `Enter` / `Cmd` + `Enter`      | Fill selected cells with the value of the active cell       |
      *
+     * Setting the `editor` option to `true` names no editor, so Handsontable treats it as if the
+     * option was not set at all. The cell keeps the editor that its [`type`](#type) provides, or the
+     * editor inherited from a higher configuration level.
+     *
      * To set the [`editor`](#editor), [`renderer`](#renderer), and [`validator`](#validator)
      * options all at once, use the [`type`](#type) option.
      *

--- a/handsontable/src/dataMap/metaManager/mods/__tests__/dynamicCellMeta.unit.ts
+++ b/handsontable/src/dataMap/metaManager/mods/__tests__/dynamicCellMeta.unit.ts
@@ -151,6 +151,35 @@ describe('DynamicCellMetaMod', () => {
     expect(cellMeta.cells).toHaveBeenCalledWith(1, 2, 'prop_2');
   });
 
+  it('should drop an "editor" of `true` returned by the "cells" setting option', () => {
+    const hotMock = new Handsontable();
+    const metaManager = new MetaManager(hotMock);
+    const mod = new DynamicCellMetaMod(metaManager as MetaManagerArg);
+    const cellMeta = {
+      row: 1,
+      col: 2,
+      visualRow: 1,
+      visualCol: 2,
+      cells() {
+        return {
+          type: 'numeric',
+          editor: true,
+        };
+      },
+    };
+
+    jest.spyOn(metaManager, 'updateCellMeta').mockReset();
+
+    mod.extendCellMeta(createCellMeta(cellMeta));
+
+    // `true` names no editor, so it must not reach the meta layers - otherwise it would both block
+    // the numeric editor the "type" supplies and throw once the cell is edited.
+    expect(metaManager.updateCellMeta).toHaveBeenCalledTimes(1);
+    expect(metaManager.updateCellMeta).toHaveBeenCalledWith(1, 2, {
+      type: 'numeric',
+    });
+  });
+
   it('should extend the cell meta object only once per table slow render cycle', () => {
     const hotMock = new Handsontable();
     const metaManager = new MetaManager(hotMock);

--- a/handsontable/src/dataMap/metaManager/mods/dynamicCellMeta.ts
+++ b/handsontable/src/dataMap/metaManager/mods/dynamicCellMeta.ts
@@ -4,7 +4,7 @@ import type { CellProperties } from '../../../settings';
 import { Hooks } from '../../../core/hooks';
 import { hasOwnProperty, extend } from '../../../helpers/object';
 import { isFunction } from '../../../helpers/function';
-import { extendByMetaType } from '../utils';
+import { extendByMetaType, normalizeEditorSetting } from '../utils';
 
 /**
  * @class DynamicCellMetaMod
@@ -192,7 +192,7 @@ export class DynamicCellMetaMod {
     }
 
     if (cellSettings) {
-      applyCellSettings(cellSettings);
+      applyCellSettings(normalizeEditorSetting(cellSettings));
     }
 
     hot.runHooks('afterGetCellMeta', visualRow, visualCol, cellMeta);

--- a/handsontable/src/dataMap/metaManager/utils.ts
+++ b/handsontable/src/dataMap/metaManager/utils.ts
@@ -115,3 +115,26 @@ export function assert(condition: () => boolean, errorMessage: string) {
 export function isNullish(variable: unknown): variable is null | undefined {
   return variable === null || variable === undefined;
 }
+
+/**
+ * Normalizes the "editor" property of the passed settings object.
+ *
+ * An `editor` of `true` names no editor, so it is treated as if the setting was not passed at all.
+ * The property is dropped rather than resolved to the text editor here, so the cell still receives
+ * the editor that its "type" (or a higher meta layer) provides - for example, a `type: 'numeric'`
+ * column keeps the numeric editor.
+ *
+ * @param {object} settings The settings object to normalize.
+ * @returns {object} The passed object, or a copy of it with the "editor" property removed.
+ */
+export function normalizeEditorSetting<T extends Record<string, unknown>>(settings: T): T {
+  if (settings.editor !== true) {
+    return settings;
+  }
+
+  const normalizedSettings = { ...settings };
+
+  delete normalizedSettings.editor;
+
+  return normalizedSettings;
+}

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA, NgZone, SimpleChange, SimpleChanges } from '@angular/core';
 import Handsontable from 'handsontable';
 import { registerPlugin, CopyPaste } from 'handsontable/plugins';
+import { NumericEditor, TextEditor } from 'handsontable/editors';
+import { registerCellType, NumericCellType } from 'handsontable/cellTypes';
 import { HotTableModule } from './hot-table.module';
 import { HOT_DESTROYED_WARNING, HotTableComponent } from './hot-table.component';
 import { GridSettings } from './models/grid-settings';
@@ -11,6 +13,8 @@ import { HOT_GLOBAL_CONFIG, HotGlobalConfigService, NON_COMMERCIAL_LICENSE } fro
 import { DynamicComponentService } from './renderer/hot-dynamic-renderer-component.service';
 
 registerPlugin(CopyPaste);
+// The boolean-editor suite needs a cell type that brings its own editor along.
+registerCellType(NumericCellType);
 
 describe('HotTableComponent', () => {
   let fixture: ComponentFixture<HotTableComponent>;
@@ -620,6 +624,71 @@ describe('HotTableComponent', () => {
       });
 
       expect(capturedZoneState).toBe(true);
+    });
+  });
+
+  describe('boolean `editor` setting', () => {
+    // Confirms the Angular wrapper inherits core's `editor: true` normalization — it passes the
+    // setting straight through, so it needs no wrapper-side handling of its own.
+    //
+    // Core accepts only a string or a constructor as `editor`. A bare `true` used to reach it
+    // untouched and throw `Only strings and functions can be passed as "editor" parameter` the
+    // moment a cell was selected, because selecting a cell prepares its editor.
+    const selectFirstCell = () => fixture.componentInstance.hotInstance.selectCell(0, 0);
+
+    const createTable = (extraSettings: GridSettings) => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { ...settings, ...extraSettings };
+      fixture.componentInstance.data = createSpreadsheetData(3, 3);
+      fixture.detectChanges();
+    };
+
+    it('should fall back to the default editor for a grid-level `editor` of `true`', () => {
+      createTable({ editor: true } as GridSettings);
+
+      expect(selectFirstCell).not.toThrow();
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(TextEditor);
+    });
+
+    it('should fall back to the default editor for a column-level `editor` of `true`', () => {
+      createTable({ columns: [{ editor: true }, {}, {}] } as GridSettings);
+
+      expect(selectFirstCell).not.toThrow();
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(TextEditor);
+      // The control column, which sets no editor, resolves the same way it always did.
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 1)).toBe(TextEditor);
+    });
+
+    it('should keep the editor a column `type` supplies when `editor` is `true`', () => {
+      createTable({ columns: [{ type: 'numeric', editor: true }, {}, {}] } as GridSettings);
+
+      expect(selectFirstCell).not.toThrow();
+      // `true` means "no editor named", not "use the default one" — resolving it to the text
+      // editor here would silently strip the numeric editor the `type` brings in.
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(NumericEditor);
+    });
+
+    it('should still disable editing for an `editor` of `false`', () => {
+      createTable({ columns: [{ editor: false }, {}, {}] } as GridSettings);
+
+      expect(selectFirstCell).not.toThrow();
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(false);
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 1)).toBe(TextEditor);
+    });
+
+    it('should normalize an `editor` of `true` arriving through a settings update', () => {
+      createTable({});
+
+      fixture.componentInstance.ngOnChanges({
+        settings: new SimpleChange(
+          fixture.componentInstance.settings,
+          { ...settings, columns: [{ editor: true }, {}, {}] } as GridSettings,
+          false
+        ),
+      } as SimpleChanges);
+
+      expect(selectFirstCell).not.toThrow();
+      expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(TextEditor);
     });
   });
 });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -644,14 +644,14 @@ describe('HotTableComponent', () => {
     };
 
     it('should fall back to the default editor for a grid-level `editor` of `true`', () => {
-      createTable({ editor: true } as GridSettings);
+      createTable({ editor: true });
 
       expect(selectFirstCell).not.toThrow();
       expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(TextEditor);
     });
 
     it('should fall back to the default editor for a column-level `editor` of `true`', () => {
-      createTable({ columns: [{ editor: true }, {}, {}] } as GridSettings);
+      createTable({ columns: [{ editor: true }, {}, {}] });
 
       expect(selectFirstCell).not.toThrow();
       expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(TextEditor);
@@ -660,7 +660,7 @@ describe('HotTableComponent', () => {
     });
 
     it('should keep the editor a column `type` supplies when `editor` is `true`', () => {
-      createTable({ columns: [{ type: 'numeric', editor: true }, {}, {}] } as GridSettings);
+      createTable({ columns: [{ type: 'numeric', editor: true }, {}, {}] });
 
       expect(selectFirstCell).not.toThrow();
       // `true` means "no editor named", not "use the default one" — resolving it to the text
@@ -669,7 +669,7 @@ describe('HotTableComponent', () => {
     });
 
     it('should still disable editing for an `editor` of `false`', () => {
-      createTable({ columns: [{ editor: false }, {}, {}] } as GridSettings);
+      createTable({ columns: [{ editor: false }, {}, {}] });
 
       expect(selectFirstCell).not.toThrow();
       expect(fixture.componentInstance.hotInstance.getCellEditor(0, 0)).toBe(false);
@@ -682,7 +682,7 @@ describe('HotTableComponent', () => {
       fixture.componentInstance.ngOnChanges({
         settings: new SimpleChange(
           fixture.componentInstance.settings,
-          { ...settings, columns: [{ editor: true }, {}, {}] } as GridSettings,
+          { ...settings, columns: [{ editor: true }, {}, {}] },
           false
         ),
       } as SimpleChanges);

--- a/wrappers/vue3/test/editorSetting.spec.ts
+++ b/wrappers/vue3/test/editorSetting.spec.ts
@@ -1,0 +1,134 @@
+import { config, mount } from '@vue/test-utils';
+import { registerAllCellTypes } from 'handsontable/registry';
+import { getCellType } from 'handsontable/cellTypes';
+import HotTable from '../src/HotTable.vue';
+import HotColumn from '../src/HotColumn.vue';
+import {
+  createSampleData,
+  mockClientDimensions,
+} from './_helpers';
+
+config.renderStubDefaultSlot = true;
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <div id="app"></div>
+  `;
+});
+
+registerAllCellTypes();
+
+/**
+ * Builds a test component that renders a grid with the passed `HotColumn` markup.
+ *
+ * @param {string} columnsTemplate The `HotColumn` elements to render inside the grid.
+ * @param {string} [tableProps] Extra props for the `HotTable` element.
+ * @returns {object} The component definition.
+ */
+function createApp(columnsTemplate: string, tableProps = '') {
+  return {
+    components: { HotTable, HotColumn },
+    data() {
+      return {
+        data: createSampleData(3, 3),
+        init() {
+          mockClientDimensions(this.rootElement, 400, 400);
+        },
+      };
+    },
+    template: `
+      <HotTable :data="data" licenseKey="non-commercial-and-evaluation"
+                :autoRowSize="false" :autoColumnSize="false"
+                :width="300" :height="300" :rowHeights="23" :colWidths="50"
+                :init="init" ${tableProps}>
+        ${columnsTemplate}
+      </HotTable>
+    `,
+  };
+}
+
+describe('an `editor` prop of `true`', () => {
+  // `true` names no editor, so it has to read as "not passed". Before the core normalization the
+  // raw `true` reached `getEditorInstance()`, which threw
+  // 'Only strings and functions can be passed as "editor" parameter' on the first cell selection.
+  it('should fall back to the default editor when passed to `HotTable`', () => {
+    const testWrapper = mount(createApp('<HotColumn></HotColumn>', ':editor="true"'));
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(hotInstance.getCellEditor(0, 0)).toBe(getCellType('text').editor);
+    expect(() => hotInstance.selectCell(0, 0)).not.toThrow();
+
+    testWrapper.unmount();
+  });
+
+  it('should fall back to the default editor when passed to `HotColumn`', () => {
+    const testWrapper = mount(createApp(`
+      <HotColumn :editor="true"></HotColumn>
+      <HotColumn></HotColumn>
+    `));
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(hotInstance.getCellEditor(0, 0)).toBe(getCellType('text').editor);
+    expect(() => hotInstance.selectCell(0, 0)).not.toThrow();
+
+    // Control column - it carries no `editor` prop, so a harness that resolves no editor at all
+    // would fail here instead of quietly passing the assertions above.
+    expect(hotInstance.getCellEditor(0, 1)).toBe(getCellType('text').editor);
+    expect(() => hotInstance.selectCell(0, 1)).not.toThrow();
+
+    testWrapper.unmount();
+  });
+
+  it('should keep the editor supplied by the column `type`', () => {
+    const testWrapper = mount(createApp(`
+      <HotColumn :type="'numeric'" :editor="true"></HotColumn>
+      <HotColumn :type="'numeric'"></HotColumn>
+    `));
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    // The numeric editor must survive - `editor: true` used to block the `type` expansion.
+    expect(hotInstance.getCellEditor(0, 0)).toBe(getCellType('numeric').editor);
+    expect(() => hotInstance.selectCell(0, 0)).not.toThrow();
+
+    // Control column - the same `type` with no `editor` prop.
+    expect(hotInstance.getCellEditor(0, 1)).toBe(getCellType('numeric').editor);
+
+    testWrapper.unmount();
+  });
+
+  it('should keep the editor inherited from the `HotTable` level', () => {
+    const testWrapper = mount(
+      createApp('<HotColumn :editor="true"></HotColumn>', ':editor="\'password\'"')
+    );
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(hotInstance.getCellEditor(0, 0)).toBe(getCellType('password').editor);
+
+    testWrapper.unmount();
+  });
+});
+
+describe('an `editor` prop of `false`', () => {
+  it('should still disable editing when passed to `HotTable`', () => {
+    const testWrapper = mount(createApp('<HotColumn></HotColumn>', ':editor="false"'));
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(hotInstance.getCellEditor(0, 0)).toBe(false);
+
+    testWrapper.unmount();
+  });
+
+  it('should still disable editing when passed to `HotColumn`', () => {
+    const testWrapper = mount(createApp(`
+      <HotColumn :type="'numeric'" :editor="false"></HotColumn>
+      <HotColumn :type="'numeric'"></HotColumn>
+    `));
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(hotInstance.getCellEditor(0, 0)).toBe(false);
+    // Control column - proves the grid resolves editors for the same `type`.
+    expect(hotInstance.getCellEditor(0, 1)).toBe(getCellType('numeric').editor);
+
+    testWrapper.unmount();
+  });
+});


### PR DESCRIPTION
### Context

The PR fixes an `editor` setting of `true` throwing instead of falling back to the default editor.

Core declares `editor?: string | ctor | boolean` (`handsontable/src/core/settings.ts`), so `editor: true` type-checks everywhere. At runtime it did not work: `getCellEditor()` returned the raw `true`, and `getEditorInstance()` (`handsontable/src/editors/registry.ts`) then threw `Only strings and functions can be passed as "editor" parameter` on the first edit. `metaSchema` documented only `false`.

DEV-2663 reported this on the Vue 3 wrapper, but the wrapper only passes the value through — vanilla and Angular throw identically. So the fix is in core, and Vue, Angular and vanilla are all covered without a wrapper-side change.

**The semantic:** `true` names no editor, so it now reads as "the setting was not passed". The `editor` key is dropped on the way into the meta layers rather than resolved to the text editor. That distinction matters — resolving it eagerly would silently drop the numeric editor of a `type: 'numeric'` column, which was the second half of the reported defect (`<HotColumn :type="'numeric'" :editor="true" />` threw *and* lost the numeric editor).

**Where it is applied:**

- `normalizeEditorSetting()` in `dataMap/metaManager/utils.ts` drops an `editor` of `true` from a settings object.
- Called from the meta layers (`globalMeta`, `tableMeta`, `columnMeta`, `cellMeta`) and from `DynamicCellMetaMod`. Verified normalized at write time: the constructor (grid-level and `columns`) and the `cells` callback.
- `getCellEditor()` also falls back to the default editor for a bare `true`. This catches a value written straight onto the cell meta — by a `beforeGetCellMeta` hook, or by `setCellMeta`, which does not route through the layer `updateMeta` calls.

`editor: false` (disable editing), a named editor, and a constructor are all untouched.

**Left alone deliberately:**

- `editor: null` still locks the cell in Vue while React inherits. `null` is outside the declared type, so this is a leniency choice rather than a correctness one, and DEV-2663 flags it as a separate decision. This PR does not change it.

### Relationship to the React wrapper (#13268, merged)

#13268 landed on `develop` after this branch was cut. The two were measured together — this branch merges `develop` with no conflicts, and every suite is green on the merged tree (see below).

**The React wrapper's `resolveEditorSetting()` is *not* made redundant by this PR, and must stay.** An earlier revision of this description claimed it was; that was wrong. Reverting the three React source files from #13268 while keeping this core fix in place fails **10** React tests. Eight of them are about `false`, which core cannot supply: `editor={false}` is a *prop-layer* problem — the old truthy check could not tell "prop absent" from "prop explicitly false", so the value never reached core at all. Core reads `false` correctly once it arrives; making it arrive is the wrapper's job.

Two of the ten are about `true` and still fail without the wrapper, for a reason core also cannot reach: `<HotColumn type="numeric" editor={true} />` hits the *component-editor* branch, because a bare `true` is truthy. Without `isComponentEditor()` excluding booleans, React builds an editor class from `true` and the cell resolves to `EDITOR_TYPE: "base"` instead of `"numeric"`. By the time core sees it, the value is a constructor, not a boolean, so there is nothing left to normalize.

**Exactly one clause is genuinely redundant** — the `hotEditor !== true` guard in `resolveEditorSetting()`:

```js
if (hotEditor && hotEditor !== true) {
```

Removing the `&& hotEditor !== true` half keeps all 94 React tests green on this branch, because `hotEditor={true}` then reaches core and the meta layers drop it. That path has real coverage (`should fall back to the default editor when the hotEditor prop is set to true`, and the `type="numeric" hotEditor={true}` column), so the green run is meaningful rather than an untested gap.

**Recommendation: keep the guard anyway.** `@handsontable/react-wrapper` declares `"handsontable": "^18.0.0"` as a peer dependency, so a user can pair a wrapper that has dropped the guard with a core that predates this fix and get the throw back. The clause costs one comparison and removes that failure mode. Its comment stays accurate either way.

### How has this been tested?

New tests, all verified to fail without the source change and pass with it. Control cases (`editor: false`, a named editor, a column with no `editor` prop) pass on both sides, so a dead harness cannot produce a green run.

- Unit — `normalizeEditorSetting()` itself, plus the four meta layers, `type` expansion, cross-layer inheritance, and the `cells` path:

  ```bash
  npm --prefix handsontable run test:unit -- --testPathPattern=metaManager
  ```

- E2E — `getCellEditor()` resolution and actually opening the editor (constructor, `columns`, `cell`, `cells`, `updateSettings`):

  ```bash
  npm --prefix handsontable run test:e2e -- --testPathPattern=getCellEditor
  npm --prefix handsontable run test:e2e -- --testPathPattern=settings/editor
  ```

- Vue 3 — the reported repro from DEV-2663, covering the ticket's full table:

  ```bash
  npm --prefix handsontable run build
  npm --prefix wrappers/vue3 run test
  ```

- Angular — five component-level tests confirming the wrapper inherits the fix with no wrapper-side change, mirroring the Vue coverage: grid-level `true`, column-level `true`, `type: 'numeric'` keeping the numeric editor, `editor: false` still disabling, and `true` arriving through `ngOnChanges`. Ported from the now-closed #13277.

  ```bash
  npm --prefix wrappers/angular-wrapper run test
  ```

Full runs on this branch: core unit 3978 passed; `getCellEditor` 26 specs / `settings/editor` 18 specs, 0 failures; Vue 39 passed; Angular 296 passed. `test:types`, `eslint` (0 errors) and `stylelint` all clean.

Re-run on this branch merged with current `develop` (which includes #13268), to confirm the two changes compose: core unit `metaManager` 274 passed, React **94 passed**, Angular **296 passed**, Vue **39 passed**. The merge itself is conflict-free.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2663
2. DEV-2661 — the core-side ticket for this exact change; covered by this PR.
3. DEV-2664 — the Angular half. Closed as covered by this PR; its Angular tests are ported here.
4. #13268 (DEV-2655) — the React half of #7561, merged. Composes with this PR; see the section above.
5. #13277 — the superseded Angular-wrapper-side fix, closed in favor of this one.

### Affected project(s):

- [x] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [x] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

The `editor` option's Typedoc in `metaSchema.ts` is updated in this PR — it previously documented only `false`.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2663

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cascading cell meta and editor resolution across many config paths; behavior change is intentional but could affect configs that relied on the old (broken) boolean.
> 
> **Overview**
> Fixes a bug where **`editor: true`** was stored on cell meta and caused **`getEditorInstance()`** to throw on the first edit. **`true`** is now treated as “no editor specified,” so cells keep the editor from **`type`** or a higher config level (e.g. numeric columns still use the numeric editor).
> 
> Core adds **`normalizeEditorSetting()`**, which strips **`editor: true`** before meta layer updates (global/table/column/cell, **`cells`**, and dynamic cell meta). **`updateSettings({ editor: true })`** no longer overwrites an existing grid editor; **`CellMeta#setMeta`** and **`getCellEditor()`** handle stray **`true`** values (e.g. hooks). **`editor: false`** and named/custom editors are unchanged. Docs and tests cover core, Vue 3, and Angular.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cde20feac732ce6dcc5b29ab218111a8c89d55c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

