### PR TITLE
DEV-2691: Show "Not enough data" for an empty average column summary

### DIFF
--- a/.changelogs/13299.json
+++ b/.changelogs/13299.json
@@ -1,5 +1,5 @@
 {
-  "issuesOrigin": "private",
+  "issuesOrigin": "public",
   "title": "Fixed a bug where the `average` column summary showed `NaN` once the summarized range held no values, for example after you cleared the source cells with the Delete key. It now shows `Not enough data`, the same result the `min` and `max` summaries already returned for an empty range. Ranges that still hold at least one value are unaffected, and empty cells stay excluded from both the sum and the divisor.",
   "type": "fixed",
   "issueOrPR": 13299,

--- a/.changelogs/13299.json
+++ b/.changelogs/13299.json
@@ -1,8 +1,8 @@
 {
-  "issuesOrigin": "public",
+  "issuesOrigin": "private",
   "title": "Fixed a bug where the `average` column summary showed `NaN` once the summarized range held no values, for example after you cleared the source cells with the Delete key. It now shows `Not enough data`, the same result the `min` and `max` summaries already returned for an empty range. Ranges that still hold at least one value are unaffected, and empty cells stay excluded from both the sum and the divisor.",
   "type": "fixed",
-  "issueOrPR": 4646,
+  "issueOrPR": 13299,
   "breaking": false,
   "framework": "none"
 }

--- a/.changelogs/4646.json
+++ b/.changelogs/4646.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a bug where the `average` column summary showed `NaN` once the summarized range held no values, for example after you cleared the source cells with the Delete key. It now shows `Not enough data`, the same result the `min` and `max` summaries already returned for an empty range. Ranges that still hold at least one value are unaffected, and empty cells stay excluded from both the sum and the divisor.",
+  "type": "fixed",
+  "issueOrPR": 4646,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/columns/column-summary/column-summary.md
+++ b/docs/content/guides/columns/column-summary/column-summary.md
@@ -101,6 +101,9 @@ To decide how a column summary is calculated, you can use one of the following s
 | `average` | Returns the sum of all values in a column,<br>divided by the number of non-empty cells in that column. |
 | `custom`  | Lets you implement a [custom summary function](#implement-a-custom-summary-function).                  |
 
+If a column holds no values to calculate from, `min`, `max`, and `average` return `Not enough data`.
+The `sum` and `count` functions return `0`.
+
 ### Column summary options
 
 You can customize each of your column summaries with configuration options.

--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -370,6 +370,78 @@ describe('ColumnSummarySpec', () => {
 
       expect(getDataAtCell(3, 0)).toBe(3.6666666666666665);
     });
+
+    it('should display "Not enough data" instead of `NaN` when the range holds no entries', async() => {
+      handsontable({
+        data: [
+          [null],
+          [null],
+          [null],
+          [null],
+        ],
+        columnSummary: [
+          {
+            sourceColumn: 0,
+            destinationColumn: 0,
+            destinationRow: 3,
+            ranges: [[0, 2]],
+            type: 'average'
+          },
+        ]
+      });
+
+      expect(getDataAtCell(3, 0)).toBe('Not enough data');
+    });
+
+    it('should display "Not enough data" after the source cells are cleared with the Delete key', async() => {
+      handsontable({
+        data: [
+          [10],
+          [10],
+          [10],
+          [null],
+        ],
+        columnSummary: [
+          {
+            sourceColumn: 0,
+            destinationColumn: 0,
+            destinationRow: 3,
+            ranges: [[0, 2]],
+            type: 'average'
+          },
+        ]
+      });
+
+      expect(getDataAtCell(3, 0)).toBe(10);
+
+      await selectCells([[0, 0, 2, 0]]);
+      await keyDownUp('delete');
+
+      expect(getDataAtCell(3, 0)).toBe('Not enough data');
+    });
+
+    it('should keep averaging over the non-empty entries only when just some of the cells are empty', async() => {
+      handsontable({
+        data: [
+          [10],
+          [null],
+          [20],
+          [null],
+        ],
+        columnSummary: [
+          {
+            sourceColumn: 0,
+            destinationColumn: 0,
+            destinationRow: 3,
+            ranges: [[0, 2]],
+            type: 'average'
+          },
+        ]
+      });
+
+      // The empty cell is left out of both the sum and the divisor, so the result is 15, not 10.
+      expect(getDataAtCell(3, 0)).toBe(15);
+    });
   });
 
   describe('customFunction', () => {

--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -442,6 +442,52 @@ describe('ColumnSummarySpec', () => {
       // The empty cell is left out of both the sum and the divisor, so the result is 15, not 10.
       expect(getDataAtCell(3, 0)).toBe(15);
     });
+
+    it('should display "Not enough data" for an empty column when `ranges` is left at its default', async() => {
+      handsontable({
+        data: [
+          [null],
+          [null],
+          [null],
+          [null],
+        ],
+        columnSummary: [
+          {
+            sourceColumn: 0,
+            destinationColumn: 0,
+            reversedRowCoords: true,
+            destinationRow: 0,
+            type: 'average'
+          },
+        ]
+      });
+
+      // The default range spans every addressable row, so it covers the destination cell too. The
+      // destination is skipped as a summary result, which leaves the range with no entries at all.
+      expect(getDataAtCell(3, 0)).toBe('Not enough data');
+    });
+
+    it('should display "Not enough data" instead of `NaN` when a range bound is not a number', async() => {
+      handsontable({
+        data: [
+          [1],
+          [2],
+          [3],
+          [null],
+        ],
+        columnSummary: [
+          {
+            sourceColumn: 0,
+            destinationColumn: 0,
+            destinationRow: 3,
+            ranges: [['a', 'b']],
+            type: 'average'
+          },
+        ]
+      });
+
+      expect(getDataAtCell(3, 0)).toBe('Not enough data');
+    });
   });
 
   describe('customFunction', () => {

--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.types.ts
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.types.ts
@@ -123,7 +123,7 @@ columnSummary.calculate(endpoint);
 const sum: number = columnSummary.calculateSum(endpoint);
 const min: number | string = columnSummary.calculateMinMax(endpoint, 'min');
 const max: number | string = columnSummary.calculateMinMax(endpoint, 'max');
-const avr: number = columnSummary.calculateAverage(endpoint);
+const avr: number | string = columnSummary.calculateAverage(endpoint);
 const empty: number = columnSummary.countEmpty([1, 1, 2, 2], 2);
 const entries: number = columnSummary.countEntries(endpoint);
 const cellValue: unknown = columnSummary.getCellValue(2, 2);

--- a/handsontable/src/plugins/columnSummary/columnSummary.ts
+++ b/handsontable/src/plugins/columnSummary/columnSummary.ts
@@ -486,9 +486,9 @@ export class ColumnSummary extends BasePlugin {
   calculateAverage(endpoint: SummaryEndpoint): number | string {
     const entriesCount = this.countEntries(endpoint);
 
-    // An all-empty range divides by zero. Report it the way `min` and `max` do instead of
-    // letting `NaN` reach the cell.
-    if (entriesCount === 0) {
+    // An all-empty range divides by zero, and a malformed range bound makes the count negative or
+    // `NaN`. Report all of them the way `min` and `max` do instead of letting `NaN` reach the cell.
+    if (!Number.isFinite(entriesCount) || entriesCount <= 0) {
       return NOT_ENOUGH_DATA;
     }
 

--- a/handsontable/src/plugins/columnSummary/columnSummary.ts
+++ b/handsontable/src/plugins/columnSummary/columnSummary.ts
@@ -8,6 +8,11 @@ import { throwWithCause } from '../../helpers/errors';
 export const PLUGIN_KEY = 'columnSummary';
 export const PLUGIN_PRIORITY = 220;
 
+/**
+ * Result shown when a range holds no value to calculate from.
+ */
+const NOT_ENOUGH_DATA = 'Not enough data';
+
 export interface SummaryEndpoint {
   ranges?: number[][];
   sourceColumn?: number;
@@ -378,7 +383,7 @@ export class ColumnSummary extends BasePlugin {
       }
     }
 
-    return result === null ? 'Not enough data' : result;
+    return result === null ? NOT_ENOUGH_DATA : result;
   }
 
   /**
@@ -476,13 +481,18 @@ export class ColumnSummary extends BasePlugin {
    *
    * @private
    * @param {object} endpoint Contains the endpoint information.
-   * @returns {number} Avarage value.
+   * @returns {number|string} Average value, or `'Not enough data'` when the range holds no entries.
    */
-  calculateAverage(endpoint: SummaryEndpoint): number {
-    const sum = this.calculateSum(endpoint);
+  calculateAverage(endpoint: SummaryEndpoint): number | string {
     const entriesCount = this.countEntries(endpoint);
 
-    return sum / entriesCount;
+    // An all-empty range divides by zero. Report it the way `min` and `max` do instead of
+    // letting `NaN` reach the cell.
+    if (entriesCount === 0) {
+      return NOT_ENOUGH_DATA;
+    }
+
+    return this.calculateSum(endpoint) / entriesCount;
   }
 
   /**


### PR DESCRIPTION
### Context

The PR fixes the `average` column summary showing `NaN` when the summarized range holds no values, reported in #4646 (open since 2017).

I first checked whether the issue still reproduces on `develop` (18.0.0, Chrome 148). It does, using the issue's own steps: select the source cells and press Delete. Delete writes `null` into the cells (`emptySelectedCells`, `handsontable/src/core.ts:2810`), `calculateAverage` was `calculateSum / countEntries`, and `countEntries` subtracts the blank cells — so an all-blank range divided `0 / 0`.

`average` was the only summary type without a guard for this. Measured on the same empty column:

| type | before | after |
|---|---|---|
| `min` | `Not enough data` | unchanged |
| `max` | `Not enough data` | unchanged |
| `count` | `0` | unchanged |
| `sum` | `0` | unchanged |
| `average` | **`NaN`** | **`Not enough data`** |

So this aligns `average` with what `min` and `max` have always done, which is also what was requested on the issue in 2018 and again in 2020.

**This is a user-visible behavior change.** An empty range now yields the string `Not enough data` instead of the number `NaN`, so code reading the destination cell programmatically gets a string. That is the same contract `min`/`max` already had. The `calculateAverage` return type widened from `number` to `number | string`, matching `calculateMinMax`. It is **not breaking** under `.ai/BREAKING-CHANGES.md`: the method is `@private` and absent from the public API reference.

The shared `'Not enough data'` literal moved into a `NOT_ENOUGH_DATA` constant, since three summary types use it now.

#### Not reproducible, so not changed

The issue also quotes a forum post claiming `10 10 10 10 0` averages to `10` instead of `8`. That does **not** reproduce — it returns `8`. Zeros are counted correctly. Whatever caused it in 1.14.3 is long gone.

#### Deliberately left out of scope

Two pre-existing quirks found while investigating. Both would drag `min`/`max` along, so they belong in their own tickets:

1. A cell holding `''` counts as the number `0`, while `null` counts as blank (`isNaN('')` is `false`). So an all-`''` column averages to `0` while an all-`null` column reports `Not enough data`.
2. `Not enough data` is a hardcoded English string that does not go through i18n. That has been true for `min`/`max` since they were written.

### How has this been tested?

Three cases added to the existing `calculateAverage` block in `columnSummary.spec.js`: an all-blank range, the issue's actual gesture (clearing populated cells with Delete), and a guard that the normal path did not move — a range with *some* blanks still averages over the non-blank cells only.

The two new `Not enough data` cases were run with the fix reverted first, and both failed with `Expected NaN to be 'Not enough data'` — so they genuinely catch the bug rather than merely passing.

```bash
# E2E — 61 specs
npm --prefix handsontable run test:e2e -- --testPathPattern=columnSummary

# Unit — 4067 tests
npm --prefix handsontable run test:unit

# Types — caught the widened return type; the type test was updated to match calculateMinMax
npm --prefix handsontable run test:types

# Lint and build
npm --prefix handsontable run eslint
npm --prefix handsontable run stylelint
npm --prefix handsontable run build
```

All pass. The full legacy E2E suite was not run locally — this machine has ~51 viewport specs that fail from display state regardless of the change; CI covers those.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #4646
2. DEV-2691

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation. The summary-functions table in the column summary guide said nothing about empty columns, for any function — this PR adds a line covering all five.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2691

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized column-summary display fix with no auth or data-pipeline impact; only behavioral change is destination cells showing a string instead of NaN when the range has no values.
> 
> **Overview**
> Fixes the **`average`** column summary showing **`NaN`** when every cell in the range is empty (e.g. after clearing with Delete). **`calculateAverage`** now checks that **`countEntries`** is finite and positive before dividing; otherwise it returns **`Not enough data`**, matching **`min`** / **`max`**. The shared message is centralized in **`NOT_ENOUGH_DATA`**, and the private return type is **`number | string`**.
> 
> Docs now state that **`min`**, **`max`**, and **`average`** show **`Not enough data`** on empty columns while **`sum`** and **`count`** stay **`0`**. New specs cover all-empty ranges, Delete-to-clear, partial blanks, default ranges, and invalid range bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c1f398ae747beaab4353b890b957d4f45300470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->