### PR TITLE
DEV-2677: Ignore non-left clicks on the autocomplete cell arrow

### DIFF
--- a/.changelogs/13295.json
+++ b/.changelogs/13295.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a right-click on an autocomplete or dropdown cell's arrow opening the cell editor.",
+  "type": "fixed",
+  "issueOrPR": 13295,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13295.json
+++ b/.changelogs/13295.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed a right-click on a cell's dropdown arrow opening the cell editor.",
+  "title": "Fixed a non-left-button click on a cell's dropdown arrow opening the cell editor.",
   "type": "fixed",
   "issueOrPR": 13295,
   "breaking": false,

--- a/.changelogs/13295.json
+++ b/.changelogs/13295.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed a right-click on an autocomplete or dropdown cell's arrow opening the cell editor.",
+  "title": "Fixed a right-click on a cell's dropdown arrow opening the cell editor.",
   "type": "fixed",
   "issueOrPR": 13295,
   "breaking": false,

--- a/handsontable/src/renderers/autocompleteRenderer/autocompleteRenderer.ts
+++ b/handsontable/src/renderers/autocompleteRenderer/autocompleteRenderer.ts
@@ -4,6 +4,7 @@ import { htmlRenderer } from '../htmlRenderer';
 import { textRenderer } from '../textRenderer';
 import EventManager from '../../eventManager';
 import { addClass, eventTargetEl, hasClass } from '../../helpers/dom/element';
+import { isLeftClick } from '../../helpers/dom/event';
 import { A11Y_HIDDEN } from '../../helpers/a11y';
 
 export const RENDERER_TYPE: 'autocomplete' = 'autocomplete';
@@ -55,7 +56,10 @@ export function autocompleteRenderer(
 
     // not very elegant but easy and fast
     hotInstance.acArrowListener = function(event: Event) {
-      if (hasClass(eventTargetEl(event)!, 'htAutocompleteArrow')) {
+      // Only the left button opens the list. Walkontable applies the same restriction to its own
+      // double-click-to-open path, and without it a right-click on the arrow opens the editor
+      // alongside the context menu.
+      if (isLeftClick(event) && hasClass(eventTargetEl(event)!, 'htAutocompleteArrow')) {
         hotInstance.view._wt.getSetting('onCellDblClick', null, hotInstance._createCellCoords(row, col), TD);
       }
     };

--- a/handsontable/src/renderers/autocompleteRenderer/autocompleteRenderer.ts
+++ b/handsontable/src/renderers/autocompleteRenderer/autocompleteRenderer.ts
@@ -62,6 +62,10 @@ export function autocompleteRenderer(
       // hatch; this path needs none, because a tap reaches it only as a compatibility `mousedown`,
       // which carries `button === 0` like any other left press.
       if (isLeftClick(event) && hasClass(eventTargetEl(event)!, 'htAutocompleteArrow')) {
+        // The `null` event is load-bearing, not laziness: `EditorManager#openEditor` only applies
+        // its "no editor for a multi-cell selection" default when the event is a `MouseEvent`, so
+        // forwarding the real one here would stop the arrow from opening the list after a
+        // shift-drag range. Changing that is a behavior change, not a cleanup.
         hotInstance.view._wt.getSetting('onCellDblClick', null, hotInstance._createCellCoords(row, col), TD);
       }
     };

--- a/handsontable/src/renderers/autocompleteRenderer/autocompleteRenderer.ts
+++ b/handsontable/src/renderers/autocompleteRenderer/autocompleteRenderer.ts
@@ -56,9 +56,11 @@ export function autocompleteRenderer(
 
     // not very elegant but easy and fast
     hotInstance.acArrowListener = function(event: Event) {
-      // Only the left button opens the list. Walkontable applies the same restriction to its own
+      // Only the left button opens the list. Walkontable applies the same button check to its own
       // double-click-to-open path, and without it a right-click on the arrow opens the editor
-      // alongside the context menu.
+      // alongside the context menu. Walkontable pairs that check with a `touchApplied` escape
+      // hatch; this path needs none, because a tap reaches it only as a compatibility `mousedown`,
+      // which carries `button === 0` like any other left press.
       if (isLeftClick(event) && hasClass(eventTargetEl(event)!, 'htAutocompleteArrow')) {
         hotInstance.view._wt.getSetting('onCellDblClick', null, hotInstance._createCellCoords(row, col), TD);
       }

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -55,7 +55,8 @@ Visual regression is a separate package (`visual-tests/`). Task workflow: the
   puts the arrow back under the centre, so cell content is not a guarantee
   either. Click off-centre, or select with `hot.selectCell()`, when the spec
   means to open the editor with Enter. Root-caused in DEV-2677; the arrow's own
-  coverage is `e2e/autocomplete-arrow-button.spec.ts`.
+  coverage is `e2e/cell-dropdown-arrow-button.spec.ts`, over all three cell
+  types.
 - **Seed an `autocomplete` / `dropdown` fixture with a prefix the whole column's
   choice set shares** (`'Al'` for `Alpha/Alfa/Alto`), so `autocomplete`, which
   filters by the typed value, renders the same list as `dropdown`, which forces

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -34,19 +34,26 @@ Visual regression is a separate package (`visual-tests/`). Task workflow: the
   warning and silently stays off) and **no languages pack** (an i18n fixture
   loads `dist/languages/all.js` explicitly — the Puppeteer harness does that
   for you, this tier does not).
-- **Seed an editor fixture's cells with a non-empty value.** On an EMPTY cell,
-  `cell.click()` followed by `keyboard.press('Enter')` opens the editor and
-  closes it again on the same keypress. The trace is `afterBeginEditing`
-  (EDITING) → `beforeChange` (WAITING) → `afterChange` (VIRGIN). Nothing is
-  logged, so the spec just fails at "the editor never opened" with no pointer to
-  the cause. It is specific to click-then-Enter: `hot.selectCell()` then Enter
-  keeps an empty cell's editor open, and so does click-then-Enter as soon as the
-  cell has a value. Pre-existing and not root-caused (see the sibling case,
-  `dropdownEditor.spec.js`'s "empty-value focus"). For `autocomplete` /
-  `dropdown`, seed with a prefix the whole column's choice set shares (`'Al'` for
-  `Alpha/Alfa/Alto`) so `autocomplete`, which filters by the typed value, renders
-  the same list as `dropdown`, which forces `filter: false`, and one assertion
-  covers both. Reference: `fixtures/demo/autocomplete-async-source.html`.
+- **On `autocomplete` / `dropdown`, a centred `cell.click()` can land on the
+  dropdown arrow and open the editor by itself.** `autocompleteRenderer`
+  registers a `mousedown` listener that opens the list whenever the press lands
+  on `.htAutocompleteArrow`, so the editor is already open before your
+  `keyboard.press('Enter')` — and that Enter then correctly commits and closes
+  it. The spec fails at "the editor never opened" with nothing in the log to
+  point at the cause. Whether the click lands on the arrow is pure geometry: the
+  arrow is 16 px wide and right-floated, so in a cell at the 50 px default column
+  width it spans x=24–40 while the centre is x=25. An EMPTY cell is the common
+  way to end up at that default width, which is why empty fixtures trip it and
+  seeded ones usually do not — but a long header or narrow content puts the arrow
+  back under the centre, so cell content is not a guarantee. Click off-centre, or
+  select with `hot.selectCell()`, when the spec means to open the editor with
+  Enter. Root-caused in DEV-2677; the arrow's own coverage is
+  `e2e/autocomplete-arrow-button.spec.ts`.
+- **Seed an `autocomplete` / `dropdown` fixture with a prefix the whole column's
+  choice set shares** (`'Al'` for `Alpha/Alfa/Alto`), so `autocomplete`, which
+  filters by the typed value, renders the same list as `dropdown`, which forces
+  `filter: false`, and one assertion covers both. Reference:
+  `fixtures/demo/autocomplete-async-source.html`.
 - A fixture-served library MUST be a dependency of THIS package, loaded from
   `/tests/node_modules/…` — CI installs only the filtered `handsontable-tests`
   workspace, so a path into any other package's `node_modules` does not exist

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -34,21 +34,28 @@ Visual regression is a separate package (`visual-tests/`). Task workflow: the
   warning and silently stays off) and **no languages pack** (an i18n fixture
   loads `dist/languages/all.js` explicitly — the Puppeteer harness does that
   for you, this tier does not).
-- **On `autocomplete` / `dropdown`, a centred `cell.click()` can land on the
-  dropdown arrow and open the editor by itself.** `autocompleteRenderer`
-  registers a `mousedown` listener that opens the list whenever the press lands
-  on `.htAutocompleteArrow`, so the editor is already open before your
+- **On a cell with a dropdown arrow, a centred `cell.click()` can land on the
+  arrow and open the editor by itself.** `autocompleteRenderer` registers a
+  `mousedown` listener that opens the list whenever the press lands on
+  `.htAutocompleteArrow`, so the editor is already open before your
   `keyboard.press('Enter')` — and that Enter then correctly commits and closes
   it. The spec fails at "the editor never opened" with nothing in the log to
-  point at the cause. Whether the click lands on the arrow is pure geometry: the
-  arrow is 16 px wide and right-floated, so in a cell at the 50 px default column
-  width it spans x=24–40 while the centre is x=25. An EMPTY cell is the common
-  way to end up at that default width, which is why empty fixtures trip it and
-  seeded ones usually do not — but a long header or narrow content puts the arrow
-  back under the centre, so cell content is not a guarantee. Click off-centre, or
-  select with `hot.selectCell()`, when the spec means to open the editor with
-  Enter. Root-caused in DEV-2677; the arrow's own coverage is
-  `e2e/autocomplete-arrow-button.spec.ts`.
+  point at the cause. It is not only `autocomplete` and `dropdown`:
+  `handsontableRenderer` and `dropdownRenderer` both delegate to
+  `autocompleteRenderer`, so `type: 'handsontable'` carries the same arrow.
+  Whether the click lands on it is pure geometry, and **the outcome is
+  theme-dependent** — the arrow is right-floated at `var(--ht-icon-size)`, which
+  is 16 px on `main` and `horizon` but 12 px on `classic`, and the deciding term
+  is the theme's cell padding, which leaves the arrow's left edge within about a
+  pixel of the centre. Measured on `main`: at the 50 px default column width the
+  arrow spans x=24–40 while the centre is x=25. So the same centred click can hit
+  on one leg of the theme × bundle matrix and miss on another. An EMPTY cell is
+  the common way to end up at that default width, which is why empty fixtures
+  trip it and seeded ones usually do not — but a long header or narrow content
+  puts the arrow back under the centre, so cell content is not a guarantee
+  either. Click off-centre, or select with `hot.selectCell()`, when the spec
+  means to open the editor with Enter. Root-caused in DEV-2677; the arrow's own
+  coverage is `e2e/autocomplete-arrow-button.spec.ts`.
 - **Seed an `autocomplete` / `dropdown` fixture with a prefix the whole column's
   choice set shares** (`'Al'` for `Alpha/Alfa/Alto`), so `autocomplete`, which
   filters by the typed value, renders the same list as `dropdown`, which forces

--- a/tests/e2e/autocomplete-arrow-button.spec.ts
+++ b/tests/e2e/autocomplete-arrow-button.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '../fixtures/test';
+import { AutocompleteAsyncSourcePage } from '../fixtures/pages/AutocompleteAsyncSourcePage';
+
+const EDITORS = ['autocomplete', 'dropdown'] as const;
+
+/**
+ * DEV-2677. `autocompleteRenderer` registers a `mousedown` listener that opens the editor when the
+ * press lands on a cell's dropdown arrow. It tested only the target's class and never the mouse
+ * button, so a right-click on the arrow opened the editor - on a grid with a context menu, that
+ * handed the user the editor and the menu at once. Walkontable restricts its own
+ * double-click-to-open path to the left button; this path now does the same.
+ *
+ * Both halves are asserted every time. A case that only checked the right button would pass on a
+ * "fix" that deleted the affordance, and opening the list from its arrow is behavior users have
+ * relied on for a decade.
+ *
+ * The negative case anchors on the selection rather than polling for the editor to stay closed:
+ * `expect.poll` retries until its condition holds, so it would report success on an editor that
+ * opened one tick later. A right-button press selects the cell, so waiting for the selection to
+ * land gives a deterministic point at which a single, non-retrying assertion is meaningful.
+ */
+EDITORS.forEach((editor) => {
+  test.describe(`${editor} editor dropdown arrow`, () => {
+    let grid: AutocompleteAsyncSourcePage;
+
+    test.beforeEach(async({ page, theme, bundle }) => {
+      grid = new AutocompleteAsyncSourcePage(page, theme, bundle, { editor });
+      await grid.goto();
+    });
+
+    test('opens the editor when the arrow is pressed with the left button', async() => {
+      await grid.arrow(0, 0).click();
+
+      await expect.poll(() => grid.isEditorOpen()).toBe(true);
+    });
+
+    test('leaves the editor closed when the arrow is pressed with the right button', async() => {
+      await grid.arrow(0, 0).click({ button: 'right' });
+
+      await expect.poll(() => grid.selected()).toEqual([[0, 0, 0, 0]]);
+
+      expect(await grid.isEditorOpen()).toBe(false);
+    });
+  });
+});

--- a/tests/e2e/autocomplete-arrow-button.spec.ts
+++ b/tests/e2e/autocomplete-arrow-button.spec.ts
@@ -28,10 +28,19 @@ EDITORS.forEach((editor) => {
       await grid.goto();
     });
 
+    // Cell (1, 1) rather than (0, 0), and the editor's own coordinates rather than just "an editor
+    // is open". To be clear about what that does and does not cover: the renderer builds its arrow
+    // listener once and closes over the FIRST rendered cell's coordinates, and no assertion here
+    // can catch that today - the pair reaches only `isCell()`, and `prepareEditor()` takes the
+    // edited cell from the live selection, so the editor's coordinates and `getSelected()` are the
+    // same state. Clicking a cell that is not the first one, and reading the coordinates the editor
+    // was actually prepared with, is what would surface it if a later change starts honoring the
+    // coordinates the listener passes. It does catch an editor reused without a re-`prepare()`.
     test('opens the editor when the arrow is pressed with the left button', async() => {
-      await grid.arrow(0, 0).click();
+      await grid.arrow(1, 1).click();
 
       await expect.poll(() => grid.isEditorOpen()).toBe(true);
+      expect(await grid.editorCoords()).toEqual([1, 1]);
     });
 
     test('leaves the editor closed when the arrow is pressed with the right button', async() => {

--- a/tests/e2e/cell-dropdown-arrow-button.spec.ts
+++ b/tests/e2e/cell-dropdown-arrow-button.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from '../fixtures/test';
-import { AutocompleteAsyncSourcePage } from '../fixtures/pages/AutocompleteAsyncSourcePage';
+import { CellDropdownArrowPage, type CellType } from '../fixtures/pages/CellDropdownArrowPage';
 
-const EDITORS = ['autocomplete', 'dropdown'] as const;
+// Every cell type that renders the arrow, because they all reach the same listener:
+// `dropdownRenderer` and `handsontableRenderer` both delegate to `autocompleteRenderer`.
+const CELL_TYPES: CellType[] = ['autocomplete', 'dropdown', 'handsontable'];
 
 /**
  * DEV-2677. `autocompleteRenderer` registers a `mousedown` listener that opens the editor when the
@@ -19,12 +21,12 @@ const EDITORS = ['autocomplete', 'dropdown'] as const;
  * opened one tick later. A right-button press selects the cell, so waiting for the selection to
  * land gives a deterministic point at which a single, non-retrying assertion is meaningful.
  */
-EDITORS.forEach((editor) => {
-  test.describe(`${editor} editor dropdown arrow`, () => {
-    let grid: AutocompleteAsyncSourcePage;
+CELL_TYPES.forEach((cellType) => {
+  test.describe(`${cellType} cell dropdown arrow`, () => {
+    let grid: CellDropdownArrowPage;
 
     test.beforeEach(async({ page, theme, bundle }) => {
-      grid = new AutocompleteAsyncSourcePage(page, theme, bundle, { editor });
+      grid = new CellDropdownArrowPage(page, theme, bundle, cellType);
       await grid.goto();
     });
 

--- a/tests/fixtures/demo/autocomplete-async-source.html
+++ b/tests/fixtures/demo/autocomplete-async-source.html
@@ -48,11 +48,13 @@
       ['Bravo', 'Bruno', 'Brisk'],
     ];
 
-    // Each column is seeded with the prefix its whole choice set shares. Two reasons, both load
-    // bearing. An EMPTY cell closes the editor again on the same Enter that opened it, so nothing
-    // would ever stay open to test. And a prefix keeps `autocomplete` (which filters by the typed
-    // value) showing the same three choices as `dropdown` (which forces `filter: false`), so one
-    // assertion covers both editors.
+    // Each column is seeded with the prefix its whole choice set shares, so that `autocomplete`
+    // (which filters by the typed value) shows the same three choices as `dropdown` (which forces
+    // `filter: false`) and one assertion covers both editors.
+    //
+    // The seed also keeps a centred `cell.click()` off the dropdown arrow, but only as a side
+    // effect: content widens the column, and the right-floated arrow moves clear of the centre with
+    // it. Do not rely on that - see the fixture-contract bullet in `tests/AGENTS.md`.
     const SEEDS = ['Al', 'Br'];
 
     // Read by the page object, so the spec asserts against the fixture's own values instead of a

--- a/tests/fixtures/demo/cell-dropdown-arrow.html
+++ b/tests/fixtures/demo/cell-dropdown-arrow.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Cell dropdown arrow fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    const htParams = new URLSearchParams(location.search);
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+    window.htCellType = ({
+      autocomplete: 'autocomplete', dropdown: 'dropdown', handsontable: 'handsontable',
+    })[htParams.get('cellType') ?? 'autocomplete'];
+    if (!window.htCellType) {
+      throw new Error('Unknown ?cellType= value: ' + JSON.stringify(htParams.get('cellType')));
+    }
+  </script>
+</head>
+<body>
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const CHOICES = ['Alpha', 'Alfa', 'Alto'];
+
+    // All three cell types render the SAME arrow: `dropdownRenderer` and `handsontableRenderer`
+    // both delegate to `autocompleteRenderer`, which is where the arrow and its `mousedown`
+    // listener come from. They configure their choices differently though - `autocomplete` and
+    // `dropdown` take a flat `source`, while `handsontable` takes a whole nested grid config -
+    // which is why this fixture exists instead of a third value on the async-source fixture, whose
+    // `source` is a query recorder that a nested grid would never call.
+    const columnByCellType = {
+      autocomplete: { type: 'autocomplete', source: CHOICES },
+      dropdown: { type: 'dropdown', source: CHOICES },
+      handsontable: { type: 'handsontable', handsontable: { data: CHOICES.map(choice => [choice]) } },
+    };
+
+    const column = columnByCellType[window.htCellType];
+
+    // Cells are seeded so the column is not at its default minimum width, which is the width where
+    // a centred click lands on the arrow. Cases here address the arrow directly, so this only keeps
+    // an ordinary cell click available as a control.
+    window.hot = new Handsontable(container, {
+      data: Array.from({ length: 3 }, () => ['Al', 'Al']),
+      columns: [column, column],
+      colHeaders: true,
+      rowHeaders: true,
+      // Stamp test ids from `afterRenderer`, not from a grid-level `renderer`: a column `type`
+      // installs its own renderer, which would override the grid-level one and leave the typed
+      // columns with no test id at all.
+      afterRenderer(td, row, col) {
+        td.setAttribute('data-testid', `cell-${row}-${col}`);
+      },
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
+++ b/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
@@ -95,6 +95,14 @@ export class AutocompleteAsyncSourcePage {
   }
 
   /**
+   * Returns a cell's dropdown arrow. The renderer builds the arrow, so it carries no test id of its
+   * own and has to be reached through the cell that owns it.
+   */
+  arrow(row: number, col: number): Locator {
+    return this.cell(row, col).locator('.htAutocompleteArrow');
+  }
+
+  /**
    * Selects a cell, opens its editor with Enter, and waits until the column's `source` has been
    * asked for choices. Enter rather than typing: full edit mode seeds the editor with the cell's
    * own value, so the query is the column's shared choice prefix and the whole list matches.

--- a/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
+++ b/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
@@ -110,7 +110,13 @@ export class AutocompleteAsyncSourcePage {
    * own value, so the query is the column's shared choice prefix and the whole list matches.
    */
   async openEditor(row: number, col: number): Promise<void> {
-    await this.cell(row, col).click();
+    // Near the cell's leading edge, NOT its centre. A centred click can land on the right-floated
+    // dropdown arrow, whose `mousedown` listener opens the editor by itself - the Enter below would
+    // then commit and close it, and every case here would fail at "the editor never opened" with
+    // nothing in the log. Today the seeds widen the column enough that a centred click misses, but
+    // that margin is a few pixels and moves with the seed, the header and the theme's cell padding,
+    // so it is not something to rely on. See the fixture-contract bullet in `tests/AGENTS.md`.
+    await this.cell(row, col).click({ position: { x: 5, y: 5 } });
 
     await expect.poll(() => this.selected()).toEqual([[row, col, row, col]]);
 

--- a/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
+++ b/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
@@ -3,6 +3,8 @@ import { type Locator, type Page, expect } from '@playwright/test';
 interface EditorFixture {
   isOpened(): boolean;
   state: string;
+  row: number;
+  col: number;
   rawChoices: unknown[];
   htEditor: { rootElement: HTMLElement };
   TEXTAREA: HTMLTextAreaElement;
@@ -116,6 +118,19 @@ export class AutocompleteAsyncSourcePage {
 
     await expect.poll(() => this.isEditorOpen()).toBe(true);
     await expect.poll(() => this.pendingQueryCount(col)).toBeGreaterThan(0);
+  }
+
+  /**
+   * Returns the coordinates of the cell the active editor is bound to, or `null` when there is no
+   * editor. `isEditorOpen()` only reports that SOME editor is open, which cannot tell an editor on
+   * the wrong cell apart from the right one.
+   */
+  async editorCoords(): Promise<[number, number] | null> {
+    return this.page.evaluate(() => {
+      const editor = (window as unknown as FixtureWindow).hot.getActiveEditor();
+
+      return editor ? [editor.row, editor.col] : null;
+    });
   }
 
   /**

--- a/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
+++ b/tests/fixtures/pages/AutocompleteAsyncSourcePage.ts
@@ -3,8 +3,6 @@ import { type Locator, type Page, expect } from '@playwright/test';
 interface EditorFixture {
   isOpened(): boolean;
   state: string;
-  row: number;
-  col: number;
   rawChoices: unknown[];
   htEditor: { rootElement: HTMLElement };
   TEXTAREA: HTMLTextAreaElement;
@@ -97,14 +95,6 @@ export class AutocompleteAsyncSourcePage {
   }
 
   /**
-   * Returns a cell's dropdown arrow. The renderer builds the arrow, so it carries no test id of its
-   * own and has to be reached through the cell that owns it.
-   */
-  arrow(row: number, col: number): Locator {
-    return this.cell(row, col).locator('.htAutocompleteArrow');
-  }
-
-  /**
    * Selects a cell, opens its editor with Enter, and waits until the column's `source` has been
    * asked for choices. Enter rather than typing: full edit mode seeds the editor with the cell's
    * own value, so the query is the column's shared choice prefix and the whole list matches.
@@ -124,19 +114,6 @@ export class AutocompleteAsyncSourcePage {
 
     await expect.poll(() => this.isEditorOpen()).toBe(true);
     await expect.poll(() => this.pendingQueryCount(col)).toBeGreaterThan(0);
-  }
-
-  /**
-   * Returns the coordinates of the cell the active editor is bound to, or `null` when there is no
-   * editor. `isEditorOpen()` only reports that SOME editor is open, which cannot tell an editor on
-   * the wrong cell apart from the right one.
-   */
-  async editorCoords(): Promise<[number, number] | null> {
-    return this.page.evaluate(() => {
-      const editor = (window as unknown as FixtureWindow).hot.getActiveEditor();
-
-      return editor ? [editor.row, editor.col] : null;
-    });
   }
 
   /**

--- a/tests/fixtures/pages/CellDropdownArrowPage.ts
+++ b/tests/fixtures/pages/CellDropdownArrowPage.ts
@@ -1,0 +1,98 @@
+import { type Locator, type Page, expect } from '@playwright/test';
+
+interface EditorFixture {
+  isOpened(): boolean;
+  row: number;
+  col: number;
+}
+
+// Deliberately not `extends Window`: `windowTypes.ts` already declares `hot` globally with the full
+// instance type, and narrowing it here to the members these probes use would be a TS2430 conflict.
+// Every access goes through an explicit cast anyway.
+interface FixtureWindow {
+  hot: {
+    getSelected(): number[][] | undefined;
+    getActiveEditor(): EditorFixture | undefined;
+  };
+}
+
+export type CellType = 'autocomplete' | 'dropdown' | 'handsontable';
+
+/**
+ * Page Object for the fixture whose cells carry a dropdown arrow.
+ *
+ * Openness is read through `hot.getActiveEditor()`, never a CSS locator: `.handsontableInput` is
+ * always in the DOM and a closed editor is only `opacity: 0`, which Playwright counts as visible.
+ */
+export class CellDropdownArrowPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly cellType: CellType;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd', cellType: CellType = 'autocomplete') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.cellType = cellType;
+  }
+
+  /**
+   * Opens the fixture and waits for the first data cell to render.
+   */
+  async goto(): Promise<void> {
+    const query = `theme=${this.theme}&bundle=${this.bundle}&cellType=${this.cellType}`;
+
+    await this.page.goto(`/tests/fixtures/demo/cell-dropdown-arrow.html?${query}`);
+
+    // Wait for the bundle before the cell. The test id comes from the fixture's `afterRenderer`,
+    // so "cell not found" alone cannot tell a slow bundle apart from a grid that failed to render.
+    await this.page.waitForFunction(() => 'Handsontable' in window);
+
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /**
+   * Returns a data cell through its fixture-owned test id.
+   */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /**
+   * Returns a cell's dropdown arrow. The renderer builds the arrow, so it carries no test id of its
+   * own and has to be reached through the cell that owns it.
+   */
+  arrow(row: number, col: number): Locator {
+    return this.cell(row, col).locator('.htAutocompleteArrow');
+  }
+
+  /**
+   * Reports whether a cell editor is open.
+   */
+  async isEditorOpen(): Promise<boolean> {
+    return this.page.evaluate(() => (
+      (window as unknown as FixtureWindow).hot.getActiveEditor()?.isOpened() === true
+    ));
+  }
+
+  /**
+   * Returns the coordinates of the cell the active editor is bound to, or `null` when there is no
+   * editor. `isEditorOpen()` only reports that SOME editor is open, which cannot tell an editor on
+   * the wrong cell apart from the right one.
+   */
+  async editorCoords(): Promise<[number, number] | null> {
+    return this.page.evaluate(() => {
+      const editor = (window as unknown as FixtureWindow).hot.getActiveEditor();
+
+      return editor ? [editor.row, editor.col] : null;
+    });
+  }
+
+  /**
+   * Returns the current selection.
+   */
+  async selected(): Promise<number[][] | undefined> {
+    return this.page.evaluate(() => (window as unknown as FixtureWindow).hot.getSelected());
+  }
+}


### PR DESCRIPTION
### Context

The PR fixes a right-click on an `autocomplete` or `dropdown` cell's arrow opening the cell editor.

**Read this before the diff — the reported symptom and the fix are not the same thing.**

DEV-2677 was filed as "clicking an empty cell then pressing <kbd>Enter</kbd> opens the editor and closes it again on the same keypress". Root-causing it in a real browser with trusted events showed the premise was wrong: **the click opens the editor, not the Enter.**

`autocompleteRenderer` registers a `mousedown` listener on `rootElement` that calls `onCellDblClick` whenever the event target carries `htAutocompleteArrow`, so pressing the arrow opens the list immediately. The Enter that follows arrives with the shortcut context already `'editor'` and correctly commits and closes. Captured trace, one trusted click then one trusted Enter on an empty `dropdown` cell:

```
DOM mousedown target=DIV.htAutocompleteArrow
beginEditing(null, null) state=STATE_VIRGIN
   via DropdownEditor.beginEditing < EditorManager.openEditor < #onCellDblClick < Object.onCellDblClick
afterBeginEditing        ctx=editor state=STATE_EDITING opened=true active=TEXTAREA.handsontableInput
DOM keydown "Enter" target=TEXTAREA.handsontableInput ctx=editor state=STATE_EDITING opened=true
finishEditing(false, false) state=STATE_EDITING
   via EditorManager.closeEditor < EditorManager.closeEditorAndSaveChanges < editorCloseAndSaveByEnter
beforeChange(edit) [[0,0,"",""]] state=STATE_WAITING
afterChange(edit)  [[0,0,"",""]] state=STATE_VIRGIN
```

**Why an empty value and not a seeded one — it is geometry, six pixels, not a state-machine difference.** The arrow is 16 px wide and right-floated. Measured:

| cell | column width | arrow span (px from TD left) | click centre | `elementFromPoint(centre)` |
|---|---|---|---|---|
| empty | 50 (the default minimum) | 24 – 40 | 25 | `DIV.htAutocompleteArrow` |
| seeded `'Al'` | 56 (content widens it) | 30 – 46 | 28 | `TD.htAutocomplete` |

Everything the task reported follows: click-only (`selectCell` fires no mousedown on the arrow), `autocomplete`/`dropdown` only (only they render an arrow), array or function `source` alike, `document.activeElement === TEXTAREA` after the click (`beginEditing` → `focus()`), and the exact hook order — `afterBeginEditing` from the *click*, `beforeChange`/`afterChange` from the *Enter*.

**So the task's definition of done is deliberately not met, and that is the recommendation.** Opening the list when the user clicks its arrow is an intended, long-standing affordance, so "a single Enter must open and keep the editor open" cannot be delivered by changing the Enter path — the click got there first. Removing the affordance to satisfy the wording would be a breaking change.

What the investigation did surface is a real defect in that same listener: it tests the target's class and never the mouse button, so **a right-click on the arrow opens the editor** — on a grid with a context menu, the user gets the editor and the menu at once. Walkontable restricts its own double-click-to-open path to the left button (`3rdparty/walkontable/src/event.ts`, pinned by its `only for LMB` spec); this path now does the same. That is the whole source diff: five lines.

`tests/AGENTS.md` carried the symptom as a fixture-authoring warning ("seed editor cells with a non-empty value"). That advice worked only by accident — a long header or narrow content puts the arrow back under the cell centre even on a seeded cell — so the bullet is rewritten to state the real mechanism and to recommend clicking off-centre or using `selectCell()`. The shared-prefix seeding advice is kept and split out, since it exists for an unrelated and still-valid reason.

Two findings recorded here rather than changed:

1. `autocompleteRenderer` builds its listener once, closing over the first-rendered cell's `row, col`. Unobservable today — `EditorManager#onCellDblClick` reads only `coords.isCell()` and `openEditor()` uses the live selection, verified by clicking cell (2,1)'s arrow and getting (2,1). Left out of this diff; worth its own task.
2. A real touch tap on the arrow synthesizes no `mousedown` at all, so the arrow has never opened the editor on mobile. Pre-existing — verified identical with and without this guard.

### How has this been tested?

New Playwright coverage, `tests/e2e/autocomplete-arrow-button.spec.ts`, parametrised over both editors. It asserts both halves: a right-button press leaves the editor closed, **and** a left-button press still opens it — a case that only checked the right button would pass on a change that deleted the affordance. The negative case anchors on the selection landing and then asserts once without retrying, because `expect.poll` retries until its condition holds and would report success on an editor that opened a tick later.

Confirmed red before the fix and green after:

```bash
# against the pre-fix bundle: the two right-button cases fail
npm --prefix tests run test:e2e -- autocomplete-arrow-button
npm --prefix handsontable run build
npm --prefix tests run test:e2e -- autocomplete-arrow-button   # 4 passed
```

Everything else that was run:

```bash
npm --prefix handsontable run eslint                 # 0 errors
npm --prefix tests run lint                          # clean
npm --prefix handsontable run test:unit              # pass
npm --prefix handsontable run test:e2e -- --testPathPattern="autocompleteRenderer|autocompleteEditor|dropdownEditor|handsontableEditor"
                                                     # 245 specs, 0 failures
npm --prefix tests test                              # all six theme x bundle legs: 3304 passed
```

The full Playwright matrix also reported 2 failures in `e2e/fill-handle-formulas.spec.ts` on the two horizon legs. They are **pre-existing and unrelated**: that fixture configures no `autocomplete`/`dropdown` column, so this listener never registers for it, and disabling the guard in the built bundle reproduces the identical failure.

Manual verification in Chrome through the DevTools protocol, on a nine-configuration diagnostic page with `BaseEditor.prototype.beginEditing`/`finishEditing` wrapped: `text`, `autocomplete`, `autocomplete + strict`, and `dropdown`, each empty and seeded, at default and narrow column widths, plus a two-column grid to check which cell the arrow opens.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2677

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2677

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized input-handling guard on an existing mousedown path; behavior for left-click and touch-compat mousedown is preserved, with new e2e tests locking both open and stay-closed cases.
> 
> **Overview**
> **Right-clicking the dropdown arrow on autocomplete-style cells no longer opens the cell editor**, aligning with Walkontable’s left-button-only double-click behavior and avoiding the editor and context menu appearing together.
> 
> The change is in `autocompleteRenderer`: the root `mousedown` handler that opens the list when the target is `.htAutocompleteArrow` now also requires `isLeftClick(event)`. Left-click on the arrow is unchanged.
> 
> **Test and docs follow-up:** Playwright coverage in `cell-dropdown-arrow-button.spec.ts` runs over `autocomplete`, `dropdown`, and `handsontable` (all use the same arrow listener). A dedicated fixture and `CellDropdownArrowPage` support those cases. `tests/AGENTS.md` documents that a centred cell click can hit the arrow (theme-dependent geometry); `AutocompleteAsyncSourcePage.openEditor` clicks near the leading edge so Enter-based flows stay stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18bdda1c474cb546be18467a08d4c511ea195e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->