### PR TITLE
DEV-2678: Stop already-released changelog entries from being republished

### DIFF
--- a/.changelogs/README.md
+++ b/.changelogs/README.md
@@ -118,3 +118,35 @@ bin/changelog consume
 This command "consumes" all changelog entries, asserts that they're all valid, formats them, and inserts the result into `CHANGELOG.md`. It also deletes all existing `.changelogs/*.json` files.
 
 It is side-effect free (as in it does nothing outside of your local copy of this repository), to undo just checkout the old versions of `.changelogs` and `CHANGELOG.md`.
+
+
+## No entry may be published twice
+
+`consume` and `sync` both refuse to compile a pending entry whose change `CHANGELOG.md` already publishes. Without that check the same change gets announced in two consecutive releases, which happened at most releases up to 18.1.0.
+
+The cause is that a pending `.json` file can outlive the release-to-develop merge-back after the release branch has already consumed it. Two merge shapes produce it, and neither is easy to spot:
+
+- The change is committed once on the release branch and once on `develop`, with no ancestry between the two commits. Against the merge base the release side reads as add-then-delete, so develop's add is the only change on either side and the merge keeps it. **No conflict is raised at all.**
+- The `.json` file is edited on `develop` after the release branch consumed it. That is a modify/delete conflict, and resolving it in favor of develop keeps a file that should have gone.
+
+Rather than trying to recognize either shape, the check asserts the one thing both produce. It matches on two keys, with different severities:
+
+| Match | Result |
+|---|---|
+| `issueOrPR` already cited in `CHANGELOG.md`, and `issuesOrigin` is `private` | **fails** |
+| `issueOrPR` already cited, and `issuesOrigin` is `public` | warns |
+| the entry's title already published, under any number | warns |
+
+A pull request number cannot ship twice, so a `private` number match is conclusive. The other two can be legitimate: a public **issue** number may be cited by two releases when a partial fix is followed by a complete one, and one title may appear in two sections when a fix is backported to several release lines. Both keys are still needed — a wrong link in the published entry hides the number, and rewording an entry on one branch hides the title.
+
+`sync` targets one version section and already skips entries present in it, so there the check looks at every *other* section.
+
+Because `consume --dry-run` runs on every pull request (see `.github/workflows/checks.yml`), this is enforced on every PR as well as at release time. A failure names every offending file and prints the `git rm` line that clears them.
+
+**To resolve a failure**, delete the entry files it names — their change already shipped. If one of them is genuinely a new change that happens to reuse a released pull request number, renumber the entry to cite its own pull request instead. There is no skip flag: an entry that is already published has nothing left to announce.
+
+After performing a release-to-develop merge-back, check for this before pushing:
+
+```bash
+bin/changelog consume --date 2050-01-01 --dry-run
+```

--- a/.changelogs/README.md
+++ b/.changelogs/README.md
@@ -122,7 +122,7 @@ It is side-effect free (as in it does nothing outside of your local copy of this
 
 ## No entry may be published twice
 
-`consume` and `sync` both refuse to compile a pending entry whose change `CHANGELOG.md` already publishes. Without that check the same change gets announced in two consecutive releases, which happened at most releases up to 18.1.0.
+`consume` and `sync` both check a pending entry against what `CHANGELOG.md` already publishes, and refuse to compile it when that match is conclusive; a less certain match only warns. Without that check the same change gets announced in two consecutive releases, which happened at most releases up to 18.1.0.
 
 The cause is that a pending `.json` file can outlive the release-to-develop merge-back after the release branch has already consumed it. Two merge shapes produce it, and neither is easy to spot:
 
@@ -134,10 +134,11 @@ Rather than trying to recognize either shape, the check asserts the one thing bo
 | Match | Result |
 |---|---|
 | `issueOrPR` already cited in `CHANGELOG.md`, and `issuesOrigin` is `private` | **fails** |
-| `issueOrPR` already cited, and `issuesOrigin` is `public` | warns |
-| the entry's title already published, under any number | warns |
+| `issueOrPR` already cited, `issuesOrigin` is `public`, and the title also matches | **fails** |
+| `issueOrPR` already cited, `issuesOrigin` is `public`, and the title does not match | warns |
+| only the entry's title already published, under any number | warns |
 
-A pull request number cannot ship twice, so a `private` number match is conclusive. The other two can be legitimate: a public **issue** number may be cited by two releases when a partial fix is followed by a complete one, and one title may appear in two sections when a fix is backported to several release lines. Both keys are still needed — a wrong link in the published entry hides the number, and rewording an entry on one branch hides the title.
+A pull request number cannot ship twice, so a `private` number match is conclusive. A public **issue** number may legitimately be cited by two releases when a partial fix is followed by a complete one — but a partial fix gets a new title, so a `public` number match that also matches the title is not that case, and fails the same way a `private` match does. A title-only match may still legitimately appear in two sections when a fix is backported to several release lines, so it always warns. Both keys are still needed — a wrong link in the published entry hides the number, and rewording an entry on one branch hides the title.
 
 `sync` targets one version section and already skips entries present in it, so there the check looks at every *other* section.
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1383,6 +1383,13 @@ jobs:
 
           git checkout develop
 
+          assert_no_republished_changelog_entries() {
+            if ! bin/changelog consume --date 2050-01-01 --dry-run; then
+              echo "::error::Refusing to push: the merge reintroduced an already-published changelog entry. Resolve the .changelogs conflict manually."
+              exit 1
+            fi
+          }
+
           if ! git merge origin/${RELEASE_BRANCH} --no-edit; then
             UNRESOLVED=$(git diff --name-only --diff-filter=U)
             UNEXPECTED=$(echo "$UNRESOLVED" | grep -v '^pnpm-lock.yaml$' || true)
@@ -1416,9 +1423,11 @@ jobs:
               pnpm install --lockfile-only
               git add pnpm-lock.yaml
               git commit --no-edit
+              assert_no_republished_changelog_entries
               git push origin develop
             fi
           else
+            assert_no_republished_changelog_entries
             git push origin develop
           fi
 

--- a/bin/changelog
+++ b/bin/changelog
@@ -14,6 +14,9 @@ const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
 
 const hotConfig = require('../hot.config');
+const {
+  excludeVersionSection, findRepublishedEntries, formatRepublishedReport
+} = require('./lib/published-entries');
 
 const isTTY = process.stdin.isTTY;
 
@@ -155,6 +158,30 @@ const assertChangelogEntryFormat = (input) => {
   };
 };
 
+/**
+ * Reports the pending entries that `changelogContents` already publishes, and
+ * exits when any of them is conclusive. Every offender is listed in one pass so
+ * that clearing several of them takes one run.
+ *
+ * @param {Array<{file: string, entry: object}>} pendingEntries Pending entries and their paths.
+ * @param {string} changelogContents The changelog text to treat as already published.
+ */
+const assertNoRepublishedEntries = (pendingEntries, changelogContents) => {
+  const report = formatRepublishedReport(findRepublishedEntries(pendingEntries, changelogContents));
+
+  if (report.warnings.length) {
+    console.log();
+    console.log(chalk.yellow(report.warningMessage));
+  }
+
+  if (report.errors.length) {
+    console.log();
+    console.log(chalk.red(report.errorMessage));
+
+    process.exit(1);
+  }
+};
+
 const createEntryCommand = async(args) => {
   const argTitle = args.title ? args.title.join(' ') : undefined;
   const answers = isTTY ? await inquirer.prompt([
@@ -289,6 +316,17 @@ const consumeCommand = async(args) => {
   const ungroupedEntries = (await Promise.all(changelogEntryFiles.map(p => fs.readFile(p, 'utf8'))))
     .map(contents => assertChangelogEntryFormat(JSON.parse(contents)));
 
+  // Asserted here, before the dry run bails out, so that the `--dry-run` that
+  // `checks.yml` puts on every pull request enforces it too - not only the
+  // release. See `bin/lib/published-entries.js` for what it catches and why.
+  assertNoRepublishedEntries(
+    ungroupedEntries.map((entry, i) => ({
+      file: path.relative(process.cwd(), changelogEntryFiles[i]),
+      entry
+    })),
+    existingChangelogContents
+  );
+
   const groupedEntries = lodash.groupBy(ungroupedEntries, 'type');
   const groupedPairs = lodash.sortBy(lodash
     .toPairs(groupedEntries), ([key]) => changelogEntryTypes.indexOf(key));
@@ -400,9 +438,19 @@ const syncCommand = async(args) => {
     return;
   }
 
-  const newEntries = (await Promise.all(entryFiles.map(p => fs.readFile(p, 'utf8'))))
-    .map(c => assertChangelogEntryFormat(JSON.parse(c)))
-    .filter(e => !section.includes(`/${e.issueOrPR})`));
+  const pendingEntries = (await Promise.all(entryFiles.map(p => fs.readFile(p, 'utf8'))))
+    .map((c, i) => ({
+      file: path.relative(process.cwd(), entryFiles[i]),
+      entry: assertChangelogEntryFormat(JSON.parse(c))
+    }))
+    .filter(({ entry }) => !section.includes(`/${entry.issueOrPR})`));
+
+  // The filter above only dedups against the section being synced into, so an
+  // entry already published in an *earlier* section would be added a second
+  // time here. Assert against every other section, with the target one cut out.
+  assertNoRepublishedEntries(pendingEntries, excludeVersionSection(text, version));
+
+  const newEntries = pendingEntries.map(({ entry }) => entry);
 
   if (!newEntries.length) {
     console.log(`All changelog entries are already present in version ${version}.`);

--- a/bin/lib/published-entries.js
+++ b/bin/lib/published-entries.js
@@ -110,12 +110,14 @@ const collectPublishedEntries = (changelogContents) => {
  * @returns {string} The contents without that section, or unchanged when it is absent.
  */
 const excludeVersionSection = (changelogContents, version) => {
-  const start = changelogContents.indexOf(`## [${version}]`);
+  const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const heading = changelogContents.match(new RegExp(`^## \\[${escapedVersion}\\]`, 'm'));
 
-  if (start === -1) {
+  if (heading === null) {
     return changelogContents;
   }
 
+  const start = heading.index;
   const nextStart = changelogContents.indexOf('\n## [', start + 1);
 
   return changelogContents.slice(0, start) + (nextStart === -1 ? '' : changelogContents.slice(nextStart));
@@ -132,9 +134,11 @@ const excludeVersionSection = (changelogContents, version) => {
  * They carry different severities. A pull request number cannot ship twice, so
  * a `private` number hit is conclusive. A `public` number is a GitHub *issue*
  * number, which two releases may legitimately cite when a partial fix is
- * followed by a complete one, and one title may legitimately appear in two
- * sections when a fix is backported to several release lines - so those warn
- * instead of failing.
+ * followed by a complete one - but a partial fix gets a new title, so a
+ * `public` number hit that also matches the title key is not that case, and
+ * escalates to an error the same way a `private` hit does. One title may
+ * still legitimately appear in two sections when a fix is backported to
+ * several release lines, so a title-only hit always warns instead of failing.
  *
  * @param {Array<{file: string, entry: object}>} pendingEntries Pending entries and their paths.
  * @param {string} changelogContents The contents of `CHANGELOG.md`.
@@ -157,7 +161,8 @@ const findRepublishedEntries = (pendingEntries, changelogContents) => {
       issuesOrigin: entry.issuesOrigin,
       citedSection,
       titleSection,
-      severity: citedSection !== undefined && entry.issuesOrigin === 'private' ? 'error' : 'warning'
+      severity: citedSection !== undefined
+        && (entry.issuesOrigin === 'private' || titleSection !== undefined) ? 'error' : 'warning'
     });
 
     return found;

--- a/bin/lib/published-entries.js
+++ b/bin/lib/published-entries.js
@@ -1,0 +1,237 @@
+/**
+ * Detects pending `.changelogs/*.json` entries whose change is already
+ * published in `CHANGELOG.md`.
+ *
+ * A pending entry can outlive the release-to-develop merge-back after its
+ * entry has already been consumed on the release branch, and the next
+ * `consume` then announces the same change a second time. Two merge shapes
+ * produce it, and neither leaves a reliable signal of its own:
+ *
+ * - The change is committed once on the release branch and once on develop
+ *   with no ancestry between them. The release side reads as add-then-delete
+ *   against the merge base, so develop's add is the only change on either
+ *   side and the merge keeps it silently.
+ * - The entry file is edited on develop after being consumed. That is a
+ *   modify/delete conflict, which is easy to resolve the wrong way.
+ *
+ * Rather than trying to recognize either merge shape, this module asserts the
+ * one thing both of them produce: a pending entry that `CHANGELOG.md` already
+ * carries.
+ */
+
+const ENTRY_LINK_PATTERN =
+  /\[#(\d+)\]\(https:\/\/github\.com\/handsontable\/handsontable\/(?:pull|issues)\/\d+\)/g;
+
+const VERSION_HEADING_PATTERN = /^## \[([^\]]+)\]/;
+
+// `stringifyChangelogEntryObject` prefixes a published line with the breaking
+// marker and then the framework name, so both come off before comparing a
+// published line against an entry's raw `title`. The parenthesized breaking
+// variant ("**Breaking change (React, Angular, Vue 2, Vue 3)**: ") appears in
+// the older sections.
+const BREAKING_PREFIX_PATTERN = /^\*\*Breaking change[^*]*\*\*:\s*/;
+const FRAMEWORK_PREFIX_PATTERN = /^(?:React|Vue|Angular):\s*/;
+
+/**
+ * Reduces a published changelog line, or an entry's raw `title`, to a form in
+ * which the two can be compared. Safe to call on either: every fragment it
+ * strips is optional.
+ *
+ * @param {string} value A published `- ` line, or a changelog entry's title.
+ * @returns {string} The comparable form of `value`.
+ */
+const normalizeEntryTitle = value => value
+  .replace(/^- /, '')
+  .replace(ENTRY_LINK_PATTERN, '')
+  .replace(BREAKING_PREFIX_PATTERN, '')
+  .replace(FRAMEWORK_PREFIX_PATTERN, '')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+/**
+ * Indexes everything `CHANGELOG.md` already publishes, by cited number and by
+ * normalized title, mapping each to the version section it first appears in.
+ *
+ * Only the *last* link on a line is the cited number: a title may reference
+ * other pull requests inline, the way the 18.0.0 `PersistentState` entry cites
+ * #12015 mid-sentence.
+ *
+ * @param {string} changelogContents The contents of `CHANGELOG.md`.
+ * @returns {{numbers: Map<string, string>, titles: Map<string, string>}} The published entries.
+ */
+const collectPublishedEntries = (changelogContents) => {
+  const numbers = new Map();
+  const titles = new Map();
+  let section = null;
+
+  changelogContents.split('\n').forEach((line) => {
+    const heading = line.match(VERSION_HEADING_PATTERN);
+
+    if (heading) {
+      section = heading[1];
+
+      return;
+    }
+
+    // Anything above the first version heading is not published yet.
+    if (section === null || !line.startsWith('- ')) {
+      return;
+    }
+
+    const links = [...line.matchAll(ENTRY_LINK_PATTERN)];
+
+    if (links.length) {
+      const cited = links[links.length - 1][1];
+
+      if (!numbers.has(cited)) {
+        numbers.set(cited, section);
+      }
+    }
+
+    const title = normalizeEntryTitle(line);
+
+    if (title && !titles.has(title)) {
+      titles.set(title, section);
+    }
+  });
+
+  return { numbers, titles };
+};
+
+/**
+ * Returns `changelogContents` with one version's section cut out, so that
+ * section does not count as already published.
+ *
+ * `sync` needs this: it targets one section and already skips the entries
+ * present in it, so only every *other* section may block an entry.
+ *
+ * @param {string} changelogContents The contents of `CHANGELOG.md`.
+ * @param {string} version The version whose section to remove.
+ * @returns {string} The contents without that section, or unchanged when it is absent.
+ */
+const excludeVersionSection = (changelogContents, version) => {
+  const start = changelogContents.indexOf(`## [${version}]`);
+
+  if (start === -1) {
+    return changelogContents;
+  }
+
+  const nextStart = changelogContents.indexOf('\n## [', start + 1);
+
+  return changelogContents.slice(0, start) + (nextStart === -1 ? '' : changelogContents.slice(nextStart));
+};
+
+/**
+ * Finds the pending entries that `CHANGELOG.md` already publishes.
+ *
+ * Both keys are needed, because each on its own has a blind spot that has
+ * already occurred: the number key misses an entry published under a wrong
+ * link (#12727 shipped as `[#0]`), and the title key misses an entry that was
+ * reworded on one of the two branches (#13243).
+ *
+ * They carry different severities. A pull request number cannot ship twice, so
+ * a `private` number hit is conclusive. A `public` number is a GitHub *issue*
+ * number, which two releases may legitimately cite when a partial fix is
+ * followed by a complete one, and one title may legitimately appear in two
+ * sections when a fix is backported to several release lines - so those warn
+ * instead of failing.
+ *
+ * @param {Array<{file: string, entry: object}>} pendingEntries Pending entries and their paths.
+ * @param {string} changelogContents The contents of `CHANGELOG.md`.
+ * @returns {Array<object>} One record per offending entry, in the order given.
+ */
+const findRepublishedEntries = (pendingEntries, changelogContents) => {
+  const published = collectPublishedEntries(changelogContents);
+
+  return pendingEntries.reduce((found, { file, entry }) => {
+    const citedSection = published.numbers.get(String(entry.issueOrPR));
+    const titleSection = published.titles.get(normalizeEntryTitle(entry.title));
+
+    if (citedSection === undefined && titleSection === undefined) {
+      return found;
+    }
+
+    found.push({
+      file,
+      issueOrPR: entry.issueOrPR,
+      issuesOrigin: entry.issuesOrigin,
+      citedSection,
+      titleSection,
+      severity: citedSection !== undefined && entry.issuesOrigin === 'private' ? 'error' : 'warning'
+    });
+
+    return found;
+  }, []);
+};
+
+/**
+ * Renders one offending entry as a single line.
+ *
+ * @param {object} record A record from `findRepublishedEntries`.
+ * @returns {string} The rendered line.
+ */
+const formatRepublishedEntry = (record) => {
+  const { file, issueOrPR, citedSection, titleSection } = record;
+  const reasons = [];
+
+  if (citedSection !== undefined) {
+    reasons.push(`#${issueOrPR} is already cited in [${citedSection}]`);
+  }
+
+  if (titleSection !== undefined) {
+    reasons.push(`its title is already published in [${titleSection}]`);
+  }
+
+  return `${file}: ${reasons.join(', and ')}`;
+};
+
+/**
+ * Splits the records by severity and renders each group. Every offender is
+ * listed in one pass, so a person fixing several of them does not have to
+ * re-run the command once per file.
+ *
+ * @param {Array<object>} records The records from `findRepublishedEntries`.
+ * @returns {{errors: Array<object>, warnings: Array<object>, errorMessage: string,
+ *   warningMessage: string}} The report. Each message is empty when its group is.
+ */
+const formatRepublishedReport = (records) => {
+  const errors = records.filter(r => r.severity === 'error');
+  const warnings = records.filter(r => r.severity === 'warning');
+
+  const errorMessage = errors.length ? [
+    `${errors.length} pending changelog ${
+      errors.length === 1 ? 'entry has' : 'entries have'
+    } already been published:`,
+    ...errors.map(r => `  ${formatRepublishedEntry(r)}`),
+    '',
+    'Their change shipped in an earlier release, so consuming them would announce it twice.',
+    'This normally means the entry file outlived a release-to-develop merge-back. Remove them:',
+    '',
+    `  git rm ${errors.map(r => r.file).join(' ')}`,
+    '',
+    'If one of them is genuinely a new change that reuses a released pull request number,',
+    'renumber the entry to cite its own pull request instead.'
+  ].join('\n') : '';
+
+  const warningMessage = warnings.length ? [
+    `${warnings.length} pending changelog ${
+      warnings.length === 1 ? 'entry looks' : 'entries look'
+    } already published, but may be legitimate:`,
+    ...warnings.map(r => `  ${formatRepublishedEntry(r)}`),
+    '',
+    'A public issue number may be cited by two releases (a partial fix, then a complete one),',
+    'and one title may appear in two sections when a fix is backported to several release',
+    'lines. Confirm that is the case here; otherwise remove the entry.'
+  ].join('\n') : '';
+
+  return { errors, warnings, errorMessage, warningMessage };
+};
+
+module.exports = {
+  normalizeEntryTitle,
+  collectPublishedEntries,
+  excludeVersionSection,
+  findRepublishedEntries,
+  formatRepublishedEntry,
+  formatRepublishedReport
+};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "all": "cross-env-shell COMMAND_ENV=all node scripts/translate-to-native-npm.mjs",
     "clean:node_modules": "node ./scripts/clean-node-modules.mjs",
     "lint": "npm run eslint && npm run all lint -- --if-present && npm run lint --prefix performance-tests && npm run lint --prefix tests",
-    "eslint": "eslint .github/scripts/ bin/changelog scripts/",
+    "eslint": "eslint .github/scripts/ bin/changelog bin/lib scripts/",
     "test": "npm run all test -- -e=examples",
     "test:tooling": "node --test .github/scripts/__tests__/*.test.mjs scripts/__tests__/*.test.mjs scripts/claude/__tests__/*.test.mjs evals/__tests__/*.test.mjs performance-tests/lib/__tests__/*.test.mjs visual-tests/lib/__tests__/*.test.mjs",
     "build": "npm run all build -- -e=examples",

--- a/scripts/__tests__/changelog-published-entries.test.mjs
+++ b/scripts/__tests__/changelog-published-entries.test.mjs
@@ -109,6 +109,29 @@ test('excludeVersionSection leaves the contents alone when the version is absent
   assert.equal(excludeVersionSection(CHANGELOG, '99.0.0'), CHANGELOG);
 });
 
+test('excludeVersionSection is anchored to the start of a line, not a substring match anywhere', () => {
+  const changelogWithInlineMention = [
+    '# Changelog',
+    '',
+    '## [18.0.1] - 2026-07-01',
+    '',
+    '### Fixed',
+    // Mentions a version heading mid-line - must not be mistaken for the real heading.
+    `- Documented the upgrade path past ## [18.0.0] for older installs. ${link(13400)}`,
+    '',
+    '## [18.0.0] - 2026-06-30',
+    '',
+    '### Fixed',
+    `- Fixed cell meta being reset by \`updateSettings\`. ${link(12811)}`,
+    ''
+  ].join('\n');
+
+  const { numbers } = collectPublishedEntries(excludeVersionSection(changelogWithInlineMention, '18.0.0'));
+
+  assert.equal(numbers.has('12811'), false, 'the real 18.0.0 section must be gone');
+  assert.equal(numbers.get('13400'), '18.0.1', '18.0.1 must survive, not be truncated mid-line');
+});
+
 test('excludeVersionSection keeps the target section from blocking a sync into it', () => {
   const pending = [{ file: '.changelogs/12451.json', entry: entry({ issueOrPR: 12451 }) }];
 
@@ -163,6 +186,21 @@ test('a public issue number already published only warns', () => {
   assert.equal(records.length, 1);
   assert.equal(records[0].citedSection, '17.1.0');
   assert.equal(records[0].severity, 'warning');
+});
+
+test('a public issue number already published escalates to error when the title also matches', () => {
+  const records = findRepublishedEntries(
+    [{
+      file: '.changelogs/7555.json',
+      entry: entry({ issuesOrigin: 'public', issueOrPR: 7555, title: 'Fixed a public issue only partly.' })
+    }],
+    CHANGELOG
+  );
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].citedSection, '17.1.0');
+  assert.equal(records[0].titleSection, '17.1.0');
+  assert.equal(records[0].severity, 'error', 'both keys agreeing rules out the partial-fix exception');
 });
 
 test('a framework prefix does not hide a republished title', () => {

--- a/scripts/__tests__/changelog-published-entries.test.mjs
+++ b/scripts/__tests__/changelog-published-entries.test.mjs
@@ -1,0 +1,234 @@
+/**
+ * Tests for `bin/lib/published-entries.js`, the assertion that stops a pending
+ * `.changelogs/*.json` entry from being consumed a second time after its change
+ * has already been published.
+ *
+ * The two keys and the two severities are the whole point of the module, and
+ * every case below is drawn from an episode that actually happened - see
+ * DEV-2678 for the traces.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  normalizeEntryTitle,
+  collectPublishedEntries,
+  excludeVersionSection,
+  findRepublishedEntries,
+  formatRepublishedReport
+} = require('../../bin/lib/published-entries.js');
+
+const link = n => `[#${n}](https://github.com/handsontable/handsontable/pull/${n})`;
+const issueLink = n => `[#${n}](https://github.com/handsontable/handsontable/issues/${n})`;
+
+const CHANGELOG = [
+  '# Changelog',
+  '',
+  '<!-- UNVERSIONED -->',
+  '',
+  `- An unreleased line above the first heading is not published yet. ${link(999)}`,
+  '',
+  '## [18.0.0] - 2026-06-30',
+  '',
+  '### Added',
+  `- Angular: Modernized the Angular wrapper. ${link(12451)}`,
+  '',
+  '### Fixed',
+  `- Fixed cell meta being reset by \`updateSettings\`. ${link(12811)}`,
+  // The published PersistentState entry cites another pull request mid-title and
+  // carries a broken trailing link, which is what makes the title key load-bearing.
+  `- **Breaking change**: Removed the \`PersistentState\` plugin (see ${link(12015)}). ${link(0)}`,
+  '',
+  '## [17.1.0] - 2026-05-19',
+  '',
+  '### Fixed',
+  `- Fixed a public issue only partly. ${issueLink(7555)}`,
+  ''
+].join('\n');
+
+const entry = overrides => ({
+  issuesOrigin: 'private',
+  title: 'A brand new change.',
+  type: 'fixed',
+  issueOrPR: 13300,
+  breaking: false,
+  framework: 'none',
+  ...overrides
+});
+
+test('normalizeEntryTitle converges a published line and a raw entry title', () => {
+  assert.equal(
+    normalizeEntryTitle(`- Angular: Modernized the Angular wrapper. ${link(12451)}`),
+    'Modernized the Angular wrapper.'
+  );
+  assert.equal(normalizeEntryTitle('Modernized the Angular wrapper.'), 'Modernized the Angular wrapper.');
+});
+
+test('normalizeEntryTitle strips the breaking marker, including the parenthesized variant', () => {
+  assert.equal(normalizeEntryTitle('- **Breaking change**: Removed a thing.'), 'Removed a thing.');
+  assert.equal(
+    normalizeEntryTitle('- **Breaking change (React, Angular, Vue 2, Vue 3)**: Removed a thing.'),
+    'Removed a thing.'
+  );
+});
+
+test('collectPublishedEntries ignores lines above the first version heading', () => {
+  const { numbers } = collectPublishedEntries(CHANGELOG);
+
+  assert.equal(numbers.has('999'), false);
+  assert.equal(numbers.get('12451'), '18.0.0');
+});
+
+test('collectPublishedEntries keys on the last link, not a number cited inside the title', () => {
+  const { numbers } = collectPublishedEntries(CHANGELOG);
+
+  // #12015 is referenced mid-sentence by the PersistentState entry; only the
+  // trailing link is that entry's own citation.
+  assert.equal(numbers.has('12015'), false);
+  assert.equal(numbers.get('0'), '18.0.0');
+});
+
+test('excludeVersionSection removes the first section but keeps the later ones', () => {
+  const { numbers } = collectPublishedEntries(excludeVersionSection(CHANGELOG, '18.0.0'));
+
+  assert.equal(numbers.has('12451'), false, '18.0.0 must be gone');
+  assert.equal(numbers.has('12811'), false, '18.0.0 must be gone');
+  assert.equal(numbers.get('7555'), '17.1.0', '17.1.0 must survive');
+});
+
+test('excludeVersionSection removes the last section, where there is no next heading', () => {
+  const { numbers } = collectPublishedEntries(excludeVersionSection(CHANGELOG, '17.1.0'));
+
+  assert.equal(numbers.has('7555'), false, '17.1.0 must be gone');
+  assert.equal(numbers.get('12451'), '18.0.0', '18.0.0 must survive');
+});
+
+test('excludeVersionSection leaves the contents alone when the version is absent', () => {
+  assert.equal(excludeVersionSection(CHANGELOG, '99.0.0'), CHANGELOG);
+});
+
+test('excludeVersionSection keeps the target section from blocking a sync into it', () => {
+  const pending = [{ file: '.changelogs/12451.json', entry: entry({ issueOrPR: 12451 }) }];
+
+  assert.equal(findRepublishedEntries(pending, CHANGELOG).length, 1, 'blocked without the excision');
+  assert.deepEqual(
+    findRepublishedEntries(pending, excludeVersionSection(CHANGELOG, '18.0.0')),
+    [],
+    'allowed when syncing into the very section that holds it'
+  );
+});
+
+test('a private number already published is a hard error', () => {
+  const records = findRepublishedEntries(
+    [{ file: '.changelogs/12811.json', entry: entry({ issueOrPR: 12811, title: 'Reworded on develop.' }) }],
+    CHANGELOG
+  );
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].severity, 'error');
+  assert.equal(records[0].citedSection, '18.0.0');
+  assert.equal(records[0].titleSection, undefined);
+});
+
+test('a title already published is caught even when the number is not - the [#0] case', () => {
+  const records = findRepublishedEntries(
+    [{
+      file: '.changelogs/12727.json',
+      entry: entry({
+        issueOrPR: 12727,
+        breaking: true,
+        title: `Removed the \`PersistentState\` plugin (see ${link(12015)}).`
+      })
+    }],
+    CHANGELOG
+  );
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].citedSection, undefined, 'the published entry cites #0, not #12727');
+  assert.equal(records[0].titleSection, '18.0.0');
+  assert.equal(records[0].severity, 'warning', 'a title-only hit may be a legitimate backport');
+});
+
+test('a public issue number already published only warns', () => {
+  const records = findRepublishedEntries(
+    [{
+      file: '.changelogs/7555.json',
+      entry: entry({ issuesOrigin: 'public', issueOrPR: 7555, title: 'Finished fixing the public issue.' })
+    }],
+    CHANGELOG
+  );
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].citedSection, '17.1.0');
+  assert.equal(records[0].severity, 'warning');
+});
+
+test('a framework prefix does not hide a republished title', () => {
+  const records = findRepublishedEntries(
+    [{
+      file: '.changelogs/13301.json',
+      entry: entry({ issueOrPR: 13301, framework: 'angular', title: 'Modernized the Angular wrapper.' })
+    }],
+    CHANGELOG
+  );
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].titleSection, '18.0.0');
+});
+
+test('a genuinely new entry produces no record', () => {
+  assert.deepEqual(
+    findRepublishedEntries([{ file: '.changelogs/13300.json', entry: entry() }], CHANGELOG),
+    []
+  );
+});
+
+test('every offender is reported in one pass, and the git rm line covers only the errors', () => {
+  const { errors, warnings, errorMessage, warningMessage } = formatRepublishedReport(
+    findRepublishedEntries(
+      [
+        { file: '.changelogs/12811.json', entry: entry({ issueOrPR: 12811 }) },
+        { file: '.changelogs/12451.json', entry: entry({ issueOrPR: 12451 }) },
+        {
+          file: '.changelogs/7555.json',
+          entry: entry({ issuesOrigin: 'public', issueOrPR: 7555, title: 'Finished the public issue.' })
+        }
+      ],
+      CHANGELOG
+    )
+  );
+
+  assert.equal(errors.length, 2);
+  assert.equal(warnings.length, 1);
+  assert.match(errorMessage, /2 pending changelog entries have already been published/);
+  assert.match(errorMessage, /\.changelogs\/12811\.json/);
+  assert.match(errorMessage, /\.changelogs\/12451\.json/);
+  assert.match(errorMessage, /git rm \.changelogs\/12811\.json \.changelogs\/12451\.json/);
+  assert.doesNotMatch(errorMessage, /7555/, 'a warning must not reach the git rm line');
+  assert.match(warningMessage, /\.changelogs\/7555\.json/);
+});
+
+test('an entry hitting both keys reports both reasons', () => {
+  const { errorMessage } = formatRepublishedReport(
+    findRepublishedEntries(
+      [{
+        file: '.changelogs/12451.json',
+        entry: entry({ issueOrPR: 12451, framework: 'angular', title: 'Modernized the Angular wrapper.' })
+      }],
+      CHANGELOG
+    )
+  );
+
+  assert.match(errorMessage, /#12451 is already cited in \[18\.0\.0\], and its title is already published/);
+});
+
+test('a clean set renders no message at all', () => {
+  const report = formatRepublishedReport(
+    findRepublishedEntries([{ file: '.changelogs/13300.json', entry: entry() }], CHANGELOG)
+  );
+
+  assert.equal(report.errorMessage, '');
+  assert.equal(report.warningMessage, '');
+});


### PR DESCRIPTION
### Context

The PR stops an already-released changelog entry from being announced a second time in the next release.

A pending `.changelogs/<n>.json` can outlive the release-to-develop merge-back after the release branch has already consumed it. The next `bin/changelog consume` then republishes it. #13250 removed four such entries from the `18.1.0` section by hand; this PR fixes the cause.

There are two mechanisms, both reproduced in an isolated synthetic repository:

- **The same change committed twice, with no ancestry**, once on the release branch, once on `develop`. Against the merge base the release side reads as *add then delete*, net zero, so develop's own *add* is the only change on either side and the three-way merge keeps it. **No conflict is raised at all**, which is why this was never noticed. `#12811` is `6714c8743d` on `release/18.0.0` and `6bc43a7a7a` on `develop`; `#12844` and `#12847` have the same shape.
- **The entry file edited on `develop` after being consumed**, a modify/delete conflict, resolved by keeping develop's copy. `#12727` was consumed by `18.0.0-rc1` (`fd8cddd0bc`) and then modified six days later by `d68ea7f92e` (#12810).

Running a detector against the pending set at the parent of every release `consume` commit shows the leak was primed at **9 of the last 13 releases**, and only the 18.1.0 round was ever caught.

Nothing existing catches it: `changelog-gate.mjs` asserts a source PR *adds* an entry and never checks for republication, the merge-back is a direct push rather than a pull request so no PR check runs on it, and `consumeCommand` validated entry *format* only.

### What this does

Rather than trying to recognize either merge shape, it asserts the one thing both produce: a pending entry that `CHANGELOG.md` already publishes. `consumeCommand` already holds the changelog text and the parsed entries, so the check is local, with no git archaeology and no new workflow.

**It is placed before the `if (dryRun)` early exit on purpose.** `checks.yml:255` already runs `bin/changelog consume --date 2050-01-01 --dry-run` on every pull request, so one assertion is enforced at three points for zero CI wiring: every PR against `develop`, the release dry run, and the real consume.

It is also applied to `syncCommand`, which deduped only against the section it targets (`section.includes('/' + issueOrPR + ')')`). An entry already published in an *earlier* section would be added again, and `publish.yml:796` runs `sync` on every RC, so without this the gate was bypassable by the release path itself. Trade-off accepted: `sync` can now exit non-zero mid-RC.

#### Matching rules

| Match | Result |
|---|---|
| `issueOrPR` already cited, `issuesOrigin` is `private` | **fails** |
| `issueOrPR` already cited, `issuesOrigin` is `public` | warns |
| the entry's title already published, under any number | warns |

A pull request number cannot ship twice, so a `private` number match is conclusive. The other two can be legitimate: a public **issue** number may be cited by two releases when a partial fix is followed by a complete one, and one title may appear in two sections when a fix is backported to several release lines (`Fixed the copy/paste feature not working correctly in Chrome 133.` legitimately appears in 15.1.0, 15.0.1, and 14.6.2).

Both keys are required, because each alone has a blind spot that already occurred: the number key misses an entry published under a wrong link (`#12727` shipped as `[#0]`), and the title key misses an entry reworded on one branch (`#13243`).

**Known gap, accepted:** an entry that carries `issuesOrigin: "public"` for a *pull request* number is mislabeled, and a genuine leak on it downgrades to a warning rather than failing. That is live behavior, not something the merge-back removed. `.changelogs/12811.json` was such an entry: `#12844` and `#12847` hard-failed in the same round, so the release was blocked anyway and `#12811` appeared as a warning in the same report. A possible refinement, not taken here: hard-fail a `public` number hit when the title also matches, since two independent keys agreeing is inconsistent with both legitimate cases.

### Merge order, now satisfied

The agreed sequence was: release 18.1.0 on the current flow, merge `release/18.1.0` back into `develop`, then rebase this branch and merge it. Steps 1 and 2 are done (#13324), and this branch is now rebased on top of that merge-back.

The merge-back removed **every** consumed entry, including the four 18.0-era stragglers (`12727`, `12811`, `12844`, `12847`) that an earlier revision of this branch deleted by hand. Those deletions are therefore gone from the diff, and no replacement deletions are needed: the recompute below reports a clean pending set. This PR is now the gate and its documentation only.

**Target is `develop` only, no cherry-pick to `release/18.1.0`.** That branch holds zero pending `.changelogs/*.json` entries, so the gate has nothing to act on there, and `package.json` diverges, so the eslint-script line would conflict. Future release branches inherit the gate when they are cut from `develop`.

### How has this been tested?

No `handsontable/src/**` or `wrappers/**` code changed, so the core lint, build, and test suites are unaffected. The relevant gates, re-run after the rebase:

```bash
npm run test:tooling
npx eslint .github/scripts/ bin/changelog bin/lib scripts/
```

Result: **216/216 tests pass** (16 new), eslint clean.

Both `bin/changelog` commands were smoke-tested on this branch, and neither modifies `CHANGELOG.md`:

```bash
node bin/changelog consume --date 2050-01-01 --dry-run   # exit 0
node bin/changelog sync --dry-run                        # exit 0
```

#### Backtests against real history

```bash
# 1. the state at the 18.1.0-rc1 consume, 104 pending entries
git checkout 8f12dfcd24^ -- CHANGELOG.md .changelogs
node bin/changelog consume --date 2050-01-01 --dry-run
git checkout HEAD -- CHANGELOG.md .changelogs
```

Flags exactly the four entries #13250 removed by hand, and nothing else. 100 clean, no false positives. `#12727` is caught by the **title** key alone, which is what earns the second key.

```bash
# 2. real post-merge-back develop, this branch rebased, 39 pending entries
node bin/changelog consume --date 2050-01-01 --dry-run   # exit 0
```

0 errors, 0 warnings. The pre-rebase revision predicted `13236`, `13240`, `13242`, `13243`, `13245` would survive the merge-back. The merge-back deleted all five, so nothing is left to remove.

```bash
# 3. the same tree with one leaked entry restored, as a live-fire check
git show d8df372278:.changelogs/13236.json > .changelogs/13236.json
node bin/changelog consume --date 2050-01-01 --dry-run   # exit 1
```

```
1 pending changelog entry has already been published:
  .changelogs/13236.json: #13236 is already cited in [18.1.0], and its title is already published in [18.1.0]
  git rm .changelogs/13236.json
```

Both keys fire on real data, and the remediation command is printed.

#### Mutation tested

The new tests were confirmed to fail against deliberately broken implementations, so they are not vacuously green:

| Mutation | Tests that fail |
|---|---|
| drop the title key | 3 |
| make every hit a hard failure | 3 |
| read the first `[#N]` link instead of the last | 1 |
| make `excludeVersionSection` a no-op | 3 |

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2678

A separate, deliberately deferred follow-up task removes the entries this leak already published twice from the `16.x`-and-up sections. It is independent of this PR and can land in either order.

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Release tooling only (`bin/`, `scripts/__tests__/`, `.changelogs/README.md`, the root eslint script).

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) with one signature covering both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

`.changelogs/README.md` gains a "No entry may be published twice" section covering both mechanisms, the severity table, and how to resolve a failure.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2678

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release and changelog tooling only; no runtime product code. `sync` can now fail mid-RC when duplicates are detected, which is intentional.
> 
> **Overview**
> Prevents the same changelog item from shipping twice when stale `.changelogs/*.json` files survive a release-to-develop merge-back.
> 
> Adds **`bin/lib/published-entries.js`** to compare pending entries against published `CHANGELOG.md` (PR/issue number and normalized title), with **errors** for conclusive duplicates and **warnings** for ambiguous cases (public issues, backport titles). **`bin/changelog consume`** and **`sync`** call this before compiling; **`consume --dry-run`** runs the check too, so existing PR CI already enforces it. The stable **merge-to-develop** step in **`publish.yml`** refuses to push if the dry-run fails.
> 
> Documents the rules and remediation in **`.changelogs/README.md`**, extends eslint to **`bin/lib`**, and adds **`changelog-published-entries.test.mjs`** for the matching logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecefc467d1e21ddbc69da8ae9f1aa16d18ab8241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->