### PR TITLE
DEV-2702: Give textExtractor its @configScope tag

### DIFF
--- a/docs/content/guides/configuration/configuration-option-levels/configuration-option-levels.md
+++ b/docs/content/guides/configuration/configuration-option-levels/configuration-option-levels.md
@@ -245,6 +245,7 @@ Search for an option by name, or filter the list down to a single level.
 | <span data-option="tabMoves" data-levels="grid"></span>[`tabMoves`](@/api/options.md#tabmoves) | Yes | No | No | No | Core |  |
 | <span data-option="tabNavigation" data-levels="grid"></span>[`tabNavigation`](@/api/options.md#tabnavigation) | Yes | No | No | No | Core |  |
 | <span data-option="textEllipsis" data-levels="grid columns cells cell"></span>[`textEllipsis`](@/api/options.md#textellipsis) | Yes | Yes | Yes | Yes | Core |  |
+| <span data-option="textExtractor" data-levels="grid"></span>[`textExtractor`](@/api/options.md#textextractor) | Yes | No | No | No | Core |  |
 | <span data-option="theme" data-levels="grid"></span>[`theme`](@/api/options.md#theme) | Yes | No | No | No | Core |  |
 | <span data-option="themeName" data-levels="grid"></span>[`themeName`](@/api/options.md#themename) | Yes | No | No | No | Core |  |
 | <span data-option="timeFormat" data-levels="grid columns cells cell"></span>[`timeFormat`](@/api/options.md#timeformat) | Yes | Yes | Yes | Yes | Core |  |

--- a/docs/content/guides/configuration/configuration-option-levels/option-levels.json
+++ b/docs/content/guides/configuration/configuration-option-levels/option-levels.json
@@ -6,9 +6,9 @@
     "cells",
     "cell"
   ],
-  "total": 168,
+  "total": 169,
   "counts": {
-    "grid": 105,
+    "grid": 106,
     "grid columns cells cell": 58,
     "grid columns": 4,
     "columns": 1
@@ -1465,6 +1465,15 @@
         "cell"
       ],
       "since": "16.0.0",
+      "note": null
+    },
+    {
+      "name": "textExtractor",
+      "category": "Core",
+      "levels": [
+        "grid"
+      ],
+      "since": "18.2.0",
       "note": null
     },
     {

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -7955,7 +7955,7 @@ export default (): Record<string, unknown> => {
      * Values that are not strings are never passed to the extractor. A numeric header stays a number,
      * so a spreadsheet still reads it as one.
      *
-     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * This option can only be set at the [grid level](@/guides/configuration/configuration-options/configuration-options.md#set-grid-options).
      * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @since 18.2.0
@@ -7963,6 +7963,7 @@ export default (): Record<string, unknown> => {
      * @type {boolean|function(string, TextExtractorContext): string}
      * @default undefined
      * @category Core
+     * @configScope grid
      *
      * @example
      * ```js


### PR DESCRIPTION
### Context

The PR fixes `Unit / test`, which is currently red on `develop` and on every pull request that merges it.

Two pull requests that were each green on their own collided on merge order:

- #13305 (DEV-2693) made a `@configScope` tag mandatory on every public option in `metaSchema.ts`, enforced by the new `test/__tests__/optionLevels.unit.js`.
- #13308 (DEV-2702) added the `textExtractor` option without one, having been written before that rule existed.

`parseOptions()` throws on a missing tag, and the call sits in the `describe` body, so the suite dies as a declaration exception rather than a named failure:

```
● configuration-option levels › encountered a declaration exception
  Option `textExtractor` has no @configScope tag in metaSchema.ts.
    at parseOptions (scripts/utils/option-levels.js:79:13)
```

`textExtractor` gets `@configScope grid`. That is not a guess: the option's own description already states it works at the grid level only and has no effect in `columns`, `cells` or `cell`, which is exactly what its sibling `sanitizer` declares.

The same collision left a dead link in that JSDoc block. #13305 moved the configuration-options guide out of `getting-started`, and `textExtractor` held the last reference to the old path. It is repointed here.

The matrix page and its JSON are regenerated, which a new option has to appear in.

`[skip changelog]` — the source change is a JSDoc tag and a documentation link. There is no runtime behavior change for users to read about.

### How has this been tested?

Verified in both directions, on a branch cut from `develop`:

```bash
# fails on unmodified develop
npm run test:unit --prefix handsontable -- --testPathPattern=optionLevels
#   Option `textExtractor` has no @configScope tag in metaSchema.ts.
#   Tests: 1 failed, 1 total

# passes with this change
npm run test:unit --prefix handsontable -- --testPathPattern=optionLevels
#   Tests: 10 passed, 10 total
```

Full runs on this branch:

```bash
npm run test:unit --prefix handsontable   # 331 suites, 4135 tests, all passing
npm run test:types --prefix handsontable  # passing
npm run eslint --prefix handsontable      # 0 errors
```

No new test is added, and the commit carries a `Refactor-only:` trailer saying why: `optionLevels.unit.js` already pins this exact behavior — it fails without the change and passes with it. A new test would only restate it.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2702
2. Follows #13308 and #13305, whose merge order caused this.

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2702

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc tag, link fix, and regenerated docs only; no application logic changes.
> 
> **Overview**
> Fixes a **red `optionLevels` unit test** on `develop` by adding the missing **`@configScope grid`** JSDoc tag on **`textExtractor`** in `metaSchema.ts`, which `parseOptions()` now requires for every public option.
> 
> The **`textExtractor`** docs link is updated from the old `getting-started/.../configuration-options` path to **`guides/configuration/configuration-options`**. Regenerated **option-levels** artifacts list **`textExtractor`** as grid-only in the matrix JSON and markdown.
> 
> There is **no runtime behavior change**—only schema metadata and generated docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 562b71ef2c374ad4daeb995610b29db510d778fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->