### PR TITLE
DEV-2629: Stop the perf comment publishing unsupportable regressions

### DIFF
--- a/.claude/skills/performance-testing/SKILL.md
+++ b/.claude/skills/performance-testing/SKILL.md
@@ -17,6 +17,7 @@ Each scenario traces a specific user interaction (scrolling, filtering, sorting,
 ```
 performance-tests/
   scripts/run.mjs           # Orchestrator: build HOT UMD -> copy to fixtures -> run Playwright
+  scripts/replay-goldens.mjs # Replays gh-pages develop goldens to re-derive the callout thresholds
   playwright.config.ts       # Sequential, 1 worker, 5 min timeout, chromium only
   trace-parser.mjs           # CDP trace -> DevTools-equivalent category breakdown
   .eslintrc.js               # Extends root config, relaxes JSDoc/console/await-in-loop rules
@@ -24,6 +25,7 @@ performance-tests/
     trace-runner.mjs          # CDP Tracing.start/stop + warmup/iteration loop + progress output
     hook-timing.mjs           # Hook pair timing (inject/get/save) for before/after measurements
     snapshot-store.mjs        # Golden baseline save/load/compare
+    median-snapshot.mjs       # Synthesizes the rolling-median develop baseline (+ its run-to-run spread)
     thresholds.mjs            # Shared classification logic (regression/improvement thresholds)
     chart-generator.mjs       # Inline SVG horizontal bar charts (base64 data URIs)
     report-builder.mjs        # Compact markdown PR comment (summary table + regression callouts)
@@ -187,13 +189,15 @@ These combine `scrollViewportTo()` with a deterministic `waitForFunction` that c
 
 | Scenario | Grid size | Action | Special |
 |---|---|---|---|
-| scroll-down | 5000x10 | `mouse.wheel(0, 350)` x 500 | - |
-| scroll-up | 5000x10 | `mouse.wheel(0, -350)` x 500 | Pre-scrolls to bottom via `scrollToRow` |
+| scroll-down | 10000x50 | `mouse.wheel(0, 350)` x 500 | - |
+| scroll-up | 10000x50 | `mouse.wheel(0, -350)` x 500 | Pre-scrolls to bottom via `scrollToRow` |
 | scroll-right | 10x5000 | `mouse.wheel(350, 0)` x 500 | - |
 | scroll-left | 10x5000 | `mouse.wheel(-350, 0)` x 500 | Pre-scrolls to right via `scrollToColumn` |
-| filtering | 1000x1000 | `filters.addCondition` + `filter()` | Hook timing |
-| sorting | 1000x1000 | `columnSorting.sort()` asc/desc alternating | Hook timing |
+| filtering | 100000x100 | `filters.addCondition` + `filter()` | Hook timing |
+| sorting | 100000x100 | `columnSorting.sort()` asc/desc alternating | Hook timing |
 | cell-editing | 5000x10 | selectCell + Enter + type + Enter x 20 | - |
+| initial-load | 100000x100 | `new Handsontable(...)` | Grid construction only |
+| source-data-validator-load | 100000x100 | `new Handsontable(...)` with `sourceDataValidator` | initial-load's fixture plus the one option |
 
 ## Run Commands
 
@@ -264,7 +268,7 @@ The `lib/` directory provides reusable helpers to avoid duplication across scena
 |---|---|---|
 | `fs-utils.mjs` | `exists(path)` | Async file existence check (used by teardown, snapshot-store, run.mjs) |
 | `scroll-utils.mjs` | `scrollToRow(page, row)`, `scrollToColumn(page, col)` | Scroll + deterministic wait for renderable index |
-| `thresholds.mjs` | `pctChange()`, `classifyChange()`, `fmtMs()`, `fmtPct()`, `fmtCv()`, etc. | Shared classification and formatting for both report builders |
+| `thresholds.mjs` | `pctChange()`, `classifyChange()`, `sumActiveComparable()`, `calcCv()`, `fmtMs()`, `fmtPct()`, `fmtCv()`, etc. | Shared classification and formatting for both report builders. The single source of the callout thresholds and colour bands: never restate either number elsewhere, and never retune one by eye (see `scripts/replay-goldens.mjs`) |
 | `hook-timing.mjs` | `injectHookTimer()`, `getHookTiming()`, `saveHookTimings()` | Hook pair timing injection, retrieval, and persistence |
 
 Always import from these shared modules rather than duplicating logic in scenario specs.

--- a/.github/actions/performance-run/action.yml
+++ b/.github/actions/performance-run/action.yml
@@ -91,6 +91,10 @@ runs:
         PR_NUMBER: ${{ github.event.pull_request.number || '' }}
         PAGES_URL: ${{ steps.report-url.outputs.pages_url || '' }}
         GITHUB_HEAD_REF: ${{ github.head_ref || '' }}
+        # The commit the report names. On a pull_request event the default GITHUB_SHA is the
+        # ephemeral refs/pull/N/merge commit, which does not exist on the branch under review, so
+        # the report would cite a SHA nobody can look up. Fall back to GITHUB_SHA off the PR path.
+        PERF_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         PERF_MODE: ${{ github.event_name == 'push' && 'golden' || 'compare' }}
       run: PERF_MODE=$PERF_MODE node scripts/run.mjs
 

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -120,6 +120,10 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           PAGES_URL: ${{ steps.report-url.outputs.pages_url || '' }}
           GITHUB_HEAD_REF: ${{ github.head_ref || '' }}
+          # The commit the report names. On a pull_request event the default GITHUB_SHA is the
+          # ephemeral refs/pull/N/merge commit, which does not exist on the branch under review, so
+          # the report would cite a SHA nobody can look up. Fall back to GITHUB_SHA off the PR path.
+          PERF_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: node scripts/run.mjs
 
       - name: Upload performance-tests output

--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -56,13 +56,15 @@ Each scenario measures a specific user interaction pattern:
 
 | Scenario | Grid size | Action | Notes |
 |---|---|---|---|
-| **scroll-down** | 5000 x 10 | `mouse.wheel(0, 350)` x 500 | Vertical scroll from top |
-| **scroll-up** | 5000 x 10 | `mouse.wheel(0, -350)` x 500 | Pre-scrolls to bottom, then scrolls up |
+| **scroll-down** | 10000 x 50 | `mouse.wheel(0, 350)` x 500 | Vertical scroll from top |
+| **scroll-up** | 10000 x 50 | `mouse.wheel(0, -350)` x 500 | Pre-scrolls to bottom, then scrolls up |
 | **scroll-right** | 10 x 5000 | `mouse.wheel(350, 0)` x 500 | Horizontal scroll from left |
 | **scroll-left** | 10 x 5000 | `mouse.wheel(-350, 0)` x 500 | Pre-scrolls to right, then scrolls left |
-| **filtering** | 1000 x 1000 | `filters.addCondition()` + `filter()` | Hook timing: beforeFilter -> afterFilter |
-| **sorting** | 1000 x 1000 | `columnSorting.sort()` | Hook timing: beforeColumnSort -> afterColumnSort |
+| **filtering** | 100000 x 100 | `filters.addCondition()` + `filter()` | Hook timing: beforeFilter -> afterFilter |
+| **sorting** | 100000 x 100 | `columnSorting.sort()` | Hook timing: beforeColumnSort -> afterColumnSort |
 | **cell-editing** | 5000 x 10 | selectCell + Enter + type + Enter x 20 | Sequential cell edits |
+| **initial-load** | 100000 x 100 | `new Handsontable(...)` | Grid construction only |
+| **source-data-validator-load** | 100000 x 100 | `new Handsontable(...)` with `sourceDataValidator` | Same fixture as initial-load plus the one option |
 
 Each scenario runs **1 warmup iteration** (discarded) followed by **3 measured iterations** with CDP tracing.
 
@@ -168,7 +170,64 @@ Additional metrics from `UpdateCounters`:
 - DOM node count (min/max)
 - Event listener count (min/max)
 
-**CV%** (coefficient of variation) is shown per metric. Values above 15% are flagged with `!!!` -- these indicate unstable measurements that may not be reliable for comparison.
+### Reading a delta
+
+Two spreads appear beside every delta, and they answer different questions. Both are a coefficient
+of variation over the sample standard deviation, and both are flagged above `CV_WARNING_THRESHOLD`
+(15%).
+
+| Column | What it measures | Typical value |
+|---|---|---|
+| **CV run** | How much the three iterations of this one run disagreed | under 4% on most scenarios |
+| **CV base** | How far apart the develop runs behind the median baseline sit | 11-19% |
+
+A tight `CV run` says the run measured itself consistently. It says nothing about whether the run is
+comparable to the baseline, which is what `CV base` reports. When the second number is wide, the
+delta beside it is measured against a moving target.
+
+`n/a` means the spread is genuinely unknown, not zero. The baseline spread is absent in golden mode,
+in the self-compare fallback, and whenever the history window is too thin for a median.
+
+### Thresholds
+
+Timing and heap are called out on separate thresholds, in `lib/thresholds.mjs`:
+
+| Constant | Value | Why |
+|---|---|---|
+| `REGRESSION_CALLOUT_THRESHOLD_TIMING` | 15 | Timing's run-to-run CV is 11-19%, so a lower bar fires mostly on noise |
+| `REGRESSION_CALLOUT_THRESHOLD_HEAP` | 5 | Heap's run-to-run CV is 0.4-3.6%, so it can be judged an order of magnitude tighter |
+
+Neither number is a guess, and neither should be changed by eye. Both come from replaying every
+develop golden against a median of the goldens before it: every such comparison measures develop
+against develop, so every delta it produces is noise, and the rate at which a threshold fires on
+that set is its false-positive rate. Reproduce it with:
+
+```bash
+git fetch origin gh-pages
+node scripts/replay-goldens.mjs --since 2026-08-27
+```
+
+The script prints the curve for both metrics and marks the value currently in force. Re-run it after
+any change to how the suite measures or to which baseline it compares against, and move each
+constant to the knee of its curve.
+
+### What the report refuses to publish
+
+A percentage is withheld, and rendered as `baseline incomplete`, when the comparison cannot support
+one:
+
+- The baseline recorded zero for an active category that the current run did record. That is a
+  failed capture, not a cheap operation, and dividing into it is what produced the `+115.7%`
+  regressions this reporting layer was rewritten to stop.
+- The two sides were measured through different trace windows (`windowSource` disagrees). After the
+  measurement fix this is a safety net rather than a common case.
+
+Such a scenario is listed under "Not assessed" rather than folded into "within tolerance": it was
+neither cleared nor flagged, and the comment says so.
+
+The **Trace window** row is informational and never coloured. After the measurement fix it is
+mark-to-mark harness wall clock, which on the scroll scenarios is 500 sequential wheel round trips
+sitting at a run-to-run CV of 0.0-0.2% regardless of what the grid does.
 
 ## Adding a new scenario
 

--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -186,7 +186,9 @@ comparable to the baseline, which is what `CV base` reports. When the second num
 delta beside it is measured against a moving target.
 
 `n/a` means the spread is genuinely unknown, not zero. The baseline spread is absent in golden mode,
-in the self-compare fallback, and whenever the history window is too thin for a median.
+in the self-compare fallback, in the single-run `latest.json` fallback (fewer than
+`MIN_VALID_SNAPSHOTS` qualifying develop snapshots, so `computeMedianSnapshot` returns `null`), and
+whenever the history window is too thin for a median.
 
 ### Thresholds
 
@@ -213,17 +215,21 @@ constant to the knee of its curve.
 
 ### What the report refuses to publish
 
-A percentage is withheld, and rendered as `baseline incomplete`, when the comparison cannot support
-one:
+A percentage is withheld when the comparison cannot support one. The label names the cause --
+`baseline incomplete`, `capture incomplete`, or `window mismatch` -- and the reasons are:
 
-- The baseline recorded zero for an active category that the current run did record. That is a
-  failed capture, not a cheap operation, and dividing into it is what produced the `+115.7%`
-  regressions this reporting layer was rewritten to stop.
-- The two sides were measured through different trace windows (`windowSource` disagrees). After the
-  measurement fix this is a safety net rather than a common case.
+- The baseline recorded zero for an active category that the current run did record
+  (`baseline incomplete`). That is a failed capture, not a cheap operation, and dividing into it is
+  what produced the `+115.7%` regressions this reporting layer was rewritten to stop.
+- This run recorded zero for an active category that the baseline did record (`capture incomplete`).
+  The mirror case: a capture failure on this run's side is no more supportable than one on the
+  baseline's, and would otherwise publish a fake win a reader cannot tell from a real one.
+- The two sides were measured through different trace windows (`windowSource` disagrees, rendered
+  `window mismatch`). After the measurement fix this is a safety net rather than a common case.
 
-Such a scenario is listed under "Not assessed" rather than folded into "within tolerance": it was
-neither cleared nor flagged, and the comment says so.
+Such a scenario is listed under "Not assessed" in the HTML report (the markdown comment says "Total
+delta not assessed") rather than folded into "within tolerance": it was neither cleared nor flagged,
+and the comment says so.
 
 The **Trace window** row is informational and never coloured. After the measurement fix it is
 mark-to-mark harness wall clock, which on the scroll scenarios is 500 sequential wheel round trips

--- a/performance-tests/lib/__tests__/html-report-builder.test.mjs
+++ b/performance-tests/lib/__tests__/html-report-builder.test.mjs
@@ -148,6 +148,66 @@ describe('buildHtmlReport -- incomplete baseline', () => {
   });
 });
 
+describe('buildHtmlReport -- cross-window comparison', () => {
+  // teardown warns that these deltas "are not measurements of a code change; they are the two
+  // windows disagreeing". Gating only the total left the per-category rows, the quick-metric strip
+  // and the heap chart publishing them, so a card badged "baseline incomplete" carried red
+  // +900% rows underneath and the dashboard counted it as a regression.
+  const crossWindow = () => payloadOf(buildHtmlReport(
+    {
+      sorting: currentScenario({
+        categories: { scripting: 200, rendering: 30, painting: 10 },
+        updateCounters: { jsHeapMaxBytes: 150_000_000, jsHeapMaxLabel: '150 MB' },
+      }),
+    },
+    { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+    { crossWindowScenarios: ['sorting'] }
+  )).scenarios[0];
+
+  test('withholds every per-category delta, not just the total', () => {
+    const changes = crossWindow().detailedMetrics
+      .filter(r => ['scripting', 'rendering', 'painting'].includes(r.key))
+      .map(r => r.change);
+
+    assert.deepEqual(changes, [null, null, null]);
+  });
+
+  test('withholds the quick-metric deltas', () => {
+    const { metrics } = crossWindow();
+
+    assert.equal(metrics.scripting.change, null);
+    assert.equal(metrics.rendering.change, null);
+    assert.equal(metrics.painting.change, null);
+    assert.equal(metrics.total.change, null);
+  });
+
+  test('withholds the heap delta, because the heap max is sampled inside the window', () => {
+    assert.equal(crossWindow().heap.change, null);
+  });
+
+  test('does not count the scenario as a regression', () => {
+    const scenario = crossWindow();
+
+    assert.equal(scenario.isRegression, false);
+    assert.equal(scenario.baselineIncomplete, true);
+  });
+
+  test('a same-window comparison still publishes heap and per-category deltas', () => {
+    const scenario = payloadOf(buildHtmlReport(
+      {
+        sorting: currentScenario({
+          updateCounters: { jsHeapMaxBytes: 150_000_000, jsHeapMaxLabel: '150 MB' },
+        }),
+      },
+      { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+      {}
+    )).scenarios[0];
+
+    assert.notEqual(scenario.heap.change, null);
+    assert.notEqual(scenario.metrics.scripting.change, null);
+  });
+});
+
 describe('buildHtmlReport -- baseline provenance', () => {
   test('flags a self-comparison so it is not described as a develop baseline', () => {
     const html = buildHtmlReport(

--- a/performance-tests/lib/__tests__/html-report-builder.test.mjs
+++ b/performance-tests/lib/__tests__/html-report-builder.test.mjs
@@ -218,6 +218,57 @@ describe('buildHtmlReport -- cross-window comparison', () => {
   });
 });
 
+describe('buildHtmlReport -- incomplete capture on the current side', () => {
+  // The branch that survived the first round: per-category deltas were gated on the window alone,
+  // so when THIS run missed a category the card badged itself incomparable and then published a
+  // green -100.0% for that very category one row below. pctChange's zero-denominator guard masks
+  // the mirror case, which is why only this direction leaked.
+  const currentMissed = () => payloadOf(buildHtmlReport(
+    { sorting: currentScenario({ categories: { scripting: 20, rendering: 0, painting: 0 } }) },
+    { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+    {}
+  )).scenarios[0];
+
+  test('publishes no delta for a category this run failed to capture', () => {
+    const { metrics } = currentMissed();
+
+    assert.equal(metrics.rendering.change, null);
+    assert.equal(metrics.painting.change, null);
+    assert.equal(metrics.total.change, null);
+  });
+
+  test('withholds the same categories in the detail table', () => {
+    const rows = currentMissed().detailedMetrics;
+
+    assert.equal(rows.find(r => r.key === 'rendering').change, null);
+    assert.equal(rows.find(r => r.key === 'painting').change, null);
+  });
+
+  test('still publishes the categories both sides did capture', () => {
+    // Withholding everything would hide usable data behind one failed capture.
+    assert.notEqual(currentMissed().metrics.scripting.change, null);
+    assert.equal(
+      currentMissed().detailedMetrics.find(r => r.key === 'scripting').incomplete, false
+    );
+  });
+
+  test('blames this run rather than the baseline', () => {
+    const scenario = currentMissed();
+
+    assert.equal(scenario.incompleteLabel, 'capture incomplete');
+    assert.ok(scenario.incompleteReason.includes('this run'));
+    assert.ok(!scenario.incompleteReason.includes('baseline'));
+  });
+
+  test('is never counted as an improvement', () => {
+    assert.equal(payloadOf(buildHtmlReport(
+      { sorting: currentScenario({ categories: { scripting: 20, rendering: 0, painting: 0 } }) },
+      { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+      {}
+    )).summary.improvements, 0);
+  });
+});
+
 describe('buildHtmlReport -- baseline provenance', () => {
   test('flags a self-comparison so it is not described as a develop baseline', () => {
     const html = buildHtmlReport(

--- a/performance-tests/lib/__tests__/html-report-builder.test.mjs
+++ b/performance-tests/lib/__tests__/html-report-builder.test.mjs
@@ -269,6 +269,77 @@ describe('buildHtmlReport -- incomplete capture on the current side', () => {
   });
 });
 
+describe('buildHtmlReport -- gating boundaries', () => {
+  test('a category zero on both sides keeps the comparison comparable', () => {
+    // Neither side captured it, so nothing is missing and nothing is withheld. It renders "--"
+    // rather than 0%, because pctChange rightly refuses a zero denominator.
+    const scenario = payloadOf(buildHtmlReport(
+      { sorting: currentScenario({ categories: { scripting: 22, rendering: 3, painting: 0 } }) },
+      {
+        timestamp: 't',
+        scenarios: {
+          sorting: goldenScenario({ categories: { scripting: 20, rendering: 3, painting: 0 } }),
+        },
+      },
+      {}
+    )).scenarios[0];
+
+    assert.equal(scenario.baselineIncomplete, false);
+    assert.equal(scenario.metrics.painting.incomplete, false);
+    assert.notEqual(scenario.metrics.scripting.change, null);
+  });
+
+  test('non-active categories still publish when only a timing category was missed', () => {
+    // loading/other/experience/idle never enter a total, so an incomplete active category says
+    // nothing about them. Only a window mismatch invalidates them.
+    const rows = payloadOf(buildHtmlReport(
+      {
+        sorting: currentScenario({
+          categories: { scripting: 20, rendering: 0, painting: 1, loading: 25 },
+        }),
+      },
+      {
+        timestamp: 't',
+        scenarios: {
+          sorting: goldenScenario({ categories: { scripting: 20, rendering: 3, painting: 1, loading: 10 } }),
+        },
+      },
+      {}
+    )).scenarios[0].detailedMetrics;
+
+    assert.equal(rows.find(r => r.key === 'rendering').change, null);
+    assert.notEqual(rows.find(r => r.key === 'loading').change, null);
+  });
+
+  test('a window mismatch withholds the non-active categories too', () => {
+    const rows = payloadOf(buildHtmlReport(
+      { sorting: currentScenario({ categories: { scripting: 20, rendering: 3, painting: 1, loading: 25 } }) },
+      {
+        timestamp: 't',
+        scenarios: {
+          sorting: goldenScenario({ categories: { scripting: 20, rendering: 3, painting: 1, loading: 10 } }),
+        },
+      },
+      { crossWindowScenarios: ['sorting'] }
+    )).scenarios[0].detailedMetrics;
+
+    assert.equal(rows.find(r => r.key === 'loading').change, null);
+  });
+
+  test('the badge carries the long explanation as its tooltip', () => {
+    // The short label cannot name the categories, and the HTML report is the artifact opened for
+    // detail -- it must not be the one surface that loses it.
+    const scenario = payloadOf(buildHtmlReport(
+      { sorting: currentScenario({ categories: { scripting: 20, rendering: 0, painting: 0 } }) },
+      { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+      {}
+    )).scenarios[0];
+
+    assert.ok(scenario.incompleteReason.includes('rendering'));
+    assert.ok(scenario.incompleteReason.includes('painting'));
+  });
+});
+
 describe('buildHtmlReport -- baseline provenance', () => {
   test('flags a self-comparison so it is not described as a develop baseline', () => {
     const html = buildHtmlReport(

--- a/performance-tests/lib/__tests__/html-report-builder.test.mjs
+++ b/performance-tests/lib/__tests__/html-report-builder.test.mjs
@@ -374,6 +374,22 @@ describe('buildHtmlReport -- scenario absent from the baseline', () => {
   test('is not counted as not-assessed, which is reserved for a failed comparison', () => {
     assert.equal(newScenario().notAssessed, false);
   });
+
+  test('is counted in its own noBaseline bucket, not folded into Neutral', () => {
+    // "Neutral" claims the scenario is flat against its baseline -- the one thing not known about a
+    // scenario the baseline does not contain at all. Before this bucket existed it fell into the
+    // remainder, i.e. Neutral, the same "assessed by omission" failure notAssessed exists to
+    // prevent for a failed comparison.
+    const payload = payloadOf(buildHtmlReport(
+      { sorting: currentScenario(), 'brand-new': currentScenario() },
+      { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+      {}
+    ));
+    const brandNew = payload.scenarios.find(s => s.name === 'brand-new');
+
+    assert.equal(payload.summary.noBaseline, 1);
+    assert.equal(brandNew.hasBaseline, false);
+  });
 });
 
 describe('buildHtmlReport -- dashboard and filters agree', () => {
@@ -402,9 +418,25 @@ describe('buildHtmlReport -- dashboard and filters agree', () => {
   test('every scenario falls into exactly one dashboard bucket', () => {
     const { summary } = mixed();
     const buckets = summary.regressions + summary.improvements + summary.neutral
-      + summary.notAssessed;
+      + summary.notAssessed + summary.noBaseline;
 
     assert.equal(buckets, summary.total);
+  });
+
+  test('a scenario absent from the baseline falls into noBaseline, not Neutral', () => {
+    const payload = payloadOf(buildHtmlReport(
+      {
+        flat: currentScenario(),
+        'brand-new': currentScenario(),
+      },
+      { timestamp: 't', scenarios: { flat: goldenScenario() } },
+      {}
+    ));
+    const flagged = payload.scenarios.filter(s => !s.hasBaseline);
+
+    assert.equal(flagged.length, payload.summary.noBaseline);
+    assert.equal(payload.summary.noBaseline, 1);
+    assert.equal(payload.summary.neutral, 1, 'only the flat scenario counts as Neutral');
   });
 
   test('the not-assessed flag drives both the counter and the filterable set', () => {

--- a/performance-tests/lib/__tests__/html-report-builder.test.mjs
+++ b/performance-tests/lib/__tests__/html-report-builder.test.mjs
@@ -340,6 +340,101 @@ describe('buildHtmlReport -- gating boundaries', () => {
   });
 });
 
+describe('buildHtmlReport -- scenario absent from the baseline', () => {
+  // A scenario just added to the suite, or one the median omitted because too few windowed
+  // snapshots carried it. There is nothing to compare against, which is not a failed capture --
+  // the markdown path returns early and prints "--", and the HTML must agree.
+  const newScenario = () => payloadOf(buildHtmlReport(
+    { sorting: currentScenario(), 'brand-new': currentScenario() },
+    { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+    {}
+  )).scenarios.find(s => s.name === 'brand-new');
+
+  test('is not reported as an incomplete capture', () => {
+    const scenario = newScenario();
+
+    assert.equal(scenario.hasBaseline, false);
+    assert.equal(scenario.baselineIncomplete, false);
+    assert.equal(scenario.incompleteLabel, null);
+  });
+
+  test('marks no category incomplete, so the detail table reads "--" like the comment', () => {
+    const scenario = newScenario();
+
+    assert.equal(scenario.metrics.scripting.incomplete, false);
+    assert.equal(scenario.metrics.rendering.incomplete, false);
+    assert.deepEqual(
+      scenario.detailedMetrics
+        .filter(r => ['scripting', 'rendering', 'painting'].includes(r.key))
+        .map(r => r.incomplete),
+      [false, false, false]
+    );
+  });
+
+  test('is not counted as not-assessed, which is reserved for a failed comparison', () => {
+    assert.equal(newScenario().notAssessed, false);
+  });
+});
+
+describe('buildHtmlReport -- dashboard and filters agree', () => {
+  // The counter and the filter are computed on opposite sides of the serialization boundary, so
+  // they can only stay consistent by reading the same flag. Deriving the predicate twice is what
+  // made the Neutral list longer than the Neutral count.
+  const mixed = () => payloadOf(buildHtmlReport(
+    {
+      flat: currentScenario(),
+      incomparable: currentScenario({ categories: { scripting: 20, rendering: 0, painting: 0 } }),
+      leaky: currentScenario({
+        updateCounters: { jsHeapMaxBytes: 200_000_000, jsHeapMaxLabel: '200 MB' },
+      }),
+    },
+    {
+      timestamp: 't',
+      scenarios: {
+        flat: goldenScenario(),
+        incomparable: goldenScenario(),
+        leaky: goldenScenario(),
+      },
+    },
+    {}
+  ));
+
+  test('every scenario falls into exactly one dashboard bucket', () => {
+    const { summary } = mixed();
+    const buckets = summary.regressions + summary.improvements + summary.neutral
+      + summary.notAssessed;
+
+    assert.equal(buckets, summary.total);
+  });
+
+  test('the not-assessed flag drives both the counter and the filterable set', () => {
+    const payload = mixed();
+    const flagged = payload.scenarios.filter(s => s.notAssessed);
+
+    assert.equal(flagged.length, payload.summary.notAssessed);
+    assert.equal(flagged.length, 1);
+    assert.equal(flagged[0].name, 'incomparable');
+  });
+
+  test('a scenario that both failed comparison and regressed counts as a regression', () => {
+    // It produced a callout, so it was assessed. Counting it in both buckets would double-count.
+    const scenario = payloadOf(buildHtmlReport(
+      {
+        sorting: currentScenario({
+          categories: { scripting: 20, rendering: 0, painting: 0 },
+          updateCounters: { jsHeapMaxBytes: 200_000_000, jsHeapMaxLabel: '200 MB' },
+        }),
+      },
+      { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+      {}
+    )).scenarios[0];
+
+    assert.equal(scenario.isRegression, true);
+    assert.equal(scenario.baselineIncomplete, true);
+    assert.equal(scenario.notAssessed, false);
+  });
+});
+
 describe('buildHtmlReport -- baseline provenance', () => {
   test('flags a self-comparison so it is not described as a develop baseline', () => {
     const html = buildHtmlReport(

--- a/performance-tests/lib/__tests__/html-report-builder.test.mjs
+++ b/performance-tests/lib/__tests__/html-report-builder.test.mjs
@@ -1,0 +1,199 @@
+// Unit tests for the self-contained HTML performance report.
+//
+// The report is a single HTML file that serializes its whole data payload into an inline
+// `<script>` block and renders it client-side. Two properties matter enough to pin: values that
+// reach the page from CI (a branch name on a fork pull request, most of all) cannot break out of
+// that block, and a delta the report refuses to publish on the scenario card is not quietly
+// published again in the detail table one click below it.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildHtmlReport } from '../html-report-builder.mjs';
+
+const ITERATIONS = {
+  categories: { scripting: [19, 20, 21], rendering: [3, 3, 3], painting: [1, 1, 1] },
+  rangeEnd: [89, 90, 91],
+};
+
+/**
+ * @param {object} [overrides]
+ * @returns {object}
+ */
+function currentScenario(overrides = {}) {
+  return {
+    categories: { scripting: 20, rendering: 3, painting: 1 },
+    updateCounters: { jsHeapMaxBytes: 100_000_000, jsHeapMaxLabel: '100 MB' },
+    rangeEnd: 90,
+    runs: 3,
+    windowSource: 'marks',
+    _iterationValues: ITERATIONS,
+    ...overrides,
+  };
+}
+
+/**
+ * @param {object} [overrides]
+ * @returns {object}
+ */
+function goldenScenario(overrides = {}) {
+  return {
+    categories: { scripting: 20, rendering: 3, painting: 1 },
+    updateCounters: { jsHeapMaxBytes: 100_000_000, jsHeapMaxLabel: '100 MB' },
+    rangeEnd: 90,
+    windowSource: 'marks',
+    spread: 12,
+    ...overrides,
+  };
+}
+
+/**
+ * @param {string} html
+ * @returns {object} the payload the client script reads
+ */
+function payloadOf(html) {
+  return JSON.parse(html.match(/window\.__PERF_DATA__ = ([\s\S]*?);\n<\/script>/)[1]);
+}
+
+describe('buildHtmlReport -- script-block containment', () => {
+  // GITHUB_HEAD_REF reaches the payload, and a fork pull request chooses its own branch name.
+  // JSON.stringify does not escape "<", so without the escape the branch name below would close
+  // the inline script and everything after it would be parsed as markup.
+  const hostile = 'x</script><img src=x onerror=alert(1)>';
+
+  test('a hostile branch name cannot close the inline script block', () => {
+    const html = buildHtmlReport(
+      { sorting: currentScenario() },
+      { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+      { branch: hostile }
+    );
+
+    assert.ok(!html.includes('</script><img'), 'the raw closing tag must not survive');
+    assert.equal((html.match(/<script/g) || []).length, 2, 'no extra script element');
+  });
+
+  test('the escaped payload is still valid JSON carrying the original value', () => {
+    const html = buildHtmlReport(
+      { sorting: currentScenario() },
+      { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+      { branch: hostile }
+    );
+
+    // "<" escaped as < is the same character to a JSON parser, so nothing is lost.
+    assert.equal(payloadOf(html).meta.branch, hostile);
+  });
+
+  test('a hostile PR number is escaped in the title rather than interpolated raw', () => {
+    const html = buildHtmlReport(
+      { sorting: currentScenario() },
+      { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+      { prNumber: hostile }
+    );
+
+    const title = html.split('\n').find(line => line.startsWith('<title>'));
+
+    assert.ok(!title.includes('<img'));
+    assert.ok(title.includes('&lt;/script&gt;'));
+  });
+});
+
+describe('buildHtmlReport -- incomplete baseline', () => {
+  const incomplete = () => buildHtmlReport(
+    {
+      filtering: currentScenario({
+        categories: { scripting: 39.62, rendering: 3.25, painting: 0.69 },
+      }),
+    },
+    {
+      timestamp: 't',
+      scenarios: {
+        filtering: goldenScenario({ categories: { scripting: 20.20, rendering: 0, painting: 0 } }),
+      },
+    },
+    {}
+  );
+
+  test('withholds the Total active delta in the detail table, not just on the badge', () => {
+    // The badge said "baseline incomplete" while the detail row published +115.6% in red -- the
+    // exact number the guard exists to suppress, one click away.
+    const row = payloadOf(incomplete()).scenarios[0].detailedMetrics
+      .find(r => r.key === 'total-active');
+
+    assert.equal(row.change, null);
+    assert.equal(row.incomplete, true);
+  });
+
+  test('the withheld percentage appears nowhere in the document', () => {
+    assert.ok(!incomplete().includes('115.'));
+  });
+
+  test('counts the scenario as not assessed rather than as neutral', () => {
+    const { summary } = payloadOf(incomplete());
+
+    assert.equal(summary.notAssessed, 1);
+    assert.equal(summary.neutral, 0);
+  });
+
+  test('a comparable baseline is still published and still counted as neutral', () => {
+    const html = buildHtmlReport(
+      { sorting: currentScenario({ categories: { scripting: 21, rendering: 3, painting: 1 } }) },
+      { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+      {}
+    );
+    const { scenarios, summary } = payloadOf(html);
+
+    assert.notEqual(scenarios[0].totalChange, null);
+    assert.equal(scenarios[0].baselineIncomplete, false);
+    assert.equal(summary.notAssessed, 0);
+    assert.equal(summary.neutral, 1);
+  });
+});
+
+describe('buildHtmlReport -- baseline provenance', () => {
+  test('flags a self-comparison so it is not described as a develop baseline', () => {
+    const html = buildHtmlReport(
+      { sorting: currentScenario() },
+      { timestamp: 'now', isSelfCompare: true, scenarios: { sorting: goldenScenario() } },
+      {}
+    );
+
+    assert.equal(payloadOf(html).baseline.isSelfCompare, true);
+  });
+
+  test('does not flag a real single-run golden', () => {
+    const html = buildHtmlReport(
+      { sorting: currentScenario() },
+      { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+      {}
+    );
+
+    assert.equal(payloadOf(html).baseline.isSelfCompare, false);
+  });
+
+  test('serializes the thresholds so the client bands cannot drift from the callouts', () => {
+    const html = buildHtmlReport(
+      { sorting: currentScenario() },
+      { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+      {}
+    );
+    const { thresholds } = payloadOf(html);
+
+    assert.ok(thresholds.heap < thresholds.timing);
+    assert.equal(typeof thresholds.cvWarning, 'number');
+  });
+});
+
+describe('buildHtmlReport -- trace window row', () => {
+  test('is marked informational so it is never coloured as a verdict', () => {
+    // After the measurement fix this row is harness wall clock: on the scroll scenarios it is 500
+    // sequential wheel round trips and does not move with grid work.
+    const html = buildHtmlReport(
+      { sorting: currentScenario() },
+      { timestamp: 't', scenarios: { sorting: goldenScenario() } },
+      {}
+    );
+    const row = payloadOf(html).scenarios[0].detailedMetrics.find(r => r.key === 'trace-window');
+
+    assert.equal(row.neutral, true);
+    assert.equal(row.note, 'harness wall clock');
+  });
+});

--- a/performance-tests/lib/__tests__/html-report-builder.test.mjs
+++ b/performance-tests/lib/__tests__/html-report-builder.test.mjs
@@ -185,6 +185,16 @@ describe('buildHtmlReport -- cross-window comparison', () => {
     assert.equal(crossWindow().heap.change, null);
   });
 
+  test('withholds every memory delta, which are extrema over the same window', () => {
+    // Heap min/max, node count and listener count are all UpdateCounters extrema taken inside the
+    // parsed window, so the argument that invalidates the heap maximum invalidates each of them.
+    const changes = crossWindow().memory.map(r => r.change);
+
+    assert.ok(changes.length > 0, 'the fixture must produce memory rows');
+    assert.deepEqual(changes, changes.map(() => null));
+    assert.ok(crossWindow().memory.every(r => r.incomplete === true));
+  });
+
   test('does not count the scenario as a regression', () => {
     const scenario = crossWindow();
 

--- a/performance-tests/lib/__tests__/median-snapshot.test.mjs
+++ b/performance-tests/lib/__tests__/median-snapshot.test.mjs
@@ -251,4 +251,35 @@ describe('computeMedianSnapshot', () => {
 
     assert.equal('hookTiming' in noneWithHook.scenarios.sorting, false);
   });
+
+  test('records how far apart the windowed runs sit, as a CV of their active time', () => {
+    // The per-iteration values are stripped before a golden is saved, so this is the only spread
+    // the baseline side can ever report -- and it is the one that matters, because it measures the
+    // run-to-run variance a PR's single run is being compared against.
+    const result = computeMedianSnapshot([
+      snapshot('2026-08-28T00:00:00Z', {
+        sorting: { categories: { scripting: 90, rendering: 10, painting: 0 } },
+      }),
+      snapshot('2026-08-29T00:00:00Z', {
+        sorting: { categories: { scripting: 100, rendering: 0, painting: 0 } },
+      }),
+      snapshot('2026-08-30T00:00:00Z', {
+        sorting: { categories: { scripting: 110, rendering: 0, painting: 0 } },
+      }),
+    ]);
+
+    // Active totals 100 / 100 / 110. Mean 103.33, sample stddev sqrt(66.67/2) = 5.7735,
+    // so the CV is 5.59%.
+    assert.ok(result.scenarios.sorting.spread > 0);
+    assert.equal(result.scenarios.sorting.spread.toFixed(2), '5.59');
+  });
+
+  test('reports a zero spread when every windowed run measured the same active time', () => {
+    const result = computeMedianSnapshot([
+      snapshot('2026-08-28T00:00:00Z'),
+      snapshot('2026-08-29T00:00:00Z'),
+    ]);
+
+    assert.equal(result.scenarios.sorting.spread, 0);
+  });
 });

--- a/performance-tests/lib/__tests__/report-builder.test.mjs
+++ b/performance-tests/lib/__tests__/report-builder.test.mjs
@@ -1,0 +1,374 @@
+// Unit tests for the markdown report -- the sticky comment posted on every pull request.
+//
+// This is the artifact reviewers actually read, and the defect this suite guards is that it used to
+// publish confident red callouts computed from baselines that could not support them. The cases
+// below pin the four things that changed: a total delta is withheld (and said to be withheld) when
+// the baseline is unusable, both reliability numbers are shown and labeled distinctly, the callout
+// fires on the timing threshold for timing and the heap threshold for heap, and the comment states
+// whether it compared against one develop run or several.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildReport } from '../report-builder.mjs';
+import {
+  BASELINE_INCOMPLETE_LABEL,
+  REGRESSION_CALLOUT_THRESHOLD_TIMING,
+  REGRESSION_CALLOUT_THRESHOLD_HEAP,
+} from '../thresholds.mjs';
+
+/**
+ * @param {object} [overrides]
+ * @returns {object} a current-run scenario result
+ */
+function currentScenario(overrides = {}) {
+  return {
+    categories: { scripting: 20, rendering: 3, painting: 1 },
+    updateCounters: { jsHeapMaxBytes: 100_000_000, jsHeapMaxLabel: '100 MB' },
+    rangeEnd: 90,
+    runs: 3,
+    windowSource: 'marks',
+    _iterationValues: {
+      categories: { scripting: [19, 20, 21], rendering: [3, 3, 3], painting: [1, 1, 1] },
+      rangeEnd: [89, 90, 91],
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * @param {object} [overrides]
+ * @returns {object} a golden (baseline) scenario entry
+ */
+function goldenScenario(overrides = {}) {
+  return {
+    categories: { scripting: 20, rendering: 3, painting: 1 },
+    updateCounters: { jsHeapMaxBytes: 100_000_000, jsHeapMaxLabel: '100 MB' },
+    rangeEnd: 90,
+    windowSource: 'marks',
+    spread: 12,
+    ...overrides,
+  };
+}
+
+/**
+ * @param {Record<string, object>} scenarios
+ * @param {object} [extra]
+ * @returns {object} a golden snapshot
+ */
+function golden(scenarios, extra = {}) {
+  return { timestamp: '2026-09-01T08:00:00.000Z', scenarios, ...extra };
+}
+
+describe('buildReport -- incomplete baseline', () => {
+  test('withholds the total delta when the baseline missed a category', () => {
+    // The filed defect, reproduced from the report data quoted in the task: the golden captured
+    // zero rendering and zero painting, and the comment published +115.7%.
+    const report = buildReport(
+      {
+        filtering: currentScenario({
+          categories: { scripting: 39.62, rendering: 3.25, painting: 0.69 },
+        }),
+      },
+      golden({
+        filtering: goldenScenario({ categories: { scripting: 20.20, rendering: 0, painting: 0 } }),
+      }),
+      {}
+    );
+
+    assert.ok(report.includes(BASELINE_INCOMPLETE_LABEL));
+    assert.ok(!report.includes('115.7%'), 'must not publish a delta against a zero baseline');
+  });
+
+  test('says the scenario was not assessed rather than clearing it', () => {
+    const report = buildReport(
+      { filtering: currentScenario() },
+      golden({
+        filtering: goldenScenario({ categories: { scripting: 20, rendering: 0, painting: 0 } }),
+      }),
+      {}
+    );
+
+    assert.ok(report.includes('Not assessed'));
+    assert.ok(report.includes('Filtering'));
+  });
+
+  test('withholds the delta when the two sides used different trace windows', () => {
+    const report = buildReport(
+      { sorting: currentScenario() },
+      golden({ sorting: goldenScenario() }),
+      { crossWindowScenarios: ['sorting'] }
+    );
+
+    assert.ok(report.includes(BASELINE_INCOMPLETE_LABEL));
+  });
+
+  test('a comparable baseline still publishes its delta', () => {
+    const report = buildReport(
+      { sorting: currentScenario({ categories: { scripting: 25, rendering: 3, painting: 1 } }) },
+      golden({ sorting: goldenScenario() }),
+      {}
+    );
+
+    assert.ok(!report.includes(BASELINE_INCOMPLETE_LABEL));
+    assert.ok(report.includes('+20.8%'));
+  });
+});
+
+describe('buildReport -- reliability columns', () => {
+  test('shows the intra-run spread and the baseline spread as separate numbers', () => {
+    const report = buildReport(
+      { sorting: currentScenario() },
+      golden({ sorting: goldenScenario({ spread: 18.5 }) }),
+      {}
+    );
+
+    assert.ok(report.includes('CV run / base'), 'the header must distinguish the two');
+    // Baseline spread comes straight from the median window.
+    assert.ok(report.includes('18.5%'));
+  });
+
+  test('renders the baseline spread as n/a when the baseline carries none', () => {
+    // Three paths reach here without a history window: golden mode, the self-compare fallback, and
+    // a thin history. A rendered 0.0% would claim a perfectly stable baseline.
+    const report = buildReport(
+      { sorting: currentScenario() },
+      golden({ sorting: goldenScenario({ spread: undefined }) }),
+      {}
+    );
+
+    assert.ok(report.includes('n/a'));
+  });
+
+  test('flags a baseline spread above the warning threshold', () => {
+    const report = buildReport(
+      { sorting: currentScenario() },
+      golden({ sorting: goldenScenario({ spread: 30 }) }),
+      {}
+    );
+
+    assert.ok(report.includes('30.0% ⚠️'));
+  });
+
+  test('computes the intra-run spread when a real trace omitted a category entirely', () => {
+    // Not every trace records every category, so the per-iteration arrays can be ragged or absent.
+    // Recombining them must not produce NaN or an empty spread just because rendering is missing.
+    const report = buildReport(
+      {
+        sorting: currentScenario({
+          categories: { scripting: 80, rendering: 0, painting: 0 },
+          _iterationValues: { categories: { scripting: [70, 80, 90] } },
+        }),
+      },
+      golden({ sorting: goldenScenario({ categories: { scripting: 80, rendering: 0, painting: 0 } }) }),
+      {}
+    );
+
+    const row = report.split('\n').find(line => line.includes('| Sorting'));
+
+    assert.ok(!row.includes('NaN'));
+    assert.ok(row.includes('12.5%'), `expected the scripting-only spread in: ${row}`);
+  });
+
+  test('renders n/a rather than NaN when no per-iteration values were kept at all', () => {
+    const report = buildReport(
+      { sorting: currentScenario({ _iterationValues: undefined }) },
+      golden({ sorting: goldenScenario() }),
+      {}
+    );
+
+    const row = report.split('\n').find(line => line.includes('| Sorting'));
+
+    assert.ok(!row.includes('NaN'));
+    assert.ok(row.includes('n/a'));
+  });
+
+  test('reports hook timing with its own spread for the scenarios that measure it', () => {
+    const report = buildReport(
+      {
+        filtering: currentScenario({
+          hookTiming: 47,
+          _iterationValues: {
+            categories: { scripting: [19, 20, 21], rendering: [3, 3, 3], painting: [1, 1, 1] },
+            hookTiming: [45, 47, 49],
+          },
+        }),
+      },
+      golden({ filtering: goldenScenario({ hookTiming: 36 }) }),
+      {}
+    );
+
+    assert.ok(report.includes('Hook timing'));
+    assert.ok(report.includes('47 ms'));
+  });
+
+  test('omits the hook-timing section entirely when no scenario measures a hook', () => {
+    const report = buildReport(
+      { sorting: currentScenario() },
+      golden({ sorting: goldenScenario() }),
+      {}
+    );
+
+    assert.ok(!report.includes('Hook timing'));
+  });
+});
+
+describe('buildReport -- callouts', () => {
+  test('does not call out a timing change below the timing threshold', () => {
+    const under = REGRESSION_CALLOUT_THRESHOLD_TIMING - 2;
+    const report = buildReport(
+      {
+        sorting: currentScenario({
+          categories: { scripting: 24 * (1 + under / 100), rendering: 0, painting: 0 },
+        }),
+      },
+      golden({ sorting: goldenScenario({ categories: { scripting: 24, rendering: 0, painting: 0 } }) }),
+      {}
+    );
+
+    assert.ok(report.includes('within tolerance'));
+  });
+
+  test('calls out a timing change above the timing threshold', () => {
+    const over = REGRESSION_CALLOUT_THRESHOLD_TIMING + 5;
+    const report = buildReport(
+      {
+        sorting: currentScenario({
+          categories: { scripting: 24 * (1 + over / 100), rendering: 0, painting: 0 },
+        }),
+      },
+      golden({ sorting: goldenScenario({ categories: { scripting: 24, rendering: 0, painting: 0 } }) }),
+      {}
+    );
+
+    assert.ok(report.includes('regressed'));
+    assert.ok(!report.includes('within tolerance'));
+  });
+
+  test('the heap column is banded on the heap threshold, not the timing one', () => {
+    // Guards the specific drift this PR exists to remove: the Δ Heap cell passes the heap threshold
+    // explicitly, so dropping that argument would silently put heap back on the timing band while
+    // every callout test stayed green. A growth between the two thresholds must read as a
+    // regression in the table, not merely in the callout below it.
+    const between = (REGRESSION_CALLOUT_THRESHOLD_HEAP + REGRESSION_CALLOUT_THRESHOLD_TIMING) / 2;
+    const report = buildReport(
+      {
+        sorting: currentScenario({
+          updateCounters: {
+            jsHeapMaxBytes: 100_000_000 * (1 + between / 100),
+            jsHeapMaxLabel: '110 MB',
+          },
+        }),
+      },
+      golden({ sorting: goldenScenario() }),
+      {}
+    );
+
+    const row = report.split('\n').find(line => line.includes('| Sorting'));
+
+    assert.ok(row.includes('🔴'), `heap delta of +${between}% must be flagged in the table: ${row}`);
+  });
+
+  test('the timing column is not banded on the heap threshold', () => {
+    const between = (REGRESSION_CALLOUT_THRESHOLD_HEAP + REGRESSION_CALLOUT_THRESHOLD_TIMING) / 2;
+    const report = buildReport(
+      {
+        sorting: currentScenario({
+          categories: { scripting: 24 * (1 + between / 100), rendering: 0, painting: 0 },
+        }),
+      },
+      golden({ sorting: goldenScenario({ categories: { scripting: 24, rendering: 0, painting: 0 } }) }),
+      {}
+    );
+
+    const row = report.split('\n').find(line => line.includes('| Sorting'));
+
+    assert.ok(!row.includes('🔴'), `timing delta of +${between}% is below the timing band: ${row}`);
+  });
+
+  test('heap is judged on the heap threshold, which is tighter than timing', () => {
+    // A heap growth between the two thresholds must fire. Sharing one constant would miss it.
+    const between = (REGRESSION_CALLOUT_THRESHOLD_HEAP + REGRESSION_CALLOUT_THRESHOLD_TIMING) / 2;
+    const report = buildReport(
+      {
+        sorting: currentScenario({
+          updateCounters: {
+            jsHeapMaxBytes: 100_000_000 * (1 + between / 100),
+            jsHeapMaxLabel: '110 MB',
+          },
+        }),
+      },
+      golden({ sorting: goldenScenario() }),
+      {}
+    );
+
+    assert.ok(report.includes('JS heap'));
+    assert.ok(report.includes('larger'));
+  });
+
+  test('an incomplete baseline never produces a timing callout', () => {
+    const report = buildReport(
+      {
+        sorting: currentScenario({ categories: { scripting: 500, rendering: 50, painting: 10 } }),
+      },
+      golden({ sorting: goldenScenario({ categories: { scripting: 20, rendering: 0, painting: 0 } }) }),
+      {}
+    );
+
+    assert.ok(!report.includes('regressed +'));
+    assert.ok(report.includes('Not assessed'));
+  });
+});
+
+describe('buildReport -- provenance', () => {
+  test('states how many develop runs the baseline is a median of', () => {
+    const report = buildReport(
+      { sorting: currentScenario() },
+      golden({ sorting: goldenScenario() }, {
+        isMedian: true,
+        medianWindowSize: 5,
+        medianSourceTimestamps: ['2026-09-01T08-28-12Z', '2026-08-31T08-44-08Z'],
+      }),
+      {}
+    );
+
+    assert.ok(report.includes('median of 5 develop runs'));
+    assert.ok(report.includes('2026-08-31T08-44-08Z to 2026-09-01T08-28-12Z'));
+  });
+
+  test('says so when the baseline is a single run', () => {
+    const report = buildReport(
+      { sorting: currentScenario() },
+      golden({ sorting: goldenScenario() }),
+      {}
+    );
+
+    assert.ok(report.includes('single develop run'));
+    assert.ok(!report.includes('median of'));
+  });
+
+  test('records the commit and run the current side came from', () => {
+    const report = buildReport(
+      { sorting: currentScenario() },
+      golden({ sorting: goldenScenario() }),
+      { commit: 'abcdef1234567890', runId: '33493660272' }
+    );
+
+    assert.ok(report.includes('commit `abcdef1`'));
+    assert.ok(report.includes('run `33493660272`'));
+  });
+
+  test('omits the provenance line entirely when there is no baseline', () => {
+    const report = buildReport({ sorting: currentScenario() }, null, {});
+
+    assert.ok(!report.includes('Baseline:'));
+  });
+});
+
+describe('buildReport -- no baseline', () => {
+  test('drops the delta columns but keeps the intra-run spread', () => {
+    const report = buildReport({ sorting: currentScenario() }, null, {});
+
+    assert.ok(!report.includes('Δ Total'));
+    assert.ok(report.includes('CV run'));
+  });
+});

--- a/performance-tests/lib/__tests__/report-builder.test.mjs
+++ b/performance-tests/lib/__tests__/report-builder.test.mjs
@@ -12,6 +12,7 @@ import assert from 'node:assert/strict';
 import { buildReport } from '../report-builder.mjs';
 import {
   BASELINE_INCOMPLETE_LABEL,
+  INCOMPARABLE_LABELS,
   REGRESSION_CALLOUT_THRESHOLD_TIMING,
   REGRESSION_CALLOUT_THRESHOLD_HEAP,
 } from '../thresholds.mjs';
@@ -98,8 +99,26 @@ describe('buildReport -- incomplete baseline', () => {
       golden({ sorting: goldenScenario() }),
       { crossWindowScenarios: ['sorting'] }
     );
+    const row = report.split('\n').find(line => line.includes('| Sorting'));
 
-    assert.ok(report.includes(BASELINE_INCOMPLETE_LABEL));
+    // Named for what actually happened. The baseline captured everything here; it is the windows
+    // that differ, so "baseline incomplete" would be both misleading and factually wrong.
+    assert.ok(row.includes(INCOMPARABLE_LABELS['window-mismatch']));
+    assert.ok(!row.includes(INCOMPARABLE_LABELS['baseline-incomplete']));
+  });
+
+  test('the heap cell and the total cell give the same reason', () => {
+    // One row must not carry two explanations for one cause: the heap cell said "baseline
+    // incomplete" while the total beside it said "window mismatch".
+    const report = buildReport(
+      { sorting: currentScenario() },
+      golden({ sorting: goldenScenario() }),
+      { crossWindowScenarios: ['sorting'] }
+    );
+    const row = report.split('\n').find(line => line.includes('| Sorting'));
+    const occurrences = row.split(INCOMPARABLE_LABELS['window-mismatch']).length - 1;
+
+    assert.equal(occurrences, 2, `total and heap must both read window mismatch: ${row}`);
   });
 
   test('a comparable baseline still publishes its delta', () => {

--- a/performance-tests/lib/__tests__/report-builder.test.mjs
+++ b/performance-tests/lib/__tests__/report-builder.test.mjs
@@ -88,7 +88,7 @@ describe('buildReport -- incomplete baseline', () => {
       {}
     );
 
-    assert.ok(report.includes('Not assessed'));
+    assert.ok(report.includes('Total delta not assessed'));
     assert.ok(report.includes('Filtering'));
   });
 
@@ -315,7 +315,79 @@ describe('buildReport -- callouts', () => {
     );
 
     assert.ok(!report.includes('regressed +'));
-    assert.ok(report.includes('Not assessed'));
+    assert.ok(report.includes('Total delta not assessed'));
+  });
+});
+
+describe('buildReport -- self-comparison', () => {
+  // teardown.mjs falls back to comparing a run against itself when no golden exists, stamping the
+  // fallback with a fresh timestamp. Branching on the timestamp alone made that indistinguishable
+  // from a real single-run golden, so the comment claimed a develop baseline and cleared every
+  // scenario as "within tolerance" on a comparison that was 0% by construction.
+  const selfCompare = golden({ sorting: goldenScenario({ spread: undefined }) }, {
+    isSelfCompare: true,
+    timestamp: '2026-09-01T10:43:05.777Z',
+  });
+
+  test('never describes a self-comparison as a develop baseline', () => {
+    const report = buildReport({ sorting: currentScenario() }, selfCompare, {});
+
+    assert.ok(!report.includes('single develop run'));
+    assert.ok(report.includes('compared against itself'));
+  });
+
+  test('does not claim the scenarios are within tolerance', () => {
+    const report = buildReport({ sorting: currentScenario() }, selfCompare, {});
+
+    assert.ok(!report.includes('within tolerance'));
+  });
+
+  test('still reports a real single-run golden as one', () => {
+    const report = buildReport(
+      { sorting: currentScenario() },
+      golden({ sorting: goldenScenario() }),
+      {}
+    );
+
+    assert.ok(report.includes('single develop run'));
+    assert.ok(!report.includes('compared against itself'));
+  });
+});
+
+describe('buildReport -- cross-window heap', () => {
+  test('withholds the heap callout too when the trace windows disagree', () => {
+    // jsHeapMaxBytes is a maximum over the UpdateCounters samples inside the parsed window, so two
+    // different windows sample two different things. Flagging heap while the total is withheld
+    // would also put a regression callout directly above a "not assessed" note for one scenario.
+    const report = buildReport(
+      {
+        sorting: currentScenario({
+          updateCounters: { jsHeapMaxBytes: 150_000_000, jsHeapMaxLabel: '150 MB' },
+        }),
+      },
+      golden({ sorting: goldenScenario() }),
+      { crossWindowScenarios: ['sorting'] }
+    );
+
+    assert.ok(!report.includes('JS heap'));
+    assert.ok(report.includes('Total delta not assessed'));
+  });
+
+  test('still assesses heap when only a timing category was missing from the baseline', () => {
+    // Heap and the timing categories are measured independently, so a baseline that missed
+    // rendering says nothing about whether its heap figure is usable.
+    const report = buildReport(
+      {
+        sorting: currentScenario({
+          updateCounters: { jsHeapMaxBytes: 150_000_000, jsHeapMaxLabel: '150 MB' },
+        }),
+      },
+      golden({ sorting: goldenScenario({ categories: { scripting: 20, rendering: 0, painting: 0 } }) }),
+      {}
+    );
+
+    assert.ok(report.includes('JS heap'));
+    assert.ok(report.includes('Total delta not assessed'));
   });
 });
 

--- a/performance-tests/lib/__tests__/report-builder.test.mjs
+++ b/performance-tests/lib/__tests__/report-builder.test.mjs
@@ -136,7 +136,9 @@ describe('buildReport -- reliability columns', () => {
       {}
     );
 
-    assert.ok(report.includes('n/a'));
+    const row = report.split('\n').find(line => line.includes('| Sorting'));
+
+    assert.ok(row.includes('n/a'), `expected n/a in the Sorting row: ${row}`);
   });
 
   test('flags a baseline spread above the warning threshold', () => {
@@ -146,7 +148,7 @@ describe('buildReport -- reliability columns', () => {
       {}
     );
 
-    assert.ok(report.includes('30.0% ⚠️'));
+    assert.ok(report.includes('30.0% \u26A0\uFE0F'));
   });
 
   test('computes the intra-run spread when a real trace omitted a category entirely', () => {
@@ -265,7 +267,7 @@ describe('buildReport -- callouts', () => {
 
     const row = report.split('\n').find(line => line.includes('| Sorting'));
 
-    assert.ok(row.includes('🔴'), `heap delta of +${between}% must be flagged in the table: ${row}`);
+    assert.ok(row.includes('\u{1F534}'), `heap delta of +${between}% must be flagged in the table: ${row}`);
   });
 
   test('the timing column is not banded on the heap threshold', () => {
@@ -282,7 +284,7 @@ describe('buildReport -- callouts', () => {
 
     const row = report.split('\n').find(line => line.includes('| Sorting'));
 
-    assert.ok(!row.includes('🔴'), `timing delta of +${between}% is below the timing band: ${row}`);
+    assert.ok(!row.includes('\u{1F534}'), `timing delta of +${between}% is below the timing band: ${row}`);
   });
 
   test('heap is judged on the heap threshold, which is tighter than timing', () => {
@@ -371,6 +373,25 @@ describe('buildReport -- cross-window heap', () => {
 
     assert.ok(!report.includes('JS heap'));
     assert.ok(report.includes('Total delta not assessed'));
+  });
+
+  test('withholds the heap delta in the summary table too, not only in the callout', () => {
+    // The table and the callouts must not reach opposite verdicts on the same run: gating only the
+    // callout printed a red "+50.0%" heap cell above a comment clearing the run.
+    const report = buildReport(
+      {
+        sorting: currentScenario({
+          updateCounters: { jsHeapMaxBytes: 150_000_000, jsHeapMaxLabel: '150 MB' },
+        }),
+      },
+      golden({ sorting: goldenScenario() }),
+      { crossWindowScenarios: ['sorting'] }
+    );
+
+    const row = report.split('\n').find(line => line.includes('| Sorting'));
+
+    assert.ok(!row.includes('+50.0%'), `heap delta must not be published: ${row}`);
+    assert.ok(!row.includes('\u{1F534}'), `nothing in the row may be flagged red: ${row}`);
   });
 
   test('still assesses heap when only a timing category was missing from the baseline', () => {

--- a/performance-tests/lib/__tests__/report-builder.test.mjs
+++ b/performance-tests/lib/__tests__/report-builder.test.mjs
@@ -429,6 +429,64 @@ describe('buildReport -- cross-window heap', () => {
     assert.ok(report.includes('JS heap'));
     assert.ok(report.includes('Total delta not assessed'));
   });
+
+  test('says heap is also not assessed when the total is withheld for a window mismatch', () => {
+    // The "Total delta not assessed" note used to read the same regardless of cause, but a window
+    // mismatch withholds heap too (jsHeapMaxBytes is a maximum over the samples inside the parsed
+    // window) while a baseline-incomplete comparison does not (heap is independent of timing).
+    const report = buildReport(
+      { sorting: currentScenario() },
+      golden({ sorting: goldenScenario() }),
+      { crossWindowScenarios: ['sorting'] }
+    );
+
+    assert.ok(report.includes('heap also not assessed'));
+  });
+
+  test('does not say heap is also not assessed for a baseline-incomplete comparison', () => {
+    const report = buildReport(
+      { filtering: currentScenario() },
+      golden({
+        filtering: goldenScenario({ categories: { scripting: 20, rendering: 0, painting: 0 } }),
+      }),
+      {}
+    );
+
+    assert.ok(!report.includes('heap also not assessed'));
+  });
+});
+
+describe('buildReport -- scenario missing from the baseline entirely', () => {
+  test('reports it as having no baseline rather than dropping it silently', () => {
+    // A scenario just added to the suite, or one the median window omitted, is not in
+    // `goldenScenarios` at all. Silently `continue`-ing past it (as the summary table already does)
+    // means it is neither "within tolerance" nor "not assessed" -- it does not appear anywhere.
+    const report = buildReport(
+      {
+        sorting: currentScenario(),
+        filtering: currentScenario(),
+      },
+      golden({ sorting: goldenScenario() }),
+      {}
+    );
+
+    assert.ok(report.includes('No baseline yet'));
+    assert.ok(report.includes('Filtering'));
+  });
+
+  test('does not fold a missing baseline into "Total delta not assessed"', () => {
+    const report = buildReport(
+      {
+        sorting: currentScenario(),
+        filtering: currentScenario(),
+      },
+      golden({ sorting: goldenScenario() }),
+      {}
+    );
+    const noBaselineLine = report.split('\n').find(line => line.includes('No baseline yet'));
+
+    assert.ok(!noBaselineLine.includes('Total delta not assessed'));
+  });
 });
 
 describe('buildReport -- provenance', () => {

--- a/performance-tests/lib/__tests__/thresholds.test.mjs
+++ b/performance-tests/lib/__tests__/thresholds.test.mjs
@@ -178,6 +178,17 @@ describe('comparability', () => {
     assert.equal(comparability(undefined, { scripting: 5 }, false).comparable, false);
   });
 
+  test('reads as prose for one, two and three categories', () => {
+    // "no scripting or rendering or painting" is the shape a plain join produces.
+    const one = comparability({ scripting: 20, rendering: 0, painting: 1 }, complete, false);
+    const two = comparability({ scripting: 20, rendering: 0, painting: 0 }, complete, false);
+    const three = comparability({}, complete, false);
+
+    assert.ok(one.label.endsWith('no rendering'));
+    assert.ok(two.label.endsWith('no rendering or painting'));
+    assert.ok(three.label.endsWith('no scripting, rendering or painting'));
+  });
+
   test('two complete sides over the same window are comparable', () => {
     const verdict = comparability(complete, complete, false);
 

--- a/performance-tests/lib/__tests__/thresholds.test.mjs
+++ b/performance-tests/lib/__tests__/thresholds.test.mjs
@@ -1,0 +1,254 @@
+// Unit tests for the shared threshold/formatting layer behind both report builders.
+//
+// Three invariants are worth pinning here, because each one was a published-wrong-number bug.
+// sumActiveComparable() refuses to compare a total against a baseline that never captured one of
+// its categories -- the filed defect, where ~4 ms of real work divided against a baseline of zero
+// was published as "+115.7% regression". classifyChange() bands on the callout threshold rather
+// than a separate hardcoded number, so the HTML report cannot paint a row red at a percentage the
+// markdown comment reports as within tolerance. And calcCv() uses the sample standard deviation,
+// which at the three iterations the suite actually runs reads meaningfully wider than the
+// population form it replaced.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  REGRESSION_CALLOUT_THRESHOLD_TIMING,
+  REGRESSION_CALLOUT_THRESHOLD_HEAP,
+  CV_WARNING_THRESHOLD,
+  BASELINE_INCOMPLETE_LABEL,
+  ACTIVE_CATEGORIES,
+  calcCv,
+  classifyChange,
+  fmtCv,
+  fmtCvValue,
+  fmtPct,
+  fmtPctWithEmoji,
+  pctChange,
+  sumActive,
+  sumActiveComparable,
+} from '../thresholds.mjs';
+
+describe('thresholds -- callout constants', () => {
+  test('timing and heap are separate numbers', () => {
+    // Heap's run-to-run spread is an order of magnitude tighter than timing's, so a shared
+    // constant either drowns the comment in timing noise or goes blind to heap leaks.
+    assert.notEqual(REGRESSION_CALLOUT_THRESHOLD_TIMING, REGRESSION_CALLOUT_THRESHOLD_HEAP);
+    assert.ok(REGRESSION_CALLOUT_THRESHOLD_HEAP < REGRESSION_CALLOUT_THRESHOLD_TIMING);
+  });
+
+  test('active categories are scripting, rendering and painting only', () => {
+    assert.deepEqual(ACTIVE_CATEGORIES, ['scripting', 'rendering', 'painting']);
+  });
+});
+
+describe('sumActive', () => {
+  test('adds the three active categories and ignores the rest', () => {
+    assert.equal(
+      sumActive({ scripting: 10, rendering: 5, painting: 2, idle: 900, other: 400, loading: 7 }),
+      17
+    );
+  });
+
+  test('treats a missing category as zero', () => {
+    assert.equal(sumActive({ scripting: 10 }), 10);
+  });
+});
+
+describe('sumActiveComparable', () => {
+  test('reports comparable when both sides captured every active category', () => {
+    const result = sumActiveComparable(
+      { scripting: 20, rendering: 3, painting: 1 },
+      { scripting: 25, rendering: 4, painting: 1 }
+    );
+
+    assert.equal(result.comparable, true);
+    assert.deepEqual(result.incompleteCategories, []);
+    assert.equal(result.baseline, 24);
+    assert.equal(result.current, 30);
+  });
+
+  test('refuses the comparison when the baseline missed a category the current run recorded', () => {
+    // The exact shape from the filed report: the golden captured no rendering and no painting.
+    const result = sumActiveComparable(
+      { scripting: 20.20, rendering: 0, painting: 0 },
+      { scripting: 39.62, rendering: 3.25, painting: 0.69 }
+    );
+
+    assert.equal(result.comparable, false);
+    assert.deepEqual(result.incompleteCategories, ['rendering', 'painting']);
+  });
+
+  test('a category absent from the baseline object counts the same as an explicit zero', () => {
+    const result = sumActiveComparable(
+      { scripting: 20 },
+      { scripting: 25, painting: 2 }
+    );
+
+    assert.equal(result.comparable, false);
+    assert.deepEqual(result.incompleteCategories, ['painting']);
+  });
+
+  test('stays comparable when both sides are zero for a category', () => {
+    // A genuinely free category is not a failed capture: nothing was measured on either side.
+    const result = sumActiveComparable(
+      { scripting: 20, rendering: 0, painting: 0 },
+      { scripting: 25, rendering: 0, painting: 0 }
+    );
+
+    assert.equal(result.comparable, true);
+    assert.deepEqual(result.incompleteCategories, []);
+  });
+
+  test('stays comparable when the current run dropped to zero and the baseline had work', () => {
+    // This direction is a real improvement, not a broken capture, so it must still be published.
+    const result = sumActiveComparable(
+      { scripting: 20, rendering: 5, painting: 1 },
+      { scripting: 20, rendering: 0, painting: 0 }
+    );
+
+    assert.equal(result.comparable, true);
+  });
+
+  test('tolerates null category objects', () => {
+    assert.equal(sumActiveComparable(null, null).comparable, true);
+    assert.equal(sumActiveComparable(undefined, { scripting: 5 }).comparable, false);
+  });
+});
+
+describe('pctChange', () => {
+  test('returns null rather than dividing by a zero baseline', () => {
+    assert.equal(pctChange(0, 42), null);
+  });
+
+  test('returns null when either side is missing', () => {
+    assert.equal(pctChange(null, 42), null);
+    assert.equal(pctChange(42, null), null);
+  });
+
+  test('computes a percentage', () => {
+    assert.equal(pctChange(100, 125), 25);
+    assert.equal(pctChange(100, 80), -20);
+  });
+});
+
+describe('classifyChange', () => {
+  test('bands on the timing callout threshold by default', () => {
+    const justUnder = classifyChange(REGRESSION_CALLOUT_THRESHOLD_TIMING - 0.1);
+    const justOver = classifyChange(REGRESSION_CALLOUT_THRESHOLD_TIMING + 0.1);
+
+    assert.equal(justUnder.status, 'neutral-up');
+    assert.equal(justOver.status, 'regression');
+  });
+
+  test('a percentage the comment would not call out is never painted as a regression', () => {
+    // The bug this guards: the bands sat at +/-10 while the callout fired at a different number,
+    // so the HTML report and the markdown comment disagreed about the same scenario.
+    assert.notEqual(classifyChange(REGRESSION_CALLOUT_THRESHOLD_TIMING).status, 'regression');
+  });
+
+  test('honours an explicit threshold, so heap rows band on the heap number', () => {
+    const pct = 8;
+
+    assert.equal(classifyChange(pct, REGRESSION_CALLOUT_THRESHOLD_HEAP).status, 'regression');
+    assert.equal(classifyChange(pct, REGRESSION_CALLOUT_THRESHOLD_TIMING).status, 'neutral-up');
+  });
+
+  test('mirrors the band on the improvement side', () => {
+    assert.equal(classifyChange(-REGRESSION_CALLOUT_THRESHOLD_TIMING - 0.1).status, 'improvement');
+    assert.equal(classifyChange(-1).status, 'neutral-down');
+  });
+
+  test('null is unknown, exact zero is neutral', () => {
+    assert.equal(classifyChange(null).status, 'unknown');
+    assert.equal(classifyChange(0).status, 'neutral');
+  });
+});
+
+describe('calcCv', () => {
+  test('uses the sample standard deviation, not the population one', () => {
+    // n=3, mean 100, deviations -10/0/+10. Sample variance is 200/2 = 100, so CV is 10%.
+    // The population form would divide by 3 and report 8.165%.
+    assert.equal(calcCv([90, 100, 110]).toFixed(3), '10.000');
+  });
+
+  test('reads wider than the population form at the three iterations the suite runs', () => {
+    const values = [90, 100, 110];
+    const mean = 100;
+    const population = Math.sqrt(
+      values.reduce((s, v) => s + (v - mean) ** 2, 0) / values.length
+    ) / mean * 100;
+
+    assert.ok(calcCv(values) > population);
+  });
+
+  test('returns null below two samples', () => {
+    assert.equal(calcCv([5]), null);
+    assert.equal(calcCv([]), null);
+    assert.equal(calcCv(null), null);
+    assert.equal(calcCv(undefined), null);
+  });
+
+  test('returns null on a zero mean rather than dividing by it', () => {
+    assert.equal(calcCv([0, 0, 0]), null);
+  });
+
+  test('is zero for identical samples', () => {
+    assert.equal(calcCv([7, 7, 7]), 0);
+  });
+});
+
+describe('fmtCvValue', () => {
+  test('renders n/a for an unknown spread rather than a number', () => {
+    // A rendered "0.0%" would claim a perfectly stable baseline where there is simply no data.
+    assert.equal(fmtCvValue(null), 'n/a');
+    assert.equal(fmtCvValue(undefined), 'n/a');
+    assert.equal(fmtCvValue(NaN), 'n/a');
+  });
+
+  test('flags a spread above the warning threshold', () => {
+    assert.ok(fmtCvValue(CV_WARNING_THRESHOLD + 1).includes('⚠️'));
+    assert.ok(!fmtCvValue(CV_WARNING_THRESHOLD - 1).includes('⚠️'));
+  });
+
+  test('does not flag exactly at the threshold', () => {
+    assert.equal(fmtCvValue(CV_WARNING_THRESHOLD), '15.0%');
+  });
+});
+
+describe('fmtCv', () => {
+  test('formats straight from a sample array', () => {
+    assert.equal(fmtCv([90, 100, 110]), '10.0%');
+  });
+
+  test('renders n/a when the array is too short to have a spread', () => {
+    assert.equal(fmtCv([100]), 'n/a');
+  });
+});
+
+describe('fmtPct and fmtPctWithEmoji', () => {
+  test('renders a sign and one decimal', () => {
+    assert.equal(fmtPct(4.25), '+4.3%');
+    assert.equal(fmtPct(-4.25), '-4.3%');
+    assert.equal(fmtPct(null), '--');
+  });
+
+  test('suppresses the emoji below one percent', () => {
+    assert.equal(fmtPctWithEmoji(0.4), '+0.4%');
+  });
+
+  test('passes the threshold through to the band', () => {
+    const pct = 8;
+
+    assert.ok(fmtPctWithEmoji(pct, REGRESSION_CALLOUT_THRESHOLD_HEAP).includes('\u{1F534}'));
+    assert.ok(!fmtPctWithEmoji(pct, REGRESSION_CALLOUT_THRESHOLD_TIMING).includes('\u{1F534}'));
+  });
+});
+
+describe('BASELINE_INCOMPLETE_LABEL', () => {
+  test('does not read as "no data"', () => {
+    // A failed capture and an absent measurement are different things, and the comment has to
+    // distinguish them -- rendering a bare "--" for both was how the original defect stayed hidden.
+    assert.notEqual(BASELINE_INCOMPLETE_LABEL, '--');
+    assert.ok(BASELINE_INCOMPLETE_LABEL.length > 0);
+  });
+});

--- a/performance-tests/lib/__tests__/thresholds.test.mjs
+++ b/performance-tests/lib/__tests__/thresholds.test.mjs
@@ -134,7 +134,48 @@ describe('comparability', () => {
 
     assert.equal(verdict.comparable, false);
     assert.equal(verdict.reason, 'window-mismatch');
-    assert.equal(verdict.label, 'window mismatch');
+    assert.equal(verdict.shortLabel, 'window mismatch');
+  });
+
+  test('a window mismatch exempts no category, since nothing from the trace is comparable', () => {
+    assert.deepEqual(comparability(complete, complete, true).incompleteCategories, ACTIVE_CATEGORIES);
+  });
+
+  test('only the uncaptured categories are marked incomparable', () => {
+    // The captured categories still describe the same quantity on both sides, so withholding them
+    // too would hide usable data behind one failed capture.
+    const verdict = comparability(complete, { scripting: 20, rendering: 0, painting: 1 }, false);
+
+    assert.deepEqual(verdict.incompleteCategories, ['rendering']);
+  });
+
+  test('a current-side failure is labelled as this run, not as the baseline', () => {
+    // "baseline incomplete" on a run whose own capture failed sends a maintainer to re-run develop
+    // for nothing.
+    const verdict = comparability(complete, { scripting: 20, rendering: 0, painting: 0 }, false);
+
+    assert.equal(verdict.reason, 'current-incomplete');
+    assert.equal(verdict.shortLabel, 'capture incomplete');
+    assert.ok(verdict.label.includes('this run'));
+    assert.ok(!verdict.label.includes('baseline'));
+  });
+
+  test('when both sides missed a category, each is named against its own side', () => {
+    // The union attributed to one side named a category the other side had actually recorded.
+    const verdict = comparability(
+      { scripting: 20, rendering: 0, painting: 1 },
+      { scripting: 20, rendering: 5, painting: 0 },
+      false
+    );
+
+    assert.equal(verdict.reason, 'both-incomplete');
+    assert.ok(verdict.label.includes('baseline captured no rendering'));
+    assert.ok(verdict.label.includes('this run captured no painting'));
+  });
+
+  test('tolerates null category objects', () => {
+    assert.equal(comparability(null, null, false).comparable, true);
+    assert.equal(comparability(undefined, { scripting: 5 }, false).comparable, false);
   });
 
   test('two complete sides over the same window are comparable', () => {

--- a/performance-tests/lib/__tests__/thresholds.test.mjs
+++ b/performance-tests/lib/__tests__/thresholds.test.mjs
@@ -19,6 +19,7 @@ import {
   ACTIVE_CATEGORIES,
   activeTotalsPerIteration,
   calcCv,
+  comparability,
   classifyChange,
   fmtCv,
   fmtCvValue,
@@ -100,14 +101,67 @@ describe('sumActiveComparable', () => {
     assert.deepEqual(result.incompleteCategories, []);
   });
 
-  test('stays comparable when the current run dropped to zero and the baseline had work', () => {
-    // This direction is a real improvement, not a broken capture, so it must still be published.
+  test('refuses the comparison when the current run missed a category the baseline recorded', () => {
+    // The mirror of the filed defect, and equally unsupportable. Publishing it would report a
+    // capture failure as a -23% improvement, which a reader cannot tell from a real one. On these
+    // scenarios a genuine 0 ms of rendering or painting does not occur.
     const result = sumActiveComparable(
       { scripting: 20, rendering: 5, painting: 1 },
       { scripting: 20, rendering: 0, painting: 0 }
     );
 
-    assert.equal(result.comparable, true);
+    assert.equal(result.comparable, false);
+    assert.equal(result.incompleteSide, 'current');
+    assert.deepEqual(result.incompleteCategories, ['rendering', 'painting']);
+  });
+
+  test('names which side failed, so a maintainer knows whether to re-run develop', () => {
+    const baselineSide = sumActiveComparable(
+      { scripting: 20, rendering: 0, painting: 1 },
+      { scripting: 20, rendering: 5, painting: 1 }
+    );
+
+    assert.equal(baselineSide.incompleteSide, 'baseline');
+    assert.equal(sumActiveComparable({ scripting: 1 }, { scripting: 1 }).incompleteSide, null);
+  });
+});
+
+describe('comparability', () => {
+  const complete = { scripting: 20, rendering: 5, painting: 1 };
+
+  test('a window mismatch is incomparable regardless of the categories', () => {
+    const verdict = comparability(complete, complete, true);
+
+    assert.equal(verdict.comparable, false);
+    assert.equal(verdict.reason, 'window-mismatch');
+    assert.equal(verdict.label, 'window mismatch');
+  });
+
+  test('two complete sides over the same window are comparable', () => {
+    const verdict = comparability(complete, complete, false);
+
+    assert.equal(verdict.comparable, true);
+    assert.equal(verdict.label, null);
+  });
+
+  test('names the missing categories in the label', () => {
+    const verdict = comparability(
+      { scripting: 20, rendering: 0, painting: 0 }, complete, false
+    );
+
+    assert.equal(verdict.comparable, false);
+    assert.ok(verdict.label.includes('baseline'));
+    assert.ok(verdict.label.includes('rendering'));
+    assert.ok(verdict.label.includes('painting'));
+  });
+
+  test('attributes a current-side failure to this run, not to the baseline', () => {
+    const verdict = comparability(
+      complete, { scripting: 20, rendering: 0, painting: 0 }, false
+    );
+
+    assert.equal(verdict.comparable, false);
+    assert.ok(verdict.label.includes('this run'));
   });
 
   test('tolerates null category objects', () => {
@@ -207,8 +261,8 @@ describe('fmtCvValue', () => {
   });
 
   test('flags a spread above the warning threshold', () => {
-    assert.ok(fmtCvValue(CV_WARNING_THRESHOLD + 1).includes('⚠️'));
-    assert.ok(!fmtCvValue(CV_WARNING_THRESHOLD - 1).includes('⚠️'));
+    assert.ok(fmtCvValue(CV_WARNING_THRESHOLD + 1).includes('\u26A0\uFE0F'));
+    assert.ok(!fmtCvValue(CV_WARNING_THRESHOLD - 1).includes('\u26A0\uFE0F'));
   });
 
   test('does not flag exactly at the threshold', () => {

--- a/performance-tests/lib/__tests__/thresholds.test.mjs
+++ b/performance-tests/lib/__tests__/thresholds.test.mjs
@@ -17,6 +17,7 @@ import {
   CV_WARNING_THRESHOLD,
   BASELINE_INCOMPLETE_LABEL,
   ACTIVE_CATEGORIES,
+  activeTotalsPerIteration,
   calcCv,
   classifyChange,
   fmtCv,
@@ -241,6 +242,53 @@ describe('fmtPct and fmtPctWithEmoji', () => {
 
     assert.ok(fmtPctWithEmoji(pct, REGRESSION_CALLOUT_THRESHOLD_HEAP).includes('\u{1F534}'));
     assert.ok(!fmtPctWithEmoji(pct, REGRESSION_CALLOUT_THRESHOLD_TIMING).includes('\u{1F534}'));
+  });
+});
+
+describe('activeTotalsPerIteration', () => {
+  test('sums the three active categories per iteration', () => {
+    assert.deepEqual(
+      activeTotalsPerIteration({
+        scripting: [10, 20, 30],
+        rendering: [1, 2, 3],
+        painting: [1, 1, 1],
+      }),
+      [12, 23, 34]
+    );
+  });
+
+  test('treats a short array as zero at the missing index, not as a shift', () => {
+    // The bug this guards: compacting the arrays would pair iteration 3's scripting with
+    // iteration 3's absent painting AND iteration 2's scripting with iteration 3's painting,
+    // producing a CV that is wrong rather than merely conservative.
+    assert.deepEqual(
+      activeTotalsPerIteration({ scripting: [10, 20, 30], painting: [1, 1] }),
+      [11, 21, 30]
+    );
+  });
+
+  test('handles a category missing entirely', () => {
+    assert.deepEqual(activeTotalsPerIteration({ scripting: [10, 20] }), [10, 20]);
+  });
+
+  test('ignores non-finite entries rather than propagating NaN', () => {
+    assert.deepEqual(
+      activeTotalsPerIteration({ scripting: [10, NaN, 30], rendering: [1, 1, 1] }),
+      [11, 1, 31]
+    );
+  });
+
+  test('returns an empty array for absent or empty input', () => {
+    assert.deepEqual(activeTotalsPerIteration(null), []);
+    assert.deepEqual(activeTotalsPerIteration(undefined), []);
+    assert.deepEqual(activeTotalsPerIteration({}), []);
+  });
+
+  test('ignores categories that are not active time', () => {
+    assert.deepEqual(
+      activeTotalsPerIteration({ scripting: [10, 10], idle: [900, 900], other: [50, 50] }),
+      [10, 10]
+    );
   });
 });
 

--- a/performance-tests/lib/html-report-builder.mjs
+++ b/performance-tests/lib/html-report-builder.mjs
@@ -6,7 +6,6 @@ import {
   REGRESSION_CALLOUT_THRESHOLD_TIMING,
   REGRESSION_CALLOUT_THRESHOLD_HEAP,
   CV_WARNING_THRESHOLD,
-  BASELINE_INCOMPLETE_LABEL,
   activeTotalsPerIteration,
   calcCv,
   classifyChange,
@@ -158,7 +157,7 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
         painting: categoryMetric('painting', gCats, cCats, verdict),
         total: { current: currentTotal, baseline: goldenTotal || 0, change: totalChange },
       },
-      detailedMetrics: buildDetailedMetrics(current, golden, baselineIncomplete, verdict),
+      detailedMetrics: buildDetailedMetrics(current, golden, verdict),
       memory: buildMemoryMetrics(current, golden, isCrossWindow),
       hookTiming: buildHookTiming(current, golden),
       heap,
@@ -206,7 +205,6 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
       heap: REGRESSION_CALLOUT_THRESHOLD_HEAP,
       cvWarning: CV_WARNING_THRESHOLD,
     },
-    baselineIncompleteLabel: BASELINE_INCOMPLETE_LABEL,
     summary: {
       total: scenarios.length,
       regressions,
@@ -219,15 +217,24 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
   };
 }
 
-function buildDetailedMetrics(current, golden, baselineIncomplete = false, verdict = null) {
+/**
+ * @param {object} current
+ * @param {object | null} golden
+ * @param {{ comparable: boolean, reason: string | null, incompleteCategories: string[] }} verdict
+ *   -- required, and deliberately not defaulted: a caller passing the old boolean argument shape
+ *   would silently un-gate every per-category delta rather than fail
+ * @returns {Array<object>}
+ */
+function buildDetailedMetrics(current, golden, verdict) {
   const rows = [];
   const cCats = current.categories || {};
   const gCats = golden?.categories || {};
-  const incompleteCategories = verdict?.incompleteCategories ?? [];
+  const baselineIncomplete = !!golden && !verdict.comparable;
+  const { incompleteCategories } = verdict;
   // Only the active categories participate in the comparability verdict. The others (loading,
   // other, experience, idle) are reported but never summed into a total, so a window mismatch is
   // the only thing that invalidates them.
-  const isCrossWindow = verdict?.reason === 'window-mismatch';
+  const isCrossWindow = verdict.reason === 'window-mismatch';
 
   for (const key of ['scripting', 'rendering', 'painting', 'loading', 'other', 'experience', 'idle']) {
     const c = cCats[key];
@@ -896,6 +903,10 @@ function buildScript() {
       ? scenario.incompleteLabel
       : fmtPct(scenario.badgeChange) + (scenario.badgeIsHeap ? ' heap' : '');
     const right = el('div', 'header-right');
+    // Naming which side missed which category is the whole point of the label, and the short form
+    // on the badge cannot carry it. Without this the HTML report -- the artifact a reader opens
+    // precisely to get the detail -- is the one surface that loses it.
+    const badgeTitle = scenario.baselineIncomplete ? scenario.incompleteReason : null;
 
     // How far apart the develop runs behind the baseline sit. A wide spread means the delta beside
     // it is measured against a moving target, which the percentage alone does not say.
@@ -907,7 +918,10 @@ function buildScript() {
       right.appendChild(spread);
     }
 
-    right.appendChild(elText('span', badgeText, 'badge ' + scenario.status));
+    const badge = elText('span', badgeText, 'badge ' + scenario.status);
+
+    if (badgeTitle) badge.title = badgeTitle;
+    right.appendChild(badge);
     header.appendChild(right);
 
     header.addEventListener('click', () => {

--- a/performance-tests/lib/html-report-builder.mjs
+++ b/performance-tests/lib/html-report-builder.mjs
@@ -79,6 +79,26 @@ function escapeHtml(value) {
 
 // --- data payload ---
 
+/**
+ * One category's before/after pair, with its delta withheld when that category is not comparable.
+ *
+ * @param {string} key
+ * @param {object} gCats -- baseline categories
+ * @param {object} cCats -- current categories
+ * @param {{ incompleteCategories: string[] }} verdict
+ * @returns {{ current: number, baseline: number, change: number | null, incomplete: boolean }}
+ */
+function categoryMetric(key, gCats, cCats, verdict) {
+  const incomplete = verdict.incompleteCategories.includes(key);
+
+  return {
+    current: cCats[key] || 0,
+    baseline: gCats[key] || 0,
+    change: incomplete ? null : pctChange(gCats[key], cCats[key]),
+    incomplete,
+  };
+}
+
 function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenSnapshots) {
   const scenarios = [];
   const crossWindow = new Set(meta.crossWindowScenarios || []);
@@ -127,28 +147,18 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
       badgeChange,
       badgeIsHeap,
       isRegression,
-      // Per-category deltas are withheld on a window mismatch for the same reason the total is:
-      // the two sides describe different slices of their traces, so a "+900%" here would be the
-      // two windows disagreeing rather than any change in the grid.
+      incompleteLabel: verdict.shortLabel,
+      incompleteReason: verdict.label,
+      // Withheld per category, on the verdict rather than on the window alone. Gating only the
+      // window left the incomplete-capture branch publishing a green "-100%" for exactly the
+      // category the verdict had just declared uncaptured.
       metrics: {
-        scripting: {
-          current: cCats.scripting || 0,
-          baseline: gCats.scripting || 0,
-          change: isCrossWindow ? null : pctChange(gCats.scripting, cCats.scripting),
-        },
-        rendering: {
-          current: cCats.rendering || 0,
-          baseline: gCats.rendering || 0,
-          change: isCrossWindow ? null : pctChange(gCats.rendering, cCats.rendering),
-        },
-        painting: {
-          current: cCats.painting || 0,
-          baseline: gCats.painting || 0,
-          change: isCrossWindow ? null : pctChange(gCats.painting, cCats.painting),
-        },
+        scripting: categoryMetric('scripting', gCats, cCats, verdict),
+        rendering: categoryMetric('rendering', gCats, cCats, verdict),
+        painting: categoryMetric('painting', gCats, cCats, verdict),
         total: { current: currentTotal, baseline: goldenTotal || 0, change: totalChange },
       },
-      detailedMetrics: buildDetailedMetrics(current, golden, baselineIncomplete, isCrossWindow),
+      detailedMetrics: buildDetailedMetrics(current, golden, baselineIncomplete, verdict),
       memory: buildMemoryMetrics(current, golden, isCrossWindow),
       hookTiming: buildHookTiming(current, golden),
       heap,
@@ -209,10 +219,15 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
   };
 }
 
-function buildDetailedMetrics(current, golden, baselineIncomplete = false, isCrossWindow = false) {
+function buildDetailedMetrics(current, golden, baselineIncomplete = false, verdict = null) {
   const rows = [];
   const cCats = current.categories || {};
   const gCats = golden?.categories || {};
+  const incompleteCategories = verdict?.incompleteCategories ?? [];
+  // Only the active categories participate in the comparability verdict. The others (loading,
+  // other, experience, idle) are reported but never summed into a total, so a window mismatch is
+  // the only thing that invalidates them.
+  const isCrossWindow = verdict?.reason === 'window-mismatch';
 
   for (const key of ['scripting', 'rendering', 'painting', 'loading', 'other', 'experience', 'idle']) {
     const c = cCats[key];
@@ -222,15 +237,18 @@ function buildDetailedMetrics(current, golden, baselineIncomplete = false, isCro
       continue;
     }
 
+    // Withheld per category: on a window mismatch these are the deltas teardown warns are "not
+    // measurements of a code change; they are the two windows disagreeing", and on an incomplete
+    // capture the affected category's delta is the fake win the total guard exists to suppress.
+    const incomplete = isCrossWindow || incompleteCategories.includes(key);
+
     rows.push({
       label: categoryLabel(key),
       key,
       current: c ?? 0,
       baseline: g ?? 0,
-      // Withheld on a window mismatch: these are the deltas teardown warns are "not measurements
-      // of a code change; they are the two windows disagreeing".
-      change: isCrossWindow ? null : pctChange(g, c),
-      incomplete: isCrossWindow,
+      change: incomplete ? null : pctChange(g, c),
+      incomplete,
       cv: calcCv(current._iterationValues?.categories?.[key]),
     });
   }
@@ -266,7 +284,9 @@ function buildDetailedMetrics(current, golden, baselineIncomplete = false, isCro
     change: pctChange(golden?.rangeEnd, current.rangeEnd),
     cv: calcCv(current._iterationValues?.rangeEnd),
     neutral: true,
-    note: 'harness wall clock',
+    // Deliberately still printed on a window mismatch, and the one percentage that is: this row is
+    // the size of the two windows, so it explains the mismatch the other rows are withheld for.
+    note: isCrossWindow ? 'harness wall clock; the windows differ' : 'harness wall clock',
   });
 
   return rows;
@@ -870,8 +890,10 @@ function buildScript() {
     titleRow.appendChild(document.createTextNode(scenario.title));
     header.appendChild(titleRow);
 
+    // The verdict's own label, not a fixed "baseline incomplete": saying the baseline failed when
+    // this run is the side that missed a category sends a maintainer to re-run develop for nothing.
     const badgeText = scenario.baselineIncomplete && !scenario.badgeIsHeap
-      ? data.baselineIncompleteLabel
+      ? scenario.incompleteLabel
       : fmtPct(scenario.badgeChange) + (scenario.badgeIsHeap ? ' heap' : '');
     const right = el('div', 'header-right');
 
@@ -1111,7 +1133,7 @@ function buildScript() {
         tr.appendChild(elText('td', Math.round(row.baseline) + ' ms', 'num'));
         tr.appendChild(elText('td', Math.round(row.current) + ' ms', 'num'));
         const changeTd = elText(
-          'td', row.incomplete ? data.baselineIncompleteLabel : fmtPct(row.change), 'num'
+          'td', row.incomplete ? scenario.incompleteLabel : fmtPct(row.change), 'num'
         );
         // An informational row (harness wall clock) states its number without a verdict on it.
         changeTd.style.color = row.neutral || row.incomplete
@@ -1154,7 +1176,7 @@ function buildScript() {
         tr.appendChild(elText('td', row.baselineDisplay, 'num'));
         tr.appendChild(elText('td', row.currentDisplay, 'num'));
         const changeTd = elText(
-          'td', row.incomplete ? data.baselineIncompleteLabel : fmtPct(row.change), 'num'
+          'td', row.incomplete ? scenario.incompleteLabel : fmtPct(row.change), 'num'
         );
         // Memory is banded on the heap threshold, which is an order of magnitude tighter than the
         // timing one because heap barely moves run to run.

--- a/performance-tests/lib/html-report-builder.mjs
+++ b/performance-tests/lib/html-report-builder.mjs
@@ -3,10 +3,15 @@
 // GitHub-native (Primer-inspired) design, vanilla JS for interactivity.
 
 import {
-  REGRESSION_CALLOUT_THRESHOLD,
+  REGRESSION_CALLOUT_THRESHOLD_TIMING,
+  REGRESSION_CALLOUT_THRESHOLD_HEAP,
+  CV_WARNING_THRESHOLD,
+  BASELINE_INCOMPLETE_LABEL,
+  calcCv,
   classifyChange,
   pctChange,
   sumActive,
+  sumActiveComparable,
   formatTitle,
 } from './thresholds.mjs';
 
@@ -21,7 +26,7 @@ export function buildHtmlReport(scenarioResults, goldenSnapshots, meta = {}) {
   const hasGolden = Object.keys(goldenScenarios).length > 0;
 
   // Build data payload for client-side rendering
-  const payload = buildPayload(scenarioResults, goldenScenarios, hasGolden, meta);
+  const payload = buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenSnapshots);
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -43,8 +48,9 @@ ${buildScript()}
 
 // --- data payload ---
 
-function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta) {
+function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenSnapshots) {
   const scenarios = [];
+  const crossWindow = new Set(meta.crossWindowScenarios || []);
 
   for (const [name, current] of Object.entries(scenarioResults)) {
     const golden = goldenScenarios[name] || null;
@@ -52,10 +58,15 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta) {
     const gCats = golden?.categories || {};
     const currentTotal = sumActive(cCats);
     const goldenTotal = golden ? sumActive(gCats) : null;
-    const totalChange = pctChange(goldenTotal, currentTotal);
+    // A baseline that missed a category the current run recorded cannot be divided into, and a
+    // baseline measured through a different trace window is not the same quantity at all. Either
+    // way the total delta is withheld rather than published.
+    const baselineIncomplete = !!golden
+      && (crossWindow.has(name) || !sumActiveComparable(gCats, cCats).comparable);
+    const totalChange = baselineIncomplete ? null : pctChange(goldenTotal, currentTotal);
     const heap = buildHeapChartData(current, golden);
-    const timingRegressed = totalChange != null && totalChange > REGRESSION_CALLOUT_THRESHOLD;
-    const heapRegressed = heap?.change != null && heap.change > REGRESSION_CALLOUT_THRESHOLD;
+    const timingRegressed = totalChange != null && totalChange > REGRESSION_CALLOUT_THRESHOLD_TIMING;
+    const heapRegressed = heap?.change != null && heap.change > REGRESSION_CALLOUT_THRESHOLD_HEAP;
     const isRegression = timingRegressed || heapRegressed;
     let { status } = classifyChange(totalChange);
 
@@ -74,6 +85,10 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta) {
       title: formatTitle(name),
       status,
       hasBaseline: !!golden,
+      baselineIncomplete,
+      // How far apart the develop runs behind the median baseline sit. Distinct from the per-row
+      // `cv`, which is the spread across this run's own iterations.
+      baselineSpread: golden?.spread ?? null,
       totalChange,
       badgeChange,
       badgeIsHeap,
@@ -118,8 +133,28 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta) {
       branch: meta.branch || 'unknown',
       baseBranch: meta.baseBranch || 'develop',
       pagesUrl: meta.pagesUrl || null,
+      commit: meta.commit || null,
+      runId: meta.runId || null,
       generatedAt: new Date().toISOString(),
     },
+    // Where the baseline came from, so the report can say whether a delta was measured against one
+    // develop run or a median of several.
+    baseline: hasGolden && goldenSnapshots
+      ? {
+        timestamp: goldenSnapshots.timestamp ?? null,
+        isMedian: !!goldenSnapshots.isMedian,
+        medianWindowSize: goldenSnapshots.medianWindowSize ?? null,
+        medianSourceTimestamps: goldenSnapshots.medianSourceTimestamps ?? [],
+      }
+      : null,
+    // Serialized rather than restated in the client script, so the colour bands and the callout
+    // thresholds cannot drift apart.
+    thresholds: {
+      timing: REGRESSION_CALLOUT_THRESHOLD_TIMING,
+      heap: REGRESSION_CALLOUT_THRESHOLD_HEAP,
+      cvWarning: CV_WARNING_THRESHOLD,
+    },
+    baselineIncompleteLabel: BASELINE_INCOMPLETE_LABEL,
     summary: {
       total: scenarios.length,
       regressions,
@@ -164,11 +199,16 @@ function buildDetailedMetrics(current, golden) {
     current: cTotal,
     baseline: gTotal,
     change: pctChange(gTotal, cTotal),
-    cv: null,
+    // Recombined per iteration rather than left null: the summed total is what the callout acts on,
+    // so its spread is the one a reader most needs beside it.
+    cv: calcCv(activeTotalsPerIteration(current._iterationValues?.categories)),
     isBold: true,
   });
 
-  // Trace window
+  // Trace window. Marked as informational: after the measurement fix this is mark-to-mark harness
+  // wall clock, not grid work. On the four scroll scenarios it is 500 sequential wheel round trips
+  // and sits at a run-to-run CV of 0.0-0.2% regardless of what the grid does, so colouring it
+  // red or green would report CI latency as a performance verdict.
   rows.push({
     label: 'Trace window',
     key: 'trace-window',
@@ -176,9 +216,33 @@ function buildDetailedMetrics(current, golden) {
     baseline: golden?.rangeEnd || 0,
     change: pctChange(golden?.rangeEnd, current.rangeEnd),
     cv: calcCv(current._iterationValues?.rangeEnd),
+    neutral: true,
+    note: 'harness wall clock',
   });
 
   return rows;
+}
+
+/**
+ * Recombines per-category iteration arrays into one active-time total per iteration.
+ *
+ * @param {Record<string, number[]> | undefined} categories
+ * @returns {number[]}
+ */
+function activeTotalsPerIteration(categories) {
+  if (!categories) {
+    return [];
+  }
+
+  const length = Math.max(
+    ...['scripting', 'rendering', 'painting'].map(key => categories[key]?.length ?? 0)
+  );
+
+  return Array.from({ length }, (_, i) => sumActive({
+    scripting: categories.scripting?.[i],
+    rendering: categories.rendering?.[i],
+    painting: categories.painting?.[i],
+  }));
 }
 
 function buildMemoryMetrics(current, golden) {
@@ -228,6 +292,7 @@ function buildHookTiming(current, golden) {
     current: current.hookTiming,
     baseline: golden?.hookTiming ?? null,
     change: golden?.hookTiming != null ? pctChange(golden.hookTiming, current.hookTiming) : null,
+    cv: calcCv(current._iterationValues?.hookTiming),
   };
 }
 
@@ -259,22 +324,6 @@ function categoryLabel(key) {
   };
 
   return labels[key] || key;
-}
-
-function calcCv(values) {
-  if (!values || values.length < 2) {
-    return null;
-  }
-
-  const mean = values.reduce((a, b) => a + b, 0) / values.length;
-
-  if (mean === 0) {
-    return null;
-  }
-
-  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / values.length;
-
-  return (Math.sqrt(variance) / Math.abs(mean)) * 100;
 }
 
 // --- CSS ---
@@ -418,6 +467,18 @@ a:hover { text-decoration: underline; }
   color: #656d76;
 }
 .card-header .arrow.open { transform: rotate(90deg); }
+/* Keeps the badge and the baseline-spread note together on the right, so the header stays a
+   two-part flex layout however many notes are attached. */
+.card-header .header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.card-header .baseline-spread {
+  font-size: 12px;
+  color: #656d76;
+  white-space: nowrap;
+}
 
 /* Change badge */
 .badge {
@@ -604,7 +665,29 @@ function buildScript() {
     if (data.meta.prNumber) parts.push('PR #' + data.meta.prNumber);
     if (data.meta.branch !== 'unknown') parts.push(data.meta.branch + ' vs ' + data.meta.baseBranch);
     parts.push('Generated: ' + new Date(data.meta.generatedAt).toUTCString());
+    if (data.meta.commit) parts.push('commit ' + String(data.meta.commit).slice(0, 7));
+    if (data.meta.runId) parts.push('run ' + data.meta.runId);
     header.appendChild(elText('div', parts.join(' \\u00B7 '), 'meta'));
+
+    // States what every delta below was measured against. Without it the report reads identically
+    // whether the baseline was a five-run median or one fluke develop push.
+    const baseline = data.baseline;
+    if (baseline) {
+      let text;
+      if (baseline.isMedian) {
+        const sources = baseline.medianSourceTimestamps || [];
+        text = 'Baseline: median of ' + baseline.medianWindowSize + ' develop runs';
+        if (sources.length > 1) {
+          text += ' (' + sources[sources.length - 1] + ' to ' + sources[0] + ')';
+        }
+      } else if (baseline.timestamp) {
+        text = 'Baseline: single develop run ' + baseline.timestamp;
+      } else {
+        text = 'Baseline: self-comparison, no develop baseline';
+      }
+      header.appendChild(elText('div', text, 'meta'));
+    }
+
     return header;
   }
 
@@ -738,9 +821,23 @@ function buildScript() {
     titleRow.appendChild(document.createTextNode(scenario.title));
     header.appendChild(titleRow);
 
-    const badgeText = fmtPct(scenario.badgeChange) + (scenario.badgeIsHeap ? ' heap' : '');
-    const badge = elText('span', badgeText, 'badge ' + scenario.status);
-    header.appendChild(badge);
+    const badgeText = scenario.baselineIncomplete && !scenario.badgeIsHeap
+      ? data.baselineIncompleteLabel
+      : fmtPct(scenario.badgeChange) + (scenario.badgeIsHeap ? ' heap' : '');
+    const right = el('div', 'header-right');
+
+    // How far apart the develop runs behind the baseline sit. A wide spread means the delta beside
+    // it is measured against a moving target, which the percentage alone does not say.
+    if (data.hasBaseline && scenario.baselineSpread != null) {
+      const spread = elText(
+        'span', 'baseline spread ' + fmtCvValue(scenario.baselineSpread), 'baseline-spread'
+      );
+      if (scenario.baselineSpread > data.thresholds.cvWarning) spread.classList.add('cv-warn');
+      right.appendChild(spread);
+    }
+
+    right.appendChild(elText('span', badgeText, 'badge ' + scenario.status));
+    header.appendChild(right);
 
     header.addEventListener('click', () => {
       const body = card.querySelector('.card-body');
@@ -931,6 +1028,9 @@ function buildScript() {
         text += ' (' + fmtPct(hookTiming.change) + ')';
       }
     }
+    if (hookTiming.cv != null) {
+      text += ' \\u00B7 CV ' + fmtCvValue(hookTiming.cv);
+    }
     div.textContent = text;
     return div;
   }
@@ -953,21 +1053,27 @@ function buildScript() {
     const tbody = el('tbody');
     for (const row of scenario.detailedMetrics) {
       const tr = el('tr');
-      const labelTd = elText('td', row.label, row.isBold ? 'bold' : '');
+      const labelTd = elText(
+        'td', row.note ? row.label + ' (' + row.note + ')' : row.label, row.isBold ? 'bold' : ''
+      );
       tr.appendChild(labelTd);
 
       if (data.hasBaseline) {
         tr.appendChild(elText('td', Math.round(row.baseline) + ' ms', 'num'));
         tr.appendChild(elText('td', Math.round(row.current) + ' ms', 'num'));
         const changeTd = elText('td', fmtPct(row.change), 'num');
-        changeTd.style.color = statusColor(classifyChangeCss(row.change));
+        // An informational row (harness wall clock) states its number without a verdict on it.
+        changeTd.style.color = row.neutral
+          ? statusColor('neutral')
+          : statusColor(classifyChangeCss(row.change));
+        if (row.note) changeTd.title = row.note;
         tr.appendChild(changeTd);
       } else {
         tr.appendChild(elText('td', Math.round(row.current) + ' ms', 'num'));
       }
 
-      const cvTd = elText('td', row.cv != null ? row.cv.toFixed(1) + '%' : '', 'num');
-      if (row.cv != null && row.cv > 15) cvTd.classList.add('cv-warn');
+      const cvTd = elText('td', fmtCvValue(row.cv), 'num');
+      if (row.cv != null && row.cv > data.thresholds.cvWarning) cvTd.classList.add('cv-warn');
       tr.appendChild(cvTd);
 
       tbody.appendChild(tr);
@@ -997,7 +1103,9 @@ function buildScript() {
         tr.appendChild(elText('td', row.baselineDisplay, 'num'));
         tr.appendChild(elText('td', row.currentDisplay, 'num'));
         const changeTd = elText('td', fmtPct(row.change), 'num');
-        changeTd.style.color = statusColor(classifyChangeCss(row.change));
+        // Memory is banded on the heap threshold, which is an order of magnitude tighter than the
+        // timing one because heap barely moves run to run.
+        changeTd.style.color = statusColor(classifyChangeCss(row.change, data.thresholds.heap));
         tr.appendChild(changeTd);
       } else {
         tr.appendChild(elText('td', row.currentDisplay, 'num'));
@@ -1111,13 +1219,21 @@ function buildScript() {
     return sign + pct.toFixed(1) + '%';
   }
 
-  function classifyChangeCss(pct) {
+  // Mirrors classifyChange() in thresholds.mjs. The band edge is not restated here: it comes from
+  // the serialized thresholds, so a row can never be painted red at a percentage the comment
+  // reports as within tolerance.
+  function classifyChangeCss(pct, threshold) {
+    const edge = threshold != null ? threshold : data.thresholds.timing;
     if (pct == null) return 'neutral';
-    if (pct > 10) return 'regression';
+    if (pct > edge) return 'regression';
     if (pct > 0) return 'neutral-up';
-    if (pct < -10) return 'improvement';
+    if (pct < -edge) return 'improvement';
     if (pct < 0) return 'neutral-down';
     return 'neutral';
+  }
+
+  function fmtCvValue(cv) {
+    return cv == null ? 'n/a' : cv.toFixed(1) + '%';
   }
 
   function statusColor(cls) {

--- a/performance-tests/lib/html-report-builder.mjs
+++ b/performance-tests/lib/html-report-builder.mjs
@@ -12,6 +12,7 @@ import {
   pctChange,
   sumActive,
   comparability,
+  NO_BASELINE_VERDICT,
   formatTitle,
 } from './thresholds.mjs';
 
@@ -112,7 +113,10 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
     // baseline measured through a different trace window is not the same quantity at all. Either
     // way the total delta is withheld rather than published.
     const isCrossWindow = crossWindow.has(name);
-    const verdict = comparability(gCats, cCats, isCrossWindow);
+    // Only ask the question when there is something to compare against. Running the check against
+    // an absent baseline reports every category as uncaptured, which the markdown path avoids by
+    // returning early -- so the two reports disagreed on a scenario that is simply new.
+    const verdict = golden ? comparability(gCats, cCats, isCrossWindow) : NO_BASELINE_VERDICT;
     const baselineIncomplete = !!golden && !verdict.comparable;
     const totalChange = baselineIncomplete ? null : pctChange(goldenTotal, currentTotal);
     // Heap is derived from the same trace window, so a window mismatch invalidates it too. It is
@@ -146,6 +150,9 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
       badgeChange,
       badgeIsHeap,
       isRegression,
+      // Serialized once and read by both the dashboard counter and the filter. Deriving it
+      // separately on each side is how the counter came to disagree with the list it labels.
+      notAssessed: baselineIncomplete && !isRegression,
       incompleteLabel: verdict.shortLabel,
       incompleteReason: verdict.label,
       // Withheld per category, on the verdict rather than on the window alone. Gating only the
@@ -175,7 +182,7 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
   // Counted separately, never folded into Neutral. A scenario whose baseline could not be compared
   // against was not cleared, and a dashboard that shows it beside the genuinely flat ones is the
   // same "assessed by omission" failure the withheld delta exists to prevent.
-  const notAssessed = scenarios.filter(s => s.baselineIncomplete && !s.isRegression).length;
+  const notAssessed = scenarios.filter(s => s.notAssessed).length;
 
   return {
     meta: {
@@ -797,6 +804,13 @@ function buildScript() {
       ['neutral', 'Neutral'],
     ];
 
+    // Offered only when there is one, mirroring the counter card. Without its own filter a
+    // not-assessed scenario would be reachable from All alone, having just been excluded from
+    // Neutral -- less discoverable than before, not more.
+    if (data.summary.notAssessed > 0) {
+      filters.push(['notAssessed', 'Not assessed']);
+    }
+
     for (const [mode, text] of filters) {
       const btn = elText('button', text, 'btn' + (filterMode === mode ? ' active' : ''));
       btn.dataset.filter = mode;
@@ -866,7 +880,13 @@ function buildScript() {
     } else if (filterMode === 'improvement') {
       list = list.filter(s => s.status === 'improvement');
     } else if (filterMode === 'neutral') {
-      list = list.filter(s => !s.isRegression && s.status !== 'regression' && s.status !== 'improvement');
+      // Excludes the not-assessed, matching the counter card of the same name. Without this the
+      // Neutral list is longer than the Neutral count, and a scenario nothing could be said about
+      // reads as one that was checked and cleared.
+      list = list.filter(s => !s.isRegression && s.status !== 'regression'
+        && s.status !== 'improvement' && !s.notAssessed);
+    } else if (filterMode === 'notAssessed') {
+      list = list.filter(s => s.notAssessed);
     }
 
     // Sort

--- a/performance-tests/lib/html-report-builder.mjs
+++ b/performance-tests/lib/html-report-builder.mjs
@@ -7,6 +7,7 @@ import {
   REGRESSION_CALLOUT_THRESHOLD_HEAP,
   CV_WARNING_THRESHOLD,
   BASELINE_INCOMPLETE_LABEL,
+  activeTotalsPerIteration,
   calcCv,
   classifyChange,
   pctChange,
@@ -111,7 +112,7 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
         },
         total: { current: currentTotal, baseline: goldenTotal || 0, change: totalChange },
       },
-      detailedMetrics: buildDetailedMetrics(current, golden),
+      detailedMetrics: buildDetailedMetrics(current, golden, baselineIncomplete),
       memory: buildMemoryMetrics(current, golden),
       hookTiming: buildHookTiming(current, golden),
       heap,
@@ -126,6 +127,10 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
 
   const regressions = scenarios.filter(s => s.isRegression).length;
   const improvements = scenarios.filter(s => s.status === 'improvement').length;
+  // Counted separately, never folded into Neutral. A scenario whose baseline could not be compared
+  // against was not cleared, and a dashboard that shows it beside the genuinely flat ones is the
+  // same "assessed by omission" failure the withheld delta exists to prevent.
+  const notAssessed = scenarios.filter(s => s.baselineIncomplete && !s.isRegression).length;
 
   return {
     meta: {
@@ -143,6 +148,7 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
       ? {
         timestamp: goldenSnapshots.timestamp ?? null,
         isMedian: !!goldenSnapshots.isMedian,
+        isSelfCompare: !!goldenSnapshots.isSelfCompare,
         medianWindowSize: goldenSnapshots.medianWindowSize ?? null,
         medianSourceTimestamps: goldenSnapshots.medianSourceTimestamps ?? [],
       }
@@ -159,14 +165,15 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
       total: scenarios.length,
       regressions,
       improvements,
-      neutral: scenarios.length - regressions - improvements,
+      notAssessed,
+      neutral: scenarios.length - regressions - improvements - notAssessed,
     },
     hasBaseline: hasGolden,
     scenarios,
   };
 }
 
-function buildDetailedMetrics(current, golden) {
+function buildDetailedMetrics(current, golden, baselineIncomplete = false) {
   const rows = [];
   const cCats = current.categories || {};
   const gCats = golden?.categories || {};
@@ -198,7 +205,10 @@ function buildDetailedMetrics(current, golden) {
     key: 'total-active',
     current: cTotal,
     baseline: gTotal,
-    change: pctChange(gTotal, cTotal),
+    // Withheld on the same terms as the card badge and the markdown comment. Publishing it here
+    // would put the exact number the badge refuses to show one click away, painted red.
+    change: baselineIncomplete ? null : pctChange(gTotal, cTotal),
+    incomplete: baselineIncomplete,
     // Recombined per iteration rather than left null: the summed total is what the callout acts on,
     // so its spread is the one a reader most needs beside it.
     cv: calcCv(activeTotalsPerIteration(current._iterationValues?.categories)),
@@ -221,28 +231,6 @@ function buildDetailedMetrics(current, golden) {
   });
 
   return rows;
-}
-
-/**
- * Recombines per-category iteration arrays into one active-time total per iteration.
- *
- * @param {Record<string, number[]> | undefined} categories
- * @returns {number[]}
- */
-function activeTotalsPerIteration(categories) {
-  if (!categories) {
-    return [];
-  }
-
-  const length = Math.max(
-    ...['scripting', 'rendering', 'painting'].map(key => categories[key]?.length ?? 0)
-  );
-
-  return Array.from({ length }, (_, i) => sumActive({
-    scripting: categories.scripting?.[i],
-    rendering: categories.rendering?.[i],
-    painting: categories.painting?.[i],
-  }));
 }
 
 function buildMemoryMetrics(current, golden) {
@@ -389,6 +377,7 @@ a:hover { text-decoration: underline; }
 .counter-card.regression .count { color: #cf222e; }
 .counter-card.improvement .count { color: #1a7f37; }
 .counter-card.neutral .count { color: #656d76; }
+.counter-card.unknown .count { color: #9a6700; }
 
 /* Filter + sort bar */
 .controls {
@@ -674,7 +663,10 @@ function buildScript() {
     const baseline = data.baseline;
     if (baseline) {
       let text;
-      if (baseline.isMedian) {
+      if (baseline.isSelfCompare) {
+        text = 'Baseline: this run compared against itself, no develop baseline was available'
+          + ' (every delta below is 0% by construction)';
+      } else if (baseline.isMedian) {
         const sources = baseline.medianSourceTimestamps || [];
         text = 'Baseline: median of ' + baseline.medianWindowSize + ' develop runs';
         if (sources.length > 1) {
@@ -683,7 +675,7 @@ function buildScript() {
       } else if (baseline.timestamp) {
         text = 'Baseline: single develop run ' + baseline.timestamp;
       } else {
-        text = 'Baseline: self-comparison, no develop baseline';
+        text = 'Baseline: unknown';
       }
       header.appendChild(elText('div', text, 'meta'));
     }
@@ -697,6 +689,9 @@ function buildScript() {
     dash.appendChild(counterCard(data.summary.regressions, 'Regressions', 'regression'));
     dash.appendChild(counterCard(data.summary.improvements, 'Improvements', 'improvement'));
     dash.appendChild(counterCard(data.summary.neutral, 'Neutral', 'neutral'));
+    if (data.summary.notAssessed > 0) {
+      dash.appendChild(counterCard(data.summary.notAssessed, 'Not assessed', 'unknown'));
+    }
     return dash;
   }
 
@@ -1061,9 +1056,11 @@ function buildScript() {
       if (data.hasBaseline) {
         tr.appendChild(elText('td', Math.round(row.baseline) + ' ms', 'num'));
         tr.appendChild(elText('td', Math.round(row.current) + ' ms', 'num'));
-        const changeTd = elText('td', fmtPct(row.change), 'num');
+        const changeTd = elText(
+          'td', row.incomplete ? data.baselineIncompleteLabel : fmtPct(row.change), 'num'
+        );
         // An informational row (harness wall clock) states its number without a verdict on it.
-        changeTd.style.color = row.neutral
+        changeTd.style.color = row.neutral || row.incomplete
           ? statusColor('neutral')
           : statusColor(classifyChangeCss(row.change));
         if (row.note) changeTd.title = row.note;

--- a/performance-tests/lib/html-report-builder.mjs
+++ b/performance-tests/lib/html-report-builder.mjs
@@ -183,6 +183,10 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
   // against was not cleared, and a dashboard that shows it beside the genuinely flat ones is the
   // same "assessed by omission" failure the withheld delta exists to prevent.
   const notAssessed = scenarios.filter(s => s.notAssessed).length;
+  // A scenario the baseline does not contain at all (new, or omitted by the median window) is not
+  // flat against a baseline -- there is nothing to be flat against. Without its own bucket it falls
+  // into the Neutral remainder below, claiming the one thing not known about it.
+  const noBaseline = scenarios.filter(s => !s.hasBaseline).length;
 
   return {
     meta: {
@@ -217,7 +221,8 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
       regressions,
       improvements,
       notAssessed,
-      neutral: scenarios.length - regressions - improvements - notAssessed,
+      noBaseline,
+      neutral: scenarios.length - regressions - improvements - notAssessed - noBaseline,
     },
     hasBaseline: hasGolden,
     scenarios,
@@ -671,8 +676,11 @@ a:hover { text-decoration: underline; }
 .metrics-table .bold { font-weight: 600; }
 .metrics-table .num { font-variant-numeric: tabular-nums; text-align: right; }
 /* Not scoped to .metrics-table: the baseline-spread note in a card header carries this class too,
-   and a table-only rule made that flag a silent no-op. */
+   and a table-only rule made that flag a silent no-op. The card-header rule below beats
+   .card-header .baseline-spread (two classes) on specificity, so the warning colour actually wins
+   there instead of just the bold weight. */
 .cv-warn { color: #cf222e; font-weight: 600; }
+.card-header .baseline-spread.cv-warn { color: #cf222e; }
 
 /* Hook timing */
 .hook-timing {
@@ -780,6 +788,9 @@ function buildScript() {
     if (data.summary.notAssessed > 0) {
       dash.appendChild(counterCard(data.summary.notAssessed, 'Not assessed', 'unknown'));
     }
+    if (data.summary.noBaseline > 0) {
+      dash.appendChild(counterCard(data.summary.noBaseline, 'No baseline', 'unknown'));
+    }
     return dash;
   }
 
@@ -809,6 +820,10 @@ function buildScript() {
     // Neutral -- less discoverable than before, not more.
     if (data.summary.notAssessed > 0) {
       filters.push(['notAssessed', 'Not assessed']);
+    }
+
+    if (data.summary.noBaseline > 0) {
+      filters.push(['noBaseline', 'No baseline']);
     }
 
     for (const [mode, text] of filters) {
@@ -880,13 +895,15 @@ function buildScript() {
     } else if (filterMode === 'improvement') {
       list = list.filter(s => s.status === 'improvement');
     } else if (filterMode === 'neutral') {
-      // Excludes the not-assessed, matching the counter card of the same name. Without this the
-      // Neutral list is longer than the Neutral count, and a scenario nothing could be said about
-      // reads as one that was checked and cleared.
+      // Excludes the not-assessed and the no-baseline scenarios, matching the counter card of the
+      // same name. Without this the Neutral list is longer than the Neutral count, and a scenario
+      // nothing could be said about reads as one that was checked and cleared.
       list = list.filter(s => !s.isRegression && s.status !== 'regression'
-        && s.status !== 'improvement' && !s.notAssessed);
+        && s.status !== 'improvement' && !s.notAssessed && s.hasBaseline);
     } else if (filterMode === 'notAssessed') {
       list = list.filter(s => s.notAssessed);
+    } else if (filterMode === 'noBaseline') {
+      list = list.filter(s => !s.hasBaseline);
     }
 
     // Sort

--- a/performance-tests/lib/html-report-builder.mjs
+++ b/performance-tests/lib/html-report-builder.mjs
@@ -12,14 +12,15 @@ import {
   classifyChange,
   pctChange,
   sumActive,
-  sumActiveComparable,
+  comparability,
   formatTitle,
 } from './thresholds.mjs';
 
 /**
  * @param {Record<string, object>} scenarioResults -- keyed by scenario name
  * @param {object | null} goldenSnapshots -- golden baseline
- * @param {object} [meta] -- { prNumber, branch, baseBranch, pagesUrl }
+ * @param {object} [meta] -- { prNumber, branch, baseBranch, pagesUrl, commit, runId,
+ *   crossWindowScenarios }
  * @returns {string} self-contained HTML document
  */
 export function buildHtmlReport(scenarioResults, goldenSnapshots, meta = {}) {
@@ -91,10 +92,13 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
     // A baseline that missed a category the current run recorded cannot be divided into, and a
     // baseline measured through a different trace window is not the same quantity at all. Either
     // way the total delta is withheld rather than published.
-    const baselineIncomplete = !!golden
-      && (crossWindow.has(name) || !sumActiveComparable(gCats, cCats).comparable);
+    const isCrossWindow = crossWindow.has(name);
+    const verdict = comparability(gCats, cCats, isCrossWindow);
+    const baselineIncomplete = !!golden && !verdict.comparable;
     const totalChange = baselineIncomplete ? null : pctChange(goldenTotal, currentTotal);
-    const heap = buildHeapChartData(current, golden);
+    // Heap is derived from the same trace window, so a window mismatch invalidates it too. It is
+    // unaffected by a missed timing category, which is measured independently.
+    const heap = buildHeapChartData(current, golden, isCrossWindow);
     const timingRegressed = totalChange != null && totalChange > REGRESSION_CALLOUT_THRESHOLD_TIMING;
     const heapRegressed = heap?.change != null && heap.change > REGRESSION_CALLOUT_THRESHOLD_HEAP;
     const isRegression = timingRegressed || heapRegressed;
@@ -123,25 +127,28 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
       badgeChange,
       badgeIsHeap,
       isRegression,
+      // Per-category deltas are withheld on a window mismatch for the same reason the total is:
+      // the two sides describe different slices of their traces, so a "+900%" here would be the
+      // two windows disagreeing rather than any change in the grid.
       metrics: {
         scripting: {
           current: cCats.scripting || 0,
           baseline: gCats.scripting || 0,
-          change: pctChange(gCats.scripting, cCats.scripting),
+          change: isCrossWindow ? null : pctChange(gCats.scripting, cCats.scripting),
         },
         rendering: {
           current: cCats.rendering || 0,
           baseline: gCats.rendering || 0,
-          change: pctChange(gCats.rendering, cCats.rendering),
+          change: isCrossWindow ? null : pctChange(gCats.rendering, cCats.rendering),
         },
         painting: {
           current: cCats.painting || 0,
           baseline: gCats.painting || 0,
-          change: pctChange(gCats.painting, cCats.painting),
+          change: isCrossWindow ? null : pctChange(gCats.painting, cCats.painting),
         },
         total: { current: currentTotal, baseline: goldenTotal || 0, change: totalChange },
       },
-      detailedMetrics: buildDetailedMetrics(current, golden, baselineIncomplete),
+      detailedMetrics: buildDetailedMetrics(current, golden, baselineIncomplete, isCrossWindow),
       memory: buildMemoryMetrics(current, golden),
       hookTiming: buildHookTiming(current, golden),
       heap,
@@ -202,7 +209,7 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
   };
 }
 
-function buildDetailedMetrics(current, golden, baselineIncomplete = false) {
+function buildDetailedMetrics(current, golden, baselineIncomplete = false, isCrossWindow = false) {
   const rows = [];
   const cCats = current.categories || {};
   const gCats = golden?.categories || {};
@@ -220,7 +227,10 @@ function buildDetailedMetrics(current, golden, baselineIncomplete = false) {
       key,
       current: c ?? 0,
       baseline: g ?? 0,
-      change: pctChange(g, c),
+      // Withheld on a window mismatch: these are the deltas teardown warns are "not measurements
+      // of a code change; they are the two windows disagreeing".
+      change: isCrossWindow ? null : pctChange(g, c),
+      incomplete: isCrossWindow,
       cv: calcCv(current._iterationValues?.categories?.[key]),
     });
   }
@@ -313,7 +323,7 @@ function buildHookTiming(current, golden) {
   };
 }
 
-function buildHeapChartData(current, golden) {
+function buildHeapChartData(current, golden, isCrossWindow = false) {
   const cur = current.updateCounters?.jsHeapMaxBytes;
 
   if (cur == null) {
@@ -325,7 +335,9 @@ function buildHeapChartData(current, golden) {
   return {
     current: cur,
     baseline,
-    change: baseline != null ? pctChange(baseline, cur) : null,
+    // jsHeapMaxBytes is a maximum over the UpdateCounters samples inside the parsed window, so two
+    // different windows sample two different things and the delta between them means nothing.
+    change: baseline != null && !isCrossWindow ? pctChange(baseline, cur) : null,
   };
 }
 
@@ -613,7 +625,9 @@ a:hover { text-decoration: underline; }
 .metrics-table tr:last-child td { border-bottom: none; }
 .metrics-table .bold { font-weight: 600; }
 .metrics-table .num { font-variant-numeric: tabular-nums; text-align: right; }
-.metrics-table .cv-warn { color: #cf222e; font-weight: 600; }
+/* Not scoped to .metrics-table: the baseline-spread note in a card header carries this class too,
+   and a table-only rule made that flag a silent no-op. */
+.cv-warn { color: #cf222e; font-weight: 600; }
 
 /* Hook timing */
 .hook-timing {
@@ -1258,8 +1272,11 @@ function buildScript() {
     return 'neutral';
   }
 
+  // Mirrors fmtCvValue() in thresholds.mjs, warning glyph included, so the markdown comment and
+  // this report flag an unreliable spread the same way.
   function fmtCvValue(cv) {
-    return cv == null ? 'n/a' : cv.toFixed(1) + '%';
+    if (cv == null) return 'n/a';
+    return cv.toFixed(1) + '%' + (cv > data.thresholds.cvWarning ? ' \\u26A0\\uFE0F' : '');
   }
 
   function statusColor(cls) {

--- a/performance-tests/lib/html-report-builder.mjs
+++ b/performance-tests/lib/html-report-builder.mjs
@@ -149,7 +149,7 @@ function buildPayload(scenarioResults, goldenScenarios, hasGolden, meta, goldenS
         total: { current: currentTotal, baseline: goldenTotal || 0, change: totalChange },
       },
       detailedMetrics: buildDetailedMetrics(current, golden, baselineIncomplete, isCrossWindow),
-      memory: buildMemoryMetrics(current, golden),
+      memory: buildMemoryMetrics(current, golden, isCrossWindow),
       hookTiming: buildHookTiming(current, golden),
       heap,
       cv: {
@@ -272,7 +272,17 @@ function buildDetailedMetrics(current, golden, baselineIncomplete = false, isCro
   return rows;
 }
 
-function buildMemoryMetrics(current, golden) {
+/**
+ * Every row here is an extremum over the UpdateCounters samples inside the parsed window -- heap,
+ * node count and listener count alike -- so a window mismatch invalidates all of them for exactly
+ * the reason it invalidates the heap maximum.
+ *
+ * @param {object} current
+ * @param {object | null} golden
+ * @param {boolean} [isCrossWindow]
+ * @returns {Array<object>}
+ */
+function buildMemoryMetrics(current, golden, isCrossWindow = false) {
   const cUc = current.updateCounters;
   const gUc = golden?.updateCounters;
 
@@ -303,7 +313,8 @@ function buildMemoryMetrics(current, golden) {
       label,
       currentDisplay: cDisplay != null ? String(cDisplay) : '--',
       baselineDisplay: gDisplay != null ? String(gDisplay) : '--',
-      change: pctChange(gUc?.[numKey], cUc[numKey]),
+      change: isCrossWindow ? null : pctChange(gUc?.[numKey], cUc[numKey]),
+      incomplete: isCrossWindow,
     });
   }
 
@@ -1142,10 +1153,14 @@ function buildScript() {
       if (data.hasBaseline) {
         tr.appendChild(elText('td', row.baselineDisplay, 'num'));
         tr.appendChild(elText('td', row.currentDisplay, 'num'));
-        const changeTd = elText('td', fmtPct(row.change), 'num');
+        const changeTd = elText(
+          'td', row.incomplete ? data.baselineIncompleteLabel : fmtPct(row.change), 'num'
+        );
         // Memory is banded on the heap threshold, which is an order of magnitude tighter than the
         // timing one because heap barely moves run to run.
-        changeTd.style.color = statusColor(classifyChangeCss(row.change, data.thresholds.heap));
+        changeTd.style.color = row.incomplete
+          ? statusColor('neutral')
+          : statusColor(classifyChangeCss(row.change, data.thresholds.heap));
         tr.appendChild(changeTd);
       } else {
         tr.appendChild(elText('td', row.currentDisplay, 'num'));

--- a/performance-tests/lib/html-report-builder.mjs
+++ b/performance-tests/lib/html-report-builder.mjs
@@ -34,17 +34,46 @@ export function buildHtmlReport(scenarioResults, goldenSnapshots, meta = {}) {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Performance Report${meta.prNumber ? ` - PR #${meta.prNumber}` : ''}</title>
+<title>Performance Report${escapeHtml(meta.prNumber ? ` - PR #${meta.prNumber}` : '')}</title>
 ${buildStyles()}
 </head>
 <body>
 <div id="app"></div>
 <script>
-window.__PERF_DATA__ = ${JSON.stringify(payload)};
+window.__PERF_DATA__ = ${serializePayload(payload)};
 </script>
 ${buildScript()}
 </body>
 </html>`;
+}
+
+/**
+ * Serializes the payload for embedding inside a `<script>` block.
+ *
+ * `JSON.stringify` does not escape `<`, so a string containing `</script>` would close the block
+ * early and everything after it would be parsed as markup. The branch name reaches this payload
+ * from `GITHUB_HEAD_REF`, which a fork pull request controls. Escaping `<` keeps the JSON valid
+ * (`<` is the same character to a JSON parser) while making that impossible.
+ *
+ * @param {object} payload
+ * @returns {string}
+ */
+function serializePayload(payload) {
+  return JSON.stringify(payload).replace(/</g, '\\u003c');
+}
+
+/**
+ * Escapes a value interpolated into markup rather than into the JSON payload.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
 }
 
 // --- data payload ---

--- a/performance-tests/lib/median-snapshot.mjs
+++ b/performance-tests/lib/median-snapshot.mjs
@@ -2,6 +2,7 @@
 // snapshots, so a PR is compared against recent trend instead of one run.
 
 import { formatHeapMinBytesLabel, formatHeapMaxBytesLabel } from '../trace-parser.mjs';
+import { calcCv, sumActive } from './thresholds.mjs';
 
 // How many of the newest marks-valid develop snapshots to median over. Small
 // enough that a real regression introduced mid-window isn't diluted by twice
@@ -121,6 +122,12 @@ function medianScenario(entries) {
     // treats a missing field as 'auto-zoom' -- an unset value here would make
     // every scenario read as cross-window-mismatched on every PR.
     windowSource: 'marks',
+    // How far apart the runs behind this median sit, as a CV of their active time. The
+    // per-iteration values are stripped before a golden is saved, so this is the only
+    // spread the baseline side can report -- and it is the more useful one: it measures
+    // run-to-run variance (11-19% per scenario), where the current run's own intra-run
+    // CV measures only how stable three back-to-back iterations were (0.9-4%).
+    spread: calcCv(entries.map(entry => sumActive(entry.categories || {}))),
     ...(hookTimingValues.length > 0 ? { hookTiming: median(hookTimingValues) } : {}),
   };
 }

--- a/performance-tests/lib/report-builder.mjs
+++ b/performance-tests/lib/report-builder.mjs
@@ -264,11 +264,16 @@ function buildTimingBreakdown(current, golden) {
 function buildRegressionCallouts(results, goldenScenarios, crossWindow) {
   const callouts = [];
   const skipped = [];
+  const noBaseline = [];
 
   for (const [name, current] of orderedScenarioEntries(results)) {
     const golden = goldenScenarios[name];
 
     if (!golden) {
+      // Not in the baseline at all -- new, or omitted by the median window -- which is not the
+      // same as a comparison that failed. Reported by name rather than silently dropped, so a
+      // scenario missing from every count above has somewhere honest to land.
+      noBaseline.push(formatTitle(name));
       continue;
     }
 
@@ -276,7 +281,12 @@ function buildRegressionCallouts(results, goldenScenarios, crossWindow) {
     const { change: totalPct, incomplete, label } = totalDelta(current, golden, isCrossWindow);
 
     if (incomplete) {
-      skipped.push(`${formatTitle(name)} (${label})`);
+      // A window mismatch withholds heap too (jsHeapMaxBytes is a maximum over the samples inside
+      // the parsed window, invalid across two different windows), so a reader must not conclude
+      // heap was still assessed just because it isn't called out separately below.
+      const heapNote = isCrossWindow ? '; heap also not assessed' : '';
+
+      skipped.push(`${formatTitle(name)} (${label}${heapNote})`);
     }
 
     // Heap survives a baseline that missed a timing category -- the two are measured independently.
@@ -312,12 +322,23 @@ function buildRegressionCallouts(results, goldenScenarios, crossWindow) {
   }
 
   // A scenario whose baseline is unusable was neither cleared nor flagged, so say so rather than
-  // letting it fall silently into "within tolerance". Scoped to the total, because heap may still
-  // have been assessed for the same scenario -- otherwise the note would contradict a callout
-  // standing directly above it.
-  const note = skipped.length > 0
-    ? `\n\n<sub>Total delta not assessed: ${skipped.join(', ')}.</sub>`
-    : '';
+  // letting it fall silently into "within tolerance". Scoped to the total by default, because heap
+  // survives a baseline that only missed a timing category -- the two are measured independently --
+  // and calling heap unassessed there would contradict a callout standing directly above it. A
+  // window mismatch is the exception: it invalidates heap too, and that entry says so explicitly.
+  const notes = [];
+
+  if (skipped.length > 0) {
+    notes.push(`Total delta not assessed: ${skipped.join(', ')}.`);
+  }
+
+  // Not in the baseline at all, which "within tolerance" cannot claim either -- there is nothing to
+  // be flat against. Kept distinct from `skipped`, which is baselines that exist but disagree.
+  if (noBaseline.length > 0) {
+    notes.push(`No baseline yet: ${noBaseline.join(', ')}.`);
+  }
+
+  const note = notes.length > 0 ? `\n\n<sub>${notes.join(' ')}</sub>` : '';
 
   if (callouts.length === 0) {
     return `All assessed scenarios within tolerance \u2705${note}`;

--- a/performance-tests/lib/report-builder.mjs
+++ b/performance-tests/lib/report-builder.mjs
@@ -3,9 +3,14 @@
 // interactive tables) lives in the HTML report instead.
 
 import {
-  REGRESSION_CALLOUT_THRESHOLD,
+  REGRESSION_CALLOUT_THRESHOLD_TIMING,
+  REGRESSION_CALLOUT_THRESHOLD_HEAP,
+  BASELINE_INCOMPLETE_LABEL,
+  calcCv,
+  fmtCvValue,
   pctChange,
   sumActive,
+  sumActiveComparable,
   fmtMs,
   fmtPct,
   fmtPctWithEmoji,
@@ -15,20 +20,35 @@ import {
 /**
  * @param {Record<string, object>} allScenarioResults -- keyed by scenario name
  * @param {object | null} goldenSnapshots -- golden baseline (or null to self-compare)
- * @param {object} [meta] -- { runUrl }
+ * @param {object} [meta] -- { pagesUrl, crossWindowScenarios, baseline }
  * @returns {string} full markdown report
  */
 export function buildReport(allScenarioResults, goldenSnapshots, meta = {}) {
   const goldenScenarios = goldenSnapshots?.scenarios || {};
   const hasGolden = Object.keys(goldenScenarios).length > 0;
+  const crossWindow = new Set(meta.crossWindowScenarios || []);
   const sections = [];
 
   // Summary table
-  sections.push(buildSummaryTable(allScenarioResults, goldenScenarios, hasGolden));
+  sections.push(buildSummaryTable(allScenarioResults, goldenScenarios, hasGolden, crossWindow));
+
+  // Hook timing, for the scenarios that measure it independently of the trace
+  const hookTiming = buildHookTimingSection(allScenarioResults, goldenScenarios, hasGolden);
+
+  if (hookTiming) {
+    sections.push(hookTiming);
+  }
 
   // Regression callouts (only for scenarios > threshold)
   if (hasGolden) {
-    sections.push(buildRegressionCallouts(allScenarioResults, goldenScenarios));
+    sections.push(buildRegressionCallouts(allScenarioResults, goldenScenarios, crossWindow));
+  }
+
+  // Where the baseline came from, so a reader can tell one run from five
+  const provenance = buildProvenanceFooter(goldenSnapshots, meta, hasGolden);
+
+  if (provenance) {
+    sections.push(provenance);
   }
 
   // Link to full HTML report on GitHub Pages
@@ -65,10 +85,87 @@ function orderedScenarioEntries(results) {
   });
 }
 
-function buildSummaryTable(results, goldenScenarios, hasGolden) {
+/**
+ * Decides whether a scenario's total delta may be published, and computes it if so.
+ *
+ * Two things disqualify a comparison. The baseline may have failed to capture a category the
+ * current run did record, in which case the two sums describe different things (the filed defect:
+ * ~4 ms of real work divided against a baseline that never measured it, published as +115.7%). Or
+ * the two sides may have been measured through different trace windows, which PR1's `windowSource`
+ * discriminator detects.
+ *
+ * @param {object} current
+ * @param {object | undefined} golden
+ * @param {boolean} isCrossWindow
+ * @returns {{ change: number | null, incomplete: boolean }}
+ */
+function totalDelta(current, golden, isCrossWindow) {
+  if (!golden) {
+    return { change: null, incomplete: false };
+  }
+
+  if (isCrossWindow) {
+    return { change: null, incomplete: true };
+  }
+
+  const { baseline, current: currentTotal, comparable } = sumActiveComparable(
+    golden.categories, current.categories
+  );
+
+  if (!comparable) {
+    return { change: null, incomplete: true };
+  }
+
+  return { change: pctChange(baseline, currentTotal), incomplete: false };
+}
+
+/**
+ * Renders the two spreads a reader needs to weigh a delta, side by side.
+ *
+ * They measure different things and are not interchangeable. The first is how much the three
+ * back-to-back iterations of this run disagreed; the second is how far apart the develop runs
+ * behind the baseline median sit. After PR1 the first is routinely under 4% while the second is
+ * 11-19%, so showing only the first would advertise a confidence the comparison does not have.
+ *
+ * @param {object} current
+ * @param {object | undefined} golden
+ * @returns {string}
+ */
+function reliabilityCell(current, golden) {
+  const iterationTotals = activeTotalsPerIteration(current._iterationValues?.categories);
+
+  return `${fmtCvValue(calcCv(iterationTotals))} / ${fmtCvValue(golden?.spread)}`;
+}
+
+/**
+ * Recombines per-category iteration arrays into one active-time total per iteration.
+ *
+ * @param {Record<string, number[]> | undefined} categories
+ * @returns {number[]}
+ */
+function activeTotalsPerIteration(categories) {
+  if (!categories) {
+    return [];
+  }
+
+  const length = Math.max(
+    ...['scripting', 'rendering', 'painting'].map(key => categories[key]?.length ?? 0)
+  );
+
+  return Array.from({ length }, (_, i) => sumActive({
+    scripting: categories.scripting?.[i],
+    rendering: categories.rendering?.[i],
+    painting: categories.painting?.[i],
+  }));
+}
+
+function buildSummaryTable(results, goldenScenarios, hasGolden, crossWindow) {
   const headers = hasGolden
-    ? ['Scenario', 'Scripting', 'Rendering', 'Painting', 'Total', '\u0394 Total', 'JS Heap', '\u0394 Heap']
-    : ['Scenario', 'Scripting', 'Rendering', 'Painting', 'Total', 'JS Heap'];
+    ? [
+      'Scenario', 'Scripting', 'Rendering', 'Painting', 'Total', '\u0394 Total',
+      'CV run / base', 'JS Heap', '\u0394 Heap',
+    ]
+    : ['Scenario', 'Scripting', 'Rendering', 'Painting', 'Total', 'CV run', 'JS Heap'];
 
   const rows = [];
 
@@ -79,25 +176,78 @@ function buildSummaryTable(results, goldenScenarios, hasGolden) {
 
     if (hasGolden) {
       const golden = goldenScenarios[name];
-      const goldenTotal = golden ? sumActive(golden.categories || {}) : null;
-      const totalChange = fmtPctWithEmoji(pctChange(goldenTotal, total));
+      const { change, incomplete } = totalDelta(current, golden, crossWindow.has(name));
+      const totalChange = incomplete ? BASELINE_INCOMPLETE_LABEL : fmtPctWithEmoji(change);
       const heapChange = fmtPctWithEmoji(
-        pctChange(golden?.updateCounters?.jsHeapMaxBytes, current.updateCounters?.jsHeapMaxBytes)
+        pctChange(golden?.updateCounters?.jsHeapMaxBytes, current.updateCounters?.jsHeapMaxBytes),
+        REGRESSION_CALLOUT_THRESHOLD_HEAP
       );
 
       rows.push([
         formatTitle(name), fmtMs(cats.scripting), fmtMs(cats.rendering),
-        fmtMs(cats.painting), fmtMs(total), totalChange, heap, heapChange,
+        fmtMs(cats.painting), fmtMs(total), totalChange,
+        reliabilityCell(current, golden), heap, heapChange,
       ]);
     } else {
       rows.push([
         formatTitle(name), fmtMs(cats.scripting), fmtMs(cats.rendering),
-        fmtMs(cats.painting), fmtMs(total), heap,
+        fmtMs(cats.painting), fmtMs(total),
+        fmtCvValue(calcCv(activeTotalsPerIteration(current._iterationValues?.categories))), heap,
       ]);
     }
   }
 
-  return `## \u26A1 Performance Results\n\n${formatMarkdownTable(headers, rows)}`;
+  const legend = hasGolden
+    ? '\n\n<sub>`CV run / base`: spread across the three iterations of this run, then across the '
+      + 'develop runs behind the baseline. A high second number means the baseline itself moves, '
+      + 'so read the delta beside it loosely.</sub>'
+    : '';
+
+  return `## \u26A1 Performance Results\n\n${formatMarkdownTable(headers, rows)}${legend}`;
+}
+
+// --- hook timing ---
+
+/**
+ * Hook timing is measured in-page around the hook pair rather than derived from the trace, so it is
+ * an independent check on the trace window. Only the scenarios that install a timer report it.
+ *
+ * @param {Record<string, object>} results
+ * @param {Record<string, object>} goldenScenarios
+ * @param {boolean} hasGolden
+ * @returns {string} markdown section, or '' when no scenario measures a hook
+ */
+function buildHookTimingSection(results, goldenScenarios, hasGolden) {
+  const rows = [];
+
+  for (const [name, current] of orderedScenarioEntries(results)) {
+    if (current.hookTiming == null) {
+      continue;
+    }
+
+    const golden = goldenScenarios[name];
+    const row = [
+      formatTitle(name),
+      fmtMs(current.hookTiming),
+      fmtCvValue(calcCv(current._iterationValues?.hookTiming)),
+    ];
+
+    if (hasGolden) {
+      row.push(fmtPctWithEmoji(pctChange(golden?.hookTiming, current.hookTiming)));
+    }
+
+    rows.push(row);
+  }
+
+  if (rows.length === 0) {
+    return '';
+  }
+
+  const headers = hasGolden
+    ? ['Scenario', 'Hook', 'CV run', '\u0394 Hook']
+    : ['Scenario', 'Hook', 'CV run'];
+
+  return `### Hook timing\n\n${formatMarkdownTable(headers, rows)}`;
 }
 
 // --- regression callouts ---
@@ -116,8 +266,9 @@ function buildTimingBreakdown(current, golden) {
   return parts.join(', ');
 }
 
-function buildRegressionCallouts(results, goldenScenarios) {
+function buildRegressionCallouts(results, goldenScenarios, crossWindow) {
   const callouts = [];
+  const skipped = [];
 
   for (const [name, current] of orderedScenarioEntries(results)) {
     const golden = goldenScenarios[name];
@@ -126,12 +277,17 @@ function buildRegressionCallouts(results, goldenScenarios) {
       continue;
     }
 
-    const totalPct = pctChange(sumActive(golden.categories || {}), sumActive(current.categories || {}));
+    const { change: totalPct, incomplete } = totalDelta(current, golden, crossWindow.has(name));
+
+    if (incomplete) {
+      skipped.push(formatTitle(name));
+    }
+
     const heapPct = pctChange(
       golden.updateCounters?.jsHeapMaxBytes, current.updateCounters?.jsHeapMaxBytes
     );
-    const timingRegressed = totalPct != null && totalPct > REGRESSION_CALLOUT_THRESHOLD;
-    const heapRegressed = heapPct != null && heapPct > REGRESSION_CALLOUT_THRESHOLD;
+    const timingRegressed = totalPct != null && totalPct > REGRESSION_CALLOUT_THRESHOLD_TIMING;
+    const heapRegressed = heapPct != null && heapPct > REGRESSION_CALLOUT_THRESHOLD_HEAP;
 
     if (!timingRegressed && !heapRegressed) {
       continue;
@@ -154,11 +310,63 @@ function buildRegressionCallouts(results, goldenScenarios) {
     callouts.push(lines.join('\n'));
   }
 
+  // A scenario whose baseline is unusable was neither cleared nor flagged, so say so rather than
+  // letting it fall silently into "within tolerance".
+  const note = skipped.length > 0
+    ? `\n\n<sub>Not assessed (${BASELINE_INCOMPLETE_LABEL}): ${skipped.join(', ')}.</sub>`
+    : '';
+
   if (callouts.length === 0) {
-    return 'All scenarios within tolerance \u2705';
+    return `All assessed scenarios within tolerance \u2705${note}`;
   }
 
-  return `### Regressions\n\n${callouts.join('\n\n')}`;
+  return `### Regressions\n\n${callouts.join('\n\n')}${note}`;
+}
+
+// --- provenance ---
+
+/**
+ * States what the deltas above were measured against. Without this the comment reads identically
+ * whether the baseline was a five-run median or one fluke develop push.
+ *
+ * @param {object | null} goldenSnapshots
+ * @param {object} meta
+ * @param {boolean} hasGolden
+ * @returns {string}
+ */
+function buildProvenanceFooter(goldenSnapshots, meta, hasGolden) {
+  if (!hasGolden) {
+    return '';
+  }
+
+  let baseline;
+
+  if (goldenSnapshots?.isMedian) {
+    const sources = goldenSnapshots.medianSourceTimestamps || [];
+    const range = sources.length > 1
+      ? ` (${sources[sources.length - 1]} to ${sources[0]})`
+      : '';
+
+    baseline = `median of ${goldenSnapshots.medianWindowSize} develop runs${range}`;
+  } else if (goldenSnapshots?.timestamp) {
+    baseline = `single develop run ${goldenSnapshots.timestamp}`;
+  } else {
+    baseline = 'self-comparison, no develop baseline';
+  }
+
+  const currentParts = [];
+
+  if (meta.commit) {
+    currentParts.push(`commit \`${String(meta.commit).slice(0, 7)}\``);
+  }
+
+  if (meta.runId) {
+    currentParts.push(`run \`${meta.runId}\``);
+  }
+
+  const current = currentParts.length > 0 ? ` Current: ${currentParts.join(', ')}.` : '';
+
+  return `<sub>Baseline: ${baseline}.${current}</sub>`;
 }
 
 // --- helpers ---

--- a/performance-tests/lib/report-builder.mjs
+++ b/performance-tests/lib/report-builder.mjs
@@ -11,6 +11,7 @@ import {
   fmtCvValue,
   pctChange,
   sumActive,
+  comparability,
   sumActiveComparable,
   fmtMs,
   fmtPct,
@@ -21,7 +22,7 @@ import {
 /**
  * @param {Record<string, object>} allScenarioResults -- keyed by scenario name
  * @param {object | null} goldenSnapshots -- golden baseline (or null to self-compare)
- * @param {object} [meta] -- { pagesUrl, crossWindowScenarios, baseline }
+ * @param {object} [meta] -- { pagesUrl, crossWindowScenarios, commit, runId }
  * @returns {string} full markdown report
  */
 export function buildReport(allScenarioResults, goldenSnapshots, meta = {}) {
@@ -103,22 +104,20 @@ function orderedScenarioEntries(results) {
  */
 function totalDelta(current, golden, isCrossWindow) {
   if (!golden) {
-    return { change: null, incomplete: false };
+    return { change: null, incomplete: false, label: null };
   }
 
-  if (isCrossWindow) {
-    return { change: null, incomplete: true };
+  const verdict = comparability(golden.categories, current.categories, isCrossWindow);
+
+  if (!verdict.comparable) {
+    return { change: null, incomplete: true, label: verdict.label };
   }
 
-  const { baseline, current: currentTotal, comparable } = sumActiveComparable(
+  const { baseline, current: currentTotal } = sumActiveComparable(
     golden.categories, current.categories
   );
 
-  if (!comparable) {
-    return { change: null, incomplete: true };
-  }
-
-  return { change: pctChange(baseline, currentTotal), incomplete: false };
+  return { change: pctChange(baseline, currentTotal), incomplete: false, label: null };
 }
 
 /**
@@ -156,12 +155,19 @@ function buildSummaryTable(results, goldenScenarios, hasGolden, crossWindow) {
 
     if (hasGolden) {
       const golden = goldenScenarios[name];
-      const { change, incomplete } = totalDelta(current, golden, crossWindow.has(name));
+      const isCrossWindow = crossWindow.has(name);
+      const { change, incomplete } = totalDelta(current, golden, isCrossWindow);
       const totalChange = incomplete ? BASELINE_INCOMPLETE_LABEL : fmtPctWithEmoji(change);
-      const heapChange = fmtPctWithEmoji(
-        pctChange(golden?.updateCounters?.jsHeapMaxBytes, current.updateCounters?.jsHeapMaxBytes),
-        REGRESSION_CALLOUT_THRESHOLD_HEAP
-      );
+      // Heap survives a missed timing category -- the two are measured independently -- but not a
+      // window mismatch: jsHeapMaxBytes is a maximum over the samples inside the window, so two
+      // windows sample two different things. Gated here as well as in the callouts, so the table
+      // and the callout below it cannot reach opposite verdicts on the same run.
+      const heapChange = isCrossWindow
+        ? BASELINE_INCOMPLETE_LABEL
+        : fmtPctWithEmoji(
+          pctChange(golden?.updateCounters?.jsHeapMaxBytes, current.updateCounters?.jsHeapMaxBytes),
+          REGRESSION_CALLOUT_THRESHOLD_HEAP
+        );
 
       rows.push([
         formatTitle(name), fmtMs(cats.scripting), fmtMs(cats.rendering),
@@ -258,10 +264,10 @@ function buildRegressionCallouts(results, goldenScenarios, crossWindow) {
     }
 
     const isCrossWindow = crossWindow.has(name);
-    const { change: totalPct, incomplete } = totalDelta(current, golden, isCrossWindow);
+    const { change: totalPct, incomplete, label } = totalDelta(current, golden, isCrossWindow);
 
     if (incomplete) {
-      skipped.push(formatTitle(name));
+      skipped.push(`${formatTitle(name)} (${label})`);
     }
 
     // Heap survives a baseline that missed a timing category -- the two are measured independently.
@@ -301,7 +307,7 @@ function buildRegressionCallouts(results, goldenScenarios, crossWindow) {
   // have been assessed for the same scenario -- otherwise the note would contradict a callout
   // standing directly above it.
   const note = skipped.length > 0
-    ? `\n\n<sub>Total delta not assessed (${BASELINE_INCOMPLETE_LABEL}): ${skipped.join(', ')}.</sub>`
+    ? `\n\n<sub>Total delta not assessed: ${skipped.join(', ')}.</sub>`
     : '';
 
   if (callouts.length === 0) {

--- a/performance-tests/lib/report-builder.mjs
+++ b/performance-tests/lib/report-builder.mjs
@@ -104,20 +104,24 @@ function orderedScenarioEntries(results) {
  */
 function totalDelta(current, golden, isCrossWindow) {
   if (!golden) {
-    return { change: null, incomplete: false, label: null };
+    return { change: null, incomplete: false, label: null, shortLabel: null };
   }
 
   const verdict = comparability(golden.categories, current.categories, isCrossWindow);
 
   if (!verdict.comparable) {
-    return { change: null, incomplete: true, label: verdict.label };
+    return {
+      change: null, incomplete: true, label: verdict.label, shortLabel: verdict.shortLabel,
+    };
   }
 
   const { baseline, current: currentTotal } = sumActiveComparable(
     golden.categories, current.categories
   );
 
-  return { change: pctChange(baseline, currentTotal), incomplete: false, label: null };
+  return {
+    change: pctChange(baseline, currentTotal), incomplete: false, label: null, shortLabel: null,
+  };
 }
 
 /**
@@ -156,8 +160,10 @@ function buildSummaryTable(results, goldenScenarios, hasGolden, crossWindow) {
     if (hasGolden) {
       const golden = goldenScenarios[name];
       const isCrossWindow = crossWindow.has(name);
-      const { change, incomplete } = totalDelta(current, golden, isCrossWindow);
-      const totalChange = incomplete ? BASELINE_INCOMPLETE_LABEL : fmtPctWithEmoji(change);
+      const { change, incomplete, shortLabel } = totalDelta(current, golden, isCrossWindow);
+      // The verdict's own wording. A fixed "baseline incomplete" misattributes a failure of this
+      // run's own capture to develop, and sends a maintainer to re-run develop for nothing.
+      const totalChange = incomplete ? shortLabel : fmtPctWithEmoji(change);
       // Heap survives a missed timing category -- the two are measured independently -- but not a
       // window mismatch: jsHeapMaxBytes is a maximum over the samples inside the window, so two
       // windows sample two different things. Gated here as well as in the callouts, so the table

--- a/performance-tests/lib/report-builder.mjs
+++ b/performance-tests/lib/report-builder.mjs
@@ -5,7 +5,7 @@
 import {
   REGRESSION_CALLOUT_THRESHOLD_TIMING,
   REGRESSION_CALLOUT_THRESHOLD_HEAP,
-  BASELINE_INCOMPLETE_LABEL,
+  INCOMPARABLE_LABELS,
   activeTotalsPerIteration,
   calcCv,
   fmtCvValue,
@@ -169,7 +169,10 @@ function buildSummaryTable(results, goldenScenarios, hasGolden, crossWindow) {
       // windows sample two different things. Gated here as well as in the callouts, so the table
       // and the callout below it cannot reach opposite verdicts on the same run.
       const heapChange = isCrossWindow
-        ? BASELINE_INCOMPLETE_LABEL
+        // Not the baseline-side label: the heap cell is only ever withheld for a window mismatch,
+        // where the baseline captured everything and it is the windows that differ. Saying
+        // "baseline incomplete" here gives one row two explanations for one cause.
+        ? INCOMPARABLE_LABELS['window-mismatch']
         : fmtPctWithEmoji(
           pctChange(golden?.updateCounters?.jsHeapMaxBytes, current.updateCounters?.jsHeapMaxBytes),
           REGRESSION_CALLOUT_THRESHOLD_HEAP

--- a/performance-tests/lib/report-builder.mjs
+++ b/performance-tests/lib/report-builder.mjs
@@ -6,6 +6,7 @@ import {
   REGRESSION_CALLOUT_THRESHOLD_TIMING,
   REGRESSION_CALLOUT_THRESHOLD_HEAP,
   BASELINE_INCOMPLETE_LABEL,
+  activeTotalsPerIteration,
   calcCv,
   fmtCvValue,
   pctChange,
@@ -39,8 +40,9 @@ export function buildReport(allScenarioResults, goldenSnapshots, meta = {}) {
     sections.push(hookTiming);
   }
 
-  // Regression callouts (only for scenarios > threshold)
-  if (hasGolden) {
+  // Regression callouts (only for scenarios > threshold). Suppressed on a self-comparison, where
+  // every delta is 0% by construction and "within tolerance" would be a claim about nothing.
+  if (hasGolden && !goldenSnapshots?.isSelfCompare) {
     sections.push(buildRegressionCallouts(allScenarioResults, goldenScenarios, crossWindow));
   }
 
@@ -135,28 +137,6 @@ function reliabilityCell(current, golden) {
   const iterationTotals = activeTotalsPerIteration(current._iterationValues?.categories);
 
   return `${fmtCvValue(calcCv(iterationTotals))} / ${fmtCvValue(golden?.spread)}`;
-}
-
-/**
- * Recombines per-category iteration arrays into one active-time total per iteration.
- *
- * @param {Record<string, number[]> | undefined} categories
- * @returns {number[]}
- */
-function activeTotalsPerIteration(categories) {
-  if (!categories) {
-    return [];
-  }
-
-  const length = Math.max(
-    ...['scripting', 'rendering', 'painting'].map(key => categories[key]?.length ?? 0)
-  );
-
-  return Array.from({ length }, (_, i) => sumActive({
-    scripting: categories.scripting?.[i],
-    rendering: categories.rendering?.[i],
-    painting: categories.painting?.[i],
-  }));
 }
 
 function buildSummaryTable(results, goldenScenarios, hasGolden, crossWindow) {
@@ -277,15 +257,21 @@ function buildRegressionCallouts(results, goldenScenarios, crossWindow) {
       continue;
     }
 
-    const { change: totalPct, incomplete } = totalDelta(current, golden, crossWindow.has(name));
+    const isCrossWindow = crossWindow.has(name);
+    const { change: totalPct, incomplete } = totalDelta(current, golden, isCrossWindow);
 
     if (incomplete) {
       skipped.push(formatTitle(name));
     }
 
-    const heapPct = pctChange(
-      golden.updateCounters?.jsHeapMaxBytes, current.updateCounters?.jsHeapMaxBytes
-    );
+    // Heap survives a baseline that missed a timing category -- the two are measured independently.
+    // It does not survive a window mismatch: jsHeapMaxBytes is a maximum over the UpdateCounters
+    // samples inside the parsed window, so two different windows sample two different things.
+    const heapPct = isCrossWindow
+      ? null
+      : pctChange(
+        golden.updateCounters?.jsHeapMaxBytes, current.updateCounters?.jsHeapMaxBytes
+      );
     const timingRegressed = totalPct != null && totalPct > REGRESSION_CALLOUT_THRESHOLD_TIMING;
     const heapRegressed = heapPct != null && heapPct > REGRESSION_CALLOUT_THRESHOLD_HEAP;
 
@@ -311,9 +297,11 @@ function buildRegressionCallouts(results, goldenScenarios, crossWindow) {
   }
 
   // A scenario whose baseline is unusable was neither cleared nor flagged, so say so rather than
-  // letting it fall silently into "within tolerance".
+  // letting it fall silently into "within tolerance". Scoped to the total, because heap may still
+  // have been assessed for the same scenario -- otherwise the note would contradict a callout
+  // standing directly above it.
   const note = skipped.length > 0
-    ? `\n\n<sub>Not assessed (${BASELINE_INCOMPLETE_LABEL}): ${skipped.join(', ')}.</sub>`
+    ? `\n\n<sub>Total delta not assessed (${BASELINE_INCOMPLETE_LABEL}): ${skipped.join(', ')}.</sub>`
     : '';
 
   if (callouts.length === 0) {
@@ -341,7 +329,10 @@ function buildProvenanceFooter(goldenSnapshots, meta, hasGolden) {
 
   let baseline;
 
-  if (goldenSnapshots?.isMedian) {
+  if (goldenSnapshots?.isSelfCompare) {
+    baseline = 'this run compared against itself, no develop baseline was available '
+      + '(every delta above is 0% by construction)';
+  } else if (goldenSnapshots?.isMedian) {
     const sources = goldenSnapshots.medianSourceTimestamps || [];
     const range = sources.length > 1
       ? ` (${sources[sources.length - 1]} to ${sources[0]})`
@@ -351,7 +342,7 @@ function buildProvenanceFooter(goldenSnapshots, meta, hasGolden) {
   } else if (goldenSnapshots?.timestamp) {
     baseline = `single develop run ${goldenSnapshots.timestamp}`;
   } else {
-    baseline = 'self-comparison, no develop baseline';
+    baseline = 'unknown';
   }
 
   const currentParts = [];

--- a/performance-tests/lib/teardown.mjs
+++ b/performance-tests/lib/teardown.mjs
@@ -237,6 +237,8 @@ export default async function teardown() {
     baseBranch: 'develop',
     pagesUrl: process.env.PAGES_URL || null,
     crossWindowScenarios: mismatched,
+    commit: process.env.GITHUB_SHA || null,
+    runId: process.env.GITHUB_RUN_ID || null,
   };
 
   const report = buildReport(scenarioResults, golden, meta);

--- a/performance-tests/lib/teardown.mjs
+++ b/performance-tests/lib/teardown.mjs
@@ -130,9 +130,15 @@ function collectIterationValues(parsedResults) {
   }
 
   for (const key of catKeys) {
-    values.categories[key] = parsedResults
-      .map(r => r.categories?.[key])
-      .filter(v => typeof v === 'number');
+    // Index-aligned to the iteration, never compacted. Dropping the entries where a category
+    // recorded nothing would both understate that category's own spread and, once the arrays are
+    // recombined into an active total, pair one iteration's scripting with another's painting.
+    // An iteration that recorded no time in a category recorded zero of it.
+    values.categories[key] = parsedResults.map((r) => {
+      const value = r.categories?.[key];
+
+      return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+    });
   }
 
   values.rangeEnd = parsedResults.map(r => r.rangeEnd);
@@ -214,6 +220,11 @@ export default async function teardown() {
 
       golden = {
         timestamp: new Date().toISOString(),
+        // Marked explicitly. The reports must not describe this as a develop baseline: every delta
+        // against it is 0% by construction, and a timestamp alone is indistinguishable from a real
+        // single-run golden, which would let "within tolerance" be claimed for a run compared
+        // against itself.
+        isSelfCompare: true,
         scenarios: stripInternalFields(scenarioResults),
       };
     }
@@ -237,7 +248,9 @@ export default async function teardown() {
     baseBranch: 'develop',
     pagesUrl: process.env.PAGES_URL || null,
     crossWindowScenarios: mismatched,
-    commit: process.env.GITHUB_SHA || null,
+    // PERF_COMMIT_SHA is the PR head on the pull_request path, where GITHUB_SHA is the ephemeral
+    // merge commit that exists on no branch. See the env block in performance-tests.yml.
+    commit: process.env.PERF_COMMIT_SHA || process.env.GITHUB_SHA || null,
     runId: process.env.GITHUB_RUN_ID || null,
   };
 

--- a/performance-tests/lib/thresholds.mjs
+++ b/performance-tests/lib/thresholds.mjs
@@ -132,6 +132,20 @@ export function sumActiveComparable(baselineCategories, currentCategories) {
 }
 
 /**
+ * Joins names for prose: "a", "a or b", "a, b or c".
+ *
+ * @param {string[]} items
+ * @returns {string}
+ */
+function joinList(items) {
+  if (items.length < 3) {
+    return items.join(' or ');
+  }
+
+  return `${items.slice(0, -1).join(', ')} or ${items[items.length - 1]}`;
+}
+
+/**
  * Decides, once per scenario, whether any delta between the two sides may be published.
  *
  * Every site that renders a percentage must consult this and no other rule. Deciding it per site
@@ -179,7 +193,7 @@ export function comparability(baselineCategories, currentCategories, isCrossWind
     ['this run', missingFrom('current')],
   ]
     .filter(([, keys]) => keys.length > 0)
-    .map(([side, keys]) => `${side} captured no ${keys.join(' or ')}`);
+    .map(([side, keys]) => `${side} captured no ${joinList(keys)}`);
   const reason = phrases.length > 1 ? 'both-incomplete' : `${incompleteSide}-incomplete`;
 
   return {

--- a/performance-tests/lib/thresholds.mjs
+++ b/performance-tests/lib/thresholds.mjs
@@ -80,26 +80,81 @@ export function sumActive(categories) {
 /**
  * Sums active time on both sides of a comparison and reports whether the two are comparable.
  *
- * A baseline that recorded zero for a category the current run did record is a failed capture, not
- * a cheap operation. `pctChange` already refuses to divide by such a category; without this check
- * `sumActive` would fold it into the total anyway and publish the resulting percentage.
+ * A run that recorded zero for a category the other side did record is a failed capture, not a
+ * cheap operation. `pctChange` already refuses to divide by a zero baseline; without this check
+ * `sumActive` would fold the category into the total anyway and publish the percentage.
+ *
+ * The check is symmetric on purpose. A baseline that missed a category inflates the delta into a
+ * fake regression; a current run that missed one deflates it into a fake improvement. The second
+ * is no more supportable than the first, and on these scenarios a genuine 0 ms of rendering or
+ * painting does not occur.
  *
  * @param {object | null | undefined} baselineCategories
  * @param {object | null | undefined} currentCategories
- * @returns {{ baseline: number, current: number, incompleteCategories: string[], comparable: boolean }}
+ * @returns {{ baseline: number, current: number, incompleteCategories: string[],
+ *   incompleteSide: 'baseline' | 'current' | null, comparable: boolean }}
  */
 export function sumActiveComparable(baselineCategories, currentCategories) {
   const baseline = baselineCategories ?? {};
   const current = currentCategories ?? {};
-  const incompleteCategories = ACTIVE_CATEGORIES.filter(
+  const missingFromBaseline = ACTIVE_CATEGORIES.filter(
     key => (baseline[key] || 0) === 0 && (current[key] || 0) > 0
   );
+  const missingFromCurrent = ACTIVE_CATEGORIES.filter(
+    key => (current[key] || 0) === 0 && (baseline[key] || 0) > 0
+  );
+  const incompleteCategories = [...new Set([...missingFromBaseline, ...missingFromCurrent])];
+  let incompleteSide = null;
+
+  if (missingFromBaseline.length > 0) {
+    incompleteSide = 'baseline';
+  } else if (missingFromCurrent.length > 0) {
+    incompleteSide = 'current';
+  }
 
   return {
     baseline: sumActive(baseline),
     current: sumActive(current),
     incompleteCategories,
+    incompleteSide,
     comparable: incompleteCategories.length === 0,
+  };
+}
+
+/**
+ * Decides, once per scenario, whether any delta between the two sides may be published.
+ *
+ * Every site that renders a percentage must consult this and no other rule. Deciding it per site
+ * is how one comment came to print a red heap regression in its table, clear the same run in its
+ * callouts, and count it as a regression in the linked report.
+ *
+ * @param {object | null | undefined} baselineCategories
+ * @param {object | null | undefined} currentCategories
+ * @param {boolean} [isCrossWindow] -- the two sides were measured over different trace windows
+ * @returns {{ comparable: boolean, reason: string | null, label: string | null }}
+ */
+export function comparability(baselineCategories, currentCategories, isCrossWindow = false) {
+  // A window mismatch invalidates every quantity derived from the trace, including the heap
+  // extrema, which are maxima over the samples inside the window.
+  if (isCrossWindow) {
+    return { comparable: false, reason: 'window-mismatch', label: 'window mismatch' };
+  }
+
+  const { comparable, incompleteCategories, incompleteSide } = sumActiveComparable(
+    baselineCategories, currentCategories
+  );
+
+  if (comparable) {
+    return { comparable: true, reason: null, label: null };
+  }
+
+  const side = incompleteSide === 'current' ? 'this run' : 'baseline';
+
+  return {
+    comparable: false,
+    reason: `${incompleteSide}-incomplete`,
+    // Naming the categories is the one detail that tells a maintainer whether to re-run develop.
+    label: `${side} captured no ${incompleteCategories.join(' or ')}`,
   };
 }
 

--- a/performance-tests/lib/thresholds.mjs
+++ b/performance-tests/lib/thresholds.mjs
@@ -131,6 +131,18 @@ export function sumActiveComparable(baselineCategories, currentCategories) {
   };
 }
 
+// The verdict for a scenario the baseline does not contain at all -- one just added to the suite,
+// or one the median omitted because too few windowed snapshots carried it. There is nothing to
+// compare against, which is not the same as a comparison that failed: every delta is simply absent
+// ("--"), and calling it "baseline incomplete" would send a maintainer looking for a capture bug.
+export const NO_BASELINE_VERDICT = Object.freeze({
+  comparable: true,
+  reason: null,
+  shortLabel: null,
+  label: null,
+  incompleteCategories: Object.freeze([]),
+});
+
 /**
  * Joins names for prose: "a", "a or b", "a, b or c".
  *

--- a/performance-tests/lib/thresholds.mjs
+++ b/performance-tests/lib/thresholds.mjs
@@ -104,6 +104,30 @@ export function sumActiveComparable(baselineCategories, currentCategories) {
 }
 
 /**
+ * Recombines per-category iteration arrays into one active-time total per iteration.
+ *
+ * Lives here rather than in either report builder so the set of active categories is stated once.
+ * A category array shorter than the others means that iteration recorded no time for it, which is
+ * a zero at that index, not a shift of every later value onto the wrong iteration.
+ *
+ * @param {Record<string, number[]> | null | undefined} categories
+ * @returns {number[]}
+ */
+export function activeTotalsPerIteration(categories) {
+  if (!categories) {
+    return [];
+  }
+
+  const length = Math.max(0, ...ACTIVE_CATEGORIES.map(key => categories[key]?.length ?? 0));
+
+  return Array.from({ length }, (_, i) => ACTIVE_CATEGORIES.reduce((sum, key) => {
+    const value = categories[key]?.[i];
+
+    return sum + (typeof value === 'number' && Number.isFinite(value) ? value : 0);
+  }, 0));
+}
+
+/**
  * @param {number | null} v -- milliseconds
  * @returns {string}
  */

--- a/performance-tests/lib/thresholds.mjs
+++ b/performance-tests/lib/thresholds.mjs
@@ -1,18 +1,43 @@
 // Shared classification logic for performance change percentages.
 // Used by both the markdown report builder and the HTML report builder.
 
-export const REGRESSION_CALLOUT_THRESHOLD = 5;
+// Timing and heap need separate thresholds: replaying the 18 post-PR1 develop goldens on gh-pages
+// against a trailing median-of-5 baseline, timing's run-to-run CV is 11-19% per scenario while
+// heap's is 0.4-3.6%. A shared value cannot serve both -- at 15 a genuine +10% heap leak is detected
+// 9% of the time instead of 93%.
+//
+// The timing number is interim. It is set at the knee of the false-positive curve measured against
+// a cross-runner baseline (34% of no-change comparisons fire a callout at 5, 3% at 15). Once the
+// suite compares two builds on the same runner in one job, re-derive it against that noise floor.
+export const REGRESSION_CALLOUT_THRESHOLD_TIMING = 15;
+export const REGRESSION_CALLOUT_THRESHOLD_HEAP = 5;
+
+// Coefficient of variation above which a measurement is flagged as unreliable.
+export const CV_WARNING_THRESHOLD = 15;
+
+// Rendered in place of a percentage when the baseline did not capture a category that the current
+// run did. A failed capture must not read as "no data", which is what a bare "--" would say.
+export const BASELINE_INCOMPLETE_LABEL = 'baseline incomplete';
+
+// The categories that make up "active" time. Loading, other, experience and idle are excluded.
+export const ACTIVE_CATEGORIES = ['scripting', 'rendering', 'painting'];
 
 /**
+ * Classifies a percentage change into a status, emoji and CSS class.
+ *
+ * The band is the callout threshold, so the colour a row is painted and the callout the comment
+ * makes can never disagree.
+ *
  * @param {number | null} pctChange -- percentage change (positive = regression)
+ * @param {number} [threshold] -- band edge; defaults to the timing callout threshold
  * @returns {{ status: string, emoji: string, cssClass: string }}
  */
-export function classifyChange(pctChange) {
+export function classifyChange(pctChange, threshold = REGRESSION_CALLOUT_THRESHOLD_TIMING) {
   if (pctChange == null) {
     return { status: 'unknown', emoji: '', cssClass: 'unknown' };
   }
 
-  if (pctChange > 10) {
+  if (pctChange > threshold) {
     return { status: 'regression', emoji: '\u{1F534}', cssClass: 'regression' };
   }
 
@@ -20,7 +45,7 @@ export function classifyChange(pctChange) {
     return { status: 'neutral-up', emoji: '\u{1F7E1}', cssClass: 'neutral-up' };
   }
 
-  if (pctChange < -10) {
+  if (pctChange < -threshold) {
     return { status: 'improvement', emoji: '\u{1F7E2}', cssClass: 'improvement' };
   }
 
@@ -53,6 +78,32 @@ export function sumActive(categories) {
 }
 
 /**
+ * Sums active time on both sides of a comparison and reports whether the two are comparable.
+ *
+ * A baseline that recorded zero for a category the current run did record is a failed capture, not
+ * a cheap operation. `pctChange` already refuses to divide by such a category; without this check
+ * `sumActive` would fold it into the total anyway and publish the resulting percentage.
+ *
+ * @param {object | null | undefined} baselineCategories
+ * @param {object | null | undefined} currentCategories
+ * @returns {{ baseline: number, current: number, incompleteCategories: string[], comparable: boolean }}
+ */
+export function sumActiveComparable(baselineCategories, currentCategories) {
+  const baseline = baselineCategories ?? {};
+  const current = currentCategories ?? {};
+  const incompleteCategories = ACTIVE_CATEGORIES.filter(
+    key => (baseline[key] || 0) === 0 && (current[key] || 0) > 0
+  );
+
+  return {
+    baseline: sumActive(baseline),
+    current: sumActive(current),
+    incompleteCategories,
+    comparable: incompleteCategories.length === 0,
+  };
+}
+
+/**
  * @param {number | null} v -- milliseconds
  * @returns {string}
  */
@@ -80,15 +131,16 @@ export function fmtPct(pct) {
 
 /**
  * @param {number | null} pct
+ * @param {number} [threshold] -- band edge passed through to `classifyChange`
  * @returns {string}
  */
-export function fmtPctWithEmoji(pct) {
+export function fmtPctWithEmoji(pct, threshold = REGRESSION_CALLOUT_THRESHOLD_TIMING) {
   if (pct == null) {
     return '--';
   }
 
   const text = fmtPct(pct);
-  const { emoji } = classifyChange(pct);
+  const { emoji } = classifyChange(pct, threshold);
 
   if (Math.abs(pct) < 1) {
     return text;
@@ -119,24 +171,50 @@ export function formatTitle(name) {
 }
 
 /**
- * @param {number[]} values
- * @returns {string}
+ * Coefficient of variation, as a percentage.
+ *
+ * Uses the sample standard deviation (n-1). The suite runs three iterations, where the population
+ * form understates spread by about 18% -- and this number gates how much trust a reader puts in the
+ * delta beside it, so it should not read tighter than the data supports.
+ *
+ * @param {number[] | null | undefined} values
+ * @returns {number | null} -- null when there is too little data or the mean is zero
  */
-export function fmtCv(values) {
-  if (!values || values.length < 2) {
-    return '';
+export function calcCv(values) {
+  if (!Array.isArray(values) || values.length < 2) {
+    return null;
   }
 
   const mean = values.reduce((a, b) => a + b, 0) / values.length;
 
   if (mean === 0) {
-    return '';
+    return null;
   }
 
-  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / values.length;
-  const stddev = Math.sqrt(variance);
-  const cv = (stddev / Math.abs(mean)) * 100;
-  const warning = cv > 15 ? ' !!!' : '';
+  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / (values.length - 1);
 
-  return `${cv.toFixed(1)}%${warning}`;
+  return (Math.sqrt(variance) / Math.abs(mean)) * 100;
+}
+
+/**
+ * Formats an already-computed CV. Renders `n/a` rather than a number when the spread is unknown --
+ * a rendered `0.0%` would read as a perfectly stable measurement.
+ *
+ * @param {number | null | undefined} cv
+ * @returns {string}
+ */
+export function fmtCvValue(cv) {
+  if (cv == null || !Number.isFinite(cv)) {
+    return 'n/a';
+  }
+
+  return `${cv.toFixed(1)}%${cv > CV_WARNING_THRESHOLD ? ' \u26A0\uFE0F' : ''}`;
+}
+
+/**
+ * @param {number[] | null | undefined} values
+ * @returns {string}
+ */
+export function fmtCv(values) {
+  return fmtCvValue(calcCv(values));
 }

--- a/performance-tests/lib/thresholds.mjs
+++ b/performance-tests/lib/thresholds.mjs
@@ -15,9 +15,19 @@ export const REGRESSION_CALLOUT_THRESHOLD_HEAP = 5;
 // Coefficient of variation above which a measurement is flagged as unreliable.
 export const CV_WARNING_THRESHOLD = 15;
 
-// Rendered in place of a percentage when the baseline did not capture a category that the current
-// run did. A failed capture must not read as "no data", which is what a bare "--" would say.
-export const BASELINE_INCOMPLETE_LABEL = 'baseline incomplete';
+// Rendered in place of a percentage when the comparison cannot support one. A failed capture must
+// not read as "no data", which is what a bare "--" would say -- and it must name the side that
+// failed, because "baseline incomplete" on a run whose own capture failed sends a maintainer to
+// re-run develop for nothing.
+export const INCOMPARABLE_LABELS = {
+  'window-mismatch': 'window mismatch',
+  'baseline-incomplete': 'baseline incomplete',
+  'current-incomplete': 'capture incomplete',
+  'both-incomplete': 'capture incomplete',
+};
+
+// The baseline-side label, kept as a named export because it is the case the task filed.
+export const BASELINE_INCOMPLETE_LABEL = INCOMPARABLE_LABELS['baseline-incomplete'];
 
 // The categories that make up "active" time. Loading, other, experience and idle are excluded.
 export const ACTIVE_CATEGORIES = ['scripting', 'rendering', 'painting'];
@@ -134,27 +144,51 @@ export function sumActiveComparable(baselineCategories, currentCategories) {
  * @returns {{ comparable: boolean, reason: string | null, label: string | null }}
  */
 export function comparability(baselineCategories, currentCategories, isCrossWindow = false) {
-  // A window mismatch invalidates every quantity derived from the trace, including the heap
-  // extrema, which are maxima over the samples inside the window.
+  // A window mismatch invalidates every quantity derived from the trace, including the heap and
+  // DOM extrema, which are taken over the samples inside the window.
   if (isCrossWindow) {
-    return { comparable: false, reason: 'window-mismatch', label: 'window mismatch' };
+    return {
+      comparable: false,
+      reason: 'window-mismatch',
+      shortLabel: INCOMPARABLE_LABELS['window-mismatch'],
+      label: 'the two sides were measured over different trace windows',
+      // Nothing derived from the trace is comparable, so no category is exempt.
+      incompleteCategories: [...ACTIVE_CATEGORIES],
+    };
   }
 
+  const baseline = baselineCategories ?? {};
+  const current = currentCategories ?? {};
   const { comparable, incompleteCategories, incompleteSide } = sumActiveComparable(
-    baselineCategories, currentCategories
+    baseline, current
   );
 
   if (comparable) {
-    return { comparable: true, reason: null, label: null };
+    return {
+      comparable: true, reason: null, shortLabel: null, label: null, incompleteCategories: [],
+    };
   }
 
-  const side = incompleteSide === 'current' ? 'this run' : 'baseline';
+  // Attribute each category to the side that actually missed it. Reporting the union against one
+  // side names a category the other side recorded, which is the opposite of the point.
+  const missingFrom = side => incompleteCategories.filter(
+    key => ((side === 'baseline' ? baseline : current)[key] || 0) === 0
+  );
+  const phrases = [
+    ['baseline', missingFrom('baseline')],
+    ['this run', missingFrom('current')],
+  ]
+    .filter(([, keys]) => keys.length > 0)
+    .map(([side, keys]) => `${side} captured no ${keys.join(' or ')}`);
+  const reason = phrases.length > 1 ? 'both-incomplete' : `${incompleteSide}-incomplete`;
 
   return {
     comparable: false,
-    reason: `${incompleteSide}-incomplete`,
+    reason,
+    shortLabel: INCOMPARABLE_LABELS[reason] ?? INCOMPARABLE_LABELS['both-incomplete'],
     // Naming the categories is the one detail that tells a maintainer whether to re-run develop.
-    label: `${side} captured no ${incompleteCategories.join(' or ')}`,
+    label: phrases.join('; '),
+    incompleteCategories,
   };
 }
 

--- a/performance-tests/lib/thresholds.mjs
+++ b/performance-tests/lib/thresholds.mjs
@@ -6,9 +6,16 @@
 // heap's is 0.4-3.6%. A shared value cannot serve both -- at 15 a genuine +10% heap leak is detected
 // 9% of the time instead of 93%.
 //
-// The timing number is interim. It is set at the knee of the false-positive curve measured against
-// a cross-runner baseline (34% of no-change comparisons fire a callout at 5, 3% at 15). Once the
-// suite compares two builds on the same runner in one job, re-derive it against that noise floor.
+// The timing number is interim, and it is only correct for the baseline it was measured against:
+// the knee of the false-positive curve for a cross-runner median baseline (34% of no-change
+// comparisons fire a callout at 5, 3% at 15). Re-derive it with scripts/replay-goldens.mjs
+// whenever the comparand changes -- a quieter baseline makes 15 far too permissive to catch
+// anything.
+//
+// Do not assume a same-runner comparison is that quieter baseline. Running the suite twice in one
+// job against a byte-identical build was measured and does not hold: the second run came out
+// slower on 8 of 9 scenarios, median +9.2%, worst +22.5%. Whatever replaces the comparand has to
+// be calibrated the same way rather than argued for from first principles.
 export const REGRESSION_CALLOUT_THRESHOLD_TIMING = 15;
 export const REGRESSION_CALLOUT_THRESHOLD_HEAP = 5;
 

--- a/performance-tests/scripts/replay-goldens.mjs
+++ b/performance-tests/scripts/replay-goldens.mjs
@@ -134,10 +134,20 @@ function replay(goldens, windowSize) {
       const baseHeap = baselineEntry.updateCounters?.jsHeapMaxBytes;
       const currentHeap = currentEntry.updateCounters?.jsHeapMaxBytes;
 
+      // Both sides must be finite numbers. A golden entry carrying updateCounters but no
+      // jsHeapMaxBytes would otherwise yield NaN, which survives a null filter, inflates the
+      // sample count, understates every fired count and prints a NaN worst-case.
+      const comparable = (base, value) => Number.isFinite(base) && base > 0
+        && Number.isFinite(value);
+
       deltas.push({
         scenario,
-        timing: baseTotal > 0 ? ((currentTotal - baseTotal) / baseTotal) * 100 : null,
-        heap: baseHeap > 0 ? ((currentHeap - baseHeap) / baseHeap) * 100 : null,
+        timing: comparable(baseTotal, currentTotal)
+          ? ((currentTotal - baseTotal) / baseTotal) * 100
+          : null,
+        heap: comparable(baseHeap, currentHeap)
+          ? ((currentHeap - baseHeap) / baseHeap) * 100
+          : null,
       });
     }
   }

--- a/performance-tests/scripts/replay-goldens.mjs
+++ b/performance-tests/scripts/replay-goldens.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+//
+// Replays the develop goldens published on gh-pages through the same median-baseline selection CI
+// uses, and reports how often a no-change comparison would have fired a regression callout.
+//
+// Every develop golden measures develop, so any delta this produces is noise by construction. That
+// makes the output a direct read of the false-positive rate at a given callout threshold, which is
+// the only defensible way to pick one. Re-run it after any change to how the suite measures or to
+// which baseline it compares against, and move REGRESSION_CALLOUT_THRESHOLD_TIMING to the knee of
+// the curve it prints.
+//
+// Usage:
+//   node performance-tests/scripts/replay-goldens.mjs
+//   node performance-tests/scripts/replay-goldens.mjs --since 2026-08-27 --window 5
+//
+// Reads the snapshots straight out of the gh-pages branch, so `git fetch origin gh-pages` first.
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  MEDIAN_WINDOW_SIZE,
+  computeMedianSnapshot,
+} from '../lib/median-snapshot.mjs';
+import {
+  REGRESSION_CALLOUT_THRESHOLD_HEAP,
+  REGRESSION_CALLOUT_THRESHOLD_TIMING,
+  calcCv,
+  sumActive,
+} from '../lib/thresholds.mjs';
+
+const GH_PAGES_REF = 'origin/gh-pages';
+const DEVELOP_REPORTS = 'performance-reports/develop';
+
+// The thresholds the curve is printed at. The two live constants are marked in the output so the
+// current setting can be read against its neighbours.
+const TIMING_THRESHOLDS = [5, 10, 15, 20, 25, 30];
+const HEAP_THRESHOLDS = [2, 3, 5, 10, 15];
+
+/**
+ * @returns {string} the repository root, so git commands are not CWD-relative
+ */
+function repoRoot() {
+  return resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+}
+
+/**
+ * @param {string[]} args
+ * @returns {string} stdout
+ */
+function git(args) {
+  return execFileSync('git', args, { cwd: repoRoot(), encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+/**
+ * @param {object} options
+ * @param {string | null} options.since -- ignore snapshot directories named before this prefix
+ * @returns {Array<{ timestamp: string, snapshot: object }>} oldest first
+ */
+function loadGoldens({ since }) {
+  let listing;
+
+  try {
+    listing = git(['ls-tree', '--name-only', GH_PAGES_REF, `${DEVELOP_REPORTS}/`]);
+  } catch {
+    throw new Error(
+      `Cannot read ${GH_PAGES_REF}. Run \`git fetch origin gh-pages\` and try again.`
+    );
+  }
+
+  const dirs = listing
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(path => path.replace(/\/$/, ''))
+    .map(path => path.slice(`${DEVELOP_REPORTS}/`.length))
+    // latest.json and index.html live alongside the timestamped directories.
+    .filter(name => /^\d{4}-\d{2}-\d{2}T/.test(name))
+    .filter(name => !since || name >= since)
+    .sort();
+
+  const goldens = [];
+
+  for (const name of dirs) {
+    let raw;
+
+    try {
+      raw = git(['show', `${GH_PAGES_REF}:${DEVELOP_REPORTS}/${name}/snapshots.json`]);
+    } catch {
+      continue;
+    }
+
+    try {
+      goldens.push({ timestamp: name, snapshot: JSON.parse(raw) });
+    } catch {
+      console.warn(`  skipping ${name}: unparseable snapshots.json`);
+    }
+  }
+
+  return goldens;
+}
+
+/**
+ * Replays each golden as if it were a PR run, against a median of only the goldens before it.
+ *
+ * @param {Array<{ timestamp: string, snapshot: object }>} goldens -- oldest first
+ * @param {number} windowSize
+ * @returns {Array<{ scenario: string, timing: number | null, heap: number | null }>}
+ */
+function replay(goldens, windowSize) {
+  const deltas = [];
+
+  for (let i = windowSize; i < goldens.length; i += 1) {
+    // Only the trailing window, never the run under test -- otherwise the baseline contains the
+    // very run it is being compared against and the noise reads far smaller than it is.
+    const window = goldens.slice(i - windowSize, i).map(entry => entry.snapshot);
+    const baseline = computeMedianSnapshot(window, { windowSize });
+
+    if (!baseline) {
+      continue;
+    }
+
+    const current = goldens[i].snapshot.scenarios || {};
+
+    for (const [scenario, currentEntry] of Object.entries(current)) {
+      const baselineEntry = baseline.scenarios?.[scenario];
+
+      if (!baselineEntry) {
+        continue;
+      }
+
+      const baseTotal = sumActive(baselineEntry.categories || {});
+      const currentTotal = sumActive(currentEntry.categories || {});
+      const baseHeap = baselineEntry.updateCounters?.jsHeapMaxBytes;
+      const currentHeap = currentEntry.updateCounters?.jsHeapMaxBytes;
+
+      deltas.push({
+        scenario,
+        timing: baseTotal > 0 ? ((currentTotal - baseTotal) / baseTotal) * 100 : null,
+        heap: baseHeap > 0 ? ((currentHeap - baseHeap) / baseHeap) * 100 : null,
+      });
+    }
+  }
+
+  return deltas;
+}
+
+/**
+ * @param {Array<object>} deltas
+ * @param {'timing' | 'heap'} key
+ * @param {number[]} thresholds
+ * @param {number} live -- the threshold currently in force, marked in the output
+ */
+function printCurve(deltas, key, thresholds, live) {
+  const values = deltas.map(d => d[key]).filter(v => v != null);
+
+  if (values.length === 0) {
+    console.log(`  no ${key} deltas to report`);
+
+    return;
+  }
+
+  console.log(`  threshold   callouts fired on no-change comparisons   (n = ${values.length})`);
+
+  for (const threshold of thresholds) {
+    // One-sided, matching the callout rule: only a slowdown is called out.
+    const fired = values.filter(v => v > threshold).length;
+    const pct = ((fired / values.length) * 100).toFixed(0).padStart(3);
+    const marker = threshold === live ? '  <-- in force' : '';
+
+    console.log(`  ${String(threshold).padStart(8)}%   ${pct}%  (${fired})${marker}`);
+  }
+
+  const sorted = [...values].map(Math.abs).sort((a, b) => a - b);
+
+  console.log(`  worst absolute delta: ${sorted[sorted.length - 1].toFixed(1)}%`);
+}
+
+/**
+ * @param {Array<{ timestamp: string, snapshot: object }>} goldens
+ */
+function printPerScenarioSpread(goldens) {
+  const scenarios = new Set(goldens.flatMap(g => Object.keys(g.snapshot.scenarios || {})));
+
+  console.log('\n  run-to-run spread across every golden replayed:\n');
+  console.log(`  ${'scenario'.padEnd(30)}${'timing CV'.padStart(11)}${'heap CV'.padStart(11)}`);
+
+  for (const scenario of [...scenarios].sort()) {
+    const entries = goldens
+      .map(g => g.snapshot.scenarios?.[scenario])
+      .filter(Boolean);
+    const timing = calcCv(entries.map(e => sumActive(e.categories || {})));
+    const heap = calcCv(entries.map(e => e.updateCounters?.jsHeapMaxBytes).filter(v => v != null));
+    const fmt = v => (v == null ? 'n/a' : `${v.toFixed(1)}%`);
+
+    console.log(`  ${scenario.padEnd(30)}${fmt(timing).padStart(11)}${fmt(heap).padStart(11)}`);
+  }
+}
+
+/**
+ * @param {string[]} argv
+ * @returns {{ since: string | null, windowSize: number }}
+ */
+function parseArgs(argv) {
+  const since = argv.includes('--since') ? argv[argv.indexOf('--since') + 1] : null;
+  const windowRaw = argv.includes('--window') ? argv[argv.indexOf('--window') + 1] : null;
+  const windowSize = windowRaw ? Number.parseInt(windowRaw, 10) : MEDIAN_WINDOW_SIZE;
+
+  if (!Number.isFinite(windowSize) || windowSize < 2) {
+    throw new Error(`--window must be an integer of at least 2, got "${windowRaw}"`);
+  }
+
+  return { since, windowSize };
+}
+
+async function main(argv) {
+  const { since, windowSize } = parseArgs(argv);
+
+  console.log(`\nReplaying develop goldens from ${GH_PAGES_REF} (window ${windowSize})`);
+
+  if (since) {
+    console.log(`Restricted to snapshots at or after ${since}`);
+  }
+
+  const goldens = loadGoldens({ since });
+
+  console.log(`Loaded ${goldens.length} golden snapshot(s)\n`);
+
+  if (goldens.length <= windowSize) {
+    throw new Error(
+      `Need more than ${windowSize} goldens to replay even one comparison, have ${goldens.length}.`
+    );
+  }
+
+  const deltas = replay(goldens, windowSize);
+
+  console.log(`Replayed ${deltas.length} scenario comparison(s). Every one measures develop`);
+  console.log('against develop, so every delta below is noise.\n');
+
+  console.log('TIMING');
+  printCurve(deltas, 'timing', TIMING_THRESHOLDS, REGRESSION_CALLOUT_THRESHOLD_TIMING);
+
+  console.log('\nHEAP');
+  printCurve(deltas, 'heap', HEAP_THRESHOLDS, REGRESSION_CALLOUT_THRESHOLD_HEAP);
+
+  printPerScenarioSpread(goldens);
+
+  console.log('');
+}
+
+// Only run when invoked directly, so the helpers stay importable from a test.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(`\n${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export { loadGoldens, replay, parseArgs };

--- a/performance-tests/scripts/replay-goldens.mjs
+++ b/performance-tests/scripts/replay-goldens.mjs
@@ -26,6 +26,7 @@ import {
   REGRESSION_CALLOUT_THRESHOLD_HEAP,
   REGRESSION_CALLOUT_THRESHOLD_TIMING,
   calcCv,
+  comparability,
   sumActive,
 } from '../lib/thresholds.mjs';
 
@@ -109,6 +110,7 @@ function loadGoldens({ since }) {
  */
 function replay(goldens, windowSize) {
   const deltas = [];
+  let skippedIncomparable = 0;
 
   for (let i = windowSize; i < goldens.length; i += 1) {
     // Only the trailing window, never the run under test -- otherwise the baseline contains the
@@ -126,6 +128,21 @@ function replay(goldens, windowSize) {
       const baselineEntry = baseline.scenarios?.[scenario];
 
       if (!baselineEntry) {
+        continue;
+      }
+
+      // Model what the reports actually publish, not every arithmetic difference. The median
+      // baseline is always marks-valid (isValidForMedian enforces it), but the run standing in for
+      // a PR is not filtered, so its window source has to be checked here the way teardown checks
+      // it. A comparison the shipped code refuses to publish must not count toward the
+      // false-positive rate used to pick the thresholds.
+      const currentWindow = currentEntry.windowSource ?? 'auto-zoom';
+      const verdict = comparability(
+        baselineEntry.categories, currentEntry.categories, currentWindow !== 'marks'
+      );
+
+      if (!verdict.comparable) {
+        skippedIncomparable += 1;
         continue;
       }
 
@@ -152,7 +169,7 @@ function replay(goldens, windowSize) {
     }
   }
 
-  return deltas;
+  return { deltas, skippedIncomparable };
 }
 
 /**
@@ -242,7 +259,14 @@ async function main(argv) {
     );
   }
 
-  const deltas = replay(goldens, windowSize);
+  const { deltas, skippedIncomparable } = replay(goldens, windowSize);
+
+  if (skippedIncomparable > 0) {
+    console.log(
+      `Skipped ${skippedIncomparable} comparison(s) the reports would refuse to publish `
+      + '(incomplete capture or window mismatch).\n'
+    );
+  }
 
   console.log(`Replayed ${deltas.length} scenario comparison(s). Every one measures develop`);
   console.log('against develop, so every delta below is noise.\n');


### PR DESCRIPTION
### Context

The PR fixes the sticky performance comment posted on every pull request, which reports regressions that are not real. This is the third PR on this task, and the last one that is scoped. PR 1 (#13255) fixed how the suite measures; PR 2 (#13317) fixed which baseline it compares against. Both landed, and the comment is still wrong, for reasons neither of them touched.

Replaying the develop goldens published on `gh-pages` through PR 2's own median selection — with the baseline drawn only from the trailing window, never from the run under test — gives the current false-positive rate. Every one of these comparisons measures develop against develop, so every delta is noise by construction:

```
threshold   red callouts fired on no-change comparisons
5 (today)     35%  (47/135)
10            13%  (17/135)
15             3%   (4/135)
20             3%   (4/135)
worst absolute no-change delta: 53.2%
```

(19 goldens, 2026-08-27 through 2026-09-01, 135 scenario comparisons. The exact counts move as develop accumulates goldens; the shape does not. Reproduce with the command below.)

More than a third of no-change comparisons currently fire a red callout. That is the number this PR is aimed at.

The remaining cause is CI runner speed. Across those goldens the per-run speed factor spans **0.63x to 1.10x**, and it moves all nine scenarios together — the `2026-08-28T10-43-13Z` run reads low on every scenario at once. Normalizing it away arithmetically was considered and rejected: a median-of-ratios estimator is blind to the highest-value regression class. Injecting a synthetic uniform +20% slowdown across all nine scenarios, raw detection is 69-81% of rows and normalized detection is 6-10%.

**How that residual gets fixed is now an open question, and this PR does not depend on the answer.** The plan had been to measure the merge base and the PR head on the same runner in one job, so runner speed would cancel. That premise was tested before any of it was built, and it failed: running the suite twice in one job against a byte-identical build, the second run was slower on **8 of 9 scenarios**, median **+9.2%**, worst **+22.5%**. There is a systematic second-position penalty, so that design would have made every PR look like a regression rather than fixing anything. A dedicated always-on machine is being evaluated instead. Either way it is a change to how the baseline is obtained, and nothing in this PR is coupled to that.

**This PR owns the reporting layer only.** It changes nothing about how the suite measures or which baseline it loads. Its job is to stop the comment publishing numbers it cannot support, and to surface the reliability data the tooling already computes and throws away. Every file it touches had zero tests before this PR.

#### Three corrections to the scope carried into this PR

The scope was written before #13255 and #13317 landed. Three items no longer described reality, and following them literally would have shipped dead code or a regression in the tool.

**1. The CV gate as filed is inert.** It was written against pre-#13255 data where intra-run CV was 58-97%. Post-#13255 it is 0.9-4.0% on seven of nine scenarios, so a 15% gate on it never fires. The signal that matters now is run-to-run spread across the median window (11-19% per scenario), which #13317 already assembles. The comment needs both, labeled distinctly.

**2. No suppression gate was added.** The scope asked for one. Simulated: threshold 10 plus "suppress when the window CV exceeds 15%" gets false callouts to 4%, but it also suppresses **51 of 89 genuine +25% regressions**. It buys accuracy by going half-blind. Raising the threshold alone is strictly better, and the knee is sharp:

```
threshold   no-change(false)   real +25%   real +50%   real +100%
5             35%                79%         91%         100%
10            13%                76%         90%          99%
15             3%                69%         88%          99%
20             3%                61%         87%          98%
```

15 is the knee. Above it, sensitivity drops with no false-positive gain.

**3. The threshold had to be split, not raised.** `REGRESSION_CALLOUT_THRESHOLD` gated heap as well as timing. Heap's run-to-run CV is 0.4-3.6% against timing's 11-19%, so one constant cannot serve both:

```
threshold   heap no-change(false)   real +10% leak   real +25% leak
2             14%                     99%              100%
3             12%                     97%              100%
5 (today)      4%                     93%              100%
10             0%                     60%              100%
15             0%                      9%              100%
```

Raising the shared constant to 15 would have taken detection of a genuine +10% heap leak from 93% to 9% — a regression in the tool, introduced by the fix for it. Heap stays at 5, which is already at its knee. Only the timing threshold moves.

The timing number is **interim, and correct only for the baseline it was measured against** — today's cross-runner median. Whenever the comparand changes, it has to be re-derived, because a quieter baseline makes 15 far too permissive to catch anything. `performance-tests/scripts/replay-goldens.mjs` is committed here so that is a command, not a judgement call.

### What changed

**One rule decides whether a delta may be published.** `comparability(baselineCategories, currentCategories, isCrossWindow)` in `thresholds.mjs` is consulted by every site in both builders that renders a percentage. Three things make a comparison unpublishable:

| Reason | Rendered as | What is withheld |
|---|---|---|
| The baseline recorded 0 ms for a category this run did record | `baseline incomplete` | the total, and that category |
| This run recorded 0 ms for a category the baseline did record | `capture incomplete` | the total, and that category |
| The two sides were measured over different trace windows | `window mismatch` | everything derived from the trace, heap and DOM counters included |

The first is the filed defect: ~4 ms of real work divided against a baseline that never measured it, published as `+115.7% 🔴`. The check is **symmetric**, because the mirror case is equally unsupportable — a capture failure on this run's side publishes a fake green `-23%` a reader cannot tell from a real win. The label names the side and the categories (`this run captured no rendering or painting`), which is the detail that says whether re-running develop would fix it. A scenario in this state is listed under "Total delta not assessed" rather than folded into "within tolerance", and counted separately in the HTML dashboard rather than as Neutral.

Categories both sides captured are still published: one failed capture does not hide the rest of the row.

**One CV implementation.** `fmtCv()` had zero callers repo-wide; `html-report-builder.mjs` carried a private near-duplicate `calcCv`; both hardcoded `15`. Now one exported `calcCv()` plus `CV_WARNING_THRESHOLD`. It uses the **sample** standard deviation (n-1): at three iterations the population form understates spread by about 18%, and this number now gates how much a reader trusts the delta beside it.

**Two reliability numbers, labeled distinctly**, as `CV run / base`. The first is the spread across this run's three iterations; the second is how far apart the develop runs behind the median baseline sit. Baseline spread was not previously available to the report layer at all — the per-iteration values are stripped before a golden is saved — so it is computed in `median-snapshot.mjs`, which already holds the whole window. It renders `n/a`, never `0.0%`, in the three paths with no history window (golden mode, the self-compare fallback, a thin history); a rendered `0.0%` would claim a perfectly stable baseline, the same class of lie this PR exists to remove. Hook-timing CV is surfaced too, from `_iterationValues.hookTiming`, collected and never read.

**Colour bands derive from the callout constants.** `classifyChange` banded at ±10 while the callout fired at a different number, and the client script carried a second copy of those bands. Left alone, the HTML report would paint a row red at +12% while the comment said "within tolerance" — precisely the "two numbers describing the same scenario" complaint on this task. The bands now come from the split constants, serialized into the payload rather than restated.

**A self-comparison is no longer reported as a develop baseline.** The no-golden fallback stamps a fresh timestamp, and both builders branched on the timestamp merely being present — so a run compared against itself printed `Baseline: single develop run <now>` and cleared every scenario. It is marked `isSelfCompare`, and the tolerance claim is suppressed.

**The Trace window row is informational and never coloured.** After #13255 it is mark-to-mark harness wall clock: on the four scroll scenarios it sits at ~16700 ms with a run-to-run CV of 0.0-0.2% regardless of what the grid does, because it is 500 sequential wheel round trips. It was still getting a red badge above 10%. It is the one percentage still printed on a window mismatch, deliberately — it is the size of the two windows, so it explains the mismatch the other rows are withheld for.

**Provenance in both reports.** `isMedian`, `medianWindowSize`, `medianSourceTimestamps` reached the CI log only, and the commit/run metadata reached the snapshot but not the report. Neither artifact said whether a delta was computed against one develop run or five. Both now do. `PERF_COMMIT_SHA` is plumbed through both CI entry points, because on the `pull_request` path the default `GITHUB_SHA` is the ephemeral merge commit, which exists on no branch.

**Script-block containment.** The payload is serialized into an inline `<script>`, and `JSON.stringify` does not escape `<`, so a branch name containing `</script>` closed the block early — and the branch name comes from `GITHUB_HEAD_REF`, which a fork pull request chooses. Pre-existing rather than introduced here, but this PR touches exactly that serialization. Escaped, with the same hole closed in the `<title>` interpolation.

**First tests for the reporting layer**, plus the two stale docs (`performance-tests/README.md` and the performance-testing skill both listed 7 scenarios at the wrong fixture sizes; reality is 9).

### Review rounds

Four automated review passes, across six commits. They found real defects each time, and the pattern is worth recording for whoever reviews this next: every miss was the same shape — gating one render site instead of the class.

- **Round 1** found 8, two serious. `buildDetailedMetrics` published the withheld `+115.6%` in the expanded detail table while the card badge above it read `baseline incomplete`. And the self-comparison-as-develop-baseline defect above.
- **Round 2** found that the cross-window heap fix had landed in one of three places, so one run produced three verdicts: a red heap cell in the table, "within tolerance" in the callout below it, and `regressions: 1` in the linked report. Also that cross-window per-category deltas were still published, in colour, under a badge saying the baseline was incomplete.
- **Enumerating the class myself** rather than patching the reported instance then found a third site: `buildMemoryMetrics`. Heap min/max, node and listener counts are all extrema over the same window.
- **Round 3** found that making the guard symmetric had opened a new hole: per-category deltas were gated on the window alone, so a run that missed a category badged itself incomparable and then published a green `-100.0%` for that category one row below. `pctChange`'s zero-denominator guard had masked the mirror case, which is why only the new direction leaked. It also found the label misattributing a current-side failure to the baseline on two of three surfaces.

That is what `comparability()` exists for: the rule is stated once, and the per-category exemption comes from the verdict rather than from a condition re-derived at each call site.

### Follow-up

Whatever replaces the comparand also carries the `cell-editing` `selectCell` change. That change removes the 20 `page.evaluate` round trips from the measured window, and is deliberately **not** here: it redefines what the scenario measures, so for the next five develop pushes the median window would hold a mix of old-definition and new-definition snapshots, reading as a large sustained improvement that could mask a real regression. It is cheapest to land alongside a baseline change that invalidates the window anyway.

Two things reviewed and deliberately left:

- `updateCounters.documentsMin/Max` are parsed and medianed but reach no report. Pre-existing, and adding a Documents row is a display decision rather than a correctness fix.
- The symmetric guard means a genuine optimisation that drives a category to 0 ms is withheld as a capture failure rather than reported as a win. The replay bounds that cost: across 135 single develop runs standing in for a PR, none recorded exactly 0 ms in any active category. Note the bound is one-directional — the baseline side of a replay is a median, which dilutes a single zero capture, so it does not bound the baseline-side rate.

**This PR does not close the task.** It stops the comment publishing unsupportable numbers, which is worth having on its own — every fix here is about not asserting more than the measurement supports, and none of it changes when the baseline strategy is settled. The 3% residual and the runner-speed cause remain, and the task stays open for them.

### Reading this PR's own performance comment

No scenario golden is invalidated by this change, so any large delta on this PR's own comment is either a genuine finding or the runner-speed noise described above. Do not read a single run of it, green or red, as validating the change.

`[skip changelog]` — this PR only touches `performance-tests/**`, two CI files and two documentation files. No published package changes.

### How has this been tested?

- **New unit tests**, the first for any of these files: `thresholds.test.mjs` (48 cases), `report-builder.test.mjs` (28), `html-report-builder.test.mjs` (22). Between them they cover the comparability rule in all four states and at the boundaries, per-category gating in both directions, sample-vs-population CV at n=3, the bands tracking the callout constants, `n/a` degradation on all three no-history paths, the self-comparison path, cross-window suppression of timing, heap and memory, script-block containment, and the provenance footer. `median-snapshot.test.mjs` gains 2 cases for the new per-scenario spread.

  ```bash
  npm run test:tooling
  ```

  283 tests pass, up from 179.

- **Mutation-checked**, so the tests are not hollow. Five separate reversions each turn the suite red: population standard deviation in `calcCv`; a shared timing/heap threshold; dropping the heap threshold argument at the `Δ Heap` call site; ungating the memory deltas; ungating `categoryMetric`.

- **Rendered in a real browser.** The HTML report was served over HTTP and loaded in Chromium: no console errors, both script blocks parse, the provenance line renders, the incomparable card shows the right label, `Total active` carries a CV where it was hardcoded `null`, `Trace window (harness wall clock)` is labeled and uncoloured, and only a spread above the threshold is flagged.

- **The threshold derivation is reproducible** and committed, rather than a number chosen by eye:

  ```bash
  git fetch origin gh-pages
  node performance-tests/scripts/replay-goldens.mjs --since 2026-08-27
  ```

  It prints both curves and marks the value currently in force. It applies the same comparability rule the reports use and checks `windowSource` on the PR side, so it cannot count a comparison the shipped code would refuse to publish. Re-run after the symmetric-guard change: 0 skipped, curve unchanged, 15 still the knee.

- `npx eslint` clean on every touched file.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2629

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2629

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the performance-tests package, CI env for reports, and documentation—no Handsontable runtime or published package behavior.
> 
> **Overview**
> **Stops the sticky perf comment and HTML report from publishing percentage deltas when the comparison cannot support them.** A shared `comparability()` rule in `thresholds.mjs` gates every delta site for incomplete baselines, incomplete current captures, and trace **window mismatch** (including heap and memory extrema), with explicit labels instead of fake regressions like `+115.7%`.
> 
> **Makes reporting more honest and aligned across surfaces.** Timing vs heap regression callouts use separate thresholds (15% / 5%) with colour bands serialized from the same constants; the markdown table adds **CV run / base** (intra-run vs median-baseline spread from `median-snapshot.mjs`); provenance and `PERF_COMMIT_SHA` in CI fix cited commits on PRs; self-compare runs are labeled and no longer read as “within tolerance”; HTML payload/title escaping hardens fork branch names.
> 
> **Adds `scripts/replay-goldens.mjs`** to re-derive threshold false-positive rates from gh-pages goldens, plus large unit-test coverage for `thresholds`, `report-builder`, and `html-report-builder`. Docs/skills are updated for nine scenarios, thresholds, and withheld-delta behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3f1db383f080bf24361137390d7cf6935bd0ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->