### PR TITLE
DEV-2723: Document colToProp/propToCol out-of-range return

### DIFF
--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -53,8 +53,7 @@ npm run test --prefix wrappers/angular-wrapper
 The repository has a PR template at `.github/PULL_REQUEST_TEMPLATE.md`. Fill in each section:
 
 - **Context** -- Explain *why* the change is needed, not just what changed. Link the ClickUp task or GitHub issue.
-- **Test evidence** -- Fill in every bullet the template lists; write "none" with a reason rather than deleting a line. For a bug fix, name the spec that fails without the fix and the red/green counts you actually measured.
-- **Commands run** -- Paste the commands and their final output lines, so a reviewer can re-run them.
+- **How has this been tested?** -- List the specific tests you added or ran (unit, E2E, manual). Include commands someone can copy-paste to reproduce.
 - **Types of changes** -- Check the box that applies: bug fix, new feature, breaking change, or translation.
 - **Related issue(s)** -- Link GitHub issues with `#xxx`. Include ClickUp task IDs (e.g. `DEV-627`) so they auto-link.
 - **Affected project(s)** -- Check every package your change touches: `handsontable`, `@handsontable/react-wrapper`, `@handsontable/angular-wrapper`, `@handsontable/vue3`.
@@ -103,31 +102,16 @@ gh pr create --draft --base develop \
   --body-file /tmp/pr-body-DEV-xxx.md
 ```
 
-The body file template (write this with the Write tool, backticks and all, no escaping).
-
-**Mirror `.github/PULL_REQUEST_TEMPLATE.md`, and re-read it before you write** — it is the source of
-truth and it changes. Do not invent or rename sections: a body with `### How has this been tested?`
-in place of `### Test evidence` and `### Commands run` silently drops the evidence bullets a reviewer
-looks for. **Tick a box in every checkbox group**, `Types of changes` included: there is no
-documentation-only option, so a docs or test correction goes under `Bug fix` with a line saying
-what defect it fixes. Leaving the whole group empty reads as an unfilled template.
+The body file template (write this with the Write tool, backticks and all, no escaping):
 
 ```markdown
 ### Context
 
 <why this change is needed; link the task and explain the problem>
 
-### Test evidence (required for source changes)
+### How has this been tested?
 
-- Unit tests added/modified (`*.unit.js`): <paths, or "none — covered by <path>">
-- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): <paths>
-- Type tests (`*.types.ts`) updated if public API changed: <paths, or "none — no signature changed">
-- For a bug fix — the spec that fails without this fix: <name, and the red/green counts you measured>
-- Demo page / recorded trace (for UI changes): <link, or "n/a">
-
-### Commands run
-
-<the commands and their final output lines, pasted>
+- <tests you added or ran, with commands>
 
 ### Types of changes
 
@@ -152,7 +136,6 @@ what defect it fixes. Leaving the whole group empty reads as an unfilled templat
 - [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
 - [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
 - [ ] My change requires a change to the documentation.
-- [ ] This change needs a manual QA pass.
 
 ClickUp task: https://app.clickup.com/t/9015210959/DEV-xxx
 ```

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -53,7 +53,8 @@ npm run test --prefix wrappers/angular-wrapper
 The repository has a PR template at `.github/PULL_REQUEST_TEMPLATE.md`. Fill in each section:
 
 - **Context** -- Explain *why* the change is needed, not just what changed. Link the ClickUp task or GitHub issue.
-- **How has this been tested?** -- List the specific tests you added or ran (unit, E2E, manual). Include commands someone can copy-paste to reproduce.
+- **Test evidence** -- Fill in every bullet the template lists; write "none" with a reason rather than deleting a line. For a bug fix, name the spec that fails without the fix and the red/green counts you actually measured.
+- **Commands run** -- Paste the commands and their final output lines, so a reviewer can re-run them.
 - **Types of changes** -- Check the box that applies: bug fix, new feature, breaking change, or translation.
 - **Related issue(s)** -- Link GitHub issues with `#xxx`. Include ClickUp task IDs (e.g. `DEV-627`) so they auto-link.
 - **Affected project(s)** -- Check every package your change touches: `handsontable`, `@handsontable/react-wrapper`, `@handsontable/angular-wrapper`, `@handsontable/vue3`.
@@ -102,16 +103,31 @@ gh pr create --draft --base develop \
   --body-file /tmp/pr-body-DEV-xxx.md
 ```
 
-The body file template (write this with the Write tool, backticks and all, no escaping):
+The body file template (write this with the Write tool, backticks and all, no escaping).
+
+**Mirror `.github/PULL_REQUEST_TEMPLATE.md`, and re-read it before you write** — it is the source of
+truth and it changes. Do not invent or rename sections: a body with `### How has this been tested?`
+in place of `### Test evidence` and `### Commands run` silently drops the evidence bullets a reviewer
+looks for. **Tick a box in every checkbox group**, `Types of changes` included: there is no
+documentation-only option, so a docs or test correction goes under `Bug fix` with a line saying
+what defect it fixes. Leaving the whole group empty reads as an unfilled template.
 
 ```markdown
 ### Context
 
 <why this change is needed; link the task and explain the problem>
 
-### How has this been tested?
+### Test evidence (required for source changes)
 
-- <tests you added or ran, with commands>
+- Unit tests added/modified (`*.unit.js`): <paths, or "none — covered by <path>">
+- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): <paths>
+- Type tests (`*.types.ts`) updated if public API changed: <paths, or "none — no signature changed">
+- For a bug fix — the spec that fails without this fix: <name, and the red/green counts you measured>
+- Demo page / recorded trace (for UI changes): <link, or "n/a">
+
+### Commands run
+
+<the commands and their final output lines, pasted>
 
 ### Types of changes
 
@@ -136,6 +152,7 @@ The body file template (write this with the Write tool, backticks and all, no es
 - [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
 - [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
 - [ ] My change requires a change to the documentation.
+- [ ] This change needs a manual QA pass.
 
 ClickUp task: https://app.clickup.com/t/9015210959/DEV-xxx
 ```

--- a/handsontable/src/__tests__/core/colToProp.spec.js
+++ b/handsontable/src/__tests__/core/colToProp.spec.js
@@ -66,6 +66,41 @@ describe('Core.colToProp', () => {
     columnIndexMapper().setIndexesSequence([3, 2, 1, 0]);
 
     expect(colToProp(0)).toBe('date');
-    expect(propToCol(10)).toBe(10); // I'm not sure if this should return result like that by design.
+    // Was `propToCol(10)` — a copy of the propToCol spec that left `colToProp` out of range
+    // untested. The pass-through below is by design (introduced with the index mappers in #5945)
+    // and is what the API reference documents.
+    expect(colToProp(10)).toBe(10);
+  });
+
+  it('should hand an out-of-range column index back unchanged', async() => {
+    handsontable({
+      data: createSpreadsheetData(2, 3),
+    });
+
+    expect(colToProp(10)).toBe(10);
+    expect(colToProp(-1)).toBe(-1);
+  });
+
+  it('should hand a non-integer argument back unchanged, `null` included', async() => {
+    handsontable({
+      data: createSpreadsheetData(2, 3),
+    });
+
+    // `UndoRedo`'s row-removal action relies on this echo: it feeds `colToProp` the result of
+    // `toVisualColumn`, which is `null` for a trimmed column, and bails out on a non-accessor.
+    expect(colToProp(null)).toBe(null);
+    expect(colToProp('name')).toBe('name');
+  });
+
+  it('should return `null` for a column declared as `{ data: null }`', async() => {
+    handsontable({
+      data: createSpreadsheetData(2, 2),
+      columns: [{ data: null }, { data: 1 }],
+    });
+
+    // A valid, in-range index that still resolves to `null` — so a `null` result does not mean
+    // "no such column".
+    expect(countCols()).toBe(2);
+    expect(colToProp(0)).toBe(null);
   });
 });

--- a/handsontable/src/__tests__/core/colToProp.spec.js
+++ b/handsontable/src/__tests__/core/colToProp.spec.js
@@ -49,7 +49,9 @@ describe('Core.colToProp', () => {
     columnIndexMapper().setIndexesSequence([4, 3, 2, 1, 0]);
 
     expect(colToProp(0)).toBe(4);
-    expect(colToProp(10)).toBe(10); // I'm not sure if this should return result like that by design.
+    // The pass-through below is by design (introduced with the index mappers in #5945) and is what
+    // the API reference documents.
+    expect(colToProp(10)).toBe(10);
   });
 
   it('should return proper value after calling the function when columns was reorganized (data is array of objects)', async() => {

--- a/handsontable/src/__tests__/core/propToCol.spec.js
+++ b/handsontable/src/__tests__/core/propToCol.spec.js
@@ -80,7 +80,10 @@ describe('Core.propToCol', () => {
     expect(propToCol('name')).toBe(null);
   });
 
-  it('should hand back a bare physical index whose column is trimmed (array data)', async() => {
+  // Not a specification of correct behavior — this pins a defect so the JSDoc and the code cannot
+  // drift apart. See the comment on the assertion below.
+  it('pins known defect DEV-2726: a bare physical index whose column is trimmed comes back ' +
+    'unchanged instead of `null` (array data)', async() => {
     const hot = handsontable({
       data: [
         ['a0', 'a1', 'a2', 'a3'],

--- a/handsontable/src/__tests__/core/propToCol.spec.js
+++ b/handsontable/src/__tests__/core/propToCol.spec.js
@@ -33,7 +33,9 @@ describe('Core.propToCol', () => {
     columnIndexMapper().setIndexesSequence([4, 3, 2, 1, 0]);
 
     expect(propToCol(0)).toBe(4);
-    expect(propToCol(10)).toBe(10); // I'm not sure if this should return result like that by design.
+    // By design: an unmatched property comes straight back (introduced with the index mappers in
+    // #5945, and `applyChanges()` depends on it to grow the grid past the last column).
+    expect(propToCol(10)).toBe(10);
   });
 
   it('should return proper value after calling the function when columns was reorganized (data is array of objects)', async() => {
@@ -51,6 +53,30 @@ describe('Core.propToCol', () => {
 
     expect(propToCol('id')).toBe(3);
     expect(propToCol(0)).toBe(3);
-    expect(propToCol(10)).toBe(10); // I'm not sure if this should return result like that by design.
+    // By design: an unmatched property comes straight back (introduced with the index mappers in
+    // #5945, and `applyChanges()` depends on it to grow the grid past the last column).
+    expect(propToCol(10)).toBe(10);
+  });
+
+  it('should return `null` for a property whose column is trimmed', async() => {
+    const hot = handsontable({
+      data: [
+        { id: 1, name: 'Ted', lastName: 'Right' },
+        { id: 2, name: 'Frank', lastName: 'Honest' },
+      ]
+    });
+
+    expect(propToCol('name')).toBe(1);
+
+    const trimmingMap = hot.columnIndexMapper.createAndRegisterIndexMap('spec-trim', 'trimming');
+
+    trimmingMap.setValueAtIndex(1, true);
+
+    await render();
+
+    // A cached property resolves through `toVisualColumn()`, which has no visual index left to
+    // return. So `null` is a real result here — the unmatched-property echo does not cover it, and
+    // a `result < countCols()` guard would let this `null` through as column 0.
+    expect(propToCol('name')).toBe(null);
   });
 });

--- a/handsontable/src/__tests__/core/propToCol.spec.js
+++ b/handsontable/src/__tests__/core/propToCol.spec.js
@@ -79,4 +79,32 @@ describe('Core.propToCol', () => {
     // a `result < countCols()` guard would let this `null` through as column 0.
     expect(propToCol('name')).toBe(null);
   });
+
+  it('should hand back a bare physical index whose column is trimmed (array data)', async() => {
+    const hot = handsontable({
+      data: [
+        ['a0', 'a1', 'a2', 'a3'],
+        ['b0', 'b1', 'b2', 'b3'],
+      ]
+    });
+
+    const trimmingMap = hot.columnIndexMapper.createAndRegisterIndexMap('spec-trim-array', 'trimming');
+
+    trimmingMap.setValueAtIndex(1, true);
+
+    await render();
+
+    expect(hot.toVisualColumn(1)).toBe(null);
+
+    // KNOWN DEFECT, tracked as DEV-2726. Plain array data caches no properties, so this takes the
+    // uncached branch, which falls back to the passed index instead of returning `null` like the
+    // cached branch above. The index it returns addresses a DIFFERENT column — visual 1 is physical
+    // 2 here — so the caller gets a wrong answer rather than an unknown one.
+    //
+    // Pinned to keep the documented behavior and the code in step. When DEV-2726 lands this
+    // expectation becomes `null`, and the `propToCol` JSDoc in `core.ts` has to be simplified with
+    // it.
+    expect(propToCol(1)).toBe(1);
+    expect(hot.toPhysicalColumn(1)).toBe(2);
+  });
 });

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -4094,17 +4094,20 @@ export default function Core(
    * Returns the property name that corresponds with the given column index.
    * If the data source is an array of arrays, it returns the columns index.
    *
-   * When the column index does not point at an existing column, the method returns the argument you
-   * passed, unchanged. It does not return `null`, unlike {@link Core#toVisualColumn} and the other
-   * index translators. Check the index against {@link Core#countCols} first if you need to tell an
-   * out-of-range call apart from a real result.
+   * When the column index points at no existing column, the method hands the argument back
+   * unchanged. It does not signal an unknown column, so the result on its own never tells you
+   * whether that column exists.
+   *
+   * The result can also be `null`, in two cases: an argument that is not an integer comes straight
+   * back, and a column declared as `{ data: null }` resolves to `null` for an index that is
+   * perfectly valid. Test the result before you use it as a property name.
    *
    * @memberof Core#
    * @function colToProp
    * @param {number} column Visual column index.
-   * @returns {string|number} Column property, physical column index, or the passed argument. When
-   *   the column's `data` option is an accessor function, that function is returned at runtime –
-   *   check `typeof` before treating the result as a property name.
+   * @returns {string|number|null} Column property, physical column index, `null`, or the passed
+   *   argument. When the column's `data` option is an accessor function, that function is returned
+   *   at runtime – check `typeof` before treating the result as a property name.
    */
   this.colToProp = function(column: number) {
     return datamap.colToProp(column);
@@ -4113,16 +4116,23 @@ export default function Core(
   /**
    * Returns column index that corresponds with the given property.
    *
-   * When the property matches no column, the method returns the argument you passed, unchanged. It
-   * does not return `null`, unlike {@link Core#toVisualColumn} and the other index translators. The
-   * TypeScript declaration narrows the result to `number`, so a returned property name is not
-   * visible to the type checker – compare against {@link Core#countCols} when the property may be
-   * unknown.
+   * When the property matches no column, the method hands the argument back unchanged, so the
+   * result on its own never tells you whether that column exists.
+   *
+   * The result can also be `null`: a property whose column is trimmed resolves through
+   * {@link Core#toVisualColumn}, which has no visual index left to return. Test the result with
+   * `Number.isInteger()` before using it as a column index. Comparing it against
+   * {@link Core#countCols} is not enough – `null` compares as `0` and passes such a check.
+   *
+   * The TypeScript declaration narrows the result to `number`, so neither a returned property name
+   * nor `null` is visible to the type checker.
    *
    * @memberof Core#
    * @function propToCol
-   * @param {string|number} prop Property name or physical column index.
-   * @returns {string|number} Visual column index, or the passed argument.
+   * @param {string|number|Function} prop Property name, physical column index, or a `columns[].data`
+   *   accessor function.
+   * @returns {string|number|Function|null} Visual column index, `null` when the column is trimmed,
+   *   or the passed argument.
    */
   this.propToCol = function(prop: string | number) {
     return datamap.propToCol(prop) as number;

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -4104,7 +4104,8 @@ export default function Core(
    *
    * @memberof Core#
    * @function colToProp
-   * @param {number} column Visual column index.
+   * @param {number} column Visual column index. An argument that is not an integer comes back
+   *   unchanged, so the declared type is narrower than what the method accepts at runtime.
    * @returns {string|number|null} Column property, physical column index, `null`, or the passed
    *   argument. When the column's `data` option is an accessor function, that function is returned
    *   at runtime – check `typeof` before treating the result as a property name.
@@ -4121,16 +4122,18 @@ export default function Core(
    *
    * The result can also be `null`, and for a **trimmed** column which of the two you get depends on
    * how the property is declared. A property held in the column cache – object data, or one named
-   * by a `columns[].data` entry – resolves through {@link Core#toVisualColumn} and comes back
+   * by a `columns[].data` entry – resolves through [[Core#toVisualColumn]] and comes back
    * `null`. A bare physical index on array data comes back unchanged instead, which does not
    * identify a usable visual column.
    *
    * So validate the result before using it as a column index: `Number.isInteger()` alone lets the
-   * second case through, and a {@link Core#countCols} comparison alone lets `null` through, because
+   * second case through, and a [[Core#countCols]] comparison alone lets `null` through, because
    * `null` compares as `0`.
    *
-   * The TypeScript declaration narrows the result to `number`, so neither a returned property name
-   * nor `null` is visible to the type checker.
+   * The TypeScript declaration is narrower than what runs at both ends. It narrows the result to
+   * `number`, so neither a returned property name nor `null` is visible to the type checker, and it
+   * narrows the parameter to `string | number`, so passing a `columns[].data` accessor function
+   * works at runtime but does not type-check.
    *
    * @memberof Core#
    * @function propToCol

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -4094,12 +4094,17 @@ export default function Core(
    * Returns the property name that corresponds with the given column index.
    * If the data source is an array of arrays, it returns the columns index.
    *
+   * When the column index does not point at an existing column, the method returns the argument you
+   * passed, unchanged. It does not return `null`, unlike {@link Core#toVisualColumn} and the other
+   * index translators. Check the index against {@link Core#countCols} first if you need to tell an
+   * out-of-range call apart from a real result.
+   *
    * @memberof Core#
    * @function colToProp
    * @param {number} column Visual column index.
-   * @returns {string|number} Column property or physical column index. When the column's `data`
-   *   option is an accessor function, that function is returned at runtime – check
-   *   `typeof` before treating the result as a property name.
+   * @returns {string|number} Column property, physical column index, or the passed argument. When
+   *   the column's `data` option is an accessor function, that function is returned at runtime –
+   *   check `typeof` before treating the result as a property name.
    */
   this.colToProp = function(column: number) {
     return datamap.colToProp(column);
@@ -4108,10 +4113,16 @@ export default function Core(
   /**
    * Returns column index that corresponds with the given property.
    *
+   * When the property matches no column, the method returns the argument you passed, unchanged. It
+   * does not return `null`, unlike {@link Core#toVisualColumn} and the other index translators. The
+   * TypeScript declaration narrows the result to `number`, so a returned property name is not
+   * visible to the type checker – compare against {@link Core#countCols} when the property may be
+   * unknown.
+   *
    * @memberof Core#
    * @function propToCol
    * @param {string|number} prop Property name or physical column index.
-   * @returns {number} Visual column index.
+   * @returns {string|number} Visual column index, or the passed argument.
    */
   this.propToCol = function(prop: string | number) {
     return datamap.propToCol(prop) as number;

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -4119,10 +4119,15 @@ export default function Core(
    * When the property matches no column, the method hands the argument back unchanged, so the
    * result on its own never tells you whether that column exists.
    *
-   * The result can also be `null`: a property whose column is trimmed resolves through
-   * {@link Core#toVisualColumn}, which has no visual index left to return. Test the result with
-   * `Number.isInteger()` before using it as a column index. Comparing it against
-   * {@link Core#countCols} is not enough – `null` compares as `0` and passes such a check.
+   * The result can also be `null`, and for a **trimmed** column which of the two you get depends on
+   * how the property is declared. A property held in the column cache – object data, or one named
+   * by a `columns[].data` entry – resolves through {@link Core#toVisualColumn} and comes back
+   * `null`. A bare physical index on array data comes back unchanged instead, which does not
+   * identify a usable visual column.
+   *
+   * So validate the result before using it as a column index: `Number.isInteger()` alone lets the
+   * second case through, and a {@link Core#countCols} comparison alone lets `null` through, because
+   * `null` compares as `0`.
    *
    * The TypeScript declaration narrows the result to `number`, so neither a returned property name
    * nor `null` is visible to the type checker.
@@ -4131,8 +4136,8 @@ export default function Core(
    * @function propToCol
    * @param {string|number|Function} prop Property name, physical column index, or a `columns[].data`
    *   accessor function.
-   * @returns {string|number|Function|null} Visual column index, `null` when the column is trimmed,
-   *   or the passed argument.
+   * @returns {string|number|Function|null} Visual column index, `null` when a cached property's
+   *   column is trimmed, or the passed argument.
    */
   this.propToCol = function(prop: string | number) {
     return datamap.propToCol(prop) as number;

--- a/handsontable/src/core/types.ts
+++ b/handsontable/src/core/types.ts
@@ -116,6 +116,12 @@ export interface HotInstance {
   toPhysicalColumn(column: number): number;
   toVisualRow(row: number): number;
   toVisualColumn(column: number): number;
+  /**
+   * These two return types are narrower than what runs. Both methods hand an unmatched argument
+   * straight back, and both can return `null` – `propToCol` for a trimmed column, `colToProp` for a
+   * column declared as `{ data: null }`. Validate the result before using it as an index or a
+   * property name.
+   */
   propToCol(prop: string | number): number;
   colToProp(column: number): string | number;
 

--- a/handsontable/src/core/types.ts
+++ b/handsontable/src/core/types.ts
@@ -118,9 +118,9 @@ export interface HotInstance {
   toVisualColumn(column: number): number;
   /**
    * These two return types are narrower than what runs. Both methods hand an unmatched argument
-   * straight back, and both can return `null` – `propToCol` for a trimmed column, `colToProp` for a
-   * column declared as `{ data: null }`. Validate the result before using it as an index or a
-   * property name.
+   * straight back, and both can return `null` – `propToCol` for a trimmed column whose property is
+   * cached, `colToProp` for a column declared as `{ data: null }`. Validate the result before using
+   * it as an index or a property name.
    */
   propToCol(prop: string | number): number;
   colToProp(column: number): string | number;

--- a/handsontable/src/core/types.ts
+++ b/handsontable/src/core/types.ts
@@ -117,10 +117,13 @@ export interface HotInstance {
   toVisualRow(row: number): number;
   toVisualColumn(column: number): number;
   /**
-   * These two return types are narrower than what runs. Both methods hand an unmatched argument
-   * straight back, and both can return `null` – `propToCol` for a trimmed column whose property is
-   * cached, `colToProp` for a column declared as `{ data: null }`. Validate the result before using
-   * it as an index or a property name.
+   * These two signatures are narrower than what runs, at both ends. Both methods hand an unmatched
+   * argument straight back, and both can return `null` – `propToCol` for a trimmed column whose
+   * property is cached, `colToProp` for a column declared as `{ data: null }`. Validate the result
+   * before using it as an index or a property name.
+   *
+   * The parameters are narrower too: `propToCol` resolves a `columns[].data` accessor function at
+   * runtime, and `colToProp` hands back any non-integer argument, but neither is accepted here.
    */
   propToCol(prop: string | number): number;
   colToProp(column: number): string | number;


### PR DESCRIPTION
### Context

The PR corrects what the API reference says `colToProp()` and `propToCol()` return when the index or property matches no column, and adds the specs that pin it. It is the patch-level half of [#7031](https://github.com/handsontable/handsontable/issues/7031); the behavior change that issue asks for is breaking and is not attempted here.

Neither method signals an unknown column. Both hand the argument straight back — `colToProp(999)` is `999`, `propToCol(999)` is `999` — while `toVisualColumn()` and the other index translators return `null` in the same situation. The API reference did not say so, so the asymmetry was invisible to anyone reading the docs.

It used to. PR [#5945](https://github.com/handsontable/handsontable/pull/5945) introduced the pass-through deliberately, in the same commit that gave the index mappers their `null`, and documented it as `@returns {String|Number} Column property, physical column index or passed argument.` That sentence was lost in a later rewrite while the code kept the behavior.

**`null` is still a possible result**, and the docs now say so rather than implying an argument always comes back:

| Case | Result |
|---|---|
| `propToCol('name')` where that column is trimmed, and the property is cached | `null` — the cached branch returns `toVisualColumn()` with no fallback |
| `propToCol(1)` where that column is trimmed, on plain array data | `1` — the uncached branch falls back to the passed index instead |
| `colToProp(0)` with `columns: [{ data: null }]` | `null` — `isDefined(null)` is `true`, so the cache hit wins, on a valid index |
| `colToProp(null)` | `null` — the non-integer echo, which `undoRedo/actions/removeRow.ts` depends on |

All measured on the built bundle. The consequence for callers is in the docs: validate before use, because `Number.isInteger()` alone lets the second row through and a `countCols()` comparison alone lets `null` through (`null` compares as `0`).

Rows 1 and 2 are the same question with two different answers, and the second is wrong rather than merely unhelpful — the index it returns addresses a different column. That is a defect in its own right, filed separately as **DEV-2726**; this PR documents the split as it stands today and pins it with a test, so the fix has a tripwire that forces the docs to be simplified along with the code.

`propToCol()` also gets a note that its TypeScript declaration narrows the result to `number`, so neither a returned property name nor `null` is visible to the type checker. The same caveat now sits on the `CoreMethods` declaration in `core/types.ts`, which is what a TypeScript consumer actually resolves to.

**No runtime code changed.** The diff is two JSDoc blocks, one interface comment, and specs.

### Why not fix the behavior here

Verified against the code and the history rather than the issue label, and it does not qualify as a patch:

- The pass-through was deliberate, added by #5945 together with its documentation.
- #7031 was filed by the author of #5945 — this is the team revisiting its own design, filed as `enhancement` + `Breaking change`, not as a bug.
- Core depends on it. `applyChanges()` grows the grid with `while (Number(datamap.propToCol(prop)) > countCols() - 1)`; `Number(null)` is `0`, so a `null`-returning `propToCol()` silently stops auto column growth. Measured: `setDataAtCell(0, 6, …)` on a 3-column array grid grows it to 7 columns, and pasting past the edge of a 2-column grid grows it to 4.
- `plugins/undoRedo/actions/removeRow.ts:233-240` uses the echo as a bail-out signal, with a comment saying so. Roughly 78 call sites across 26 files would each need a null-safety pass.

Note that #7031 asks about indexes **beyond the table boundaries**, which is a different case from a trimmed column the mapper still knows about. DEV-2726 covers the second one and is separable — `columnIndexMapper.getNumberOfIndexes()` tells them apart, so fixing it leaves the pass-through above untouched.

### Test evidence (required for source changes)

- Unit tests added/modified (`*.unit.js`): none — these two methods are covered by the E2E specs below, which run against a real grid and a real `columnIndexMapper`.
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none — this PR touches no runtime behavior, so the coverage it needs is the two existing Jasmine specs for the methods themselves (`handsontable/src/__tests__/core/colToProp.spec.js`, `handsontable/src/__tests__/core/propToCol.spec.js`), edited in place as the frozen-suite rules allow.
- Type tests (`*.types.ts`) updated if public API changed: none — `core/types.ts` gained a comment; no signature changed.
- For a bug fix — the spec that fails without this fix: `colToProp.spec.js` › "should return proper value after calling the function when columns was reorganized (data is array of objects)" contained `expect(propToCol(10)).toBe(10)` inside `describe('Core.colToProp')` — a copy-paste that left `colToProp` out of range asserted **nowhere**, so the contract this PR publishes could have changed with every spec still green. Now `expect(colToProp(10)).toBe(10)`, plus dedicated cases for the pass-through, the `null` echo, the `{ data: null }` column, and both sides of the trimmed-column split.
- Demo page / recorded trace (for UI changes): n/a — no UI change.

Also replaced: the two `// I'm not sure if this should return result like that by design.` comments beside those assertions, with what the archaeology settled — it is by design, and `applyChanges()` depends on it.

### Commands run

```
$ npm run test:e2e --prefix handsontable -- --testPathPattern="colToProp|propToCol"
17 specs, 0 failures

$ npm run eslint --prefix handsontable
✖ 602 problems (0 errors, 602 warnings)

$ npm run test:types --prefix handsontable
✓ tsc -p ./test/types

$ npm run build --prefix handsontable
✓ node scripts/prepare-package-for-publish.mjs
```

[skip changelog]

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

The template has no documentation-only option. This is filed as a bug fix because two real defects are corrected — an API reference that stated the wrong return contract, and a spec asserting a different method than the one it was written for. No runtime behavior changes.

### Related issue(s):

1. DEV-2723
2. DEV-2726 (the trimmed-column defect this PR documents but does not fix)
3. #7031

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation. This PR is that change — the API reference is generated from these JSDoc blocks.
- [ ] This change needs a manual QA pass.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2723

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes with no production code paths modified.
> 
> **Overview**
> **Documents** how `colToProp()` and `propToCol()` behave when the index or property does not map to a column: both **echo the argument** (by design since #5945), unlike `toVisualColumn()` / other mappers that return `null`. The JSDoc in `core.ts` and a note on `CoreMethods` in `core/types.ts` also spell out when **`null` is a real result** (trimmed cached properties, `{ data: null }` columns, non-integer/`null` echoes) and warn callers to validate results.
> 
> **Tests** expand `colToProp.spec.js` and `propToCol.spec.js`: fix a copy-paste that asserted `propToCol(10)` inside the `colToProp` suite, add cases for out-of-range pass-through, non-integer echo, and trimmed-column behavior, and **pin known defect DEV-2726** (array data + trimmed physical index returns the wrong index instead of `null`).
> 
> **No runtime implementation changes** — behavior is unchanged; docs and specs are aligned with the current bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c49de1e59ce199e470a1939deb99b0571511b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->