### PR TITLE
DEV-2684: Document that className applies to the container and the cells

### DIFF
--- a/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
+++ b/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
@@ -38,7 +38,7 @@ Choose an approach based on your goal:
 
 In this example, you add a custom class `custom-cell` to the cell in the top-left corner and a `custom-table` CSS class that highlights the table headers.
 
-To add a CSS class to a cell, column, or row, use the [`className`](@/api/options.md#classname) option. Set it in the grid configuration, in a `columns` entry, or per cell through the [`cells`](@/api/options.md#cells) callback. The class you provide is added to the cell's `<td>` element, where your CSS rules can target it.
+To add a CSS class to a cell, column, or row, use the [`className`](@/api/options.md#classname) option. Set it in the grid configuration, in a `columns` entry, or per cell through the [`cells`](@/api/options.md#cells) callback. The class you provide is added to the cell's `<td>` element, where your CSS rules can target it. Set in the grid configuration, it is also added to the container element that holds the grid -- see [`className`](@/api/options.md#classname) for the full breakdown.
 
 ::: only-for javascript
 

--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -365,13 +365,13 @@ When your custom renderer should preserve the default text output, call the buil
 
 ## Extend a built-in renderer
 
-When you build on top of a built-in renderer, Handsontable does not call that base renderer for you. You call it inside your custom renderer before your extra logic.
+When you build on top of a built-in renderer such as `textRenderer` or `htmlRenderer`, Handsontable doesn't call it for you. You call it inside your custom renderer, before your extra logic.
 
-Use `textRenderer` as the base when you want plain-text output and then apply styling or additional DOM changes.
+Use `textRenderer` when you want plain-text output and then apply styling or additional DOM changes.
 
-Use `htmlRenderer` as the base when your output is trusted HTML and you intentionally render with `innerHTML`.
+Use `htmlRenderer` when your output is trusted HTML and you intentionally render with `innerHTML`.
 
-Skip a base renderer when your renderer fully controls cell output from scratch, for example the image-based `coverRenderer` in [Render custom HTML in cells](#render-custom-html-in-cells).
+Skip the built-in renderer when your renderer fully controls cell output from scratch, for example the image-based `coverRenderer` in [Render custom HTML in cells](#render-custom-html-in-cells).
 
 Both of the following call styles are valid:
 
@@ -382,6 +382,14 @@ textRenderer.apply(this, arguments);
 // Direct invocation style, common in ESM and TypeScript examples.
 textRenderer(instance, td, row, column, prop, value, cellProperties);
 ```
+
+### Handsontable runs `baseRenderer` for you
+
+`baseRenderer` is a separate renderer, and it isn't one of the renderers described above. It adds the cell's class names and ARIA attributes, including [`className`](@/api/options.md#classname), [`readOnly`](@/api/options.md#readonly), and the invalid-cell class.
+
+Since version 17.0.0, Handsontable runs `baseRenderer` for you. It runs after your custom renderer, whenever your renderer didn't run it. Your cells keep their class names even when your renderer calls no built-in renderer at all. Before version 17.0.0, such cells received no class names.
+
+Call `baseRenderer` yourself when you need it to run before your changes -- for example, when your renderer sets a class that `baseRenderer` also manages, such as the invalid-cell class. A `baseRenderer` that runs last removes that class.
 
 ## Render custom HTML in cells
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -1154,6 +1154,64 @@ The **Formulas** plugin uses [HyperFormula](https://hyperformula.handsontable.co
 
 See the [Formulas installation](@/guides/formulas/installation/installation.md) guide to install and license HyperFormula, and the [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) guide for configuration details.
 
+## 8. Custom renderers always receive the base cell classes
+
+Starting in **version 17.0**, Handsontable runs `baseRenderer` for every cell, even when the cell's renderer never calls it. `baseRenderer` adds the cell's class names and ARIA attributes.
+
+### What changed
+
+- **Automatic base renderer**: Handsontable runs `baseRenderer` after your custom renderer, whenever your renderer didn't run it
+- **Consistent cell classes**: Cells drawn by a custom renderer now receive [`className`](@/api/options.md#classname), the read-only class, the invalid-cell class, and the matching ARIA attributes
+- **Built-in renderers**: The built-in renderers no longer call `baseRenderer` themselves, because Handsontable calls it for them
+
+### Why this change
+
+Before version 17.0, a custom renderer that called no built-in renderer produced cells without those class names. One grid could show one column with the classes and another column without them, depending on how each column's renderer was written.
+
+### How to migrate
+
+Most applications need no action. Your custom renderers keep working, and their cells gain the class names they were missing.
+
+Two cases need attention:
+
+1. **You styled cells based on a missing class.** Cells drawn by a custom renderer now carry `className` and the other base classes. Review CSS that relied on those classes being absent.
+2. **Your renderer sets a class that `baseRenderer` also manages.** `baseRenderer` runs last, and it removes the invalid-cell class from valid cells. Call `baseRenderer` at the start of your renderer to keep control of the order.
+
+Before:
+
+```js
+// Handsontable 16.2 - this cell receives no `className` from the grid settings
+function myRenderer(instance, td, row, col, prop, value, cellProperties) {
+  td.textContent = value;
+}
+```
+
+After:
+
+```js
+// Handsontable 17.0 - this cell receives `className` automatically.
+// Call `baseRenderer` first only when you need it to run before your changes.
+function myRenderer(instance, td, row, col, prop, value, cellProperties) {
+  baseRenderer(instance, td, row, col, prop, value, cellProperties);
+  td.textContent = value;
+}
+```
+
+### What to expect
+
+- **Consistent classes**: Every cell receives the base class names, whichever renderer draws it
+- **No duplicate work**: Handsontable skips its own call when your renderer already ran `baseRenderer`
+- **Same API**: Renderer signatures are unchanged
+
+### Timeline
+
+- **Version 17.0**: Handsontable runs `baseRenderer` for every cell
+
+### Related resources
+
+- [Cell renderer](@/guides/cell-functions/cell-renderer/cell-renderer.md) - Write and extend cell renderers
+- [`className`](@/api/options.md#classname) - Add CSS class names to cells and to the container element
+
 ## Summary of breaking changes
 
 | Change                                            | Action Required                                                            |
@@ -1163,6 +1221,7 @@ See the [Formulas installation](@/guides/formulas/installation/installation.md) 
 | CSS-based themes (optional migration)             | Consider migrating to Theme API for runtime features                       |
 | `core-js` dependency removed                      | Add `core-js` or other polyfills in your app if you support older environments |
 | Built-in HyperFormula (deprecation)               | In 18.0, import HyperFormula yourself and pass it to the Formulas plugin with `licenseKey: 'internal-use-in-handsontable'` |
+| Custom renderers receive the base cell classes    | Review CSS that relied on those classes being absent from custom-rendered cells |
 
 ## Result
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -1162,7 +1162,7 @@ Starting in **version 17.0**, Handsontable runs `baseRenderer` for every cell, e
 
 - **Automatic base renderer**: Handsontable runs `baseRenderer` after your custom renderer, whenever your renderer didn't run it
 - **Consistent cell classes**: Cells drawn by a custom renderer now receive [`className`](@/api/options.md#classname), the read-only class, the invalid-cell class, and the matching ARIA attributes
-- **Built-in renderers**: The built-in renderers no longer call `baseRenderer` themselves, because Handsontable calls it for them
+- **Built-in renderers**: Most built-in renderers no longer call `baseRenderer` themselves, because Handsontable calls it for them. `multiSelectRenderer` is the exception, and still calls it as its first statement
 
 ### Why this change
 
@@ -1175,27 +1175,28 @@ Most applications need no action. Your custom renderers keep working, and their 
 Two cases need attention:
 
 1. **You styled cells based on a missing class.** Cells drawn by a custom renderer now carry `className` and the other base classes. Review CSS that relied on those classes being absent.
-2. **Your renderer sets a class that `baseRenderer` also manages.** `baseRenderer` runs last, and it removes the invalid-cell class from valid cells. Call `baseRenderer` at the start of your renderer to keep control of the order.
+2. **Your renderer sets a class that `baseRenderer` also manages.** Handsontable's own call runs after your renderer, and it removes the invalid-cell class from valid cells. Call `baseRenderer` at the start of your renderer to keep control of the order. A renderer that already calls `baseRenderer`, or that chains `multiSelectRenderer`, needs no change.
 
-Before:
-
-```js
-// Handsontable 16.2 - this cell receives no `className` from the grid settings
-function myRenderer(instance, td, row, col, prop, value, cellProperties) {
-  td.textContent = value;
-}
-```
-
-After:
+Before, in 16.2 the call was required to get the class names:
 
 ```js
-// Handsontable 17.0 - this cell receives `className` automatically.
-// Call `baseRenderer` first only when you need it to run before your changes.
+import { baseRenderer } from 'handsontable/renderers';
+
 function myRenderer(instance, td, row, col, prop, value, cellProperties) {
   baseRenderer(instance, td, row, col, prop, value, cellProperties);
   td.textContent = value;
 }
 ```
+
+After, in 17.0 the same cell gets them without the call:
+
+```js
+function myRenderer(instance, td, row, col, prop, value, cellProperties) {
+  td.textContent = value;
+}
+```
+
+Keep the explicit call only when you need `baseRenderer` to run before your own changes, as described in case 2 above.
 
 ### What to expect
 

--- a/docs/content/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md
+++ b/docs/content/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md
@@ -74,7 +74,7 @@ This recipe shows how to edit weekly values in table cells and render a mini bar
 - Optional coloring: green when a value is at or above the row average, red when below.
 - Interactive behavior -- when you edit W1-W5, Handsontable re-renders the sparkline SVG for that row.
 
-## Step 1: Call the base renderer first
+## Step 1: Run `baseRenderer` before the SVG
 
 The example calls `baseRenderer` before it changes the cell content. That applies read-only styling, validation classes, and ARIA attributes before the SVG replaces the cell content.
 

--- a/docs/content/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md
+++ b/docs/content/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md
@@ -76,7 +76,9 @@ This recipe shows how to edit weekly values in table cells and render a mini bar
 
 ## Step 1: Call the base renderer first
 
-Always call `baseRenderer` before you change the cell content. That keeps read-only styling, validation classes, and ARIA attributes consistent with other cells.
+The example calls `baseRenderer` before it changes the cell content. That applies read-only styling, validation classes, and ARIA attributes before the SVG replaces the cell content.
+
+You don't have to call `baseRenderer` yourself. Since version 17.0.0, Handsontable runs it after your renderer whenever your renderer didn't run it. Call it yourself when you need it to run first -- for example, when your renderer sets a class that `baseRenderer` also manages, such as `htInvalid`. A `baseRenderer` that runs last removes that class.
 
 ## Step 2: Map cell values to slots
 

--- a/handsontable/src/__tests__/settings/className.spec.js
+++ b/handsontable/src/__tests__/settings/className.spec.js
@@ -62,5 +62,39 @@ describe('settings', () => {
       expect(getCellMeta(0, 0).className).toEqual(['class-1']);
       expect(getCellMeta(0, 1).className).toEqual(['class-1']);
     });
+
+    it('should add the className to a cell whose renderer calls no built-in renderer', async() => {
+      handsontable({
+        data: [['a1', 'b1']],
+        className: 'class-1',
+        columns: [
+          {},
+          {
+            renderer(instance, td, row, col, prop, value) {
+              td.textContent = `${value}`;
+            },
+          },
+        ],
+      });
+
+      // The custom renderer never chains a built-in renderer. Handsontable runs `baseRenderer`
+      // afterwards, so both cells carry the class name.
+      expect(getCell(0, 0).classList.contains('class-1')).toBe(true);
+      expect(getCell(0, 1).classList.contains('class-1')).toBe(true);
+    });
+
+    it('should keep the className on the container when the cells clear it', async() => {
+      const hot = handsontable({
+        data: [['a1', 'b1']],
+        className: 'class-1',
+        cells() {
+          return { className: '' };
+        },
+      });
+
+      expect(hot.rootElement.classList.contains('class-1')).toBe(true);
+      expect(getCell(0, 0).classList.contains('class-1')).toBe(false);
+      expect(getCell(0, 1).classList.contains('class-1')).toBe(false);
+    });
   });
 });

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -853,7 +853,7 @@ export default (): Record<string, unknown> => {
      * | [`cells`](#cells) or [`cell`](#cell) | No                | The matching cells   |
      *
      * At the grid level, Handsontable adds the class names to two places. It adds them to the
-     * container element – the element you pass to the constructor – and, through
+     * container element – the element that holds the grid – and, through
      * [cascading configuration](@/guides/getting-started/configuration-options/configuration-options.md#cascading-configuration),
      * to every cell. To add class names to the `<table>` element instead, use [`tableClassName`](#tableClassName).
      *

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -842,6 +842,44 @@ export default (): Record<string, unknown> => {
      * To style the summary row, use the class name assigned automatically by the [`ColumnSummary`](@/api/columnSummary.md) plugin: `columnSummaryResult`.
      * :::
      *
+     * ### Where Handsontable adds the class names
+     *
+     * The target depends on the level at which you set the option:
+     *
+     * | Level                                | Container element | Cells                |
+     * | ------------------------------------ | ----------------- | -------------------- |
+     * | Grid                                 | Yes               | Every cell           |
+     * | [`columns`](#columns)                | No                | Cells of that column |
+     * | [`cells`](#cells) or [`cell`](#cell) | No                | The matching cells   |
+     *
+     * At the grid level, Handsontable adds the class names to two places. It adds them to the
+     * container element – the element you pass to the constructor – and, through
+     * [cascading configuration](@/guides/getting-started/configuration-options/configuration-options.md#cascading-configuration),
+     * to every cell. To add class names to the `<table>` element instead, use [`tableClassName`](#tableClassName).
+     *
+     * To style the container element alone, set `className` at the grid level and clear it at the
+     * cell level:
+     *
+     * ```js
+     * const hot = new Handsontable(container, {
+     *   className: 'your-class-name',
+     *   // the container element keeps `your-class-name`, the cells don't receive it
+     *   cells() {
+     *     return { className: '' };
+     *   },
+     * });
+     * ```
+     *
+     * A `className` set at a lower level replaces the value from a higher level. It doesn't merge
+     * with it. To keep a class name from a higher level, repeat it at the lower level.
+     *
+     * ### Custom renderers
+     *
+     * Handsontable adds these class names to a cell even when the cell uses a custom
+     * [renderer](@/guides/cell-functions/cell-renderer/cell-renderer.md) that calls no built-in
+     * renderer. Handsontable runs `baseRenderer` after your renderer whenever your renderer didn't
+     * run it. Before version 17.0.0, such a cell received no class names.
+     *
      * To apply different CSS class names on different levels, use Handsontable's [cascading configuration](@/guides/getting-started/configuration-options/configuration-options.md#cascading-configuration).
      *
      * Read more:


### PR DESCRIPTION
### Context

The PR fixes the documentation gaps behind #8479, and adds the regression tests that were missing.

Issue #8479 reports that `className` set at the grid level also lands on every `TD`, while the documentation described it as a container-only option. The issue turned out to be three separate threads:

1. **A custom renderer dropped the cell classes.** This was a real bug, and it is already fixed. PR #11997 (commit 118f537d1e, released in 17.0.0) added the `_isBaseRendererCalled` flag and a fallback call, now in `handsontable/src/renderers/renderCell.ts`. Verified against released builds with a custom renderer that chains no built-in renderer:

   | Version | Root `DIV` | Default-renderer `TD` | Custom-renderer `TD` |
   | --- | --- | --- | --- |
   | 16.0.0 | `aaaa` | `aaaa` | `class=""` -- class lost |
   | 17.0.0 | `aaaa` | `aaaa` | `aaaa` |
   | 18.0.0 | `aaaa` | `aaaa` | `aaaa` |

2. **Grid-level `className` goes on the container element and on every cell.** This is the cascading configuration model working as designed. Changing it would be a breaking change.

3. **A `cells()` function returning `className` replaces the value from a higher level.** Also by design -- cascading configuration overwrites, it does not merge.

So no source behavior needs to change. What was missing was documentation:

- The `className` JSDoc described cells only. It never stated that at the grid level the class names also land on the container element, which is the reporter's original question.
- The 17.0.0 automatic base renderer was documented nowhere. The changelog entry for #11997 mentions only `Intl.NumberFormat` support, which is why nobody connected that PR to this issue.
- `sparkline-cell-renderer.md` still told readers to "always call `baseRenderer`". Since 17.0.0 Handsontable calls it for you.
- `cell-renderer.md` used "base renderer" to mean "the built-in renderer you extend", which reads as a contradiction next to the `baseRenderer` export.

### What changed

- `handsontable/src/dataMap/metaManager/metaSchema.ts` -- the `className` JSDoc now shows which levels target the container element and which target cells, documents that a lower level replaces a higher level rather than merging, gives the container-only recipe, and states the custom-renderer behavior.
- `docs/content/guides/cell-functions/cell-renderer/cell-renderer.md` -- disambiguates "built-in renderer" from `baseRenderer`, and adds a section explaining that Handsontable runs `baseRenderer` for you, including when you would still call it yourself.
- `docs/content/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md` -- replaces the outdated "always call `baseRenderer`" instruction. The explicit call is kept in the example, because calling it first is what gives you control over ordering.
- `docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md` -- adds the missing migration step for the 17.0.0 renderer behavior change, with before/after examples, plus a row in the summary table.
- `handsontable/src/__tests__/settings/className.spec.js` -- two new cases.

### How has this been tested?

The existing spec covered `rootElement` and `getCellMeta().className`, but never the `TD` itself with a custom renderer. That path was pinned only at the unit level in `renderCell.unit.ts`. Two cases were added:

- a cell whose renderer calls no built-in renderer still receives `className`;
- clearing `className` through `cells()` leaves the container element's class intact.

Both new assertions were verified to fail when inverted, so they exercise the behavior rather than passing vacuously.

```bash
npm run test:e2e --prefix handsontable -- --testPathPattern=settings/className   # 10 specs, 0 failures
npm run test:unit --prefix handsontable -- --testPathPattern=renderCell          # 9 passed
npm run eslint --prefix handsontable                                             # 0 errors
```

The version table above was measured in Chrome against the released 16.0.0, 17.0.0, and 18.0.0 builds from the CDN.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2684
2. Closes #8479
3. Context: #11997 is the PR that fixed the renderer half in 17.0.0

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

[skip changelog] -- this PR changes documentation and tests only. No source behavior changes.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2684

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and regression tests only; no changes to rendering or `className` application logic.
> 
> **Overview**
> Closes documentation gaps around **`className`** and the **17.0 automatic `baseRenderer`** (no runtime changes in this PR).
> 
> **`className`** is now documented as applying to the **grid container and cells** when set at grid level, with a table of levels, the container-only recipe (`cells()` returning `className: ''`), replace-not-merge cascading, and that custom renderers still get classes via the post-render `baseRenderer` fallback. Updates span API JSDoc in `metaSchema.ts`, the formatting-cells guide, and related links.
> 
> **Renderer docs** distinguish extending **`textRenderer`/`htmlRenderer`** from the **`baseRenderer`** export, explain that since **17.0** Handsontable runs `baseRenderer` after custom renderers when they did not, and when you should still call it first. The **16.2→17.0 migration guide** adds section **8** plus a summary-table row; the sparkline recipe drops “always call `baseRenderer`” in favor of that model.
> 
> **Tests:** two e2e cases in `className.spec.js` — `className` on cells with a renderer that chains no built-in renderer, and clearing cell `className` via `cells()` while the root container keeps the class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 579824b47c0e8e8be901736014809aae2e34bda9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->