### PR TITLE
RELEASE-862: Document the single-pass layout change and fix its @since tag

### DIFF
--- a/docs/content/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md
@@ -235,9 +235,8 @@ Contact the [Sales Team](https://handsontable.com/get-a-quote) for a renewal.
 
 ## 4. Check custom layout code if the grid renders a wrong scrollbar
 
-Handsontable 18.1 renders the grid in a single pass. It predicts whether scrollbars appear from the
-cached row heights and column widths, then renders once. Handsontable 18.0 rendered the grid,
-measured the result, and rendered it again.
+Handsontable 18.1 predicts whether scrollbars appear from the cached row heights and column widths.
+Handsontable 18.0 rendered the grid, measured the result, and decided from the measurement.
 
 The prediction matches the DOM as long as a cell renders at the size Handsontable cached for it.
 When the two differ, the grid can show a scrollbar it does not need, miss one it does need, or leave

--- a/docs/content/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md
@@ -18,9 +18,9 @@ category: Upgrade and migration
 
 Migrate from Handsontable 18.0 to Handsontable 18.1.
 
-Handsontable 18.1 is a minor release and removes no public API. Three changes still need your
-attention: one blocks the grid, one changes what a column-header click does, and one makes a
-notification appear that 18.0 suppressed.
+Handsontable 18.1 is a minor release and removes no public API. Four changes still need your
+attention: one blocks the grid, one changes what a column-header click does, one makes a
+notification appear that 18.0 suppressed, and one changes how the grid decides its layout.
 
 For a detailed list of changes in this release, see the [Changelog](@/guides/upgrade-and-migration/changelog/changelog.md).
 
@@ -233,6 +233,54 @@ means an expiration date in the past.
 Nothing to change in your code. To remove the notice, renew the license and pass the new key.
 Contact the [Sales Team](https://handsontable.com/get-a-quote) for a renewal.
 
+## 4. Check custom layout code if the grid renders a wrong scrollbar
+
+Handsontable 18.1 renders the grid in a single pass. It predicts whether scrollbars appear from the
+cached row heights and column widths, then renders once. Handsontable 18.0 rendered the grid,
+measured the result, and rendered it again.
+
+The prediction matches the DOM as long as a cell renders at the size Handsontable cached for it.
+When the two differ, the grid can show a scrollbar it does not need, miss one it does need, or leave
+the viewport short by a row or a column.
+
+The [`mergeCells`](@/guides/cell-features/merge-cells/merge-cells.md) plugin turns the new path off
+for you. A merged cell's height depends on the viewport that the layout is computing, so the
+prediction cannot resolve it.
+
+### Who is affected
+
+You are affected if a cell's rendered size is not known before the cell renders:
+
+- You wrote a plugin whose content size depends on the viewport that the layout is computing. This is
+  the case `mergeCells` opts out of. No other plugin opts out for you.
+- You use a custom renderer or custom CSS that changes a cell's box after Handsontable measured it,
+  for example a style rule that overrides a row height.
+
+If your grid renders the same in 18.1 as it did in 18.0, this section does not apply to you. No
+configuration change is needed.
+
+### How to migrate
+
+Return `false` from the [`modifySinglePassLayout`](@/api/hooks.md#modifysinglepasslayout) hook to
+restore the 18.0 layout path for that instance:
+
+```js
+const hot = new Handsontable(container, {
+  modifySinglePassLayout() {
+    return false;
+  },
+});
+```
+
+From a plugin, register the hook the way `mergeCells` does:
+
+```js
+this.addHook('modifySinglePassLayout', () => false);
+```
+
+Handsontable reads the hook on every layout pass, so enabling or disabling a plugin through
+[`updateSettings()`](@/api/core.md#updatesettings) takes effect without re-creating the grid.
+
 ## Summary of changes
 
 | Change | Who is affected | Action required |
@@ -241,6 +289,7 @@ Contact the [Sales Team](https://handsontable.com/get-a-quote) for a renewal.
 | Column sorting runs on mouse up, and only the header label and its sort indicator sort on click | Tests or scripts that dispatch `mousedown` on a header cell to sort | Dispatch `mousedown` and `mouseup` on the `.colHeader.sortAction` label, without moving the pointer |
 | `beforeColumnMove` and `afterColumnMove` no longer fire on a plain header click | Code using either hook to detect a header click | Use [`afterColumnSort`](@/api/hooks.md#aftercolumnsort) or [`afterOnCellMouseUp`](@/api/hooks.md#afteroncellmouseup) instead |
 | Expired license keys are detected again | Instances running a key past its date | Nothing in code. Renew the license to remove the notice |
+| The grid renders in a single pass and predicts scrollbars instead of measuring them | Plugins whose content size depends on the viewport, and custom renderers or CSS that resize a cell after it is measured | Nothing, unless the layout renders differently. Return `false` from [`modifySinglePassLayout`](@/api/hooks.md#modifysinglepasslayout) to restore the 18.0 path |
 
 ## Result
 

--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -3165,7 +3165,7 @@ export const REGISTERED_HOOKS = [
    * whose content size depends on the viewport that is being computed (for example, merged cells) opts
    * out this way; user code can also return `false` to disable single-pass rendering.
    *
-   * @since 18.0.0
+   * @since 18.1.0
    * @event Hooks#modifySinglePassLayout
    * @param {boolean} singlePassLayout `true` when single-pass rendering is currently enabled.
    * @returns {boolean|void} Return `false` to force the legacy measure-then-render path.


### PR DESCRIPTION
### Context

The PR adds a fourth item to the 18.0 to 18.1 migration guide and corrects the `@since` tag of the `modifySinglePassLayout` hook. Both follow up on RELEASE-862, which added the guide.

**1. The migration guide does not mention the layout-model change.**

18.1 flipped the default layout model for every grid (`singlePassLayout: true`, `walkontable/src/settings/defaults.ts`). The grid now predicts whether scrollbars appear from the cached row heights and column widths and renders once, instead of rendering, measuring, and re-rendering. The changelog records it under `Changed` (#12951), but the migration guide says nothing about it or about its opt-out.

The prediction is exact only while a cell renders at the size Handsontable cached for it. When the two diverge, the grid can show a scrollbar it does not need, miss one it does need, or leave the viewport short by a row or a column. `mergeCells` is the only built-in plugin that opts out (`mergeCells.ts:267`), so a third-party plugin with the same viewport circularity, or a custom renderer or CSS rule that resizes a cell after measurement, has no automatic opt-out and no documented path from the symptom to `modifySinglePassLayout`.

The new item 4 is written as a conditional check rather than a required action: it opens by saying that no configuration change is needed if the grid renders the same as it did in 18.0. It names the symptom, the two affected groups, and the one-line opt-out, for both instance settings and plugin code.

**2. `modifySinglePassLayout` is tagged `@since 18.0.0`, but it shipped in 18.1.0.**

The hook was introduced by 294dfcae23 (#12951). `git tag --contains 294dfcae23` returns `18.1.0-rc` through `18.1.0-rc6` only, never `18.0.0` or any `18.0.0-rc*`. The changelog lists it under 18.1.0 `Added`. The tag renders on the public `api/hooks.md` page, so the reference currently tells users the hook is available in a version that does not have it.

### How has this been tested?

- Verified the version claim against git, not against the changelog alone:
  ```bash
  git log --oneline -S"modifySinglePassLayout" -- handsontable/src/core/hooks/constants.ts
  git tag --contains 294dfcae23
  ```
- Verified that `mergeCells` is the only opt-out site:
  ```bash
  grep -rn "modifySinglePassLayout" handsontable/src --include="*.ts" | grep -v __tests__
  ```
- No test change: the source edit is a JSDoc tag correction with no runtime behavior. The commit carries a `Refactor-only:` trailer.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. RELEASE-862
2. #12951

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

[skip changelog] The only source change is a JSDoc `@since` tag correction. It has no runtime effect and describes a hook that the 18.1.0 changelog already announces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSDoc-only edits with no production code paths modified.
> 
> **Overview**
> **Documents the 18.1 single-pass layout change** in the 18.0→18.1 migration guide and **fixes API metadata** for the opt-out hook.
> 
> The guide now counts a **fourth** upgrade concern: 18.1 **predicts scrollbars from cached row/column sizes** and renders once, instead of 18.0’s measure-then-render loop. A new **section 4** explains when wrong/missing scrollbars or a short viewport can appear (viewport-dependent plugins, custom renderers/CSS), notes that **`mergeCells` opts out automatically**, and shows returning **`false` from `modifySinglePassLayout`** on the instance or from a plugin to restore the legacy path. The **summary table** gains a matching row.
> 
> In source, **`modifySinglePassLayout`’s `@since` tag** is corrected from **18.0.0 to 18.1.0** so generated API docs match when the hook actually shipped. **No runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c82d3fc14e88a3f48beaca9ccd1cd1072c3a93e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->