### PR TITLE
DEV-2746: Deflake the Interval unit tests and the autocomplete case-sensitivity wait

### DIFF
--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -2426,7 +2426,9 @@ describe('AutocompleteEditor', () => {
       editorInput.val('e');
 
       await keyDownUp('e'); // e
-      await waitForNextAnimationFrames(2);
+      // Every choice contains a lowercase 'e', so the queried list settles at the full 9 rows.
+      // Poll for that state instead of guessing how long the editor's deferred query takes.
+      await waitUntil(() => getActiveEditor().htEditor?.getData().length === 9);
 
       {
         const ac = getActiveEditor();
@@ -2449,7 +2451,9 @@ describe('AutocompleteEditor', () => {
         await keyDownUp('e'); // E (same as 'e')
       }
 
-      await waitForNextAnimationFrames(2);
+      // The case-sensitive query for an uppercase 'E' matches nothing - the emptied list IS the
+      // asserted behavior, so polling for it cannot mask a failure.
+      await waitUntil(() => getActiveEditor().htEditor?.getData().length === 0);
 
       {
         const ac = getActiveEditor();

--- a/handsontable/src/utils/__tests__/Interval.unit.ts
+++ b/handsontable/src/utils/__tests__/Interval.unit.ts
@@ -1,6 +1,18 @@
 import Interval from '../interval';
 
+// Fake timers drive the whole loop deterministically: `Interval` ticks on `requestAnimationFrame`
+// (read from `window` at call time, so the mocked one) and gates on `Date.now()` elapsed time,
+// both of which `advanceTimersByTime()` moves in lockstep. The previous real-`setTimeout`
+// checkpoints raced the event loop - a 50 ms stall on a loaded runner flipped them (DEV-2746,
+// from DEV-2668's flake data).
 describe('Interval', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
 
   it('should create instance of Interval object', () => {
     const i = Interval.create(() => {}, 10);
@@ -15,73 +27,70 @@ describe('Interval', () => {
   });
 
   it('should create object with delay passed as a number of FPS', () => {
-    const i = Interval.create(() => {}, '60fps');
+    const i = Interval.create(() => {}, '60fps' as unknown as number);
 
     expect(i.delay).toBe(1000 / 60);
   });
 
-  it('should create interval object which is stopped by default', (done) => {
-    const spy = jasmine.createSpy();
+  it('should create interval object which is stopped by default', () => {
+    const spy = jest.fn();
 
-    Interval.create(spy);
+    Interval.create(spy, 100);
 
-    setTimeout(() => {
-      expect(spy).not.toHaveBeenCalled();
-      done();
-    }, 100);
+    jest.advanceTimersByTime(1000);
+
+    expect(spy).not.toHaveBeenCalled();
   });
 
-  it('should repeatedly invoke callback function after calling `start` method', (done) => {
-    const spy = jasmine.createSpy();
+  it('should repeatedly invoke callback function after calling `start` method', () => {
+    const spy = jest.fn();
     const i = Interval.create(spy, 100);
 
     i.start();
 
-    setTimeout(() => {
-      expect(spy).not.toHaveBeenCalled();
-    }, 50);
+    jest.advanceTimersByTime(50);
 
-    setTimeout(() => {
-      expect(spy.calls.count()).toBe(1);
-    }, 150);
+    expect(spy).not.toHaveBeenCalled();
 
-    setTimeout(() => {
-      expect(spy.calls.count()).toBe(2);
-    }, 250);
+    jest.advanceTimersByTime(100); // t = 150
 
-    setTimeout(() => {
-      expect(spy.calls.count()).toBe(3);
-      i.stop();
-      done();
-    }, 350);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(100); // t = 250
+
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(100); // t = 350
+
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    i.stop();
   });
 
-  it('should stop repeatedly invoking callback function after calling `stop` method', (done) => {
-    const spy = jasmine.createSpy();
+  it('should stop repeatedly invoking callback function after calling `stop` method', () => {
+    const spy = jest.fn();
     const i = Interval.create(spy, 100);
 
     i.start();
 
-    setTimeout(() => {
-      expect(spy).not.toHaveBeenCalled();
-    }, 50);
+    jest.advanceTimersByTime(50);
 
-    setTimeout(() => {
-      expect(spy.calls.count()).toBe(1);
-      i.stop();
-    }, 150);
+    expect(spy).not.toHaveBeenCalled();
 
-    setTimeout(() => {
-      expect(spy.calls.count()).toBe(1);
-      i.start();
-    }, 250);
+    jest.advanceTimersByTime(100); // t = 150
 
-    setTimeout(() => {
-      // Allow 2 or 3 calls: timing can vary (100ms interval may fire once or twice in 150ms window)
-      expect(spy.calls.count()).toBeGreaterThanOrEqual(2);
-      expect(spy.calls.count()).toBeLessThanOrEqual(3);
-      i.stop();
-      done();
-    }, 400);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    i.stop();
+    jest.advanceTimersByTime(100); // t = 250: stopped, so nothing may fire
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    i.start();
+    jest.advanceTimersByTime(150); // t = 400: one full 100 ms interval since the restart
+
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    i.stop();
   });
 });

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -159,6 +159,41 @@ export async function waitForNameAnimationFrames(framesToWait = 1) {
 }
 
 /**
+ * Polls the provided condition on every animation frame until it returns a truthy value, or
+ * rejects after `timeout` milliseconds. The condition-based replacement for a fixed `sleep()` or
+ * a frame-count wait: it resolves as soon as the observable state is really there, and a state
+ * that never arrives fails with a named reason instead of passing a stale assertion later.
+ *
+ * @param {Function} condition A function returning a truthy value once the awaited state is reached.
+ * @param {number} [timeout=4000] How long to keep polling, in milliseconds.
+ * @returns {Promise<void>}
+ */
+export function waitUntil(condition, timeout = 4000) {
+  const startTime = Date.now();
+  const requestFrame = window.requestAnimationFrame ?? (callback => window.setTimeout(callback, 16));
+
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      if (condition()) {
+        resolve();
+
+        return;
+      }
+
+      if (Date.now() - startTime > timeout) {
+        reject(new Error(`waitUntil: the condition was not met within ${timeout}ms`));
+
+        return;
+      }
+
+      requestFrame(check);
+    };
+
+    check();
+  });
+}
+
+/**
  * Normalize frame count input.
  *
  * @param {number} framesToWait The number of frames to normalize.


### PR DESCRIPTION
### Context

The PR removes the last two test-side items on the CI-flakiness investigation's flake ledger (part B of that plan, after the two migration PRs, #13334 and #13336):

1. **`Interval.unit.ts` — 3 CI incidents in 4 days (08-28 → 08-31).** The timing tests asserted real-`setTimeout` wall-clock checkpoints (`expect(spy).not.toHaveBeenCalled()` at 50 ms against a 100 ms interval), so any ≥50 ms event-loop stall on a loaded runner flipped them. Rewritten on Jest fake timers: `Interval` ticks on `requestAnimationFrame` (read from `window` at call time, so the mocked one) gated by `Date.now()`, and `advanceTimersByTime()` moves both in lockstep. The assertions became **exact** — the old stop/start test's "2 or 3 calls, timing can vary" tolerance is now `toBe(2)`, so the tests got stronger, not just quieter. Jest tier is not frozen; this is an in-place fix by policy.

2. **AutocompleteEditor "default filtering should be case sensitive when filteringCaseSensitive is true" — 1 incident.** Its `waitForNextAnimationFrames(2)` (~32 ms) raced the editor's deferred query and the inner grid's render. Routed as a frozen-suite edit (the ledger shows one hit, not a recurrence, and the ticket allowed this route): the fixed waits become `waitUntil()` polls on the asserted list state itself — settled at 9 rows after the lowercase query, emptied after the case-sensitive uppercase one — so the poll condition cannot mask the behavior under test.

This adds the **`waitUntil(condition, timeout)` helper to `test/helpers/common.js`** (auto-mounted as a spec global like its siblings): the condition-based replacement the frozen tier never had, which is why fixed sleeps and frame-count waits kept being the path of least resistance (the enforcement audit behind the CI-flakiness investigation task flagged the missing "legal alternative" explicitly). It rejects with a named reason on timeout instead of letting a stale assertion fail later.

### How has this been tested?

- `npm run test:unit --testPathPattern=Interval` — 6/6 in 0.6 s (previously ≥1 s of real waiting), exact call counts.
- `npm run test:e2e --testPathPattern=autocompleteEditor` — 140 specs, 0 failures.
- `npx eslint` on all three files — 0 errors (12 pre-existing warn-level debt findings elsewhere in the autocomplete file, untouched).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2746
2. The CI-flakiness investigation task (linked in ClickUp) — the flake ledger this closes out, test-side

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2746
