### PR TITLE
DEV-2644: Override pacote's sigstore to clear two dev-toolchain CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
       "@rollup/pluginutils>picomatch": "^4.0.4",
       "serialize-javascript": "^7.0.3",
       "pacote>tar": "^7.5.11",
+      "pacote>sigstore": "^4.1.1",
       "node-gyp>tar": "^7.5.11",
       "cacache>tar": "^7.5.11",
       "undici": "^6.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ overrides:
   '@rollup/pluginutils>picomatch': ^4.0.4
   serialize-javascript: ^7.0.3
   pacote>tar: ^7.5.11
+  pacote>sigstore: ^4.1.1
   node-gyp>tar: ^7.5.11
   cacache>tar: ^7.5.11
   undici: ^6.24.0
@@ -2902,6 +2903,10 @@ packages:
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
+  '@gar/promise-retry@1.0.3':
+    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -3924,9 +3929,17 @@ packages:
     resolution: {integrity: sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  '@npmcli/agent@4.0.2':
+    resolution: {integrity: sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@npmcli/fs@4.0.0':
     resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/fs@5.0.0':
+    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@npmcli/git@6.0.3':
     resolution: {integrity: sha512-GUYESQlxZRAdhs3UhbB6pVRNUELQOHXwK9ruDkwmCv2aZ5y0SApQzUJCg02p3A7Ue2J5hxvlk1YI53c00NmRyQ==}
@@ -3952,6 +3965,10 @@ packages:
   '@npmcli/redact@3.2.2':
     resolution: {integrity: sha512-7VmYAmk4csGv08QzrDKScdzn11jHPFGyqJW39FyPgPuAp3zIaUmuCo1yxw9aGs+NEJuTGQ9Gwqpt93vtJubucg==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/redact@4.0.0':
+    resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@npmcli/run-script@9.1.0':
     resolution: {integrity: sha512-aoNSbxtkePXUlbZB+anS1LqsJdctG5n3UVhfU47+CDdwMi6uNTBMF9gPcQRnqghQd2FGzcwwIFBruFMxjhBewg==}
@@ -5489,29 +5506,29 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@sigstore/bundle@3.1.0':
-    resolution: {integrity: sha512-Mm1E3/CmDDCz3nDhFKTuYdB47EdRFRQMOE/EAbiG1MJW77/w1b3P7Qx7JSrVJs8PfwOLOVcKQCHErIwCTyPbag==}
+  '@sigstore/bundle@4.0.0':
+    resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/core@3.2.1':
+    resolution: {integrity: sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/protobuf-specs@0.5.2':
+    resolution: {integrity: sha512-SQqvFMt4V78fdjcDdYX6HbiVSOR4QK3ZgwCa2KOsopAgPIHy1rU5UDUmzLl02r5oyyaYcYHR1hpwDRk/yUe+Mw==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  '@sigstore/core@2.0.0':
-    resolution: {integrity: sha512-nYxaSb/MtlSI+JWcwTHQxyNmWeWrUXJJ/G4liLrGG7+tS4vAz6LF3xRXqLH6wPIVUoZQel2Fs4ddLx4NCpiIYg==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  '@sigstore/sign@4.1.1':
+    resolution: {integrity: sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@sigstore/protobuf-specs@0.4.3':
-    resolution: {integrity: sha512-fk2zjD9117RL9BjqEwF7fwv7Q/P9yGsMV4MUJZ/DocaQJ6+3pKr+syBq1owU5Q5qGw5CUbXzm+4yJ2JVRDQeSA==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  '@sigstore/tuf@4.0.2':
+    resolution: {integrity: sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@sigstore/sign@3.1.0':
-    resolution: {integrity: sha512-knzjmaOHOov1Ur7N/z4B1oPqZ0QX5geUfhrVaqVlu+hl0EAoL4o+l0MSULINcD5GCWe3Z0+YJO8ues6vFlW0Yw==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-
-  '@sigstore/tuf@3.1.1':
-    resolution: {integrity: sha512-eFFvlcBIoGwVkkwmTi/vEQFSva3xs5Ot3WmBcjgjVdiaoelBLQaQ/ZBfhlG0MnG0cmTYScPpk7eDdGDWUcFUmg==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-
-  '@sigstore/verify@2.1.1':
-    resolution: {integrity: sha512-hVJD77oT67aowHxwT4+M6PGOp+E2LtLdTK3+FC0lBO9T7sYwItDMXZ7Z07IDCvR1M717a4axbIWckrW67KMP/w==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  '@sigstore/verify@3.1.1':
+    resolution: {integrity: sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@simonwep/pickr@1.9.1':
     resolution: {integrity: sha512-fR3qmfAcPf/HSFS7GEnTmZLM3+xERv1+jyMBbzT63ilRRM8veYjI7ELvkHHKk0/du3lHp7uh/FqatjM3646X1g==}
@@ -5710,9 +5727,9 @@ packages:
     resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  '@tufjs/models@3.0.1':
-    resolution: {integrity: sha512-UUYHISyhCU3ZgN8yaear3cGATHb3SMuKHsQ/nVbHXcmnBf+LzQ/cQfhNG+rfaSHgqGKNEm2cOCLVLELStUQ1JA==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  '@tufjs/models@4.1.0':
+    resolution: {integrity: sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -6920,6 +6937,10 @@ packages:
   cacache@19.0.1:
     resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  cacache@20.0.4:
+    resolution: {integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   cache-point@2.0.0:
     resolution: {integrity: sha512-4gkeHlFpSKgm3vm2gJN5sPqfmijYRFYCQ6tv5cLw0xVmT6r1z1vd4FNnpuOREco3cBs1G709sZ72LdgddKvL5w==}
@@ -10012,6 +10033,10 @@ packages:
     resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  make-fetch-happen@15.0.6:
+    resolution: {integrity: sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
@@ -10329,6 +10354,10 @@ packages:
     resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  minipass-fetch@5.0.2:
+    resolution: {integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   minipass-flush@1.0.7:
     resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
     engines: {node: '>= 8'}
@@ -10339,6 +10368,10 @@ packages:
 
   minipass-sized@1.0.3:
     resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
+    engines: {node: '>=8'}
+
+  minipass-sized@2.0.0:
+    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
     engines: {node: '>=8'}
 
   minipass@3.3.6:
@@ -11107,6 +11140,10 @@ packages:
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   process-ancestry@0.1.0:
     resolution: {integrity: sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==}
@@ -11880,9 +11917,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  sigstore@3.1.0:
-    resolution: {integrity: sha512-ZpzWAFHIFqyFE56dXqgX/DkDRZdz+rRcjoIk/RQU4IX0wiCv1l8S7ZrXDHcCc+uaf+6o7w3h2l3g6GYG5TKN9Q==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  sigstore@4.1.1:
+    resolution: {integrity: sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
@@ -12056,6 +12093,10 @@ packages:
   ssri@12.0.0:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  ssri@13.0.1:
+    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -12593,9 +12634,9 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
-  tuf-js@3.1.0:
-    resolution: {integrity: sha512-3T3T04WzowbwV2FDiGXBbr81t64g1MUGGJRgT4x5o97N+8ArdhVCAF9IxFrxuSJmM3E5Asn7nKHkao0ibcZXAg==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  tuf-js@4.1.0:
+    resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
@@ -15793,6 +15834,8 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
+  '@gar/promise-retry@1.0.3': {}
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -16960,7 +17003,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@npmcli/agent@4.0.2':
+    dependencies:
+      agent-base: 7.1.4
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 11.5.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@npmcli/fs@4.0.0':
+    dependencies:
+      semver: 7.8.4
+
+  '@npmcli/fs@5.0.0':
     dependencies:
       semver: 7.8.4
 
@@ -16997,6 +17054,8 @@ snapshots:
       which: 5.0.0
 
   '@npmcli/redact@3.2.2': {}
+
+  '@npmcli/redact@4.0.0': {}
 
   '@npmcli/run-script@9.1.0':
     dependencies:
@@ -18461,37 +18520,37 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@sigstore/bundle@3.1.0':
+  '@sigstore/bundle@4.0.0':
     dependencies:
-      '@sigstore/protobuf-specs': 0.4.3
+      '@sigstore/protobuf-specs': 0.5.2
 
-  '@sigstore/core@2.0.0': {}
+  '@sigstore/core@3.2.1': {}
 
-  '@sigstore/protobuf-specs@0.4.3': {}
+  '@sigstore/protobuf-specs@0.5.2': {}
 
-  '@sigstore/sign@3.1.0':
+  '@sigstore/sign@4.1.1':
     dependencies:
-      '@sigstore/bundle': 3.1.0
-      '@sigstore/core': 2.0.0
-      '@sigstore/protobuf-specs': 0.4.3
-      make-fetch-happen: 14.0.3
-      proc-log: 5.0.0
-      promise-retry: 2.0.1
+      '@gar/promise-retry': 1.0.3
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.1
+      '@sigstore/protobuf-specs': 0.5.2
+      make-fetch-happen: 15.0.6
+      proc-log: 6.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/tuf@3.1.1':
+  '@sigstore/tuf@4.0.2':
     dependencies:
-      '@sigstore/protobuf-specs': 0.4.3
-      tuf-js: 3.1.0
+      '@sigstore/protobuf-specs': 0.5.2
+      tuf-js: 4.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/verify@2.1.1':
+  '@sigstore/verify@3.1.1':
     dependencies:
-      '@sigstore/bundle': 3.1.0
-      '@sigstore/core': 2.0.0
-      '@sigstore/protobuf-specs': 0.4.3
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.1
+      '@sigstore/protobuf-specs': 0.5.2
 
   '@simonwep/pickr@1.9.1':
     dependencies:
@@ -18712,10 +18771,10 @@ snapshots:
 
   '@tufjs/canonical-json@2.0.0': {}
 
-  '@tufjs/models@3.0.1':
+  '@tufjs/models@4.1.0':
     dependencies:
       '@tufjs/canonical-json': 2.0.0
-      minimatch: 9.0.9
+      minimatch: 10.2.5
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -20400,6 +20459,19 @@ snapshots:
       ssri: 12.0.0
       tar: 7.5.16
       unique-filename: 4.0.0
+
+  cacache@20.0.4:
+    dependencies:
+      '@npmcli/fs': 5.0.0
+      fs-minipass: 3.0.3
+      glob: 13.0.6
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      p-map: 7.0.4
+      ssri: 13.0.1
 
   cache-point@2.0.0:
     dependencies:
@@ -24667,6 +24739,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  make-fetch-happen@15.0.6:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/agent': 4.0.2
+      '@npmcli/redact': 4.0.0
+      cacache: 20.0.4
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.3
+      minipass-fetch: 5.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 6.1.0
+      ssri: 13.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
@@ -25260,6 +25349,14 @@ snapshots:
     optionalDependencies:
       encoding: 0.1.13
 
+  minipass-fetch@5.0.2:
+    dependencies:
+      minipass: 7.1.3
+      minipass-sized: 2.0.0
+      minizlib: 3.1.0
+    optionalDependencies:
+      iconv-lite: 0.7.2
+
   minipass-flush@1.0.7:
     dependencies:
       minipass: 3.3.6
@@ -25271,6 +25368,10 @@ snapshots:
   minipass-sized@1.0.3:
     dependencies:
       minipass: 3.3.6
+
+  minipass-sized@2.0.0:
+    dependencies:
+      minipass: 7.1.3
 
   minipass@3.3.6:
     dependencies:
@@ -25767,7 +25868,7 @@ snapshots:
       npm-registry-fetch: 18.0.2
       proc-log: 5.0.0
       promise-retry: 2.0.1
-      sigstore: 3.1.0
+      sigstore: 4.1.1
       ssri: 12.0.0
       tar: 7.5.16
     transitivePeerDependencies:
@@ -26092,6 +26193,8 @@ snapshots:
   prismjs@1.30.0: {}
 
   proc-log@5.0.0: {}
+
+  proc-log@6.1.0: {}
 
   process-ancestry@0.1.0: {}
 
@@ -27194,14 +27297,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sigstore@3.1.0:
+  sigstore@4.1.1:
     dependencies:
-      '@sigstore/bundle': 3.1.0
-      '@sigstore/core': 2.0.0
-      '@sigstore/protobuf-specs': 0.4.3
-      '@sigstore/sign': 3.1.0
-      '@sigstore/tuf': 3.1.1
-      '@sigstore/verify': 2.1.1
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.1
+      '@sigstore/protobuf-specs': 0.5.2
+      '@sigstore/sign': 4.1.1
+      '@sigstore/tuf': 4.0.2
+      '@sigstore/verify': 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -27394,6 +27497,10 @@ snapshots:
       frac: 1.1.2
 
   ssri@12.0.0:
+    dependencies:
+      minipass: 7.1.3
+
+  ssri@13.0.1:
     dependencies:
       minipass: 7.1.3
 
@@ -27992,11 +28099,11 @@ snapshots:
       tslib: 1.14.1
       typescript: 5.1.3
 
-  tuf-js@3.1.0:
+  tuf-js@4.1.0:
     dependencies:
-      '@tufjs/models': 3.0.1
+      '@tufjs/models': 4.1.0
       debug: 4.4.3
-      make-fetch-happen: 14.0.3
+      make-fetch-happen: 15.0.6
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
### Context

The PR clears two CVE alerts in `pnpm-lock.yaml` with a single scoped override:

| Package | Before | After | Advisory |
|---|---|---|---|
| `sigstore` | 3.1.0 | 4.1.1 | High, GHSA-52v5-jr5w-gjxr (CVE-2026-48815) |
| `@sigstore/core` | 2.0.0 | 3.2.1 | Moderate, GHSA-jfc7-64v2-mr8c (CVE-2026-48758) |

The change is one line in root `package.json`:

```
"pacote>sigstore": "^4.1.1",
```

`@sigstore/core` reaches 3.2.1 unaided — every edge into it from sigstore 4.1.1 is `^3.2.x` — so no second override was needed and none was added.

### Why an override, when this repo treats them as a last resort

The chain is `wrappers/angular-wrapper` devDependency `@angular/cli@19` → `pacote@20.0.0` → `sigstore@3.1.0` → `@sigstore/core@2.0.0`. It is dev/build tooling only; `handsontable/package.json` declares no runtime dependencies, so nothing here reaches customers.

No lower-tier fix exists, and this was checked rather than assumed:

- **`@angular/cli@19` pins `pacote` at exactly `20.0.0`**, so no re-resolve can move it.
- **Angular 19 is out of support.** 19.2.27 is the terminal release and nothing further will ship on that line, so there is no newer 19.x to bump to.
- **A backport is structurally impossible.** Every `pacote@20.x` still declares `sigstore: ^3.0.0`, and there is no patched sigstore 3.x — the fix exists only in 4.1.1+. No `^3` range can ever resolve clean.
- Upstream's own fix was deletion: `@angular/cli@22.1.0+` drops `pacote` entirely (their PR to bump it was autoclosed).

The alternative considered and rejected was bumping `@angular/cli` to 21, which does resolve a patched sigstore. It was implemented and fully tested first, and it worked — but it moved **131 packages across 1551 lockfile lines**, changed the tool that builds the published wrapper, pulled in CLI 21's MCP-server dependency block (express 5, hono, jose, algoliasearch), and left the CLI a major ahead of the framework. This override moves the sigstore subtree only, in **221 lines**, and does not touch the build toolchain at all. Given the goal was the smallest change that clears the alerts without regression, the override won on blast radius.

A follow-up task covers the real fix — migrating the wrapper off EOL Angular 19 to an LTS major, at which point `@angular/cli@22.1+` removes `pacote` and **this override should be deleted**.

### The risk, and what was actually verified

The override forces sigstore past pacote@20's declared `sigstore: ^3.0.0`. Two things make that safe here, and the distinction between them matters:

**Measured.** pacote's `require('sigstore')` at `lib/registry.js:6` is eager and top-level, so a module-load failure was the real risk. Tested against the real store paths: `pacote@20.0.0/node_modules/sigstore` symlinks to `sigstore@4.1.1`, `require('pacote')` loads cleanly, `require('pacote/lib/registry.js')` loads, and `sigstore.verify` is a function. The reason it holds is specific — sigstore 4.1.1 has no `"type": "module"` and no `exports` map, still CommonJS with `main: dist/index.js`. Had sigstore 4 gone ESM-only, that eager require would have thrown `ERR_REQUIRE_ESM`.

**Argued, not measured.** pacote's entire sigstore surface is one call, `await sigstore.verify(bundle, options)` at `registry.js:327` (exactly one `sigstore.` reference in the file), whose return value is discarded — the only 3→4 break on that path is the return type widening `Promise<void>` → `Promise<Signer>`. `VerifyOptions` in 4.1.1 still declares all three fields pacote passes (`keySelector`, `tufCachePath`, `tufForceCache`). The call sits inside `if (this.opts.verifyAttestations)` at `registry.js:229`, and `verifyAttestations` appears nowhere in `@angular/cli@19.2.27`. Only `ng add` and `ng update` reach pacote at all, and neither is invoked anywhere in this repo.

So the guarantee on the verification path is **"this code is unreachable in our usage"**, not "this code was exercised and works" — it cannot be exercised, precisely because the flag is never set. Stating that plainly rather than letting the green checks imply more than they cover.

### How has this been tested?

```bash
pnpm install --frozen-lockfile                    # clean, no peer warnings for sigstore/pacote/@angular/ng-packagr
npm --prefix handsontable run build               # exit 0
npm --prefix wrappers/angular-wrapper run build   # exit 0
SKIP_LATEST=1 npm run typecheck --prefix docs/angular-type-check
npm --prefix wrappers/angular-wrapper run test:ci # 13 suites, 291 tests passed
npm --prefix wrappers/angular-wrapper run lint    # All files pass linting
npm --prefix handsontable run test:unit           # 325 suites, 3953 tests passed
npm run test:tooling                              # 107 tests passed
pnpm audit --audit-level=moderate
```

**The published artifact is byte-identical.** A baseline was built at the branch point, then the override applied and the wrapper rebuilt. `diff -r` of `dist/hot-table` is empty across all 27 files, confirmed independently by a path + size + sha256 manifest. That includes the post-build-rewritten `dist/hot-table/package.json` (sha256 `ec467b2b…`, 1143 B), all 21 `.d.ts` files, and `fesm2022/handsontable-angular-wrapper.mjs` (73405 B) with its sourcemap (110741 B) — the sourcemap matching matters, since that is where tool versions and absolute build paths normally leak.

`npm pack` on both dists produces the **same tarball bytes**: sha256 `6ff960ed73e568751d598b7eb0ec5f3bb5dc30c0804851379ed19f6a154bc23f`, `cmp`-identical at 142366 bytes, npm's own shasum `aa829b53…` and integrity `sha512-jgRCy7jOCCa9a…` matching from both, and the 26 extracted files identical by checksum. Deleting `dist/` and rebuilding from scratch reproduces the same result.

`docs/angular-type-check` links `@handsontable/angular-wrapper` to the built `dist/hot-table` and compiles the docs' Angular 19 examples against it — a real consumer of the artifact. Run as CI runs it: **636 files prepared, zero type errors in strict mode.**

**Dependabot-equivalent proof.** `pnpm audit --audit-level=moderate` went 95 → 93 vulnerabilities (high 52 → 51, moderate 33 → 32). Set-differencing the unique GHSA IDs before and after: removed exactly `GHSA-52v5-jr5w-gjxr` and `GHSA-jfc7-64v2-mr8c`; newly appeared, **empty**. Since Dependabot reads the lockfile graph: no `sigstore` below 4.1.1 and no `@sigstore/core` below 3.2.1 remains anywhere in `pnpm-lock.yaml`.

### Lockfile churn

`package.json` +1, `pnpm-lock.yaml` 221 lines (165 insertions, 57 deletions).

One new package (`@gar/promise-retry@1.0.3`), zero removals, 18 version changes, **zero downgrades**. Nine of the eighteen are additive `X → X,Y` — the existing copy stays for its current consumers and a second is added for sigstore 4's subtree, so nothing outside that subtree was moved off what it had. The nine full replacements are precisely the sigstore/tuf chain.

Confirmed unchanged: `@angular/cli` 19.2.27, `pacote` 20.0.0, all `@angular/*` framework packages 19.2.25, `@angular-devkit/build-angular` 19.2.27, `ng-packagr` 19.2.2, typescript, zone.js, and every sibling DEV-2608 package (form-data, linkify-it, ip-address, tmp, undici, typed-rest-client, all 12 `@octokit/*`, astro, sharp, `@argos-ci/core`).

Licences of all 19 new or changed packages, read from each `package.json` in the store: Apache-2.0 for the seven sigstore packages, ISC for the `@npmcli/*` / cacache / make-fetch-happen / ssri / proc-log / minipass-sized group, MIT for `@gar/promise-retry`, `@tufjs/models`, `minipass-fetch` and `tuf-js`. All permissive, satisfying the transitive-licence requirement.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2644
2. DEV-2608 (parent)
3. DEV-2671 (follow-up: migrate the wrapper off EOL Angular 19; remove this override then)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

No package source changes. The diff covers root `package.json` and `pnpm-lock.yaml`. The published `@handsontable/angular-wrapper` tarball is byte-identical, as shown above.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

[skip changelog] — development dependencies only, no user-facing change.

### Known gaps, stated rather than glossed

1. **Nothing in the test suite would fail if this override were deleted.** The CVE would return silently until the next audit or Dependabot run. The mandatory-test gate does not fire, since no `handsontable/src/**` or `wrappers/**` file changed. A tooling test asserting the resolved sigstore major in the lockfile would close this cheaply — happy to add it if reviewers want it.
2. **The Node floor rose.** sigstore 4.1.1 requires `^20.17.0 || >=22.9.0`, up from 3.1.0's `^18.17.0 || >=20.5.0`. Every CI path satisfies it today only because `.nvmrc` is major-only `22` and `setup-node` resolves the newest 22.x. Pinning `.nvmrc` below 22.9.0 later would break pacote's module load.
3. **`ng add` / `ng update` were not validated**, deliberately. They are the only commands that reach pacote, we never invoke them, and that is the accepted basis for this fix rather than an oversight.
4. The wrapper E2E and visual tiers and `ng serve` were not run. Given the tarball is byte-identical and the override touches a dev-time npm-fetch path only, the artifact risk is nil.

ClickUp task: https://app.clickup.com/t/86cba8yxr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only override on dev-time package verification; published wrapper artifacts are unchanged, with the main caveat being sigstore 4’s higher Node engine floor (^20.17.0 || >=22.9.0).
> 
> **Overview**
> Adds a **pnpm override** `"pacote>sigstore": "^4.1.1"` so the dev toolchain path `@angular/cli` → `pacote@20` resolves **sigstore 4.1.1** instead of 3.1.0, clearing **GHSA-52v5-jr5w-gjxr** and **GHSA-jfc7-64v2-mr8c** (including `@sigstore/core` 3.2.1 via sigstore 4’s dependency tree).
> 
> The lockfile updates the sigstore/TUF/npm-fetch subtree (`@sigstore/*`, `tuf-js`, `make-fetch-happen`, `cacache`, etc.) without bumping `@angular/cli`, `pacote`, or application source. This is a **scoped dev-dependency fix** chosen over a major CLI upgrade; the override should be removed when the Angular wrapper moves off EOL Angular 19.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d06b63e23d3c39fed3a4546d27ba478d681f61ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->