### PR TITLE
DEV-2619: Drop archived Performance Lab reference from performance guide

### DIFF
--- a/docs/content/guides/optimization/performance/performance.md
+++ b/docs/content/guides/optimization/performance/performance.md
@@ -24,7 +24,7 @@ Boost your grid's performance by setting a constant column size, suspending rend
 
 Handsontable performs multiple calculations to display the grid properly. The most demanding actions are performed on load, change, and scroll events. Every single operation decreases the performance, but most of them are unavoidable.
 
-To measure Handsontable's execution times in various configurations, we use our own library called [Performance Lab](https://github.com/handsontable/performance-lab). Some tests have shown that there are methods that may potentially boost the performance of your application. These only work in certain cases, but we hope they can be successfully applied to your app as well.
+The optimizations on this page come from measuring Handsontable's execution times in various configurations. Each one applies only in certain cases. Check which ones fit your application.
 
 ## Set constant row and column sizes
 

--- a/docs/content/guides/optimization/performance/performance.md
+++ b/docs/content/guides/optimization/performance/performance.md
@@ -24,7 +24,7 @@ Boost your grid's performance by setting a constant column size, suspending rend
 
 Handsontable performs multiple calculations to display the grid properly. The most demanding actions are performed on load, change, and scroll events. Every single operation decreases the performance, but most of them are unavoidable.
 
-The optimizations on this page come from measuring Handsontable's execution times in various configurations. Each one applies only in certain cases. Check which ones fit your application.
+The optimizations on this page come from measuring Handsontable's execution times in various configurations. Each one applies only in certain cases. Check which ones fit your application. To see how those measurements work, browse the [performance test suite](https://github.com/handsontable/handsontable/tree/develop/performance-tests) in the Handsontable repository. It runs scripted interactions in a real browser and records the timings.
 
 ## Set constant row and column sizes
 


### PR DESCRIPTION
### Context

The PR fixes a stale claim in the public performance guide.

`docs/content/guides/optimization/performance/performance.md` told readers, in the present tense, that we measure execution times with "our own library called Performance Lab" and linked to `handsontable/performance-lab`. That repository was archived on 2026-08-25 (fallout from DEV-2614). The link still resolves, because archived public repos stay readable, so nothing was broken for readers -- but the guide was pointing customers at a tool we had just retired.

DEV-2619 asked for an editorial decision between two options:

1. Repoint the sentence at the monorepo's `performance-tests/` directory, which is the current measurement system.
2. Drop the tooling name entirely and keep the surrounding advice.

This PR lands close to option 1. The guide no longer presents the measurement system as "our own library" a reader can adopt, and the dead `performance-lab` reference is gone. In its place the paragraph keeps the advice, and adds one pointer to `performance-tests/` for readers who want to see how the numbers are produced.

The task's own recommendation was option 2, on the grounds that `performance-tests/` is internal dev tooling. Two things argue for keeping the pointer. `performance-tests/README.md` has a runnable quick start (`cd performance-tests && node scripts/run.mjs`), so a reader who follows the link gets something concrete rather than a dead end. And the wording frames it as a test suite, not a library, so it does not repeat the mistake the old sentence made.

Before:

> To measure Handsontable's execution times in various configurations, we use our own library called [Performance Lab](https://github.com/handsontable/performance-lab). Some tests have shown that there are methods that may potentially boost the performance of your application. These only work in certain cases, but we hope they can be successfully applied to your app as well.

After:

> The optimizations on this page come from measuring Handsontable's execution times in various configurations. Each one applies only in certain cases. Check which ones fit your application. To see how those measurements work, browse the [performance test suite](https://github.com/handsontable/handsontable/tree/develop/performance-tests) in the Handsontable repository. It runs scripted interactions in a real browser and records the timings.

The rewrite also clears three docs-site style violations the old sentence carried: first person ("we use our own", "we hope"), one long compound sentence, and hedged wording ("may potentially", "we hope").

`[skip changelog]` -- documentation only, no package source touched.

### How has this been tested?

This is a prose change to a Markdown guide. It touches no frontmatter, no code fences, and no package source, so no unit, E2E, or visual suite covers it. `docs:lint` only lints `.js`, `.mjs`, `.ts`, and `.astro` files, so it does not apply to this file either.

Verified by inspection and by CI:

- Read the edited paragraph in context to confirm it still follows the preceding sentence ("...most of them are unavoidable.").
- Confirmed no reference to the archived repository survives anywhere in the monorepo, case-insensitively:

```bash
grep -rIni "performance.\?lab" --exclude-dir=node_modules --exclude-dir=.git .
```

Zero hits. This was the only occurrence in the repository before the edit, which matches the org-wide code search recorded on the task.

- Confirmed the new link resolves: `curl -sIL -o /dev/null -w "%{http_code}" https://github.com/handsontable/handsontable/tree/develop/performance-tests` returns `200`. `performance-tests/` is present on both `master` and `develop`.
- `Docs / lint`, `Docs / plugins`, and `Docs / preview / deploy` pass, so the page still builds and renders in the preview.
- The changelog, scope, and test-presence gates all pass, as expected for a docs-only diff.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2619
2. DEV-2614 -- the archival of `handsontable/performance-lab` that this cleans up after.

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation only (`docs/`). No package source is touched.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) -- one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation. The documentation change is the whole of this PR.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2619

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only prose and link change; no package behavior or APIs affected.
> 
> **Overview**
> Updates the **Performance** guide overview so it no longer points readers at the archived **Performance Lab** repo or first-person “we use our own library” wording.
> 
> The paragraph now states that the listed optimizations were derived from timing measurements, that each tip applies only in some cases, and links to the monorepo **`performance-tests/`** suite with a short note that it runs scripted browser interactions and records timings. Editorial tone is tightened (less hedging, shorter sentences).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b83e8ce098f458fa7ee251db5bd74728cfc9a18d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->