### PR TITLE
SU-833: Note return false as a minimal way to block beforeKeyDown

### DIFF
--- a/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
@@ -494,6 +494,16 @@ The following demo uses [`beforeKeyDown`](@/api/hooks.md#beforekeydown) callback
 - Pressing <kbd>**Delete**</kbd> or <kbd>**Backspace**</kbd> on a cell deletes the cell and shifts all cells beneath it in the column up resulting in the cursor, which doesn't move, having the value previously beneath it, now in the current cell.
 - Pressing <kbd>**Enter**</kbd> in a cell where the value remains unchanged pushes all the cells in the column beneath and including the current cell down one row. This results in a blank cell under the cursor which hasn't moved.
 
+The example below replaces the default action with a custom one, so it needs `stopImmediatePropagation()` + `preventDefault()`. If you only need to block a key's default handling, with no replacement action, `return false` is enough:
+
+```js
+hot.addHook('beforeKeyDown', (event) => {
+  if (event.key === 'Enter') {
+    return false;
+  }
+});
+```
+
 ::: only-for javascript
 
 ::: example #example2 --js 1 --ts 2


### PR DESCRIPTION
### Context

The `beforeKeyDown` example in this guide only demonstrates `stopImmediatePropagation()` + `preventDefault()`. Elsewhere, the `Custom shortcuts guide` documents return false as sufficient on its own for blocking a shortcut with no replacement action. An AI docs-assistant regression traced back to this guide as one likely source of the model asserting `return false` doesn't work.

This adds a short note pointing out `return false` as the minimal option when no replacement action is needed, next to the existing `stopImmediatePropagation()/preventDefault()` example.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature or improvement (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Additional language file or change to the existing one (translations)

### Related issue(s):
ClickUp: https://app.clickup.com/t/9015210959/SU-833

### Affected project(s):
- [x] handsontable
- [ ]  @handsontable/angular-wrapper
- [ ]  @handsontable/react-wrapper
- [ ]  @handsontable/vue3

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md), and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the cla/signed check on this PR confirms it.
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> The **Events and hooks** guide’s `beforeKeyDown` section now distinguishes two patterns: use **`stopImmediatePropagation()` + `preventDefault()`** when you replace the default key behavior (as in the existing demo), and **`return false`** when you only want to block Handsontable’s default handling with no custom action.
> 
> A short explanatory note and a minimal `beforeKeyDown` snippet (blocking **Enter** via `return false`) were added immediately before the existing interactive example, aligning this page with guidance elsewhere (e.g. custom shortcuts) and reducing confusion that `return false` is ineffective.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbde766a19a83d94629dbc25b46ac3d6e3e39403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->