### PR TITLE
DEV-2711: Add the missing @configScope tag to textExtractor

### DIFF
--- a/docs/content/guides/configuration/configuration-option-levels/configuration-option-levels.md
+++ b/docs/content/guides/configuration/configuration-option-levels/configuration-option-levels.md
@@ -245,6 +245,7 @@ Search for an option by name, or filter the list down to a single level.
 | <span data-option="tabMoves" data-levels="grid"></span>[`tabMoves`](@/api/options.md#tabmoves) | Yes | No | No | No | Core |  |
 | <span data-option="tabNavigation" data-levels="grid"></span>[`tabNavigation`](@/api/options.md#tabnavigation) | Yes | No | No | No | Core |  |
 | <span data-option="textEllipsis" data-levels="grid columns cells cell"></span>[`textEllipsis`](@/api/options.md#textellipsis) | Yes | Yes | Yes | Yes | Core |  |
+| <span data-option="textExtractor" data-levels="grid"></span>[`textExtractor`](@/api/options.md#textextractor) | Yes | No | No | No | Core |  |
 | <span data-option="theme" data-levels="grid"></span>[`theme`](@/api/options.md#theme) | Yes | No | No | No | Core |  |
 | <span data-option="themeName" data-levels="grid"></span>[`themeName`](@/api/options.md#themename) | Yes | No | No | No | Core |  |
 | <span data-option="timeFormat" data-levels="grid columns cells cell"></span>[`timeFormat`](@/api/options.md#timeformat) | Yes | Yes | Yes | Yes | Core |  |

--- a/docs/content/guides/configuration/configuration-option-levels/option-levels.json
+++ b/docs/content/guides/configuration/configuration-option-levels/option-levels.json
@@ -6,9 +6,9 @@
     "cells",
     "cell"
   ],
-  "total": 168,
+  "total": 169,
   "counts": {
-    "grid": 105,
+    "grid": 106,
     "grid columns cells cell": 58,
     "grid columns": 4,
     "columns": 1
@@ -1465,6 +1465,15 @@
         "cell"
       ],
       "since": "16.0.0",
+      "note": null
+    },
+    {
+      "name": "textExtractor",
+      "category": "Core",
+      "levels": [
+        "grid"
+      ],
+      "since": "18.2.0",
       "note": null
     },
     {

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -7963,6 +7963,7 @@ export default (): Record<string, unknown> => {
      * @type {boolean|function(string, TextExtractorContext): string}
      * @default undefined
      * @category Core
+     * @configScope grid
      *
      * @example
      * ```js


### PR DESCRIPTION
### Context

The PR fixes a red `develop`.

`textExtractor` landed in #13308 without a `@configScope` tag in `metaSchema.ts`, so `parseOptions` throws and `optionLevels.unit.js` fails:

```
FAIL test/__tests__/optionLevels.unit.js
  ● configuration-option levels › encountered a declaration exception
    Option `textExtractor` has no @configScope tag in metaSchema.ts.
      at parseOptions (scripts/utils/option-levels.js:79:13)
```

The blast radius is wider than one job. `Visual`, `Build`, `E2E`, `Integration`, `Performance` and `Walkontable` are all gated on `!failure()`, so a red `Unit / test` skips the entire rest of the pipeline on every PR opened against `develop`.

**The tag alone is not the whole fix.** `optionLevels.unit.js` pins three things together: the tags in `metaSchema.ts`, the generator, and the two artifacts committed into the docs. Adding only the tag moves the failure to two other tests:

- `should keep the committed guide page in sync with the generator`
- `should keep the committed JSON in sync with the schema`

That missed generator run is what left `develop` red in the first place.

So this PR does both halves:

1. `handsontable/src/dataMap/metaManager/metaSchema.ts` — adds `@configScope grid`, matching [`sanitizer`](https://github.com/handsontable/handsontable/blob/develop/handsontable/src/dataMap/metaManager/metaSchema.ts), the counterpart named in the same doc block. The option's own JSDoc already stated the scope in prose: "This option can only be set at the grid level."
2. The two regenerated docs artifacts, via `npm run generate:option-levels --prefix handsontable`. Never hand-edited — `total` goes 168 → 169 and `grid` 105 → 106, with one new table row and no unrelated churn.

`textExtractor` was the only option missing a tag. The parser throws on the first one it hits, which would hide any others, so every public option block was scanned rather than assumed.

### How has this been tested?

```bash
# The suite that was red - 10/10 green, including both sync tests
npm --prefix handsontable run test:unit -- --testPathPattern=optionLevels

# Lint on the changed source file - clean
cd handsontable && npx eslint src/dataMap/metaManager/metaSchema.ts

# The generator is idempotent - re-running produces no further diff
npm run generate:option-levels --prefix handsontable && git diff --stat
```

No new test is added: `optionLevels.unit.js` already is the coverage for this, and it is the test that was failing. The commit carries a `Refactor-only:` trailer for the test-presence gate.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2711
2. Follows up #13308 (DEV-2702), which introduced the option.

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

[skip changelog] — there is no user-facing behavior change. The source edit is a single JSDoc tag, and the two docs files are generated output. #13308's entry already covers the `textExtractor` feature itself.

ClickUp task: https://app.clickup.com/t/123kvxe8y6y
