### PR TITLE
DEV-2703: Document the frozen area viewport size limit

### DIFF
--- a/docs/content/guides/columns/column-freezing/column-freezing.md
+++ b/docs/content/guides/columns/column-freezing/column-freezing.md
@@ -18,6 +18,7 @@ vue:
   metaTitle: Column freezing - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
+menuTag: updated
 ---
 Lock the position of specified columns, keeping them visible when scrolling.
 

--- a/docs/content/guides/columns/column-freezing/column-freezing.md
+++ b/docs/content/guides/columns/column-freezing/column-freezing.md
@@ -129,6 +129,16 @@ Mind that when you unfreeze a frozen column, it doesn't go back to the original 
 
 :::
 
+## Frozen area size limit
+
+Freeze only as many columns as fit within the grid's width.
+
+Handsontable always draws frozen columns in full. It never shrinks them, and it never scrolls them. If the frozen columns need more space than the grid has, they cover the whole grid. The remaining columns stay out of reach: the horizontal scrollbar still moves, but the view no longer changes.
+
+This applies to the total width of the frozen columns, not to how many there are. A single frozen column that you resize wider than the grid causes the same result.
+
+To avoid this, keep the combined width of your frozen columns smaller than the width of the grid. If your grid has to work at several sizes, pick a number of frozen columns that fits the narrowest one.
+
 ## Related API reference
 
 **Configuration options**

--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -603,6 +603,8 @@ Taller rows or wider columns lower these limits proportionally. For example, wit
 
 If your dataset can grow past these limits, load it in smaller chunks, for example with server-side or lazy data loading.
 
+Frozen rows and columns carry a separate limit: the frozen area must fit within the grid's width and height. Handsontable always draws that area in full, so when it needs more room than the grid has, it covers the whole grid and the rest can no longer be scrolled into view. Read more in [Column freezing](@/guides/columns/column-freezing/column-freezing.md) and [Row freezing](@/guides/rows/row-freezing/row-freezing.md).
+
 ## Result
 
 Your grid now renders at the dimensions you specified, responding to container size or fixed pixel values as configured.

--- a/docs/content/guides/rows/row-freezing/row-freezing.md
+++ b/docs/content/guides/rows/row-freezing/row-freezing.md
@@ -91,6 +91,16 @@ const hot = new Handsontable(container, {
 
 You can combine `fixedRowsTop` and `fixedRowsBottom` to keep both a header and a footer row in view at the same time.
 
+## Frozen area size limit
+
+Freeze only as many rows as fit within the grid's height.
+
+Handsontable always draws frozen rows in full. It never shrinks them, and it never scrolls them. If the frozen rows need more space than the grid has, they cover the whole grid. The remaining rows stay out of reach: the vertical scrollbar still moves, but the view no longer changes.
+
+This applies to the total height of the frozen rows, not to how many there are. Taller rows reach the limit sooner.
+
+Both `fixedRowsTop` and `fixedRowsBottom` behave this way. To avoid the problem, keep the combined height of your frozen rows smaller than the height of the grid. If your grid has to work at several sizes, pick a number of frozen rows that fits the shortest one.
+
 ## Result
 
 After completing this guide, the rows you specify with `fixedRowsTop` or `fixedRowsBottom` stay visible while you scroll through the rest of the grid.

--- a/docs/content/guides/rows/row-freezing/row-freezing.md
+++ b/docs/content/guides/rows/row-freezing/row-freezing.md
@@ -91,19 +91,21 @@ const hot = new Handsontable(container, {
 
 You can combine `fixedRowsTop` and `fixedRowsBottom` to keep both a header and a footer row in view at the same time.
 
+## Result
+
+After completing this guide, the rows you specify with `fixedRowsTop` or `fixedRowsBottom` stay visible while you scroll through the rest of the grid.
+
 ## Frozen area size limit
 
-Freeze only as many rows as fit within the grid's height.
+When your grid has a defined [`height`](@/api/options.md#height), freeze only as many rows as fit within it.
 
 Handsontable always draws frozen rows in full. It never shrinks them, and it never scrolls them. If the frozen rows need more space than the grid has, they cover the whole grid. The remaining rows stay out of reach: the vertical scrollbar still moves, but the view no longer changes.
 
 This applies to the total height of the frozen rows, not to how many there are. Taller rows reach the limit sooner.
 
-Both `fixedRowsTop` and `fixedRowsBottom` behave this way. To avoid the problem, keep the combined height of your frozen rows smaller than the height of the grid. If your grid has to work at several sizes, pick a number of frozen rows that fits the shortest one.
+Both `fixedRowsTop` and `fixedRowsBottom` behave this way. Keep the combined height of your frozen rows smaller than the grid's height. If your grid has to work at several sizes, pick a number of frozen rows that fits the shortest one.
 
-## Result
-
-After completing this guide, the rows you specify with `fixedRowsTop` or `fixedRowsBottom` stay visible while you scroll through the rest of the grid.
+Without a defined `height`, the grid grows to fit its rows, so the frozen rows cannot outgrow it and this limit does not apply. Read more in [Grid size](@/guides/getting-started/grid-size/grid-size.md).
 
 ## Related API reference
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -3122,6 +3122,12 @@ export default (): Record<string, unknown> => {
      *
      * If your grid's [layout direction](@/guides/internationalization/layout-direction/layout-direction.md) is RTL, the `fixedColumnsStart` option sets the number of [frozen columns](@/guides/columns/column-freezing/column-freezing.md) at the right-hand edge of the grid.
      *
+     * ::: tip
+     * Freeze only as many columns as fit within the grid's width. Frozen columns are always drawn in full.
+     * If they need more space than the grid has, they cover the whole grid. You can then no longer scroll
+     * the remaining columns into view.
+     * :::
+     *
      * Read more:
      * - [Column freezing](@/guides/columns/column-freezing/column-freezing.md)
      * - [Layout direction](@/guides/internationalization/layout-direction/layout-direction.md)
@@ -3169,6 +3175,12 @@ export default (): Record<string, unknown> => {
      * no vertical scrollbar is created and the fixed bottom rows area is not displayed.
      * :::
      *
+     * ::: tip
+     * Freeze only as many rows as fit within the grid's height. Frozen rows are always drawn in full.
+     * If they need more space than the grid has, they cover the whole grid. You can then no longer scroll
+     * the remaining rows into view.
+     * :::
+     *
      * Read more:
      * - [Row freezing](@/guides/rows/row-freezing/row-freezing.md)
      * - [`height`](#height)
@@ -3196,6 +3208,12 @@ export default (): Record<string, unknown> => {
      * For the top frozen rows area to be visually separated from the scrollable body, you must also set the [`height`](#height) option
      * in Handsontable's configuration. If the grid expands to fill its parent container without a defined height,
      * no vertical scrollbar is created and the fixed top rows area is not displayed.
+     * :::
+     *
+     * ::: tip
+     * Freeze only as many rows as fit within the grid's height. Frozen rows are always drawn in full.
+     * If they need more space than the grid has, they cover the whole grid. You can then no longer scroll
+     * the remaining rows into view.
      * :::
      *
      * Read more:


### PR DESCRIPTION
### Context

The PR documents a limitation that was never written down anywhere: the frozen (fixed) area has to fit within the grid's width or height.

Handsontable always draws the frozen area in full. It never shrinks it and never scrolls it. When `fixedColumnsStart`, `fixedRowsTop`, or `fixedRowsBottom` describe an area bigger than the space the grid has, the frozen overlay overflows its container and paints over the master table. The scrollbar still moves, but the view stops changing, so the rest of the grid becomes unreachable. `selectCell()` on a column past the frozen block succeeds while the viewport never moves.

This is the long-standing behavior reported in #4259 (open since 2017). Fixing it is a design decision that has been marked `Status: To be discussed` for eight years and is tracked separately. Writing the limitation down needs no such decision, so it ships on its own.

Verified reproducing on released 18.0.0 and on develop (`accbc16448`) for all four options. `fixedRowsBottom` was checked rather than assumed: 40 frozen bottom rows produce a 1161px overlay in a 385px grid and leave only rows 189-200 visible.

What changed:

- `handsontable/src/dataMap/metaManager/metaSchema.ts` — a `::: tip` on `fixedColumnsStart`, `fixedRowsTop`, and `fixedRowsBottom`. The two row options already carry a `height` tip, so the size constraint is a separate second tip rather than a longer single block.
- `docs/content/guides/columns/column-freezing/column-freezing.md` — a new "Frozen area size limit" section.
- `docs/content/guides/rows/row-freezing/row-freezing.md` — the same section, covering both `fixedRowsTop` and `fixedRowsBottom`.

`fixedColumnsLeft` is deliberately skipped. It is a legacy alias and its JSDoc already redirects to `fixedColumnsStart`, which now carries the note.

Comments and prose only. No runtime code is touched, which is why the commit carries a `Refactor-only:` trailer.

[skip changelog]

### How has this been tested?

Documentation-only change, so there is no behavior to assert. The underlying limitation was verified in a real browser before the text was written, and lint was run over the changed files.

```bash
# Lint - 0 errors (the 602 warnings are pre-existing, in spec files this PR does not touch)
npm run eslint --prefix handsontable

# Lint the one source file this PR changes - exits clean
npx eslint --ext .ts handsontable/src/dataMap/metaManager/metaSchema.ts
```

Manual verification of the documented behavior, in Chrome, against both released 18.0.0 and this branch's build:

| Setting | Frozen area needs | Grid has | Result |
|---|---|---|---|
| `fixedColumnsStart: 26` | 1340px | 953px | only columns A-R reachable |
| `fixedColumnsStart: 1`, column 0 resized to 1400px | 1400px | 953px | only column A reachable |
| `fixedRowsTop: 40` | 1190px | 385px | only rows 1-13 reachable |
| `fixedRowsBottom: 40` | 1161px | 385px | only rows 189-200 reachable |

Stylelint and a rebuild were skipped on purpose: the diff contains no CSS or SCSS, and no runtime code.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

Documentation only — none of the above categories applies.

### Related issue(s):

1. #4259
2. DEV-2703

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

The documentation change is this PR, so no further documentation work follows from it.

ClickUp task: https://app.clickup.com/t/86cbba4m2

https://claude.ai/code/session_01LCYZFqfFkbJ2th1pScMsZZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no behavioral or security impact on the grid runtime.
> 
> **Overview**
> Documents a long-standing behavior: **frozen rows and columns must fit within the grid’s width/height** or the fixed overlay can cover the viewport while scrollbars still move without revealing the rest of the grid.
> 
> Adds **“Frozen area size limit”** sections to the column- and row-freezing guides (including `menuTag: updated` on column freezing), a short cross-reference under **Known limitations** in the grid-size guide, and matching **`::: tip`** blocks on `fixedColumnsStart`, `fixedRowsTop`, and `fixedRowsBottom` in `metaSchema.ts`. **`fixedColumnsLeft`** is intentionally unchanged (legacy alias). **No runtime code** — prose and API docs only, related to #4259 / DEV-2703.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fbbe1c04097bf02113413ed40c268a2da87d06a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->