### PR TITLE
DEV-2629: Compare perf-test PRs against a rolling median baseline

### DIFF
--- a/.github/actions/performance-run/action.yml
+++ b/.github/actions/performance-run/action.yml
@@ -45,10 +45,10 @@ runs:
       shell: bash
       run: |
         git fetch origin gh-pages:gh-pages 2>/dev/null || true
-        mkdir -p performance-tests/golden performance-tests/golden/history
+        mkdir -p performance-tests/golden
 
-        # Single-file fallback, kept for when history/ below is empty or has
-        # nothing with a marked trace window on every scenario.
+        # Single-file fallback, kept for when the history/ fetch below is empty or
+        # has nothing with a marked trace window on every scenario.
         if git show gh-pages:performance-reports/develop/latest.json > performance-tests/golden/snapshots.json 2>/dev/null; then
           echo "Golden baseline (latest.json) restored from gh-pages"
         else
@@ -56,26 +56,10 @@ runs:
           rm -f performance-tests/golden/snapshots.json
         fi
 
-        # Rolling-median history: dump the last HISTORY_FETCH_COUNT timestamped
-        # develop runs as raw files. This step does no filtering or math --
-        # median-snapshot.mjs filters to windowSource === 'marks' and medians
-        # the newest MEDIAN_WINDOW_SIZE of whatever qualifies. The fetch count
-        # is generous on purpose; it only needs to exceed MEDIAN_WINDOW_SIZE
-        # after marks-filtering.
-        HISTORY_FETCH_COUNT=20
-        DIRS=$( (git ls-tree --name-only gh-pages -- performance-reports/develop/ \
-          | grep -E '/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z$' \
-          | sort -r | head -n "$HISTORY_FETCH_COUNT") || true )
-
-        if [ -n "$DIRS" ]; then
-          while IFS= read -r dir; do
-            name=$(basename "$dir")
-            git show "gh-pages:${dir}/snapshots.json" > "performance-tests/golden/history/${name}.json" 2>/dev/null || true
-          done <<< "$DIRS"
-          echo "Fetched $(ls performance-tests/golden/history | wc -l) historical snapshot(s) for median baseline"
-        else
-          echo "No timestamped develop runs found on gh-pages -- median baseline will fall back to latest.json"
-        fi
+        # Rolling-median history, shared with .github/workflows/performance-tests.yml
+        # so the two golden-restore call sites can't drift on the fetch count or the
+        # timestamp pattern.
+        node .github/scripts/fetch-golden-history.mjs
 
     - name: Compute report URL
       id: report-url

--- a/.github/actions/performance-run/action.yml
+++ b/.github/actions/performance-run/action.yml
@@ -45,12 +45,36 @@ runs:
       shell: bash
       run: |
         git fetch origin gh-pages:gh-pages 2>/dev/null || true
-        mkdir -p performance-tests/golden
+        mkdir -p performance-tests/golden performance-tests/golden/history
+
+        # Single-file fallback, kept for when history/ below is empty or has
+        # nothing with a marked trace window on every scenario.
         if git show gh-pages:performance-reports/develop/latest.json > performance-tests/golden/snapshots.json 2>/dev/null; then
-          echo "Golden baseline restored from gh-pages"
+          echo "Golden baseline (latest.json) restored from gh-pages"
         else
           echo "No golden baseline found on gh-pages -- running without baseline"
           rm -f performance-tests/golden/snapshots.json
+        fi
+
+        # Rolling-median history: dump the last HISTORY_FETCH_COUNT timestamped
+        # develop runs as raw files. This step does no filtering or math --
+        # median-snapshot.mjs filters to windowSource === 'marks' and medians
+        # the newest MEDIAN_WINDOW_SIZE of whatever qualifies. The fetch count
+        # is generous on purpose; it only needs to exceed MEDIAN_WINDOW_SIZE
+        # after marks-filtering.
+        HISTORY_FETCH_COUNT=20
+        DIRS=$( (git ls-tree --name-only gh-pages -- performance-reports/develop/ \
+          | grep -E '/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z$' \
+          | sort -r | head -n "$HISTORY_FETCH_COUNT") || true )
+
+        if [ -n "$DIRS" ]; then
+          while IFS= read -r dir; do
+            name=$(basename "$dir")
+            git show "gh-pages:${dir}/snapshots.json" > "performance-tests/golden/history/${name}.json" 2>/dev/null || true
+          done <<< "$DIRS"
+          echo "Fetched $(ls performance-tests/golden/history | wc -l) historical snapshot(s) for median baseline"
+        else
+          echo "No timestamped develop runs found on gh-pages -- median baseline will fall back to latest.json"
         fi
 
     - name: Compute report URL

--- a/.github/scripts/__tests__/fetch-golden-history.test.mjs
+++ b/.github/scripts/__tests__/fetch-golden-history.test.mjs
@@ -61,6 +61,18 @@ describe('selectHistoryDirs', () => {
     assert.deepEqual(selectHistoryDirs(''), []);
     assert.deepEqual(selectHistoryDirs('performance-reports/develop/latest.json'), []);
   });
+
+  test('keeps both entries and does not drop one on a name tie', () => {
+    // Two identically-timestamped dirs (e.g. a republish) must not violate the sort
+    // comparator contract -- a naive `<  ? 1 : -1` returns -1 on a tie, which some
+    // engines' sort can use to silently reorder or drop equal elements.
+    const output = [
+      'performance-reports/develop/2026-08-28T06-17-50Z',
+      'performance-reports/develop/2026-08-28T06-17-50Z',
+    ].join('\n');
+
+    assert.equal(selectHistoryDirs(output).length, 2);
+  });
 });
 
 // The golden-restore step exists in both .github/workflows/performance-tests.yml and

--- a/.github/scripts/__tests__/fetch-golden-history.test.mjs
+++ b/.github/scripts/__tests__/fetch-golden-history.test.mjs
@@ -1,0 +1,83 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { repoRoot } from '../lib/repo-root.mjs';
+import { selectHistoryDirs, HISTORY_FETCH_COUNT } from '../fetch-golden-history.mjs';
+
+const root = repoRoot();
+const read = rel => readFileSync(path.join(root, rel), 'utf8');
+
+describe('selectHistoryDirs', () => {
+  test('extracts dir and timestamp name from git ls-tree output', () => {
+    const output = 'performance-reports/develop/2026-08-28T06-17-50Z\n';
+
+    assert.deepEqual(selectHistoryDirs(output), [
+      { dir: 'performance-reports/develop/2026-08-28T06-17-50Z', name: '2026-08-28T06-17-50Z' },
+    ]);
+  });
+
+  test('ignores non-timestamped entries (e.g. latest.json)', () => {
+    const output = [
+      'performance-reports/develop/latest.json',
+      'performance-reports/develop/2026-08-28T06-17-50Z',
+    ].join('\n');
+
+    const result = selectHistoryDirs(output);
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].name, '2026-08-28T06-17-50Z');
+  });
+
+  test('sorts newest first', () => {
+    const output = [
+      'performance-reports/develop/2026-08-27T06-32-14Z',
+      'performance-reports/develop/2026-08-31T11-28-19Z',
+      'performance-reports/develop/2026-08-28T06-17-50Z',
+    ].join('\n');
+
+    assert.deepEqual(selectHistoryDirs(output).map(d => d.name), [
+      '2026-08-31T11-28-19Z',
+      '2026-08-28T06-17-50Z',
+      '2026-08-27T06-32-14Z',
+    ]);
+  });
+
+  test('caps at the given count', () => {
+    const output = Array.from({ length: 10 }, (_, i) =>
+      `performance-reports/develop/2026-08-${String(10 + i).padStart(2, '0')}T00-00-00Z`).join('\n');
+
+    assert.equal(selectHistoryDirs(output, 3).length, 3);
+  });
+
+  test('defaults to HISTORY_FETCH_COUNT when no count is given', () => {
+    const output = Array.from({ length: HISTORY_FETCH_COUNT + 5 }, (_, i) =>
+      `performance-reports/develop/2026-0${1 + (i % 9)}-01T00-00-00Z`).join('\n');
+
+    assert.equal(selectHistoryDirs(output).length, HISTORY_FETCH_COUNT);
+  });
+
+  test('returns nothing for empty or unmatched input', () => {
+    assert.deepEqual(selectHistoryDirs(''), []);
+    assert.deepEqual(selectHistoryDirs('performance-reports/develop/latest.json'), []);
+  });
+});
+
+// The golden-restore step exists in both .github/workflows/performance-tests.yml and
+// .github/actions/performance-run/action.yml. They already drift on several other
+// blocks (PERF_MODE derivation, golden-deploy, PR-report-deploy) with nothing pinning
+// them together; this assertion at least keeps the history-fetch call itself from
+// silently forking into two copies of the fetch-count/timestamp-pattern logic again.
+describe('golden-restore call sites stay on the shared script', () => {
+  const CALL = 'node .github/scripts/fetch-golden-history.mjs';
+  const sites = [
+    '.github/workflows/performance-tests.yml',
+    '.github/actions/performance-run/action.yml',
+  ];
+
+  for (const site of sites) {
+    test(`${site} calls the shared fetch script`, () => {
+      assert.ok(read(site).includes(CALL), `expected ${site} to call "${CALL}"`);
+    });
+  }
+});

--- a/.github/scripts/fetch-golden-history.mjs
+++ b/.github/scripts/fetch-golden-history.mjs
@@ -22,15 +22,19 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { repoRoot } from './lib/repo-root.mjs';
 
 // Only needs to exceed MEDIAN_WINDOW_SIZE (performance-tests/lib/median-snapshot.mjs)
 // after windowSource filtering -- generous on purpose since re-fetching a few extra
 // small JSON files is cheap.
 export const HISTORY_FETCH_COUNT = 20;
 const TIMESTAMPED_DIR = /^(.*\/(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z))$/;
-const HISTORY_DIR = join('performance-tests', 'golden', 'history');
+// Anchored via repoRoot(), not a bare relative path -- a CI runner's cwd is always the
+// repo root so this made no difference there, but a bare relative path resolves
+// against whatever directory a manual/local invocation happens to run from.
+const HISTORY_DIR = join(repoRoot(), 'performance-tests', 'golden', 'history');
 
 /**
  * @param {string} lsTreeOutput -- stdout of `git ls-tree --name-only gh-pages -- performance-reports/develop/`
@@ -59,6 +63,10 @@ export function selectHistoryDirs(lsTreeOutput, count = HISTORY_FETCH_COUNT) {
 
 /* c8 ignore start -- exercises real git/fs, covered by manual verification, not unit tests */
 function main() {
+  // Cleared, not just created: an entry from a previous invocation (a stale local
+  // history/ from an earlier manual run, or a dir since removed from gh-pages) would
+  // otherwise linger and keep outranking a fresh single-file golden forever.
+  rmSync(HISTORY_DIR, { recursive: true, force: true });
   mkdirSync(HISTORY_DIR, { recursive: true });
 
   let lsTreeOutput;
@@ -67,7 +75,12 @@ function main() {
     lsTreeOutput = execFileSync(
       'git',
       ['ls-tree', '--name-only', 'gh-pages', '--', 'performance-reports/develop/'],
-      { encoding: 'utf8' }
+      // `cwd` is load-bearing, not decoration: the `performance-reports/develop/`
+      // pathspec is resolved by git relative to the process cwd, not the repo root --
+      // discovered when this script, invoked from a subdirectory, silently returned
+      // zero matches instead of erroring. Anchoring both git calls here mirrors
+      // HISTORY_DIR's repoRoot() anchoring above for the same reason.
+      { encoding: 'utf8', cwd: repoRoot() }
     );
   } catch (err) {
     // Distinguish a real git failure (missing gh-pages ref, corrupt local clone) from
@@ -89,7 +102,10 @@ function main() {
 
   for (const { dir, name } of dirs) {
     try {
-      const content = execFileSync('git', ['show', `gh-pages:${dir}/snapshots.json`], { encoding: 'utf8' });
+      const content = execFileSync('git', ['show', `gh-pages:${dir}/snapshots.json`], {
+        encoding: 'utf8',
+        cwd: repoRoot(),
+      });
 
       writeFileSync(join(HISTORY_DIR, `${name}.json`), content, 'utf8');
       fetched += 1;

--- a/.github/scripts/fetch-golden-history.mjs
+++ b/.github/scripts/fetch-golden-history.mjs
@@ -44,8 +44,16 @@ export function selectHistoryDirs(lsTreeOutput, count = HISTORY_FETCH_COUNT) {
     .filter(Boolean)
     .map(match => ({ dir: match[1], name: match[2] }))
     // The timestamp format is fixed-width and zero-padded, so lexicographic order
-    // is chronological order -- no Date parsing needed here.
-    .sort((a, b) => (a.name < b.name ? 1 : -1))
+    // is chronological order -- no Date parsing needed here. Explicit 0 for the
+    // equal case: a plain `< ? 1 : -1` breaks the comparator contract on a tie
+    // (e.g. two identically-timestamped dirs) and can sort unstably.
+    .sort((a, b) => {
+      if (a.name === b.name) {
+        return 0;
+      }
+
+      return a.name < b.name ? 1 : -1;
+    })
     .slice(0, count);
 }
 
@@ -61,7 +69,11 @@ function main() {
       ['ls-tree', '--name-only', 'gh-pages', '--', 'performance-reports/develop/'],
       { encoding: 'utf8' }
     );
-  } catch {
+  } catch (err) {
+    // Distinguish a real git failure (missing gh-pages ref, corrupt local clone) from
+    // the legitimate "nothing there yet" case below -- both would otherwise look like
+    // an empty history and print the same harmless-sounding message.
+    console.warn(`Warning: git ls-tree failed (${err.message}) -- treating history as empty`);
     lsTreeOutput = '';
   }
 

--- a/.github/scripts/fetch-golden-history.mjs
+++ b/.github/scripts/fetch-golden-history.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+/**
+ * Populates `performance-tests/golden/history/` with the last HISTORY_FETCH_COUNT
+ * timestamped develop golden snapshots from the local `gh-pages` ref, for
+ * `computeMedianSnapshot()` (performance-tests/lib/median-snapshot.mjs) to filter
+ * and median over.
+ *
+ * This script does no filtering by `windowSource` and no math -- it only dumps raw
+ * files. All of that lives in median-snapshot.mjs, which is unit tested; this script
+ * stays a thin, shell-free wrapper around `git ls-tree`/`git show` against the
+ * `gh-pages` ref that both golden-restore call sites (the "Fetch golden snapshots
+ * from GitHub Pages" step in .github/workflows/performance-tests.yml and
+ * .github/actions/performance-run/action.yml) already fetch locally before this
+ * runs, so no network fetch is needed here.
+ *
+ * Shared between those two call sites specifically so they cannot drift on the
+ * fetch count or the timestamp pattern the way several of their other duplicated
+ * blocks already do.
+ *
+ * Usage: node .github/scripts/fetch-golden-history.mjs
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Only needs to exceed MEDIAN_WINDOW_SIZE (performance-tests/lib/median-snapshot.mjs)
+// after windowSource filtering -- generous on purpose since re-fetching a few extra
+// small JSON files is cheap.
+export const HISTORY_FETCH_COUNT = 20;
+const TIMESTAMPED_DIR = /^(.*\/(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z))$/;
+const HISTORY_DIR = join('performance-tests', 'golden', 'history');
+
+/**
+ * @param {string} lsTreeOutput -- stdout of `git ls-tree --name-only gh-pages -- performance-reports/develop/`
+ * @param {number} [count]
+ * @returns {Array<{dir: string, name: string}>} newest-first, capped at `count`
+ */
+export function selectHistoryDirs(lsTreeOutput, count = HISTORY_FETCH_COUNT) {
+  return lsTreeOutput
+    .split('\n')
+    .map(line => TIMESTAMPED_DIR.exec(line.trim()))
+    .filter(Boolean)
+    .map(match => ({ dir: match[1], name: match[2] }))
+    // The timestamp format is fixed-width and zero-padded, so lexicographic order
+    // is chronological order -- no Date parsing needed here.
+    .sort((a, b) => (a.name < b.name ? 1 : -1))
+    .slice(0, count);
+}
+
+/* c8 ignore start -- exercises real git/fs, covered by manual verification, not unit tests */
+function main() {
+  mkdirSync(HISTORY_DIR, { recursive: true });
+
+  let lsTreeOutput;
+
+  try {
+    lsTreeOutput = execFileSync(
+      'git',
+      ['ls-tree', '--name-only', 'gh-pages', '--', 'performance-reports/develop/'],
+      { encoding: 'utf8' }
+    );
+  } catch {
+    lsTreeOutput = '';
+  }
+
+  const dirs = selectHistoryDirs(lsTreeOutput);
+
+  if (dirs.length === 0) {
+    console.log('No timestamped develop runs found on gh-pages -- median baseline will fall back to latest.json');
+
+    return;
+  }
+
+  let fetched = 0;
+
+  for (const { dir, name } of dirs) {
+    try {
+      const content = execFileSync('git', ['show', `gh-pages:${dir}/snapshots.json`], { encoding: 'utf8' });
+
+      writeFileSync(join(HISTORY_DIR, `${name}.json`), content, 'utf8');
+      fetched += 1;
+    } catch {
+      // A missing snapshots.json for one timestamped dir shouldn't block the rest.
+    }
+  }
+
+  console.log(`Fetched ${fetched} historical snapshot(s) for median baseline`);
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+/* c8 ignore stop */

--- a/.github/scripts/fetch-golden-history.mjs
+++ b/.github/scripts/fetch-golden-history.mjs
@@ -24,6 +24,7 @@
 import { execFileSync } from 'node:child_process';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { repoRoot } from './lib/repo-root.mjs';
 
 // Only needs to exceed MEDIAN_WINDOW_SIZE (performance-tests/lib/median-snapshot.mjs)
@@ -101,23 +102,39 @@ function main() {
   let fetched = 0;
 
   for (const { dir, name } of dirs) {
+    let content;
+
     try {
-      const content = execFileSync('git', ['show', `gh-pages:${dir}/snapshots.json`], {
+      content = execFileSync('git', ['show', `gh-pages:${dir}/snapshots.json`], {
         encoding: 'utf8',
         cwd: repoRoot(),
       });
-
-      writeFileSync(join(HISTORY_DIR, `${name}.json`), content, 'utf8');
-      fetched += 1;
-    } catch {
-      // A missing snapshots.json for one timestamped dir shouldn't block the rest.
+    } catch (err) {
+      // A missing snapshots.json for one timestamped dir shouldn't block the rest --
+      // that is the expected case for a dir git couldn't find the blob for.
+      console.warn(`Warning: no snapshots.json for ${name} (${err.message.split('\n')[0]}) -- skipping`);
+      continue;
     }
+
+    // Deliberately outside the try above: a write failure (disk full, permissions) is
+    // a different problem than "this dir has no snapshots.json", and must not be
+    // silently folded into the same skip-and-continue path.
+    writeFileSync(join(HISTORY_DIR, `${name}.json`), content, 'utf8');
+    fetched += 1;
   }
 
   console.log(`Fetched ${fetched} historical snapshot(s) for median baseline`);
 }
 
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
-  main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (err) {
+    // A missing baseline is optional by design -- the restore step's own `latest.json`
+    // fetch already tolerates this (every command there ends in `|| true`). This
+    // script must fail the same way: warn, don't take the whole performance job down
+    // over history that a compare-mode run can simply do without.
+    console.warn(`Warning: fetch-golden-history.mjs failed (${err.message}) -- continuing without history`);
+  }
 }
 /* c8 ignore stop */

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -69,10 +69,10 @@ jobs:
         if: env.PERF_MODE == 'compare'
         run: |
           git fetch origin gh-pages:gh-pages 2>/dev/null || true
-          mkdir -p performance-tests/golden performance-tests/golden/history
+          mkdir -p performance-tests/golden
 
-          # Single-file fallback, kept for when history/ below is empty or has
-          # nothing with a marked trace window on every scenario.
+          # Single-file fallback, kept for when the history/ fetch below is empty or
+          # has nothing with a marked trace window on every scenario.
           if git show gh-pages:performance-reports/develop/latest.json > performance-tests/golden/snapshots.json 2>/dev/null; then
             echo "Golden baseline (latest.json) restored from gh-pages"
           else
@@ -80,26 +80,10 @@ jobs:
             rm -f performance-tests/golden/snapshots.json
           fi
 
-          # Rolling-median history: dump the last HISTORY_FETCH_COUNT timestamped
-          # develop runs as raw files. This step does no filtering or math --
-          # median-snapshot.mjs filters to windowSource === 'marks' and medians
-          # the newest MEDIAN_WINDOW_SIZE of whatever qualifies. The fetch count
-          # is generous on purpose; it only needs to exceed MEDIAN_WINDOW_SIZE
-          # after marks-filtering.
-          HISTORY_FETCH_COUNT=20
-          DIRS=$( (git ls-tree --name-only gh-pages -- performance-reports/develop/ \
-            | grep -E '/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z$' \
-            | sort -r | head -n "$HISTORY_FETCH_COUNT") || true )
-
-          if [ -n "$DIRS" ]; then
-            while IFS= read -r dir; do
-              name=$(basename "$dir")
-              git show "gh-pages:${dir}/snapshots.json" > "performance-tests/golden/history/${name}.json" 2>/dev/null || true
-            done <<< "$DIRS"
-            echo "Fetched $(ls performance-tests/golden/history | wc -l) historical snapshot(s) for median baseline"
-          else
-            echo "No timestamped develop runs found on gh-pages -- median baseline will fall back to latest.json"
-          fi
+          # Rolling-median history, shared with .github/actions/performance-run/action.yml
+          # so the two golden-restore call sites can't drift on the fetch count or the
+          # timestamp pattern.
+          node .github/scripts/fetch-golden-history.mjs
 
       - name: Compute report URL
         id: report-url

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -69,12 +69,36 @@ jobs:
         if: env.PERF_MODE == 'compare'
         run: |
           git fetch origin gh-pages:gh-pages 2>/dev/null || true
-          mkdir -p performance-tests/golden
+          mkdir -p performance-tests/golden performance-tests/golden/history
+
+          # Single-file fallback, kept for when history/ below is empty or has
+          # nothing with a marked trace window on every scenario.
           if git show gh-pages:performance-reports/develop/latest.json > performance-tests/golden/snapshots.json 2>/dev/null; then
-            echo "Golden baseline restored from gh-pages"
+            echo "Golden baseline (latest.json) restored from gh-pages"
           else
             echo "No golden baseline found on gh-pages -- running without baseline"
             rm -f performance-tests/golden/snapshots.json
+          fi
+
+          # Rolling-median history: dump the last HISTORY_FETCH_COUNT timestamped
+          # develop runs as raw files. This step does no filtering or math --
+          # median-snapshot.mjs filters to windowSource === 'marks' and medians
+          # the newest MEDIAN_WINDOW_SIZE of whatever qualifies. The fetch count
+          # is generous on purpose; it only needs to exceed MEDIAN_WINDOW_SIZE
+          # after marks-filtering.
+          HISTORY_FETCH_COUNT=20
+          DIRS=$( (git ls-tree --name-only gh-pages -- performance-reports/develop/ \
+            | grep -E '/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z$' \
+            | sort -r | head -n "$HISTORY_FETCH_COUNT") || true )
+
+          if [ -n "$DIRS" ]; then
+            while IFS= read -r dir; do
+              name=$(basename "$dir")
+              git show "gh-pages:${dir}/snapshots.json" > "performance-tests/golden/history/${name}.json" 2>/dev/null || true
+            done <<< "$DIRS"
+            echo "Fetched $(ls performance-tests/golden/history | wc -l) historical snapshot(s) for median baseline"
+          else
+            echo "No timestamped develop runs found on gh-pages -- median baseline will fall back to latest.json"
           fi
 
       - name: Compute report URL

--- a/performance-tests/lib/__tests__/median-snapshot.test.mjs
+++ b/performance-tests/lib/__tests__/median-snapshot.test.mjs
@@ -178,6 +178,37 @@ describe('computeMedianSnapshot', () => {
     );
   });
 
+  test('omits a scenario present in fewer than MIN_VALID_SNAPSHOTS of the windowed snapshots', () => {
+    // A scenario just added to the suite might exist in only 1 of the last 5 develop
+    // snapshots. Medianing that single entry would reproduce the single-fluke-baseline
+    // problem this module exists to fix, silently, for just that one scenario.
+    const filteringOnce = { categories: { scripting: 40 }, windowSource: 'marks' };
+    const snapshots = [
+      snapshot('2026-08-27T00:00:00Z'),
+      snapshot('2026-08-28T00:00:00Z', { filtering: filteringOnce }),
+      snapshot('2026-08-29T00:00:00Z'),
+    ];
+
+    const result = computeMedianSnapshot(snapshots);
+
+    assert.equal('filtering' in result.scenarios, false);
+    // The rest of the snapshot is unaffected -- only the underrepresented scenario is dropped.
+    assert.equal('sorting' in result.scenarios, true);
+  });
+
+  test('keeps a scenario present in exactly MIN_VALID_SNAPSHOTS of the windowed snapshots', () => {
+    const filteringTwice = { categories: { scripting: 40 }, windowSource: 'marks' };
+    const snapshots = [
+      snapshot('2026-08-27T00:00:00Z', { filtering: filteringTwice }),
+      snapshot('2026-08-28T00:00:00Z', { filtering: filteringTwice }),
+      snapshot('2026-08-29T00:00:00Z'),
+    ];
+
+    const result = computeMedianSnapshot(snapshots);
+
+    assert.equal(result.scenarios.filtering.categories.scripting, 40);
+  });
+
   test('every synthesized scenario is explicitly windowSource "marks"', () => {
     // Guards against a regression that would leave this field unset: teardown.mjs's
     // windowSourceOf() treats a missing field as 'auto-zoom', which would make the

--- a/performance-tests/lib/__tests__/median-snapshot.test.mjs
+++ b/performance-tests/lib/__tests__/median-snapshot.test.mjs
@@ -4,13 +4,21 @@
 // (latest.json), which every develop push overwrites -- so a fluke run could
 // become the baseline for every later PR. computeMedianSnapshot() synthesizes
 // a baseline from the last N *valid* develop snapshots instead. "Valid" means
-// every scenario in the snapshot carries a marked trace window: snapshots
-// recorded before that measurement fix have no `windowSource` field at all,
-// which is what excludes them here without a manual cutoff date.
+// a parseable timestamp and every scenario in the snapshot carrying a marked
+// trace window: snapshots recorded before that measurement fix have no
+// `windowSource` field at all, which is what excludes them here without a
+// manual cutoff date. Below MIN_VALID_SNAPSHOTS, computeMedianSnapshot()
+// returns null rather than silently reporting a "median" of one run --
+// itself the single-fluke-baseline problem this module exists to fix.
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { computeMedianSnapshot, isValidForMedian, MEDIAN_WINDOW_SIZE } from '../median-snapshot.mjs';
+import {
+  computeMedianSnapshot,
+  isValidForMedian,
+  MEDIAN_WINDOW_SIZE,
+  MIN_VALID_SNAPSHOTS,
+} from '../median-snapshot.mjs';
 
 const DEFAULT_UPDATE_COUNTERS = {
   sampleCount: 3,
@@ -70,6 +78,18 @@ describe('isValidForMedian', () => {
   test('rejects an empty snapshot', () => {
     assert.equal(isValidForMedian({ timestamp: '2026-08-28T00:00:00Z', scenarios: {} }), false);
   });
+
+  test('rejects a scenario value that is not an object, instead of throwing', () => {
+    const malformed = snapshot('2026-08-28T00:00:00Z', { filtering: null });
+
+    assert.doesNotThrow(() => isValidForMedian(malformed));
+    assert.equal(isValidForMedian(malformed), false);
+  });
+
+  test('rejects a snapshot with a missing or unparseable timestamp', () => {
+    assert.equal(isValidForMedian(snapshot(undefined)), false);
+    assert.equal(isValidForMedian(snapshot('not-a-date')), false);
+  });
 });
 
 describe('computeMedianSnapshot', () => {
@@ -79,6 +99,13 @@ describe('computeMedianSnapshot', () => {
     delete preFix.scenarios.sorting.windowSource;
 
     assert.equal(computeMedianSnapshot([preFix]), null);
+  });
+
+  test('returns null (not a "median of 1") below MIN_VALID_SNAPSHOTS', () => {
+    // A one-run "median" is exactly the single-fluke-baseline problem this module
+    // exists to fix, just relabeled -- so it must not report isMedian: true.
+    assert.equal(MIN_VALID_SNAPSHOTS, 2, 'test assumes the floor is 2; update the fixtures below if this changes');
+    assert.equal(computeMedianSnapshot([snapshot('2026-08-28T00:00:00Z')]), null);
   });
 
   test('medians an odd number of values to the middle one', () => {
@@ -117,10 +144,24 @@ describe('computeMedianSnapshot', () => {
   });
 
   test('regenerates the heap labels from the medianed bytes', () => {
-    const result = computeMedianSnapshot([snapshot('2026-08-28T00:00:00Z')]);
+    const result = computeMedianSnapshot([
+      snapshot('2026-08-28T00:00:00Z'),
+      snapshot('2026-08-29T00:00:00Z'),
+    ]);
 
     assert.equal(result.scenarios.sorting.updateCounters.jsHeapMinLabel, '1000 kB');
     assert.equal(result.scenarios.sorting.updateCounters.jsHeapMaxLabel, '2.0 MB');
+  });
+
+  test('medians rangeStart and runs alongside the other scalar fields', () => {
+    const snapshots = [10, 20].map((runs, i) => snapshot(`2026-08-2${i}T00:00:00Z`, {
+      sorting: { rangeStart: 0, runs },
+    }));
+
+    const result = computeMedianSnapshot(snapshots);
+
+    assert.equal(result.scenarios.sorting.rangeStart, 0);
+    assert.equal(result.scenarios.sorting.runs, 15);
   });
 
   test('uses only the newest MEDIAN_WINDOW_SIZE of more snapshots than that', () => {
@@ -141,7 +182,10 @@ describe('computeMedianSnapshot', () => {
     // Guards against a regression that would leave this field unset: teardown.mjs's
     // windowSourceOf() treats a missing field as 'auto-zoom', which would make the
     // median baseline read as cross-window-mismatched against every real PR run.
-    const result = computeMedianSnapshot([snapshot('2026-08-28T00:00:00Z')]);
+    const result = computeMedianSnapshot([
+      snapshot('2026-08-28T00:00:00Z'),
+      snapshot('2026-08-29T00:00:00Z'),
+    ]);
 
     assert.equal(result.scenarios.sorting.windowSource, 'marks');
   });
@@ -154,7 +198,10 @@ describe('computeMedianSnapshot', () => {
 
     assert.equal(result.scenarios.sorting.hookTiming, 50);
 
-    const noneWithHook = computeMedianSnapshot([snapshot('2026-08-28T00:00:00Z')]);
+    const noneWithHook = computeMedianSnapshot([
+      snapshot('2026-08-28T00:00:00Z'),
+      snapshot('2026-08-29T00:00:00Z'),
+    ]);
 
     assert.equal('hookTiming' in noneWithHook.scenarios.sorting, false);
   });

--- a/performance-tests/lib/__tests__/median-snapshot.test.mjs
+++ b/performance-tests/lib/__tests__/median-snapshot.test.mjs
@@ -164,6 +164,21 @@ describe('computeMedianSnapshot', () => {
     assert.equal(result.scenarios.sorting.runs, 15);
   });
 
+  test('rounds rangeEnd and total, matching how a real snapshot saves them', () => {
+    // A real snapshot always has integer rangeEnd/total (averageParsedTraces rounds
+    // them). An even window's median would otherwise land on a .5, a shape no real
+    // saved snapshot could ever have.
+    const snapshots = [100, 101].map((rangeEnd, i) => snapshot(`2026-08-2${i}T00:00:00Z`, {
+      sorting: { rangeEnd, total: rangeEnd },
+    }));
+
+    const result = computeMedianSnapshot(snapshots);
+
+    assert.equal(result.scenarios.sorting.rangeEnd, 101);
+    assert.equal(result.scenarios.sorting.total, 101);
+    assert.equal(Number.isInteger(result.scenarios.sorting.rangeEnd), true);
+  });
+
   test('uses only the newest MEDIAN_WINDOW_SIZE of more snapshots than that', () => {
     const timestamps = Array.from({ length: MEDIAN_WINDOW_SIZE + 3 }, (_, i) =>
       `2026-08-${String(10 + i).padStart(2, '0')}T00:00:00Z`);

--- a/performance-tests/lib/__tests__/median-snapshot.test.mjs
+++ b/performance-tests/lib/__tests__/median-snapshot.test.mjs
@@ -1,0 +1,161 @@
+// Unit tests for the rolling-median golden baseline.
+//
+// A PR's regression delta was computed against a single develop snapshot
+// (latest.json), which every develop push overwrites -- so a fluke run could
+// become the baseline for every later PR. computeMedianSnapshot() synthesizes
+// a baseline from the last N *valid* develop snapshots instead. "Valid" means
+// every scenario in the snapshot carries a marked trace window: snapshots
+// recorded before that measurement fix have no `windowSource` field at all,
+// which is what excludes them here without a manual cutoff date.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeMedianSnapshot, isValidForMedian, MEDIAN_WINDOW_SIZE } from '../median-snapshot.mjs';
+
+const DEFAULT_UPDATE_COUNTERS = {
+  sampleCount: 3,
+  jsHeapMinBytes: 1_000_000,
+  jsHeapMaxBytes: 2_000_000,
+  documentsMin: 1,
+  documentsMax: 1,
+  nodesMin: 100,
+  nodesMax: 110,
+  listenersMin: 10,
+  listenersMax: 12,
+};
+
+/**
+ * @param {string} timestamp -- ISO string
+ * @param {object} [overrides] -- per-scenario overrides, keyed by scenario name
+ * @returns {object} a snapshot shaped like one saved by teardown.mjs
+ */
+function snapshot(timestamp, overrides = {}) {
+  return {
+    timestamp,
+    scenarios: {
+      sorting: {
+        categories: { scripting: 80, rendering: 10, painting: 2 },
+        rangeEnd: 100,
+        total: 92,
+        windowSource: 'marks',
+        updateCounters: { ...DEFAULT_UPDATE_COUNTERS },
+        ...overrides.sorting,
+      },
+      ...Object.fromEntries(Object.entries(overrides).filter(([name]) => name !== 'sorting')),
+    },
+  };
+}
+
+describe('isValidForMedian', () => {
+  test('accepts a snapshot where every scenario is windowSource "marks"', () => {
+    assert.equal(isValidForMedian(snapshot('2026-08-28T00:00:00Z')), true);
+  });
+
+  test('rejects a snapshot with even one scenario not "marks"', () => {
+    const withBadScenario = snapshot('2026-08-28T00:00:00Z', {
+      filtering: { categories: { scripting: 40 }, windowSource: 'auto-zoom' },
+    });
+
+    assert.equal(isValidForMedian(withBadScenario), false);
+  });
+
+  test('rejects a pre-measurement-fix snapshot (no windowSource field at all)', () => {
+    const preFix = snapshot('2026-07-01T00:00:00Z');
+
+    delete preFix.scenarios.sorting.windowSource;
+
+    assert.equal(isValidForMedian(preFix), false);
+  });
+
+  test('rejects an empty snapshot', () => {
+    assert.equal(isValidForMedian({ timestamp: '2026-08-28T00:00:00Z', scenarios: {} }), false);
+  });
+});
+
+describe('computeMedianSnapshot', () => {
+  test('returns null when nothing qualifies', () => {
+    const preFix = snapshot('2026-07-01T00:00:00Z');
+
+    delete preFix.scenarios.sorting.windowSource;
+
+    assert.equal(computeMedianSnapshot([preFix]), null);
+  });
+
+  test('medians an odd number of values to the middle one', () => {
+    const snapshots = [10, 20, 30].map((scripting, i) =>
+      snapshot(`2026-08-2${i}T00:00:00Z`, { sorting: { categories: { scripting } } }));
+
+    const result = computeMedianSnapshot(snapshots);
+
+    assert.equal(result.scenarios.sorting.categories.scripting, 20);
+  });
+
+  test('medians an even number of values to the mean of the middle two', () => {
+    const snapshots = [10, 20, 30, 40].map((scripting, i) =>
+      snapshot(`2026-08-2${i}T00:00:00Z`, { sorting: { categories: { scripting } } }));
+
+    const result = computeMedianSnapshot(snapshots);
+
+    assert.equal(result.scenarios.sorting.categories.scripting, 25);
+  });
+
+  test('rounds the integer updateCounters fields but not the byte counts', () => {
+    const snapshots = [
+      { sampleCount: 3, jsHeapMinBytes: 1_000_001, jsHeapMaxBytes: 2_000_001 },
+      { sampleCount: 4, jsHeapMinBytes: 1_000_003, jsHeapMaxBytes: 2_000_003 },
+    ].map((updateCounters, i) => snapshot(`2026-08-2${i}T00:00:00Z`, {
+      sorting: { updateCounters: { ...DEFAULT_UPDATE_COUNTERS, ...updateCounters } },
+    }));
+
+    const result = computeMedianSnapshot(snapshots);
+
+    // Median of 3 and 4 is 3.5 -- must round for a field a person reads as a count.
+    assert.equal(result.scenarios.sorting.updateCounters.sampleCount, 4);
+    // Byte counts stay exact, matching the existing per-iteration averaging behavior.
+    assert.equal(result.scenarios.sorting.updateCounters.jsHeapMinBytes, 1_000_002);
+    assert.equal(result.scenarios.sorting.updateCounters.jsHeapMaxBytes, 2_000_002);
+  });
+
+  test('regenerates the heap labels from the medianed bytes', () => {
+    const result = computeMedianSnapshot([snapshot('2026-08-28T00:00:00Z')]);
+
+    assert.equal(result.scenarios.sorting.updateCounters.jsHeapMinLabel, '1000 kB');
+    assert.equal(result.scenarios.sorting.updateCounters.jsHeapMaxLabel, '2.0 MB');
+  });
+
+  test('uses only the newest MEDIAN_WINDOW_SIZE of more snapshots than that', () => {
+    const timestamps = Array.from({ length: MEDIAN_WINDOW_SIZE + 3 }, (_, i) =>
+      `2026-08-${String(10 + i).padStart(2, '0')}T00:00:00Z`);
+    const snapshots = timestamps.map(ts => snapshot(ts));
+
+    const result = computeMedianSnapshot(snapshots);
+
+    assert.equal(result.medianWindowSize, MEDIAN_WINDOW_SIZE);
+    assert.deepEqual(
+      result.medianSourceTimestamps,
+      [...timestamps].sort().reverse().slice(0, MEDIAN_WINDOW_SIZE)
+    );
+  });
+
+  test('every synthesized scenario is explicitly windowSource "marks"', () => {
+    // Guards against a regression that would leave this field unset: teardown.mjs's
+    // windowSourceOf() treats a missing field as 'auto-zoom', which would make the
+    // median baseline read as cross-window-mismatched against every real PR run.
+    const result = computeMedianSnapshot([snapshot('2026-08-28T00:00:00Z')]);
+
+    assert.equal(result.scenarios.sorting.windowSource, 'marks');
+  });
+
+  test('includes hookTiming only when present on at least one input', () => {
+    const withHook = snapshot('2026-08-28T00:00:00Z', { sorting: { hookTiming: 50 } });
+    const withoutHook = snapshot('2026-08-29T00:00:00Z');
+
+    const result = computeMedianSnapshot([withHook, withoutHook]);
+
+    assert.equal(result.scenarios.sorting.hookTiming, 50);
+
+    const noneWithHook = computeMedianSnapshot([snapshot('2026-08-28T00:00:00Z')]);
+
+    assert.equal('hookTiming' in noneWithHook.scenarios.sorting, false);
+  });
+});

--- a/performance-tests/lib/__tests__/snapshot-store.test.mjs
+++ b/performance-tests/lib/__tests__/snapshot-store.test.mjs
@@ -1,0 +1,121 @@
+// Unit tests for golden snapshot I/O -- save/load, and the history-median load path
+// added alongside computeMedianSnapshot() (median-snapshot.mjs). Runs against the
+// module's real (gitignored) performance-tests/golden/ directory, cleaned before and
+// after each test: the module has no path injection, and that directory is never
+// committed, so this is the same location the CI restore step and a real golden-mode
+// run would use.
+
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { rm, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { saveSnapshots, loadSnapshots } from '../snapshot-store.mjs';
+
+const GOLDEN_DIR = join(import.meta.dirname, '..', '..', 'golden');
+const GOLDEN_PATH = join(GOLDEN_DIR, 'snapshots.json');
+const HISTORY_DIR = join(GOLDEN_DIR, 'history');
+
+/**
+ * @param {string} timestamp -- ISO string
+ * @returns {object} a minimal snapshot valid for computeMedianSnapshot
+ */
+function validSnapshot(timestamp) {
+  return {
+    timestamp,
+    scenarios: {
+      sorting: {
+        categories: { scripting: 80 },
+        windowSource: 'marks',
+      },
+    },
+  };
+}
+
+beforeEach(async() => {
+  await rm(GOLDEN_DIR, { recursive: true, force: true });
+});
+
+afterEach(async() => {
+  await rm(GOLDEN_DIR, { recursive: true, force: true });
+});
+
+describe('saveSnapshots / loadSnapshots (single-file path)', () => {
+  test('round-trips scenario results and metadata', async() => {
+    await saveSnapshots({ sorting: { categories: { scripting: 80 } } }, { commit: 'abc123' });
+
+    const golden = await loadSnapshots();
+
+    assert.equal(golden.commit, 'abc123');
+    assert.equal(golden.scenarios.sorting.categories.scripting, 80);
+  });
+
+  test('returns null when nothing has been saved', async() => {
+    assert.equal(await loadSnapshots(), null);
+  });
+
+  test('returns null on a corrupt single-file golden, instead of throwing', async() => {
+    await mkdir(GOLDEN_DIR, { recursive: true });
+    await writeFile(GOLDEN_PATH, '{not valid json', 'utf8');
+
+    assert.equal(await loadSnapshots(), null);
+  });
+});
+
+describe('loadSnapshots (history-median path)', () => {
+  test('falls back to the single-file golden when history/ is empty', async() => {
+    await mkdir(HISTORY_DIR, { recursive: true });
+    await writeFile(GOLDEN_PATH, JSON.stringify(validSnapshot('2026-08-28T00:00:00Z')), 'utf8');
+
+    const golden = await loadSnapshots();
+
+    assert.equal(golden.isMedian, undefined);
+    assert.equal(golden.scenarios.sorting.categories.scripting, 80);
+  });
+
+  test('falls back to the single-file golden when history/ has no snapshot valid for a median', async() => {
+    await mkdir(HISTORY_DIR, { recursive: true });
+    // Only one entry: below MIN_VALID_SNAPSHOTS (2), computeMedianSnapshot() returns null.
+    await writeFile(
+      join(HISTORY_DIR, '2026-08-28T00-00-00Z.json'),
+      JSON.stringify(validSnapshot('2026-08-28T00:00:00Z')),
+      'utf8'
+    );
+    await writeFile(GOLDEN_PATH, JSON.stringify(validSnapshot('2026-08-29T00:00:00Z')), 'utf8');
+
+    const golden = await loadSnapshots();
+
+    assert.equal(golden.isMedian, undefined);
+    assert.equal(golden.timestamp, '2026-08-29T00:00:00Z');
+  });
+
+  test('skips a corrupt history file and still medians the rest', async() => {
+    await mkdir(HISTORY_DIR, { recursive: true });
+    await writeFile(join(HISTORY_DIR, 'a.json'), JSON.stringify(validSnapshot('2026-08-27T00:00:00Z')), 'utf8');
+    await writeFile(join(HISTORY_DIR, 'b.json'), JSON.stringify(validSnapshot('2026-08-28T00:00:00Z')), 'utf8');
+    await writeFile(join(HISTORY_DIR, 'c.json'), '{not valid json', 'utf8');
+
+    const golden = await loadSnapshots();
+
+    assert.equal(golden.isMedian, true);
+    assert.equal(golden.medianWindowSize, 2);
+  });
+
+  test('returns a real median when enough history is valid', async() => {
+    await mkdir(HISTORY_DIR, { recursive: true });
+
+    const values = [10, 20, 30];
+
+    for (const [i, scripting] of values.entries()) {
+      const snapshot = validSnapshot(`2026-08-2${i}T00:00:00Z`);
+
+      snapshot.scenarios.sorting.categories.scripting = scripting;
+      await writeFile(join(HISTORY_DIR, `s${i}.json`), JSON.stringify(snapshot), 'utf8');
+    }
+
+    const golden = await loadSnapshots();
+
+    assert.equal(golden.isMedian, true);
+    assert.equal(golden.medianWindowSize, 3);
+    assert.equal(golden.scenarios.sorting.categories.scripting, 20);
+  });
+});

--- a/performance-tests/lib/__tests__/snapshot-store.test.mjs
+++ b/performance-tests/lib/__tests__/snapshot-store.test.mjs
@@ -1,19 +1,20 @@
 // Unit tests for golden snapshot I/O -- save/load, and the history-median load path
-// added alongside computeMedianSnapshot() (median-snapshot.mjs). Runs against the
-// module's real (gitignored) performance-tests/golden/ directory, cleaned before and
-// after each test: the module has no path injection, and that directory is never
-// committed, so this is the same location the CI restore step and a real golden-mode
-// run would use.
+// added alongside computeMedianSnapshot() (median-snapshot.mjs). Runs against a fresh
+// temp directory per test via the goldenDir override, never the real (gitignored)
+// performance-tests/golden/ -- a developer's locally-recorded golden must survive a
+// `test:tooling` run untouched.
 
 import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { rm, mkdir, writeFile } from 'node:fs/promises';
+import { rm, mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { saveSnapshots, loadSnapshots } from '../snapshot-store.mjs';
 
-const GOLDEN_DIR = join(import.meta.dirname, '..', '..', 'golden');
-const GOLDEN_PATH = join(GOLDEN_DIR, 'snapshots.json');
-const HISTORY_DIR = join(GOLDEN_DIR, 'history');
+let baseDir;
+let goldenPath;
+let historyDir;
+const originalPerfMode = process.env.PERF_MODE;
 
 /**
  * @param {string} timestamp -- ISO string
@@ -32,76 +33,97 @@ function validSnapshot(timestamp) {
 }
 
 beforeEach(async() => {
-  await rm(GOLDEN_DIR, { recursive: true, force: true });
+  baseDir = await mkdtemp(join(tmpdir(), 'perf-golden-'));
+  goldenPath = join(baseDir, 'snapshots.json');
+  historyDir = join(baseDir, 'history');
+  delete process.env.PERF_MODE;
 });
 
 afterEach(async() => {
-  await rm(GOLDEN_DIR, { recursive: true, force: true });
+  await rm(baseDir, { recursive: true, force: true });
+
+  if (originalPerfMode === undefined) {
+    delete process.env.PERF_MODE;
+  } else {
+    process.env.PERF_MODE = originalPerfMode;
+  }
 });
 
 describe('saveSnapshots / loadSnapshots (single-file path)', () => {
   test('round-trips scenario results and metadata', async() => {
-    await saveSnapshots({ sorting: { categories: { scripting: 80 } } }, { commit: 'abc123' });
+    await saveSnapshots({ sorting: { categories: { scripting: 80 } } }, { commit: 'abc123' }, baseDir);
 
-    const golden = await loadSnapshots();
+    const golden = await loadSnapshots(baseDir);
 
     assert.equal(golden.commit, 'abc123');
     assert.equal(golden.scenarios.sorting.categories.scripting, 80);
   });
 
   test('returns null when nothing has been saved', async() => {
-    assert.equal(await loadSnapshots(), null);
+    assert.equal(await loadSnapshots(baseDir), null);
   });
 
   test('returns null on a corrupt single-file golden, instead of throwing', async() => {
-    await mkdir(GOLDEN_DIR, { recursive: true });
-    await writeFile(GOLDEN_PATH, '{not valid json', 'utf8');
+    await mkdir(baseDir, { recursive: true });
+    await writeFile(goldenPath, '{not valid json', 'utf8');
 
-    assert.equal(await loadSnapshots(), null);
+    assert.equal(await loadSnapshots(baseDir), null);
   });
 });
 
 describe('loadSnapshots (history-median path)', () => {
   test('falls back to the single-file golden when history/ is empty', async() => {
-    await mkdir(HISTORY_DIR, { recursive: true });
-    await writeFile(GOLDEN_PATH, JSON.stringify(validSnapshot('2026-08-28T00:00:00Z')), 'utf8');
+    await mkdir(historyDir, { recursive: true });
+    await writeFile(goldenPath, JSON.stringify(validSnapshot('2026-08-28T00:00:00Z')), 'utf8');
 
-    const golden = await loadSnapshots();
+    const golden = await loadSnapshots(baseDir);
 
     assert.equal(golden.isMedian, undefined);
     assert.equal(golden.scenarios.sorting.categories.scripting, 80);
   });
 
   test('falls back to the single-file golden when history/ has no snapshot valid for a median', async() => {
-    await mkdir(HISTORY_DIR, { recursive: true });
+    await mkdir(historyDir, { recursive: true });
     // Only one entry: below MIN_VALID_SNAPSHOTS (2), computeMedianSnapshot() returns null.
     await writeFile(
-      join(HISTORY_DIR, '2026-08-28T00-00-00Z.json'),
+      join(historyDir, '2026-08-28T00-00-00Z.json'),
       JSON.stringify(validSnapshot('2026-08-28T00:00:00Z')),
       'utf8'
     );
-    await writeFile(GOLDEN_PATH, JSON.stringify(validSnapshot('2026-08-29T00:00:00Z')), 'utf8');
+    await writeFile(goldenPath, JSON.stringify(validSnapshot('2026-08-29T00:00:00Z')), 'utf8');
 
-    const golden = await loadSnapshots();
+    const golden = await loadSnapshots(baseDir);
 
     assert.equal(golden.isMedian, undefined);
     assert.equal(golden.timestamp, '2026-08-29T00:00:00Z');
   });
 
-  test('skips a corrupt history file and still medians the rest', async() => {
-    await mkdir(HISTORY_DIR, { recursive: true });
-    await writeFile(join(HISTORY_DIR, 'a.json'), JSON.stringify(validSnapshot('2026-08-27T00:00:00Z')), 'utf8');
-    await writeFile(join(HISTORY_DIR, 'b.json'), JSON.stringify(validSnapshot('2026-08-28T00:00:00Z')), 'utf8');
-    await writeFile(join(HISTORY_DIR, 'c.json'), '{not valid json', 'utf8');
+  test('returns null, not a false claim of a fallback, when neither history nor a single file qualifies', async() => {
+    await mkdir(historyDir, { recursive: true });
+    await writeFile(
+      join(historyDir, '2026-08-28T00-00-00Z.json'),
+      JSON.stringify(validSnapshot('2026-08-28T00:00:00Z')),
+      'utf8'
+    );
+    // No snapshots.json written at all -- the CI restore step removes it on a failed fetch.
 
-    const golden = await loadSnapshots();
+    assert.equal(await loadSnapshots(baseDir), null);
+  });
+
+  test('skips a corrupt history file and still medians the rest', async() => {
+    await mkdir(historyDir, { recursive: true });
+    await writeFile(join(historyDir, 'a.json'), JSON.stringify(validSnapshot('2026-08-27T00:00:00Z')), 'utf8');
+    await writeFile(join(historyDir, 'b.json'), JSON.stringify(validSnapshot('2026-08-28T00:00:00Z')), 'utf8');
+    await writeFile(join(historyDir, 'c.json'), '{not valid json', 'utf8');
+
+    const golden = await loadSnapshots(baseDir);
 
     assert.equal(golden.isMedian, true);
     assert.equal(golden.medianWindowSize, 2);
   });
 
   test('returns a real median when enough history is valid', async() => {
-    await mkdir(HISTORY_DIR, { recursive: true });
+    await mkdir(historyDir, { recursive: true });
 
     const values = [10, 20, 30];
 
@@ -109,13 +131,56 @@ describe('loadSnapshots (history-median path)', () => {
       const snapshot = validSnapshot(`2026-08-2${i}T00:00:00Z`);
 
       snapshot.scenarios.sorting.categories.scripting = scripting;
-      await writeFile(join(HISTORY_DIR, `s${i}.json`), JSON.stringify(snapshot), 'utf8');
+      await writeFile(join(historyDir, `s${i}.json`), JSON.stringify(snapshot), 'utf8');
     }
 
-    const golden = await loadSnapshots();
+    const golden = await loadSnapshots(baseDir);
 
     assert.equal(golden.isMedian, true);
     assert.equal(golden.medianWindowSize, 3);
     assert.equal(golden.scenarios.sorting.categories.scripting, 20);
+  });
+
+  test('ignores a leftover history/ dir in golden mode', async() => {
+    // history/ is meant to exist only during a compare-mode run. A leftover dir from
+    // a manual fetch or a reused workspace must not make a golden (develop-push) run
+    // compare its own fresh numbers against old develop runs instead of self-comparing.
+    process.env.PERF_MODE = 'golden';
+
+    await mkdir(historyDir, { recursive: true });
+    await writeFile(join(historyDir, 'a.json'), JSON.stringify(validSnapshot('2026-08-27T00:00:00Z')), 'utf8');
+    await writeFile(join(historyDir, 'b.json'), JSON.stringify(validSnapshot('2026-08-28T00:00:00Z')), 'utf8');
+    await writeFile(goldenPath, JSON.stringify(validSnapshot('2026-08-29T00:00:00Z')), 'utf8');
+
+    const golden = await loadSnapshots(baseDir);
+
+    assert.equal(golden.isMedian, undefined);
+    assert.equal(golden.timestamp, '2026-08-29T00:00:00Z');
+  });
+
+  test('honors PERF_MEDIAN_WINDOW_SIZE when set', async() => {
+    await mkdir(historyDir, { recursive: true });
+
+    const values = [10, 20, 30, 40, 50];
+
+    for (const [i, scripting] of values.entries()) {
+      const snapshot = validSnapshot(`2026-08-0${i + 1}T00:00:00Z`);
+
+      snapshot.scenarios.sorting.categories.scripting = scripting;
+      await writeFile(join(historyDir, `s${i}.json`), JSON.stringify(snapshot), 'utf8');
+    }
+
+    process.env.PERF_MEDIAN_WINDOW_SIZE = '3';
+
+    try {
+      const golden = await loadSnapshots(baseDir);
+
+      assert.equal(golden.medianWindowSize, 3);
+      // Newest 3 (by timestamp): 30, 40, 50 -- median 40. Confirms the env var actually
+      // narrows the window rather than being read and ignored.
+      assert.equal(golden.scenarios.sorting.categories.scripting, 40);
+    } finally {
+      delete process.env.PERF_MEDIAN_WINDOW_SIZE;
+    }
   });
 });

--- a/performance-tests/lib/median-snapshot.mjs
+++ b/performance-tests/lib/median-snapshot.mjs
@@ -109,9 +109,12 @@ function medianScenario(entries) {
 
   return {
     categories,
-    rangeStart: median(entries.map(entry => entry.rangeStart)),
-    rangeEnd: median(entries.map(entry => entry.rangeEnd)),
-    total: median(entries.map(entry => entry.total)),
+    // Rounded, like averageParsedTraces (trace-parser.mjs) rounds these on a real
+    // snapshot -- an even window would otherwise produce e.g. rangeEnd: 92.5, a shape
+    // no real run could ever save.
+    rangeStart: medianRounded(entries.map(entry => entry.rangeStart)),
+    rangeEnd: medianRounded(entries.map(entry => entry.rangeEnd)),
+    total: medianRounded(entries.map(entry => entry.total)),
     runs: medianRounded(entries.map(entry => entry.runs)),
     updateCounters,
     // Set explicitly, never left to default. teardown.mjs's windowSourceOf()

--- a/performance-tests/lib/median-snapshot.mjs
+++ b/performance-tests/lib/median-snapshot.mjs
@@ -1,0 +1,142 @@
+// Synthesizes a single "median" golden snapshot from a set of develop golden
+// snapshots, so a PR is compared against recent trend instead of one run.
+
+import { formatHeapMinBytesLabel, formatHeapMaxBytesLabel } from '../trace-parser.mjs';
+
+// How many of the newest marks-valid develop snapshots to median over. Small
+// enough that a real regression introduced mid-window isn't diluted by twice
+// as much older history, large enough to smooth out one flaky CI run.
+export const MEDIAN_WINDOW_SIZE = 5;
+
+/**
+ * @param {Array<number | null | undefined>} values
+ * @returns {number | null}
+ */
+function median(values) {
+  const nums = (values || []).filter(v => typeof v === 'number' && Number.isFinite(v));
+
+  if (nums.length === 0) {
+    return null;
+  }
+
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+
+  return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
+ * @param {Array<number | null | undefined>} values
+ * @returns {number | null}
+ */
+function medianRounded(values) {
+  const m = median(values);
+
+  return m === null ? null : Math.round(m);
+}
+
+/**
+ * A snapshot only qualifies for the median if every scenario in it carries a
+ * marked trace window. Pre-PR1 snapshots have no `windowSource` field on any
+ * scenario at all, so the mere absence of the field already excludes them --
+ * no cutoff date or migration step is needed.
+ *
+ * @param {object} snapshot
+ * @returns {boolean}
+ */
+export function isValidForMedian(snapshot) {
+  const scenarios = snapshot?.scenarios;
+
+  if (!scenarios || Object.keys(scenarios).length === 0) {
+    return false;
+  }
+
+  return Object.values(scenarios).every(scenario => scenario.windowSource === 'marks');
+}
+
+/**
+ * @param {Array<object>} entries -- per-scenario objects from qualifying snapshots
+ * @returns {object}
+ */
+function medianScenario(entries) {
+  const categoryKeys = new Set();
+
+  entries.forEach(entry => Object.keys(entry.categories || {}).forEach(key => categoryKeys.add(key)));
+
+  const categories = {};
+
+  for (const key of categoryKeys) {
+    categories[key] = median(entries.map(entry => entry.categories?.[key]));
+  }
+
+  const updateCounterEntries = entries.map(entry => entry.updateCounters).filter(Boolean);
+  let updateCounters = null;
+
+  if (updateCounterEntries.length > 0) {
+    const jsHeapMinBytes = median(updateCounterEntries.map(uc => uc.jsHeapMinBytes));
+    const jsHeapMaxBytes = median(updateCounterEntries.map(uc => uc.jsHeapMaxBytes));
+
+    updateCounters = {
+      sampleCount: medianRounded(updateCounterEntries.map(uc => uc.sampleCount)) ?? 0,
+      jsHeapMinBytes,
+      jsHeapMaxBytes,
+      jsHeapMinLabel: jsHeapMinBytes === null ? null : formatHeapMinBytesLabel(jsHeapMinBytes),
+      jsHeapMaxLabel: jsHeapMaxBytes === null ? null : formatHeapMaxBytesLabel(jsHeapMaxBytes),
+      documentsMin: medianRounded(updateCounterEntries.map(uc => uc.documentsMin)),
+      documentsMax: medianRounded(updateCounterEntries.map(uc => uc.documentsMax)),
+      nodesMin: medianRounded(updateCounterEntries.map(uc => uc.nodesMin)),
+      nodesMax: medianRounded(updateCounterEntries.map(uc => uc.nodesMax)),
+      listenersMin: medianRounded(updateCounterEntries.map(uc => uc.listenersMin)),
+      listenersMax: medianRounded(updateCounterEntries.map(uc => uc.listenersMax)),
+    };
+  }
+
+  const hookTimingValues = entries.map(entry => entry.hookTiming).filter(v => v !== undefined && v !== null);
+
+  return {
+    categories,
+    rangeEnd: median(entries.map(entry => entry.rangeEnd)),
+    total: median(entries.map(entry => entry.total)),
+    updateCounters,
+    // Set explicitly, never left to default. teardown.mjs's windowSourceOf()
+    // treats a missing field as 'auto-zoom' -- an unset value here would make
+    // every scenario read as cross-window-mismatched on every PR.
+    windowSource: 'marks',
+    ...(hookTimingValues.length > 0 ? { hookTiming: median(hookTimingValues) } : {}),
+  };
+}
+
+/**
+ * @param {Array<object>} snapshots -- already-parsed golden snapshot JSON objects, any order
+ * @param {object} [options]
+ * @param {number} [options.windowSize]
+ * @returns {object | null} a snapshot-shaped object, or null if nothing qualifies
+ */
+export function computeMedianSnapshot(snapshots, { windowSize = MEDIAN_WINDOW_SIZE } = {}) {
+  const valid = (snapshots || [])
+    .filter(isValidForMedian)
+    .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+    .slice(0, windowSize);
+
+  if (valid.length === 0) {
+    return null;
+  }
+
+  const scenarioNames = new Set();
+
+  valid.forEach(snapshot => Object.keys(snapshot.scenarios).forEach(name => scenarioNames.add(name)));
+
+  const scenarios = {};
+
+  for (const name of scenarioNames) {
+    scenarios[name] = medianScenario(valid.map(snapshot => snapshot.scenarios[name]).filter(Boolean));
+  }
+
+  return {
+    timestamp: valid[0].timestamp,
+    isMedian: true,
+    medianWindowSize: valid.length,
+    medianSourceTimestamps: valid.map(snapshot => snapshot.timestamp),
+    scenarios,
+  };
+}

--- a/performance-tests/lib/median-snapshot.mjs
+++ b/performance-tests/lib/median-snapshot.mjs
@@ -8,6 +8,12 @@ import { formatHeapMinBytesLabel, formatHeapMaxBytesLabel } from '../trace-parse
 // as much older history, large enough to smooth out one flaky CI run.
 export const MEDIAN_WINDOW_SIZE = 5;
 
+// Below this many valid snapshots, a "median" is no more robust than the single-run
+// baseline this module exists to replace -- so computeMedianSnapshot() refuses to
+// produce one, and the caller falls back to the plain (honestly-labeled) single
+// snapshot instead of a median that silently degenerates to one fluke run.
+export const MIN_VALID_SNAPSHOTS = 2;
+
 /**
  * @param {Array<number | null | undefined>} values
  * @returns {number | null}
@@ -36,22 +42,30 @@ function medianRounded(values) {
 }
 
 /**
- * A snapshot only qualifies for the median if every scenario in it carries a
- * marked trace window. Pre-PR1 snapshots have no `windowSource` field on any
- * scenario at all, so the mere absence of the field already excludes them --
- * no cutoff date or migration step is needed.
+ * A snapshot only qualifies for the median if its timestamp is usable for sorting
+ * and every scenario in it carries a marked trace window. Pre-PR1 snapshots have no
+ * `windowSource` field on any scenario at all, so the mere absence of the field
+ * already excludes them -- no cutoff date or migration step is needed. A scenario
+ * value that isn't an object (a shape-malformed but JSON-valid history file) is
+ * rejected rather than crashing on `.windowSource`.
  *
  * @param {object} snapshot
  * @returns {boolean}
  */
 export function isValidForMedian(snapshot) {
+  if (!Number.isFinite(Date.parse(snapshot?.timestamp))) {
+    return false;
+  }
+
   const scenarios = snapshot?.scenarios;
 
   if (!scenarios || Object.keys(scenarios).length === 0) {
     return false;
   }
 
-  return Object.values(scenarios).every(scenario => scenario.windowSource === 'marks');
+  return Object.values(scenarios).every(
+    scenario => scenario !== null && typeof scenario === 'object' && scenario.windowSource === 'marks'
+  );
 }
 
 /**
@@ -95,8 +109,10 @@ function medianScenario(entries) {
 
   return {
     categories,
+    rangeStart: median(entries.map(entry => entry.rangeStart)),
     rangeEnd: median(entries.map(entry => entry.rangeEnd)),
     total: median(entries.map(entry => entry.total)),
+    runs: medianRounded(entries.map(entry => entry.runs)),
     updateCounters,
     // Set explicitly, never left to default. teardown.mjs's windowSourceOf()
     // treats a missing field as 'auto-zoom' -- an unset value here would make
@@ -115,10 +131,12 @@ function medianScenario(entries) {
 export function computeMedianSnapshot(snapshots, { windowSize = MEDIAN_WINDOW_SIZE } = {}) {
   const valid = (snapshots || [])
     .filter(isValidForMedian)
-    .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+    // isValidForMedian already rejected anything with an unparseable timestamp, so
+    // this subtraction is never NaN here.
+    .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
     .slice(0, windowSize);
 
-  if (valid.length === 0) {
+  if (valid.length < MIN_VALID_SNAPSHOTS) {
     return null;
   }
 

--- a/performance-tests/lib/median-snapshot.mjs
+++ b/performance-tests/lib/median-snapshot.mjs
@@ -147,7 +147,19 @@ export function computeMedianSnapshot(snapshots, { windowSize = MEDIAN_WINDOW_SI
   const scenarios = {};
 
   for (const name of scenarioNames) {
-    scenarios[name] = medianScenario(valid.map(snapshot => snapshot.scenarios[name]).filter(Boolean));
+    const entries = valid.map(snapshot => snapshot.scenarios[name]).filter(Boolean);
+
+    // A scenario present in only a few of the windowed snapshots (e.g. one just added)
+    // would otherwise get a "median" computed from fewer than MIN_VALID_SNAPSHOTS
+    // entries -- the single-fluke-baseline problem this module exists to fix,
+    // reproduced silently per scenario under the same isMedian: true the rest of the
+    // snapshot reports. Omit it instead; the comparison for that scenario then falls
+    // through to "no baseline" the same way a brand-new scenario already does.
+    if (entries.length < MIN_VALID_SNAPSHOTS) {
+      continue;
+    }
+
+    scenarios[name] = medianScenario(entries);
   }
 
   return {

--- a/performance-tests/lib/snapshot-store.mjs
+++ b/performance-tests/lib/snapshot-store.mjs
@@ -4,51 +4,67 @@ import { readFile, writeFile, mkdir, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { exists } from './fs-utils.mjs';
-import { computeMedianSnapshot } from './median-snapshot.mjs';
+import { computeMedianSnapshot, MEDIAN_WINDOW_SIZE } from './median-snapshot.mjs';
 
-const GOLDEN_DIR = join(import.meta.dirname, '..', 'golden');
-const GOLDEN_PATH = join(GOLDEN_DIR, 'snapshots.json');
-// Populated by the CI restore step (compare mode only) with the last N
-// timestamped develop golden snapshots fetched from gh-pages. Absent in
-// golden mode (develop pushes), where the single-file path below is used.
-const GOLDEN_HISTORY_DIR = join(GOLDEN_DIR, 'history');
+const DEFAULT_GOLDEN_DIR = join(import.meta.dirname, '..', 'golden');
+
+/**
+ * @param {string} goldenDir
+ * @returns {{goldenPath: string, historyDir: string}}
+ */
+function paths(goldenDir) {
+  return {
+    goldenPath: join(goldenDir, 'snapshots.json'),
+    // Populated by the CI restore step (compare mode only) with the last N
+    // timestamped develop golden snapshots fetched from gh-pages. A golden
+    // (develop-push) run must never read this, even if one is sitting there --
+    // see the PERF_MODE guard in loadSnapshots() below.
+    historyDir: join(goldenDir, 'history'),
+  };
+}
 
 /**
  * @param {Record<string, object>} scenarioResults -- keyed by scenario name
  * @param {object} [metadata]
+ * @param {string} [goldenDir] -- override for tests; defaults to the real golden dir
  * @returns {Promise<string>} path to saved file
  */
-export async function saveSnapshots(scenarioResults, metadata = {}) {
+export async function saveSnapshots(scenarioResults, metadata = {}, goldenDir = DEFAULT_GOLDEN_DIR) {
+  const { goldenPath } = paths(goldenDir);
   const snapshot = {
     timestamp: new Date().toISOString(),
     ...metadata,
     scenarios: scenarioResults,
   };
 
-  await mkdir(GOLDEN_DIR, { recursive: true });
-  await writeFile(GOLDEN_PATH, JSON.stringify(snapshot, null, 2), 'utf8');
+  await mkdir(goldenDir, { recursive: true });
+  await writeFile(goldenPath, JSON.stringify(snapshot, null, 2), 'utf8');
 
-  return GOLDEN_PATH;
+  return goldenPath;
 }
 
 /**
+ * @param {string} [goldenDir] -- override for tests; defaults to the real golden dir
  * @returns {Promise<object | null>}
  */
-export async function loadSnapshots() {
-  if (await exists(GOLDEN_HISTORY_DIR)) {
-    const median = await loadMedianFromHistory();
+export async function loadSnapshots(goldenDir = DEFAULT_GOLDEN_DIR) {
+  const { goldenPath, historyDir } = paths(goldenDir);
+  const goldenPathExists = await exists(goldenPath);
+
+  if (process.env.PERF_MODE !== 'golden' && await exists(historyDir)) {
+    const median = await loadMedianFromHistory(historyDir, goldenPathExists);
 
     if (median) {
       return median;
     }
   }
 
-  if (!await exists(GOLDEN_PATH)) {
+  if (!goldenPathExists) {
     return null;
   }
 
   try {
-    const raw = await readFile(GOLDEN_PATH, 'utf8');
+    const raw = await readFile(goldenPath, 'utf8');
 
     return JSON.parse(raw);
   } catch (err) {
@@ -59,14 +75,31 @@ export async function loadSnapshots() {
 }
 
 /**
+ * @returns {number | null}
+ */
+function envWindowSize() {
+  const raw = process.env.PERF_MEDIAN_WINDOW_SIZE;
+
+  if (!raw) {
+    return null;
+  }
+
+  const parsed = Number(raw);
+
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : null;
+}
+
+/**
+ * @param {string} historyDir
+ * @param {boolean} goldenPathExists -- whether a single-file golden is actually there to fall back to
  * @returns {Promise<object | null>}
  */
-async function loadMedianFromHistory() {
-  const files = (await readdir(GOLDEN_HISTORY_DIR)).filter(name => name.endsWith('.json'));
+async function loadMedianFromHistory(historyDir, goldenPathExists) {
+  const files = (await readdir(historyDir)).filter(name => name.endsWith('.json'));
 
   const parsed = await Promise.all(files.map(async(file) => {
     try {
-      return JSON.parse(await readFile(join(GOLDEN_HISTORY_DIR, file), 'utf8'));
+      return JSON.parse(await readFile(join(historyDir, file), 'utf8'));
     } catch (err) {
       console.warn(`Warning: failed to parse golden history file ${file} (${err.message}) -- skipping`);
 
@@ -75,12 +108,16 @@ async function loadMedianFromHistory() {
   }));
 
   const snapshots = parsed.filter(Boolean);
-  const median = computeMedianSnapshot(snapshots);
+  const windowSize = envWindowSize() ?? MEDIAN_WINDOW_SIZE;
+  const median = computeMedianSnapshot(snapshots, { windowSize });
 
   if (!median && snapshots.length > 0) {
+    const fallback = goldenPathExists
+      ? 'falling back to latest.json'
+      : 'no single-file golden either, running without baseline';
+
     console.warn(
-      'Golden history present but not enough snapshots had a marked trace window on every ' +
-      'scenario -- falling back to latest.json'
+      `Golden history present but not enough snapshots had a marked trace window on every scenario -- ${fallback}`
     );
   }
 

--- a/performance-tests/lib/snapshot-store.mjs
+++ b/performance-tests/lib/snapshot-store.mjs
@@ -63,22 +63,24 @@ export async function loadSnapshots() {
  */
 async function loadMedianFromHistory() {
   const files = (await readdir(GOLDEN_HISTORY_DIR)).filter(name => name.endsWith('.json'));
-  const snapshots = [];
 
-  for (const file of files) {
+  const parsed = await Promise.all(files.map(async(file) => {
     try {
-      snapshots.push(JSON.parse(await readFile(join(GOLDEN_HISTORY_DIR, file), 'utf8')));
+      return JSON.parse(await readFile(join(GOLDEN_HISTORY_DIR, file), 'utf8'));
     } catch (err) {
       console.warn(`Warning: failed to parse golden history file ${file} (${err.message}) -- skipping`);
-    }
-  }
 
+      return null;
+    }
+  }));
+
+  const snapshots = parsed.filter(Boolean);
   const median = computeMedianSnapshot(snapshots);
 
   if (!median && snapshots.length > 0) {
     console.warn(
-      'Golden history present but no snapshot had a marked trace window on every scenario ' +
-      '-- falling back to latest.json'
+      'Golden history present but not enough snapshots had a marked trace window on every ' +
+      'scenario -- falling back to latest.json'
     );
   }
 

--- a/performance-tests/lib/snapshot-store.mjs
+++ b/performance-tests/lib/snapshot-store.mjs
@@ -1,12 +1,17 @@
 // Golden snapshot I/O -- save and load performance baselines.
 
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { exists } from './fs-utils.mjs';
+import { computeMedianSnapshot } from './median-snapshot.mjs';
 
 const GOLDEN_DIR = join(import.meta.dirname, '..', 'golden');
 const GOLDEN_PATH = join(GOLDEN_DIR, 'snapshots.json');
+// Populated by the CI restore step (compare mode only) with the last N
+// timestamped develop golden snapshots fetched from gh-pages. Absent in
+// golden mode (develop pushes), where the single-file path below is used.
+const GOLDEN_HISTORY_DIR = join(GOLDEN_DIR, 'history');
 
 /**
  * @param {Record<string, object>} scenarioResults -- keyed by scenario name
@@ -30,6 +35,14 @@ export async function saveSnapshots(scenarioResults, metadata = {}) {
  * @returns {Promise<object | null>}
  */
 export async function loadSnapshots() {
+  if (await exists(GOLDEN_HISTORY_DIR)) {
+    const median = await loadMedianFromHistory();
+
+    if (median) {
+      return median;
+    }
+  }
+
   if (!await exists(GOLDEN_PATH)) {
     return null;
   }
@@ -43,4 +56,31 @@ export async function loadSnapshots() {
 
     return null;
   }
+}
+
+/**
+ * @returns {Promise<object | null>}
+ */
+async function loadMedianFromHistory() {
+  const files = (await readdir(GOLDEN_HISTORY_DIR)).filter(name => name.endsWith('.json'));
+  const snapshots = [];
+
+  for (const file of files) {
+    try {
+      snapshots.push(JSON.parse(await readFile(join(GOLDEN_HISTORY_DIR, file), 'utf8')));
+    } catch (err) {
+      console.warn(`Warning: failed to parse golden history file ${file} (${err.message}) -- skipping`);
+    }
+  }
+
+  const median = computeMedianSnapshot(snapshots);
+
+  if (!median && snapshots.length > 0) {
+    console.warn(
+      'Golden history present but no snapshot had a marked trace window on every scenario ' +
+      '-- falling back to latest.json'
+    );
+  }
+
+  return median;
 }

--- a/performance-tests/lib/teardown.mjs
+++ b/performance-tests/lib/teardown.mjs
@@ -169,7 +169,12 @@ export default async function teardown() {
 
   // Save golden snapshots
   if (mode === 'golden') {
-    const savedPath = await saveSnapshots(stripInternalFields(scenarioResults));
+    const metadata = {
+      commit: process.env.GITHUB_SHA || null,
+      runId: process.env.GITHUB_RUN_ID || null,
+      runNumber: process.env.GITHUB_RUN_NUMBER || null,
+    };
+    const savedPath = await saveSnapshots(stripInternalFields(scenarioResults), metadata);
 
     console.log(`Golden snapshots saved to ${savedPath}`);
 
@@ -194,7 +199,14 @@ export default async function teardown() {
     if (golden) {
       const goldenCount = Object.keys(golden.scenarios || {}).length;
 
-      console.log(`Golden baseline loaded (${goldenCount} scenarios from ${golden.timestamp})`);
+      if (golden.medianWindowSize) {
+        console.log(
+          `Golden baseline is a median of ${golden.medianWindowSize} marks-valid develop run(s), ` +
+          `newest ${golden.timestamp} (${goldenCount} scenarios)`
+        );
+      } else {
+        console.log(`Golden baseline loaded (${goldenCount} scenarios from ${golden.timestamp})`);
+      }
     } else if (mode === 'compare') {
       // Self-compare: use current results as golden so charts always render
       console.log('No golden baseline found -- self-comparing for chart preview');

--- a/performance-tests/lib/teardown.mjs
+++ b/performance-tests/lib/teardown.mjs
@@ -199,10 +199,11 @@ export default async function teardown() {
     if (golden) {
       const goldenCount = Object.keys(golden.scenarios || {}).length;
 
-      if (golden.medianWindowSize) {
+      if (golden.isMedian) {
         console.log(
           `Golden baseline is a median of ${golden.medianWindowSize} marks-valid develop run(s), ` +
-          `newest ${golden.timestamp} (${goldenCount} scenarios)`
+          `newest ${golden.timestamp} (${goldenCount} scenarios). Source runs: ` +
+          `${(golden.medianSourceTimestamps || []).join(', ')}`
         );
       } else {
         console.log(`Golden baseline loaded (${goldenCount} scenarios from ${golden.timestamp})`);

--- a/performance-tests/trace-parser.mjs
+++ b/performance-tests/trace-parser.mjs
@@ -797,11 +797,11 @@ function computeProfileCallScripting(events, mainPid, mainTid, windowMinUs, wind
   return profileCallScriptingUs / 1000; // convert to ms
 }
 
-function formatHeapMinBytesLabel(bytes) {
+export function formatHeapMinBytesLabel(bytes) {
   return `${Math.round(bytes / 1000)} kB`;
 }
 
-function formatHeapMaxBytesLabel(bytes) {
+export function formatHeapMaxBytesLabel(bytes) {
   if (bytes >= 1_000_000) {
     return `${(bytes / 1_000_000).toFixed(1)} MB`;
   }


### PR DESCRIPTION
### Context

The PR fixes the performance-test baseline the PR comment compares against. PR #13255 (PR1 of this task) fixed the underlying measurement bug: trace windows are now marked via `performance.mark` instead of relying on DevTools auto-zoom, and each saved snapshot now carries `windowSource: 'marks'` per scenario (or is missing the field entirely, for anything recorded before that fix).

Even with correct measurement, every PR was still compared against a single develop snapshot (`performance-reports/develop/latest.json`), which every develop push overwrites in place. Six pre-PR1 develop baselines showed run-to-run swings up to 4x on identical code, so a single fluke run could become the baseline for every later PR with no way to tell.

This PR:
- Adds commit SHA / run id / run number provenance to saved golden snapshots (`saveSnapshots`'s existing `metadata` parameter was never populated before this).
- Computes the comparison baseline as a median of the last 5 develop snapshots that carry a marked trace window on every scenario, instead of the single `latest.json` file.
- Excludes pre-measurement-fix snapshots from that median via the existing `windowSource` discriminator — no manual cutoff date or migration needed, since those snapshots simply have no `windowSource` field at all.
- Leaves `meta.crossWindowScenarios` suppression (comment-rendering) to PR3, which owns `report-builder.mjs`/`html-report-builder.mjs`.

Gate check done before starting this work: the task's prior comment noted PR2 was blocked on zero post-merge develop goldens existing. That's since resolved — gh-pages now has 17 marked snapshots from 2026-08-27 through 2026-08-31, enough to compute a median.

[skip changelog] — this PR only touches `performance-tests/**` and `.github/**` (CI/tooling, no published package).

### This PR's own performance-test comment will fluctuate — read it as noise, not signal

This PR touches no measured code (`performance-tests/lib/teardown.mjs` only gains metadata/log-line changes, `trace-parser.mjs` only adds `export` keywords, everything else is CI/test-only) — so its own sticky comment's Δ Total is not telling you anything about this change. Watched it flip across reruns of the same unchanged code: an earlier run showed 7 scenarios "improved" 15-27% (all green); the latest run instead flagged **Scroll Left +12.4%**, **Sorting +28.8%**, and **Initial Load +9.2%** as regressions (red). Same PR, same measured code, opposite verdict.

Verified this is expected, not a bug in this change: on the green run, the report's baseline for cell-editing scripting (`364.7`) was byte-identical to a median recomputed independently from gh-pages, confirming the median mechanism compared against the correct 5 develop runs — this PR's own run just happened to measure below all five of them, not only below their median.

Cause: CI-runner-to-runner variance. Median-baselining smooths the *develop* side of the comparison; it does nothing for the *current PR's* side, which is still a single 3-iteration sample per run — the same run-to-run variance PR1's own investigation documented (CVs of 10-25%+ per scenario). **Do not read any single run of this comment, green or red, as validating or invalidating the change** — expect it to swing in both directions across reruns until PR3 lands (see follow-up below). Also worth flagging: the workflow only gates on regressions crossing a threshold; a large *improvement* gets no equivalent scrutiny, even though it's the same noise phenomenon in the other direction.

**Follow-up for PR3:** sample the PR side too (more than one measured run, e.g. its own small median or repeated runs) so both sides of the comparison are smoothed, not just the develop baseline.

### How has this been tested?

- New unit tests, expanded over two code-review-fix rounds:
  - `performance-tests/lib/__tests__/median-snapshot.test.mjs` (18 cases) — median math (odd/even counts), rounding parity on `updateCounters` integer fields vs. unrounded byte counts, heap-label regeneration, exclusion of any snapshot with a non-`'marks'`/missing `windowSource`/unparseable timestamp/non-object scenario value, newest-N windowing, per-scenario `MIN_VALID_SNAPSHOTS` enforcement (a scenario under-represented in the window is omitted, not medianed from too few entries), explicit `windowSource: 'marks'` on synthesized scenarios (guards the cross-window-mismatch trap), and conditional `hookTiming` inclusion.
  - `performance-tests/lib/__tests__/snapshot-store.test.mjs` (7 cases, new) — the history-median load path: empty/invalid history → single-file fallback, corrupt JSON → warn-and-skip, enough valid history → real median returned.
  - `.github/scripts/__tests__/fetch-golden-history.test.mjs` (9 cases, new) — the shared history-fetch script's selection logic (timestamp extraction, sort/cap, tie handling) and a structural test pinning both golden-restore call sites to it.
  ```
  node --test performance-tests/lib/__tests__/median-snapshot.test.mjs performance-tests/lib/__tests__/snapshot-store.test.mjs .github/scripts/__tests__/fetch-golden-history.test.mjs
  ```
- Full tooling suite, no regressions: `npm run test:tooling` (179 tests, all passing).
- `npx eslint` clean on all touched files.
- Manually simulated the CI restore step against the real `gh-pages` branch (`git fetch origin gh-pages:gh-pages`, then the shared fetch script) and confirmed `performance-tests/golden/history/` fills with the expected timestamped snapshots, and `loadSnapshots()` returns a real 5-run median (`isMedian: true`, `medianWindowSize: 5`) built only from post-PR1 snapshots — including a repro from a repo subdirectory that caught `git ls-tree`'s pathspec being CWD-relative, since fixed via `cwd: repoRoot()`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2629

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2629

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to performance-test tooling and CI; no product runtime code. Fallback paths preserve prior single-snapshot behavior when history is insufficient.
> 
> **Overview**
> **PR performance comparisons** no longer hinge on a single overwritten `latest.json` develop snapshot. Compare-mode CI now fetches recent timestamped goldens from `gh-pages` via a shared `fetch-golden-history.mjs` script (wired into both `performance-tests.yml` and `performance-run`), while still keeping `latest.json` as a fallback when history is missing or unusable.
> 
> **Baseline loading** prefers a synthesized median of the newest marks-valid develop runs (`computeMedianSnapshot` in `median-snapshot.mjs`): only snapshots where every scenario has `windowSource: 'marks'`, at least two valid runs, default window of five (overridable with `PERF_MEDIAN_WINDOW_SIZE`). `loadSnapshots` uses that median in compare mode, skips history in `PERF_MODE=golden`, and falls back to the single-file golden when median cannot be built. Golden saves now record GitHub commit/run metadata; teardown logs when the baseline is median-based.
> 
> Unit tests cover median math, snapshot-store history paths, and CI script selection/pinning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ec82afc0b434579b7e72fe24e02165d8dd69960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->