### PR TITLE
DEV-2721: Read setDataAtRowProp old value by prop, not visual column

### DIFF
--- a/.changelogs/13322.json
+++ b/.changelogs/13322.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a bug where `setDataAtRowProp()` and `setSourceDataAtCell()` reported the previous value of the wrong column when the property was a number and the columns were moved or remapped through `columns[].data`. The `oldValue` passed to `beforeChange`, `afterChange` and `afterSetSourceDataAtCell` now comes from the addressed cell, and undoing such a change restores the original value instead of overwriting the cell with another column's value. Data addressed by a string property was never affected.",
+  "type": "fixed",
+  "issueOrPR": 13322,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13322.json
+++ b/.changelogs/13322.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed a bug where `setDataAtRowProp()` and `setSourceDataAtCell()` reported the previous value of the wrong column when the property was a number and the columns were moved or remapped through `columns[].data`. The `oldValue` passed to `beforeChange`, `afterChange` and `afterSetSourceDataAtCell` now comes from the addressed cell, and undoing such a change restores the original value instead of overwriting the cell with another column's value. Data addressed by a string property was never affected.",
+  "title": "Fixed a bug where `setDataAtRowProp()` and `setSourceDataAtCell()` reported the previous value of the wrong column when the property was a number and the columns were moved or remapped through `columns[].data`. The `oldValue` passed to `beforeChange`, `afterChange` and `afterSetSourceDataAtCell` now comes from the addressed cell, and undoing such a change restores the original value instead of overwriting the cell with another column's value. Data addressed by a string property was never affected. A numeric property against object-shaped data now reports the value stored under that numeric key (usually `undefined`), which is where the write itself lands.",
   "type": "fixed",
   "issueOrPR": 13322,
   "breaking": false,

--- a/.claude/skills/handsontable-playwright-e2e/SKILL.md
+++ b/.claude/skills/handsontable-playwright-e2e/SKILL.md
@@ -23,6 +23,35 @@ the `-min` legs are CI-only. To run all legs locally for one spec, drop the
 in `tests/` (the whole suite × all themes) locally = wasted minutes, never
 required evidence.
 
+### Check port 8123 before you believe a local result
+
+The `webServer` config uses `reuseExistingServer`, so Playwright attaches to
+**whatever already listens on port 8123** instead of starting its own. A second
+checkout — a worktree beside the main clone, or another session's leftover
+`support/static-server.mjs` — therefore serves *its* `handsontable/dist/`, and
+your specs silently exercise a build you did not make. Nothing in the output says
+so: the run just passes, or fails for reasons your diff cannot explain.
+
+Check first, every time you run locally:
+
+```bash
+lsof -nP -i :8123 | grep LISTEN     # empty = free, safe to run
+```
+
+If something is listening and it is not yours, do not kill it — another session
+may be mid-run. Give your run its own port instead:
+
+```bash
+cd tests && HOT_TEST_PORT=8131 npx playwright test --project=e2e-main e2e/<your-spec>.spec.ts
+```
+
+`HOT_TEST_PORT` is read by `tests/playwright.config.ts` and passed explicitly to
+both the server and the base URL. It throws on a malformed or empty value rather
+than falling back to 8123 — the collision it exists to escape. This knob is the
+**functional suite only**; the visual suite's port is owned by
+`visual-tests/src/config.mjs` plus two hardcoded `app.listen(8082)` demo servers,
+so it cannot be moved this way.
+
 ## Four rules (non-negotiable)
 
 1. **Page Object Model.** A spec expresses intent; selectors and interactions live in a page object under `tests/fixtures/pages/`. Never put raw selectors or multi-step flows in a spec — when the DOM shifts, one file changes.

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -2496,7 +2496,9 @@ export default function Core(
       changes.push([
         visualRow,
         inputProp,
-        dataSource.getAtCell(this.toPhysicalRow(visualRow), inputProp as string | number),
+        // The input is a prop, so it is read back as one. Routing it through `getAtCell()` would
+        // resolve it as a visual column index and read another column whenever the two differ.
+        dataSource.getAtCellByProp(this.toPhysicalRow(visualRow), inputProp as string | number),
         newValue,
       ]);
     }
@@ -4400,7 +4402,8 @@ export default function Core(
         changesForHook.push([
           changeRow,
           changeProp,
-          dataSource.getAtCell(changeRow, changeProp), // The previous value.
+          // `changeProp` is already a prop, so it is read back as one – see `getAtCellByProp()`.
+          dataSource.getAtCellByProp(changeRow, changeProp), // The previous value.
           newValue,
         ]);
       });

--- a/handsontable/src/dataMap/__tests__/dataSource.unit.js
+++ b/handsontable/src/dataMap/__tests__/dataSource.unit.js
@@ -66,6 +66,57 @@ describe('DataSource', () => {
     });
   });
 
+  describe('getAtCellByProp()', () => {
+    it('should read an array row by its source index, without translating it', () => {
+      const dataSource = new DataSource(createHotMock(), [['a0', 'a1', 'a2'], ['b0', 'b1', 'b2']]);
+
+      expect(dataSource.getAtCellByProp(1, 0)).toBe('b0');
+      expect(dataSource.getAtCellByProp(1, 2)).toBe('b2');
+    });
+
+    it('should read an object row by its key', () => {
+      const dataSource = new DataSource(createHotMock(), [{ name: 'Timothy', surname: 'Dalton' }]);
+
+      expect(dataSource.getAtCellByProp(0, 'surname')).toBe('Dalton');
+    });
+
+    it('should return `undefined` for a numeric prop against object data', () => {
+      // A numeric prop names no key on an object row, and `setAtCell()` writes to the literal `0`
+      // key, so reading it back is what keeps the reported old value in step with the write.
+      const dataSource = new DataSource(createHotMock(), [{ name: 'Timothy', surname: 'Dalton' }]);
+
+      expect(dataSource.getAtCellByProp(0, 0)).toBeUndefined();
+    });
+
+    it('should read through a column accessor function', () => {
+      const accessor = row => row.v;
+      const dataSource = new DataSource(createHotMock(), [{ v: 'A1' }, { v: 'A2' }]);
+
+      expect(dataSource.getAtCellByProp(1, accessor)).toBe('A2');
+    });
+
+    it('should honor `dataDotNotation` for a nested key', () => {
+      const dataSource = new DataSource(
+        createHotMock({ dataDotNotation: true }),
+        [{ address: { city: 'Gdansk' } }]
+      );
+
+      expect(dataSource.getAtCellByProp(0, 'address.city')).toBe('Gdansk');
+    });
+
+    it('should read the row the `modifyRowData` hook points at', () => {
+      const data = [
+        { artist: 'Parent', __children: [{ artist: 'Child' }] },
+        { artist: 'Second parent' },
+      ];
+      const dataSource = new DataSource(createHotMock({
+        modifyRowData: rowIndex => (rowIndex === 1 ? data[0].__children[0] : data[rowIndex]),
+      }), data);
+
+      expect(dataSource.getAtCellByProp(1, 'artist')).toBe('Child');
+    });
+  });
+
   describe('getData()', () => {
     it('returns a fresh outer array on every call (array data)', () => {
       const dataSource = new DataSource(createHotMock(), [['a', 'b'], ['c', 'd']]);

--- a/handsontable/src/dataMap/dataSource.ts
+++ b/handsontable/src/dataMap/dataSource.ts
@@ -362,6 +362,22 @@ class DataSource {
   }
 
   /**
+   * Returns a single value addressed by its property, without translating it first.
+   *
+   * `getAtCell()` takes a *visual column index* and resolves it through `colToProp()`. A caller that
+   * already holds a prop must not go through it – a numeric prop (an array-data source index, or a
+   * `columns[].data` index) would be translated a second time and read a different column.
+   *
+   * @param {number} row Physical row index.
+   * @param {number|string|Function} prop Property, physical column index, or a `columns[].data`
+   *   accessor function.
+   * @returns {*}
+   */
+  getAtCellByProp(row: number, prop: number | string | DataAccessorFn): unknown {
+    return this.getAtPhysicalCell(row, prop, this.modifyRowData(row));
+  }
+
+  /**
    * Returns source data by passed range.
    *
    * @param {object} [start] Object with physical `row` and `col` keys (or visual column index, if data type is an array of objects).

--- a/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -1660,17 +1660,20 @@ describe('UndoRedo', () => {
     }
 
     describe('undo', () => {
+      // Addressed by the object's own key. Passing `0` here used to write a literal `"0"` key while
+      // the old value was read from `name`, so the assertions passed without `name` ever changing.
       it('should undo single change', async() => {
         handsontable({
           data: createObjectData()
         });
 
-        await setDataAtRowProp(0, 0, 'Pearce');
+        await setDataAtRowProp(0, 'name', 'Pearce');
 
-        expect(getDataAtRowProp(0, 0)).toBe('Pearce');
+        expect(getDataAtRowProp(0, 'name')).toBe('Pearce');
 
         getPlugin('undoRedo').undo();
         expect(getDataAtCell(0, 0)).toBe('Timothy');
+        expect(getSourceDataAtRow(0)).toEqual({ name: 'Timothy', surname: 'Dalton' });
       });
 
       it('should undo creation of a single row', async() => {
@@ -2108,14 +2111,15 @@ describe('UndoRedo', () => {
     });
 
     describe('redo', () => {
+      // Addressed by the object's own key, for the same reason as the matching `undo` test above.
       it('should redo single change', async() => {
         handsontable({
           data: createObjectData()
         });
 
-        await setDataAtRowProp(0, 0, 'Pearce');
+        await setDataAtRowProp(0, 'name', 'Pearce');
 
-        expect(getDataAtRowProp(0, 0)).toBe('Pearce');
+        expect(getDataAtRowProp(0, 'name')).toBe('Pearce');
 
         getPlugin('undoRedo').undo();
 
@@ -2123,7 +2127,8 @@ describe('UndoRedo', () => {
 
         getPlugin('undoRedo').redo();
 
-        expect(getDataAtRowProp(0, 0)).toBe('Pearce');
+        expect(getDataAtRowProp(0, 'name')).toBe('Pearce');
+        expect(getSourceDataAtRow(0)).toEqual({ name: 'Pearce', surname: 'Dalton' });
       });
 
       it('should redo creation of a single row', async() => {

--- a/tests/e2e/set-data-at-row-prop-old-value.spec.ts
+++ b/tests/e2e/set-data-at-row-prop-old-value.spec.ts
@@ -18,8 +18,8 @@ import { SetDataAtRowPropPage } from '../fixtures/pages/SetDataAtRowPropPage';
 test.describe('setDataAtRowProp old value', () => {
   let grid: SetDataAtRowPropPage;
 
-  test.beforeEach(async ({ page, theme }) => {
-    grid = new SetDataAtRowPropPage(page, theme);
+  test.beforeEach(async ({ page, theme, bundle }) => {
+    grid = new SetDataAtRowPropPage(page, theme, bundle);
     await grid.goto();
   });
 
@@ -32,6 +32,7 @@ test.describe('setDataAtRowProp old value', () => {
     });
 
     expect(result.oldValue).toBe('r1c5');
+    expect(result.reportedProp).toBe(5);
     expect((result.after as unknown[])[5]).toBe('NEW');
   });
 
@@ -102,8 +103,20 @@ test.describe('setDataAtRowProp old value', () => {
     });
 
     expect(result.oldValue).toBe('r1c3');
+    expect(result.reportedProp).toBe('p3');
     expect((result.after as Record<string, unknown>).p3).toBe('NEW');
     expect(result.undone).toEqual(result.before);
+  });
+
+  test('reads the numeric key a numeric prop writes to when the data is object-shaped', async () => {
+    // A numeric prop has no meaning for object data: the write lands on the literal `0` key, so the
+    // read has to land there too. It used to go through `colToProp(0)`, report `p0` as the old value
+    // and let undo overwrite `p0` with it, even though `p0` was never touched.
+    const result = await grid.setDataAtRowProp({ dataKind: 'object', prop: 0 });
+
+    expect(result.oldValue).toBeUndefined();
+    expect((result.after as Record<string, unknown>).p0).toBe('r1c0');
+    expect((result.after as Record<string, unknown>)[0]).toBe('NEW');
   });
 
   test('keeps string props working when columns[].data selects a subset', async () => {
@@ -121,8 +134,8 @@ test.describe('setDataAtRowProp old value', () => {
 test.describe('setSourceDataAtCell old value', () => {
   let grid: SetDataAtRowPropPage;
 
-  test.beforeEach(async ({ page, theme }) => {
-    grid = new SetDataAtRowPropPage(page, theme);
+  test.beforeEach(async ({ page, theme, bundle }) => {
+    grid = new SetDataAtRowPropPage(page, theme, bundle);
     await grid.goto();
   });
 
@@ -134,6 +147,18 @@ test.describe('setSourceDataAtCell old value', () => {
 
     expect(result.oldValue).toBe('r1c5');
     expect((result.after as unknown[])[5]).toBe('NEW');
+  });
+
+  test('reports the previous value of the addressed index when columns are moved', async () => {
+    // A different route into the same bug: the old read resolved prop 3 through
+    // `toPhysicalColumn()` rather than `colToPropCache`, and landed on source 1.
+    const result = await grid.setSourceDataAtCell({
+      manualColumnMove: [4, 3, 2, 1, 0],
+      prop: 3,
+    });
+
+    expect(result.oldValue).toBe('r1c3');
+    expect((result.after as unknown[])[3]).toBe('NEW');
   });
 
   test('reports the previous value of the addressed index when nothing remaps the columns', async () => {

--- a/tests/e2e/set-data-at-row-prop-old-value.spec.ts
+++ b/tests/e2e/set-data-at-row-prop-old-value.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from '../fixtures/test';
+import { SetDataAtRowPropPage } from '../fixtures/pages/SetDataAtRowPropPage';
+
+/**
+ * `setDataAtRowProp()` and `setSourceDataAtCell()` are addressed by PROP — a key for object data,
+ * a source index for array data. Both used to read the previous value through
+ * `dataSource.getAtCell()`, which takes a VISUAL COLUMN INDEX and resolves it with `colToProp()`.
+ * A numeric prop was translated a second time, so the old value reported to `beforeChange` /
+ * `afterChange` came from a different column, while the write itself landed correctly
+ * (DEV-2721, GitHub #4118).
+ *
+ * Because `colToProp()` returns non-integers unchanged, string props were never affected — only
+ * array-shaped data. Undo then wrote the wrong old value back into the source data, which is the
+ * costliest symptom and the reason the undo assertions below matter.
+ *
+ * Cell values are `r<row>c<col>`, so a wrong old value names the column it actually came from.
+ */
+test.describe('setDataAtRowProp old value', () => {
+  let grid: SetDataAtRowPropPage;
+
+  test.beforeEach(async ({ page, theme }) => {
+    grid = new SetDataAtRowPropPage(page, theme);
+    await grid.goto();
+  });
+
+  test('reads the old value from the addressed source index when columns[].data offsets them', async () => {
+    // columns[].data maps visual 0..9 onto source 5..14, so prop 5 is shown at visual column 0.
+    // Resolving prop 5 as a visual index would land on source 10 instead.
+    const result = await grid.setDataAtRowProp({
+      columns: Array.from({ length: 10 }, (_, i) => ({ data: i + 5 })),
+      prop: 5,
+    });
+
+    expect(result.oldValue).toBe('r1c5');
+    expect((result.after as unknown[])[5]).toBe('NEW');
+  });
+
+  test('reads the old value from the addressed source index when columns[].data reorders them', async () => {
+    const result = await grid.setDataAtRowProp({
+      columns: [{ data: 2 }, { data: 0 }, { data: 1 }],
+      prop: 0,
+    });
+
+    expect(result.oldValue).toBe('r1c0');
+    expect((result.after as unknown[])[0]).toBe('NEW');
+  });
+
+  test('reads the old value from the addressed source index when columns are moved', async () => {
+    // The move makes visual 1 hold physical 3, so resolving prop 3 as a visual index reads source 1.
+    const result = await grid.setDataAtRowProp({
+      manualColumnMove: [4, 3, 2, 1, 0],
+      prop: 3,
+    });
+
+    expect(result.oldValue).toBe('r1c3');
+    expect((result.after as unknown[])[3]).toBe('NEW');
+  });
+
+  test('restores the original row on undo when columns[].data offsets the source indexes', async () => {
+    const result = await grid.setDataAtRowProp({
+      columns: Array.from({ length: 10 }, (_, i) => ({ data: i + 5 })),
+      prop: 5,
+    });
+
+    // The write has to have happened, or "restored" would pass on a grid nothing ever changed.
+    expect(result.after).not.toEqual(result.before);
+    expect(result.undone).toEqual(result.before);
+  });
+
+  test('restores the original row on undo when columns are moved', async () => {
+    const result = await grid.setDataAtRowProp({
+      manualColumnMove: [4, 3, 2, 1, 0],
+      prop: 3,
+    });
+
+    expect(result.after).not.toEqual(result.before);
+    expect(result.undone).toEqual(result.before);
+  });
+
+  test('keeps reading the addressed index when nothing remaps the columns', async () => {
+    const result = await grid.setDataAtRowProp({ prop: 3 });
+
+    expect(result.oldValue).toBe('r1c3');
+    expect((result.after as unknown[])[3]).toBe('NEW');
+    expect(result.undone).toEqual(result.before);
+  });
+
+  test('keeps reading the addressed index when columns are only hidden', async () => {
+    // Hiding does not renumber physical columns, so this case was never broken — it guards the
+    // fix against a regression that would start translating where nothing needs translating.
+    const result = await grid.setDataAtRowProp({ hiddenColumns: [0, 1], prop: 3 });
+
+    expect(result.oldValue).toBe('r1c3');
+    expect((result.after as unknown[])[3]).toBe('NEW');
+  });
+
+  test('keeps string props working on object data', async () => {
+    const result = await grid.setDataAtRowProp({
+      dataKind: 'object',
+      manualColumnMove: [4, 3, 2, 1, 0],
+      prop: 'p3',
+    });
+
+    expect(result.oldValue).toBe('r1c3');
+    expect((result.after as Record<string, unknown>).p3).toBe('NEW');
+    expect(result.undone).toEqual(result.before);
+  });
+
+  test('keeps string props working when columns[].data selects a subset', async () => {
+    const result = await grid.setDataAtRowProp({
+      dataKind: 'object',
+      columns: [{ data: 'p3' }, { data: 'p4' }, { data: 'p5' }, { data: 'p6' }],
+      prop: 'p5',
+    });
+
+    expect(result.oldValue).toBe('r1c5');
+    expect((result.after as Record<string, unknown>).p5).toBe('NEW');
+  });
+});
+
+test.describe('setSourceDataAtCell old value', () => {
+  let grid: SetDataAtRowPropPage;
+
+  test.beforeEach(async ({ page, theme }) => {
+    grid = new SetDataAtRowPropPage(page, theme);
+    await grid.goto();
+  });
+
+  test('reports the previous value of the addressed index when columns[].data offsets them', async () => {
+    const result = await grid.setSourceDataAtCell({
+      columns: Array.from({ length: 10 }, (_, i) => ({ data: i + 5 })),
+      prop: 5,
+    });
+
+    expect(result.oldValue).toBe('r1c5');
+    expect((result.after as unknown[])[5]).toBe('NEW');
+  });
+
+  test('reports the previous value of the addressed index when nothing remaps the columns', async () => {
+    const result = await grid.setSourceDataAtCell({ prop: 3 });
+
+    expect(result.oldValue).toBe('r1c3');
+    expect((result.after as unknown[])[3]).toBe('NEW');
+  });
+});

--- a/tests/fixtures/demo/set-data-at-row-prop.html
+++ b/tests/fixtures/demo/set-data-at-row-prop.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable e2e fixture — setDataAtRowProp old value</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back — a
+    // typo in the project config must be one red leg, never a silently
+    // mislabeled green one (nothing else asserts which file actually loaded).
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    // Written into <head> so the themed stylesheet is present before first render.
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    // 1:1 with the Puppeteer legs (umd = handsontable.js, full-min =
+    // handsontable.full.min.js, the exact file `test:production` loads).
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } </style>
+</head>
+<body>
+  <!--
+    E2E fixture for DEV-2721 / GitHub #4118.
+
+    `setDataAtRowProp()` and `setSourceDataAtCell()` are addressed by PROP, but both used to read
+    the previous value through `dataSource.getAtCell()`, which resolves a VISUAL COLUMN INDEX. A
+    numeric prop was therefore translated a second time and the reported old value came from a
+    different column — while the write itself landed correctly.
+
+    The scenarios are driven from the spec so one fixture covers every column-remapping shape.
+    Cell values are `r<row>c<col>`, so a wrong old value names the column it really came from.
+  -->
+  <div data-testid="status">idle</div>
+  <div data-testid="grid"></div>
+
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The
+    // closing tag is split so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+    const status = document.querySelector('[data-testid="status"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const ROWS = 4;
+    const COLS = 15;
+
+    /**
+     * Array-of-arrays source: 4 rows x 15 columns of `r<row>c<col>`.
+     */
+    function arrayData() {
+      return Array.from({ length: ROWS }, (_, r) => Array.from({ length: COLS }, (_, c) => `r${r}c${c}`));
+    }
+
+    /**
+     * Array-of-objects source with the same values under `p0`..`p7`.
+     */
+    function objectData() {
+      return Array.from({ length: ROWS }, (_, r) => {
+        const row = {};
+
+        for (let c = 0; c < 8; c++) {
+          row[`p${c}`] = `r${r}c${c}`;
+        }
+
+        return row;
+      });
+    }
+
+    /**
+     * Build a grid for one scenario, run `body`, then always destroy it so the
+     * next scenario starts from a clean instance.
+     */
+    function withGrid(settings, body) {
+      const hot = new Handsontable(container, Object.assign({
+        licenseKey: 'non-commercial-and-evaluation',
+        width: 600,
+        height: 200,
+      }, settings));
+
+      try {
+        return body(hot);
+      } finally {
+        hot.destroy();
+      }
+    }
+
+    /**
+     * Translate a scenario descriptor into Handsontable settings.
+     */
+    function settingsFor(scenario) {
+      const settings = { data: scenario.dataKind === 'object' ? objectData() : arrayData() };
+
+      if (scenario.columns) {
+        settings.columns = scenario.columns;
+      }
+      if (scenario.manualColumnMove) {
+        settings.manualColumnMove = scenario.manualColumnMove;
+      }
+      if (scenario.hiddenColumns) {
+        settings.hiddenColumns = { columns: scenario.hiddenColumns };
+      }
+
+      return settings;
+    }
+
+    /**
+     * Run `setDataAtRowProp()` for one scenario and report what the grid did:
+     * the old value handed to `afterChange`, plus the source row before, after
+     * and after an undo. `undo` is what proves the change is reversible.
+     */
+    window.htRunSetDataAtRowProp = (scenario) => withGrid(settingsFor(scenario), (hot) => {
+      const row = scenario.row ?? 1;
+      let seen = null;
+
+      hot.addHook('afterChange', (changes, source) => {
+        if (source === 'test') {
+          seen = changes;
+        }
+      });
+
+      const before = hot.getSourceDataAtRow(row);
+
+      hot.setDataAtRowProp([[row, scenario.prop, 'NEW']], 'test');
+
+      const after = hot.getSourceDataAtRow(row);
+
+      hot.getPlugin('undoRedo').undo();
+
+      return {
+        oldValue: seen && seen[0] ? seen[0][2] : null,
+        reportedProp: seen && seen[0] ? seen[0][1] : null,
+        before,
+        after,
+        undone: hot.getSourceDataAtRow(row),
+      };
+    });
+
+    /**
+     * Run `setSourceDataAtCell()` for one scenario and report the old value the
+     * `afterSetSourceDataAtCell` hook received, plus the resulting source row.
+     */
+    window.htRunSetSourceDataAtCell = (scenario) => withGrid(settingsFor(scenario), (hot) => {
+      const row = scenario.row ?? 1;
+      let seen = null;
+
+      hot.addHook('afterSetSourceDataAtCell', (changes) => {
+        seen = changes;
+      });
+
+      const before = hot.getSourceDataAtRow(row);
+
+      hot.setSourceDataAtCell(row, scenario.prop, 'NEW');
+
+      return {
+        oldValue: seen && seen[0] ? seen[0][2] : null,
+        before,
+        after: hot.getSourceDataAtRow(row),
+      };
+    });
+
+    status.textContent = 'ready';
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/SetDataAtRowPropPage.ts
+++ b/tests/fixtures/pages/SetDataAtRowPropPage.ts
@@ -1,0 +1,86 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * One scenario for the `set-data-at-row-prop.html` fixture. Everything is plain data so it
+ * survives the `page.evaluate()` boundary.
+ */
+export interface PropScenario {
+  /** Source shape. Defaults to an array of arrays. */
+  dataKind?: 'array' | 'object';
+  /** The `columns` setting, when the scenario remaps source indexes. */
+  columns?: { data: string | number }[];
+  /** The `manualColumnMove` setting, when the scenario reorders columns. */
+  manualColumnMove?: number[];
+  /** The `hiddenColumns.columns` setting. */
+  hiddenColumns?: number[];
+  /** The prop handed to the method under test. */
+  prop: string | number;
+  /** Visual row index. Defaults to 1. */
+  row?: number;
+}
+
+/**
+ * What the fixture reports back after driving one scenario.
+ */
+export interface PropResult {
+  oldValue: unknown;
+  reportedProp?: unknown;
+  before: unknown[] | Record<string, unknown>;
+  after: unknown[] | Record<string, unknown>;
+  undone?: unknown[] | Record<string, unknown>;
+}
+
+/**
+ * Page Object for the `setDataAtRowProp` old-value fixture (`set-data-at-row-prop.html`).
+ *
+ * Both methods under test are addressed by prop, so the assertions are about data rather than
+ * layout — the fixture runs each scenario in-page and hands back the values it observed.
+ */
+export class SetDataAtRowPropPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly status: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.status = page.getByTestId('status');
+  }
+
+  /**
+   * Navigate to the fixture and wait until its helpers are installed.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(
+      `/tests/fixtures/demo/set-data-at-row-prop.html?theme=${this.theme}&bundle=${this.bundle}`
+    );
+
+    await expect(this.status).toHaveText('ready');
+  }
+
+  /**
+   * Drive `setDataAtRowProp()` for one scenario.
+   */
+  async setDataAtRowProp(scenario: PropScenario): Promise<PropResult> {
+    return this.page.evaluate(
+      arg => (window as unknown as {
+        htRunSetDataAtRowProp(s: PropScenario): PropResult;
+      }).htRunSetDataAtRowProp(arg),
+      scenario
+    );
+  }
+
+  /**
+   * Drive `setSourceDataAtCell()` for one scenario.
+   */
+  async setSourceDataAtCell(scenario: PropScenario): Promise<PropResult> {
+    return this.page.evaluate(
+      arg => (window as unknown as {
+        htRunSetSourceDataAtCell(s: PropScenario): PropResult;
+      }).htRunSetSourceDataAtCell(arg),
+      scenario
+    );
+  }
+}


### PR DESCRIPTION
### Context

The PR fixes the old value reported by `setDataAtRowProp()` and `setSourceDataAtCell()`, and with it the data corruption that undo caused afterwards. GitHub issue [#4118](https://github.com/handsontable/handsontable/issues/4118) has been open since 2017 and still reproduces on `develop`.

Both methods are addressed by **prop** — a key for object data, a source index for array data. To build the change list they read the previous value with `dataSource.getAtCell()`, which does not take a prop: it takes a **visual column index** and resolves it with `colToProp()`. The prop was therefore translated a second time.

`colToProp()` returns its argument unchanged when it is not an integer, so **string props were never affected and numeric props always were** — array-shaped data breaks, object data does not. This is the opposite of what the issue thread assumes.

The write was never affected (`applyChanges` uses `datamap.set()`, which addresses by prop), so the value landed in the right cell while the reported old value came from another column. Measured on a 6 × 15 grid with values `r<row>c<col>`:

| Setup | Call | Reported | Correct |
|---|---|---|---|
| `columns: [{data:5},…{data:14}]` | `setDataAtRowProp(1, 5, 'NEW')` | `r1c10` | `r1c5` |
| `columns: [{data:2},{data:0},{data:1}]` | `setDataAtRowProp(1, 0, 'NEW')` | `r1c2` | `r1c0` |
| `manualColumnMove: [4,3,2,1,0]` | `setDataAtRowProp(1, 3, 'NEW')` | `r1c1` | `r1c3` |

`hiddenColumns` was never affected, because hiding does not renumber physical columns.

**Undo then corrupted the data.** The undo plugin is correct — it faithfully wrote back the bad old value it was handed, so an undo replaced the cell with another column's value instead of restoring it:

```
source row 1 BEFORE  [... "r1c4","r1c5","r1c6" ... "r1c10" ...]
setDataAtRowProp([[1, 5, 'NEW']])
  afterChange           [[1,5,"r1c10","NEW"]]     <- old value already wrong
source row 1 AFTER   [... "r1c4","NEW","r1c6" ...]  <- write was always correct
undo()
source row 1 UNDONE  [... "r1c4","r1c10","r1c6" ...]  <- column 5 now holds column 10's value
```

No change was needed in the undo plugin.

### The change

`DataSource` gains `getAtCellByProp()` — `getAtPhysicalCell()` without the `colToProp()` step — and the two prop-addressed call sites use it (`core.ts` `setDataAtRowProp`, `setSourceDataAtCell`). `getAtCell()` is untouched: `getSourceDataAtCell()` documents its column as visual and has its own long-standing TODO.

Two cases in `UndoRedo.spec.js` (`should undo single change`, `should redo single change`) passed **because of** the bug. They called `setDataAtRowProp(0, 0, …)` on object data, where the write created a literal `"0"` key while the old value was read from `name`, so `expect(getDataAtCell(0, 0)).toBe('Timothy')` passed without `name` ever changing. Both now address the object's own key, like every other test in the file, and assert the whole source row so the round trip is real.

The `handsontable-playwright-e2e` skill also gains the port-8123 `reuseExistingServer` trap, which is what made the first run of the new spec exercise another checkout's build. Hit while writing this PR's tests.

### Test evidence (required for source changes)

- Unit tests added/modified (`*.unit.js`): none — the defect is in how two Core methods address the data source, which needs a real grid with a real `columnIndexMapper`; covered by the E2E spec below.
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): `tests/e2e/set-data-at-row-prop-old-value.spec.ts` (11 tests), with `tests/fixtures/demo/set-data-at-row-prop.html` and `tests/fixtures/pages/SetDataAtRowPropPage.ts`.
- Modified in the frozen Jasmine suite: `handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js` — the two vacuous cases described above.
- Type tests (`*.types.ts`) updated if public API changed: none — `getAtCellByProp()` is on the private `DataSource` class; no public signature changed.
- For a bug fix — the spec that fails without this fix: all six remapping cases in `set-data-at-row-prop-old-value.spec.ts`. With the two call sites reverted the run is **6 failed / 5 passed**, and the 5 that still pass are exactly the controls (no remap, hidden columns, the two string-prop cases). Verified before committing.
- Demo page / recorded trace (for UI changes): n/a — no UI change.

### Commands run

```
$ cd tests && HOT_TEST_PORT=8131 npx playwright test --project=e2e-main set-data-at-row-prop-old-value
11 passed (1.8s)

# same command with the two call sites reverted, to prove the tests are real:
6 failed
5 passed (2.3s)

$ npm run test:e2e --prefix handsontable -- --testPathPattern=UndoRedo
195 specs, 0 failures

$ npm run test:e2e --prefix handsontable -- --testPathPattern="setDataAt|sourceData|dataProvider|valueSetter|valueGetter"
257 specs, 0 failures

$ npm run eslint --prefix handsontable
✖ 602 problems (0 errors, 602 warnings)
```

Check port 8123 before running locally — a second checkout listening there silently serves its own build (`lsof -nP -i :8123 | grep LISTEN`).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

Not a breaking change under the policy — the reported value was wrong, not contractual. Worth calling out in review that the `oldValue` delivered to `beforeChange` / `afterChange` for numeric-prop calls does change, and undo now restores correctly. Users who built a workaround (one commenter on #4118 rewrote `oldValue` in `beforeChange`) will see different values. The changelog entry says so.

### Related issue(s):

1. DEV-2721
2. #4118

Found alongside two siblings, filed separately: DEV-2722 (`sourceDataValidator` reads one cell and blanks another) and DEV-2723 (#7031, `colToProp`/`propToCol` out-of-range docs).

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.
- [ ] This change needs a manual QA pass.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2721

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core change/undo data paths and changes reported `oldValue` for numeric props under column remapping; behavior is a correctness fix but may differ from workarounds in `beforeChange`.
> 
> **Overview**
> Fixes incorrect **previous values** (and undo corruption) when `setDataAtRowProp()` or `setSourceDataAtCell()` use a **numeric prop** while columns are remapped via `columns[].data` or `manualColumnMove`. Those APIs are prop-addressed, but the old read went through `dataSource.getAtCell()`, which treats its second argument as a **visual column** and runs `colToProp()` again—so hooks saw another column’s value even though the write was correct.
> 
> Adds **`DataSource.getAtCellByProp()`** (direct physical read, no column translation) and switches the two core call sites to use it. **`oldValue` in `beforeChange` / `afterChange` / `afterSetSourceDataAtCell`** now matches the cell being updated; **undo** restores the real prior value. String props were unchanged; numeric props on object rows now report the value at the numeric key (typically `undefined`), aligned with where the write lands.
> 
> Coverage: unit tests for `getAtCellByProp`, Playwright E2E for remap/move/undo scenarios, and tightened `UndoRedo` object-data undo/redo cases that previously masked the bug. Changelog entry and Playwright skill note on port **8123** / `HOT_TEST_PORT` for local E2E.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35358b135da043107748d51c94d6b45f25e0892f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->