### PR TITLE
Docs: retitle changelog series pages to N.x (prod-docs/18.1)

### DIFF
--- a/docs/content/guides/upgrade-and-migration/changelog-10/changelog-10.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-10/changelog-10.md
@@ -1,16 +1,16 @@
 ---
 type: reference
-title: Changelog 10.0
-metaTitle: Changelog 10.0 - JavaScript Data Grid | Handsontable
-description: See the full history of changes made to Handsontable 10.0 in each minor and patch release.
+title: Changelog 10.x
+metaTitle: Changelog 10.x - JavaScript Data Grid | Handsontable
+description: See the full history of changes made to Handsontable 10.x in each minor and patch release.
 permalink: /changelog-10
 canonicalUrl: /changelog-10
 react:
-  metaTitle: Changelog 10.0 - React Data Grid | Handsontable
+  metaTitle: Changelog 10.x - React Data Grid | Handsontable
 angular:
-  metaTitle: Changelog 10.0 - Angular Data Grid | Handsontable
+  metaTitle: Changelog 10.x - Angular Data Grid | Handsontable
 vue:
-  metaTitle: Changelog 10.0 - Vue Data Grid | Handsontable
+  metaTitle: Changelog 10.x - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-11/changelog-11.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-11/changelog-11.md
@@ -1,16 +1,16 @@
 ---
 type: reference
-title: Changelog 11.0
-metaTitle: Changelog 11.0 - JavaScript Data Grid | Handsontable
-description: See the full history of changes made to Handsontable 11.0 in each minor and patch release.
+title: Changelog 11.x
+metaTitle: Changelog 11.x - JavaScript Data Grid | Handsontable
+description: See the full history of changes made to Handsontable 11.x in each minor and patch release.
 permalink: /changelog-11
 canonicalUrl: /changelog-11
 react:
-  metaTitle: Changelog 11.0 - React Data Grid | Handsontable
+  metaTitle: Changelog 11.x - React Data Grid | Handsontable
 angular:
-  metaTitle: Changelog 11.0 - Angular Data Grid | Handsontable
+  metaTitle: Changelog 11.x - Angular Data Grid | Handsontable
 vue:
-  metaTitle: Changelog 11.0 - Vue Data Grid | Handsontable
+  metaTitle: Changelog 11.x - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-12/changelog-12.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-12/changelog-12.md
@@ -1,16 +1,16 @@
 ---
 type: reference
-title: Changelog 12.0
-metaTitle: Changelog 12.0 - JavaScript Data Grid | Handsontable
-description: See the full history of changes made to Handsontable 12.0 in each minor and patch release.
+title: Changelog 12.x
+metaTitle: Changelog 12.x - JavaScript Data Grid | Handsontable
+description: See the full history of changes made to Handsontable 12.x in each minor and patch release.
 permalink: /changelog-12
 canonicalUrl: /changelog-12
 react:
-  metaTitle: Changelog 12.0 - React Data Grid | Handsontable
+  metaTitle: Changelog 12.x - React Data Grid | Handsontable
 angular:
-  metaTitle: Changelog 12.0 - Angular Data Grid | Handsontable
+  metaTitle: Changelog 12.x - Angular Data Grid | Handsontable
 vue:
-  metaTitle: Changelog 12.0 - Vue Data Grid | Handsontable
+  metaTitle: Changelog 12.x - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-13/changelog-13.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-13/changelog-13.md
@@ -1,16 +1,16 @@
 ---
 type: reference
-title: Changelog 13.0
-metaTitle: Changelog 13.0 - JavaScript Data Grid | Handsontable
-description: See the full history of changes made to Handsontable 13.0 in each minor and patch release.
+title: Changelog 13.x
+metaTitle: Changelog 13.x - JavaScript Data Grid | Handsontable
+description: See the full history of changes made to Handsontable 13.x in each minor and patch release.
 permalink: /changelog-13
 canonicalUrl: /changelog-13
 react:
-  metaTitle: Changelog 13.0 - React Data Grid | Handsontable
+  metaTitle: Changelog 13.x - React Data Grid | Handsontable
 angular:
-  metaTitle: Changelog 13.0 - Angular Data Grid | Handsontable
+  metaTitle: Changelog 13.x - Angular Data Grid | Handsontable
 vue:
-  metaTitle: Changelog 13.0 - Vue Data Grid | Handsontable
+  metaTitle: Changelog 13.x - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-14/changelog-14.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-14/changelog-14.md
@@ -1,16 +1,16 @@
 ---
 type: reference
-title: Changelog 14.0
-metaTitle: Changelog 14.0 - JavaScript Data Grid | Handsontable
-description: See the full history of changes made to Handsontable 14.0 in each minor and patch release.
+title: Changelog 14.x
+metaTitle: Changelog 14.x - JavaScript Data Grid | Handsontable
+description: See the full history of changes made to Handsontable 14.x in each minor and patch release.
 permalink: /changelog-14
 canonicalUrl: /changelog-14
 react:
-  metaTitle: Changelog 14.0 - React Data Grid | Handsontable
+  metaTitle: Changelog 14.x - React Data Grid | Handsontable
 angular:
-  metaTitle: Changelog 14.0 - Angular Data Grid | Handsontable
+  metaTitle: Changelog 14.x - Angular Data Grid | Handsontable
 vue:
-  metaTitle: Changelog 14.0 - Vue Data Grid | Handsontable
+  metaTitle: Changelog 14.x - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-15/changelog-15.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-15/changelog-15.md
@@ -1,16 +1,16 @@
 ---
 type: reference
-title: Changelog 15.0
-metaTitle: Changelog 15.0 - JavaScript Data Grid | Handsontable
-description: See the full history of changes made to Handsontable 15.0 in each minor and patch release.
+title: Changelog 15.x
+metaTitle: Changelog 15.x - JavaScript Data Grid | Handsontable
+description: See the full history of changes made to Handsontable 15.x in each minor and patch release.
 permalink: /changelog-15
 canonicalUrl: /changelog-15
 react:
-  metaTitle: Changelog 15.0 - React Data Grid | Handsontable
+  metaTitle: Changelog 15.x - React Data Grid | Handsontable
 angular:
-  metaTitle: Changelog 15.0 - Angular Data Grid | Handsontable
+  metaTitle: Changelog 15.x - Angular Data Grid | Handsontable
 vue:
-  metaTitle: Changelog 15.0 - Vue Data Grid | Handsontable
+  metaTitle: Changelog 15.x - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-16/changelog-16.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-16/changelog-16.md
@@ -1,16 +1,16 @@
 ---
 type: reference
-title: Changelog 16.0
-metaTitle: Changelog 16.0 - JavaScript Data Grid | Handsontable
-description: See the full history of changes made to Handsontable 16.0 in each minor and patch release.
+title: Changelog 16.x
+metaTitle: Changelog 16.x - JavaScript Data Grid | Handsontable
+description: See the full history of changes made to Handsontable 16.x in each minor and patch release.
 permalink: /changelog-16
 canonicalUrl: /changelog-16
 react:
-  metaTitle: Changelog 16.0 - React Data Grid | Handsontable
+  metaTitle: Changelog 16.x - React Data Grid | Handsontable
 angular:
-  metaTitle: Changelog 16.0 - Angular Data Grid | Handsontable
+  metaTitle: Changelog 16.x - Angular Data Grid | Handsontable
 vue:
-  metaTitle: Changelog 16.0 - Vue Data Grid | Handsontable
+  metaTitle: Changelog 16.x - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md
@@ -1,16 +1,16 @@
 ---
 type: reference
-title: Changelog 17.0
-metaTitle: Changelog 17.0 - JavaScript Data Grid | Handsontable
-description: See the full history of changes made to Handsontable 17.0 in each minor and patch release.
+title: Changelog 17.x
+metaTitle: Changelog 17.x - JavaScript Data Grid | Handsontable
+description: See the full history of changes made to Handsontable 17.x in each minor and patch release.
 permalink: /changelog-17
 canonicalUrl: /changelog-17
 react:
-  metaTitle: Changelog 17.0 - React Data Grid | Handsontable
+  metaTitle: Changelog 17.x - React Data Grid | Handsontable
 angular:
-  metaTitle: Changelog 17.0 - Angular Data Grid | Handsontable
+  metaTitle: Changelog 17.x - Angular Data Grid | Handsontable
 vue:
-  metaTitle: Changelog 17.0 - Vue Data Grid | Handsontable
+  metaTitle: Changelog 17.x - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-18/changelog-18.md
@@ -1,16 +1,16 @@
 ---
 type: reference
-title: Changelog 18.0
-metaTitle: Changelog 18.0 - JavaScript Data Grid | Handsontable
-description: See the full history of changes made to Handsontable 18.0 in each minor and patch release.
+title: Changelog 18.x
+metaTitle: Changelog 18.x - JavaScript Data Grid | Handsontable
+description: See the full history of changes made to Handsontable 18.x in each minor and patch release.
 permalink: /changelog-18
 canonicalUrl: /changelog-18
 react:
-  metaTitle: Changelog 18.0 - React Data Grid | Handsontable
+  metaTitle: Changelog 18.x - React Data Grid | Handsontable
 angular:
-  metaTitle: Changelog 18.0 - Angular Data Grid | Handsontable
+  metaTitle: Changelog 18.x - Angular Data Grid | Handsontable
 vue:
-  metaTitle: Changelog 18.0 - Vue Data Grid | Handsontable
+  metaTitle: Changelog 18.x - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
@@ -1,16 +1,16 @@
 ---
 type: reference
-title: Changelog 8.0
-metaTitle: Changelog 8.0 - JavaScript Data Grid | Handsontable
-description: See the full history of changes made to Handsontable 8.0 in each minor and patch release.
+title: Changelog 8.x
+metaTitle: Changelog 8.x - JavaScript Data Grid | Handsontable
+description: See the full history of changes made to Handsontable 8.x in each minor and patch release.
 permalink: /changelog-8
 canonicalUrl: /changelog-8
 react:
-  metaTitle: Changelog 8.0 - React Data Grid | Handsontable
+  metaTitle: Changelog 8.x - React Data Grid | Handsontable
 angular:
-  metaTitle: Changelog 8.0 - Angular Data Grid | Handsontable
+  metaTitle: Changelog 8.x - Angular Data Grid | Handsontable
 vue:
-  metaTitle: Changelog 8.0 - Vue Data Grid | Handsontable
+  metaTitle: Changelog 8.x - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-9/changelog-9.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-9/changelog-9.md
@@ -1,16 +1,16 @@
 ---
 type: reference
-title: Changelog 9.0
-metaTitle: Changelog 9.0 - JavaScript Data Grid | Handsontable
-description: See the full history of changes made to Handsontable 9.0 in each minor and patch release.
+title: Changelog 9.x
+metaTitle: Changelog 9.x - JavaScript Data Grid | Handsontable
+description: See the full history of changes made to Handsontable 9.x in each minor and patch release.
 permalink: /changelog-9
 canonicalUrl: /changelog-9
 react:
-  metaTitle: Changelog 9.0 - React Data Grid | Handsontable
+  metaTitle: Changelog 9.x - React Data Grid | Handsontable
 angular:
-  metaTitle: Changelog 9.0 - Angular Data Grid | Handsontable
+  metaTitle: Changelog 9.x - Angular Data Grid | Handsontable
 vue:
-  metaTitle: Changelog 9.0 - Vue Data Grid | Handsontable
+  metaTitle: Changelog 9.x - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
+++ b/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
@@ -71,8 +71,8 @@ The following dependencies were deprecated in version 17.0 and removed in versio
 
 | Removed | Deprecated in | Replacement | Migration guide |
 | ------- | ------------- | ----------- | --------------- |
-| `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks | 16.1 | Persist state in your application code. The `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` methods that relied on the plugin are deprecated (see below). | [Changelog 17.0](@/guides/upgrade-and-migration/changelog-17/changelog-17.md) |
-| `hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, and `hot.undoRedo` | Before 16.0 | `hot.getPlugin('undoRedo')` | [Changelog 17.0](@/guides/upgrade-and-migration/changelog-17/changelog-17.md) |
+| `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks | 16.1 | Persist state in your application code. The `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` methods that relied on the plugin are deprecated (see below). | [Changelog 17.x](@/guides/upgrade-and-migration/changelog-17/changelog-17.md) |
+| `hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, and `hot.undoRedo` | Before 16.0 | `hot.getPlugin('undoRedo')` | [Changelog 17.x](@/guides/upgrade-and-migration/changelog-17/changelog-17.md) |
 
 ## List of current deprecations
 


### PR DESCRIPTION
## Summary
- Clean cherry-pick of #13328 onto `prod-docs/18.1` so the live site picks it up: changelog series pages retitled from **Changelog N.0** to **Changelog N.x** (title, metaTitles, description — they accumulate the whole series, and /changelog-18/ currently presents itself as 18.0 while containing 18.1.0), plus the two matching link texts in the deprecation policy.

## Test plan
- [x] Cherry-pick applied clean (12 files, ±68 lines, identical to #13328)
- [ ] After merge: live /docs/javascript-data-grid/changelog-18/ shows "Changelog 18.x" as H1 and in the sidebar

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)