### PR TITLE
CVE-2026-59873: Bump tar to 7.5.19 or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,10 +98,10 @@
       "@parcel/watcher>picomatch": "^4.0.4",
       "@rollup/pluginutils>picomatch": "^4.0.4",
       "serialize-javascript": "^7.0.3",
-      "pacote>tar": "^7.5.11",
+      "pacote>tar": "^7.5.19",
       "pacote>sigstore": "^4.1.1",
-      "node-gyp>tar": "^7.5.11",
-      "cacache>tar": "^7.5.11",
+      "node-gyp>tar": "^7.5.19",
+      "cacache>tar": "^7.5.19",
       "typed-rest-client": "^3.1.0",
       "undici": "^6.28.0",
       "@astrojs/mdx": "^6.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,10 +33,10 @@ overrides:
   '@parcel/watcher>picomatch': ^4.0.4
   '@rollup/pluginutils>picomatch': ^4.0.4
   serialize-javascript: ^7.0.3
-  pacote>tar: ^7.5.11
+  pacote>tar: ^7.5.19
   pacote>sigstore: ^4.1.1
-  node-gyp>tar: ^7.5.11
-  cacache>tar: ^7.5.11
+  node-gyp>tar: ^7.5.19
+  cacache>tar: ^7.5.19
   typed-rest-client: ^3.1.0
   undici: ^6.28.0
   '@astrojs/mdx': ^6.0.1
@@ -12346,8 +12346,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -20434,7 +20434,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 7.0.4
       ssri: 12.0.0
-      tar: 7.5.16
+      tar: 7.5.22
       unique-filename: 4.0.0
 
   cacache@20.0.4:
@@ -25515,7 +25515,7 @@ snapshots:
       nopt: 8.1.0
       proc-log: 5.0.0
       semver: 7.8.4
-      tar: 7.5.16
+      tar: 7.5.22
       tinyglobby: 0.2.17
       which: 5.0.0
     transitivePeerDependencies:
@@ -25837,7 +25837,7 @@ snapshots:
       promise-retry: 2.0.1
       sigstore: 4.1.1
       ssri: 12.0.0
-      tar: 7.5.16
+      tar: 7.5.22
     transitivePeerDependencies:
       - supports-color
 
@@ -27803,7 +27803,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.16:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
### Context

The PR fixes a critical Dependabot alert ([Dependabot alert 5525](https://github.com/handsontable/handsontable/security/dependabot/5525)): `tar` up to and including 7.5.18 is vulnerable to a decompression/parse denial of service (GHSA-23hp-3jrh-7fpw, CVE-2026-59873), fixed in 7.5.19.

The package is transitive only. It reaches the workspace through the `@angular/cli` dev dependency of `@handsontable/angular-wrapper`, by way of `pacote`, `node-gyp` and `cacache`. The root `pnpm.overrides` already pinned those three edges, but at `^7.5.11`, so the lockfile still resolved `tar` 7.5.16.

Raising the three overrides to `^7.5.19` re-resolves the lockfile to `tar` 7.5.22 and keeps the floor above the vulnerable range for future installs. No product code or runtime dependency changes, so no changelog entry applies.

### How has this been tested?

`pnpm why tar -r` reports a single version, 7.5.22, after the install. The full lockfile diff is limited to the `tar` entries.

```bash
pnpm install --no-frozen-lockfile
pnpm why tar -r

npm --prefix handsontable run build
npm --prefix handsontable run test:unit          # 328 suites, 4043 tests
npm --prefix wrappers/angular-wrapper run test   # 13 suites, 291 tests
npm --prefix wrappers/react-wrapper run test     # 16 suites, 94 tests
npm --prefix wrappers/vue3 run test              # 4 suites, 33 tests
```

All of the above pass. The Angular wrapper matters most here: its toolchain is the one that pulls `tar` in.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. [Dependabot alert 5525](https://github.com/handsontable/handsontable/security/dependabot/5525) — GHSA-23hp-3jrh-7fpw / CVE-2026-59873

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

[skip changelog] — dependency override only, no source change.
