### PR TITLE
DEV-2658: Reword the #13243 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - React: Fixed a memory leak in the React wrapper where the portal containers used by component-based renderers were retained for every scrolled cell instead of being released once a cell left the viewport. [#12895](https://github.com/handsontable/handsontable/pull/12895)
 - React: Fixed missing TypeScript autocomplete and type checking for `<HotTable>` and `<HotColumn>` props. [#13007](https://github.com/handsontable/handsontable/issues/13007)
 - Angular: Fixed custom editor shortcut groups in the Angular wrapper. [#13160](https://github.com/handsontable/handsontable/pull/13160)
-- Fixed an issue where clicking focusable plugin UI placed in the grid's layout slots (for example, pagination controls) closed the open cell editor and deselected the grid. [#13243](https://github.com/handsontable/handsontable/pull/13243)
+- Fixed the grid no longer responding to keyboard shortcuts after clicking focusable plugin UI placed in the grid's layout slots (for example, pagination controls). [#13243](https://github.com/handsontable/handsontable/pull/13243)
 - Fixed an open cell editor staying visible over an unrelated row, and committing to a row you could no longer see, when the edited cell was hidden - for example by turning a Pagination page or hiding its row or column. [#13245](https://github.com/handsontable/handsontable/pull/13245)
 
 ## [18.0.0] - 2026-06-30

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -141,7 +141,7 @@ For more information about this release, see:
 - React: Fixed a memory leak in the React wrapper where the portal containers used by component-based renderers were retained for every scrolled cell instead of being released once a cell left the viewport. [#12895](https://github.com/handsontable/handsontable/pull/12895)
 - React: Fixed missing TypeScript autocomplete and type checking for `<HotTable>` and `<HotColumn>` props. [#13007](https://github.com/handsontable/handsontable/issues/13007)
 - Angular: Fixed custom editor shortcut groups in the Angular wrapper. [#13160](https://github.com/handsontable/handsontable/pull/13160)
-- Fixed an issue where clicking focusable plugin UI placed in the grid's layout slots (for example, pagination controls) closed the open cell editor and deselected the grid. [#13243](https://github.com/handsontable/handsontable/pull/13243)
+- Fixed the grid no longer responding to keyboard shortcuts after clicking focusable plugin UI placed in the grid's layout slots (for example, pagination controls). [#13243](https://github.com/handsontable/handsontable/pull/13243)
 - Fixed an open cell editor staying visible over an unrelated row, and committing to a row you could no longer see, when the edited cell was hidden - for example by turning a Pagination page or hiding its row or column. [#13245](https://github.com/handsontable/handsontable/pull/13245)
 
 ## 18.0.0


### PR DESCRIPTION
### Context

The PR rewords the #13243 changelog entry in the 18.1.0 section. The entry claimed the fix stopped clicks on layout-slot UI (for example, pagination controls) from closing the open cell editor and deselecting the grid. That behavior is by design and unchanged since Pagination shipped in 16.1: a layout-slot click is an outside click governed by `outsideClickDeselects`, which #13245 confirmed and pinned in `tests/e2e/layout-slot-focus.spec.ts`. What #13243 fixed was `hot.unlisten()` firing on such clicks, which left the grid deaf to the keyboard.

DEV-2658 (release QA) reported the editor-close/deselect as a still-present bug based on the changelog wording. The entry now describes the fix that shipped.

Targets `release/18.1.0` because the compiled entry exists only there; `develop` has no 18.1.0 section yet.

`[skip changelog]` – changelog-only change.

### How has this been tested?

- Docs-only change (two changelog files, one line each); no code touched.
- Verified the described behavior on the release branch with real browser clicks against a local `18.1.0-rc4` build and against 16.1.1, 17.0.0, and 18.0.0 CDN builds: editor closes and selection clears on a page-size click in every version, `isListening()` stays `true` on rc4.
- `npx playwright test --project=e2e-main e2e/layout-slot-focus.spec.ts` in `tests/`: 4 passed.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2658
2. DEV-2627 (#13243, #13245)

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2658

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog wording only; no runtime or API changes.
> 
> **Overview**
> **Documentation-only:** rewords the 18.1.0 changelog bullet for [#13243](https://github.com/handsontable/handsontable/pull/13243) in `CHANGELOG.md` and the docs mirror `changelog.md`.
> 
> The previous text said clicking focusable UI in layout slots (e.g. pagination) no longer closed the editor and cleared selection. That matches intentional `outsideClickDeselects` behavior, not the fix. The entry now states that after such a click the grid **stopped responding to keyboard shortcuts**—aligning the release notes with what #13243 actually addressed (`hot.unlisten()` leaving the instance not listening).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86cd0f19e9d51a6559d1f73c5da439000f68acb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->