### PR TITLE
DEV-2758: Skip unresolvable menu item keys instead of rendering them

### DIFF
--- a/.changelogs/13340.json
+++ b/.changelogs/13340.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed unavailable context menu and column menu items being shown as rows labeled with their raw configuration key.",
+  "type": "fixed",
+  "issueOrPR": 13340,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13340.json
+++ b/.changelogs/13340.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed unavailable context menu and column menu items being shown as rows labeled with their raw configuration key.",
+  "title": "Fixed unavailable context menu and column menu items being shown as rows labeled with their raw configuration key, and a `parent:child` item key throwing an error when clicked.",
   "type": "fixed",
   "issueOrPR": 13340,
   "breaking": false,

--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -125,6 +125,69 @@ The `filter_by_condition`, `filter_by_condition2`, `filter_operators`, `filter_b
 `filter_action_bar` items build the filtering interface and take effect only in the dropdown (column)
 menu, not in the context menu. See [Filter menu items](@/guides/accessories-and-menus/column-menu/column-menu.md#filter-menu-items).
 
+The table above lists every key you can use. A key that is not on it is skipped, and Handsontable
+logs a console warning naming it. A key is also skipped when the plugin it needs is not enabled, so
+check the "Requires" column when an item does not appear.
+
+### Command names are not menu item keys
+
+Some commands are addressed with a `parent:child` name, such as `alignment:left`. Those names work
+with [`executeCommand()`](@/api/contextMenu.md#executecommand), which runs a command directly:
+
+::: only-for javascript
+```js
+hot.getPlugin('contextMenu').executeCommand('alignment:left');
+```
+:::
+
+::: only-for react
+```jsx
+hotRef.current.hotInstance.getPlugin('contextMenu').executeCommand('alignment:left');
+```
+:::
+
+They are not menu item keys. Listing `alignment:left` in `contextMenu` does not create a "Left"
+item, because only the keys in the table above are resolved.
+
+To show part of a submenu, keep the predefined submenu items and filter out the ones you don't
+want. The items you keep carry their own actions, so they keep working:
+
+::: only-for javascript
+```js
+const hot = new Handsontable(container, {
+  contextMenu: true,
+  afterContextMenuDefaultOptions(options) {
+    const alignment = options.items.find(item => item.key === 'alignment');
+    const verticalKeys = ['alignment:top', 'alignment:middle', 'alignment:bottom'];
+
+    alignment.submenu.items = alignment.submenu.items
+      .filter(item => !verticalKeys.includes(item.key));
+  },
+});
+```
+:::
+
+::: only-for react
+```jsx
+<HotTable
+  contextMenu={true}
+  afterContextMenuDefaultOptions={(options) => {
+    const alignment = options.items.find(item => item.key === 'alignment');
+    const verticalKeys = ['alignment:top', 'alignment:middle', 'alignment:bottom'];
+
+    alignment.submenu.items = alignment.submenu.items
+      .filter(item => !verticalKeys.includes(item.key));
+  }}
+/>
+```
+:::
+
+The alignment submenu then offers only the horizontal options. For the column menu, use
+`afterDropdownMenuDefaultOptions` instead.
+
+To build a submenu item of your own, give it a `name` and a `callback`. A custom item runs only the
+`callback` you write — it does not inherit an action from a predefined key of the same name.
+
 To see the context menu, right-click on a cell. On touch devices, long-press a cell to open the context menu.
 
 ::: only-for javascript

--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -126,67 +126,8 @@ The `filter_by_condition`, `filter_by_condition2`, `filter_operators`, `filter_b
 menu, not in the context menu. See [Filter menu items](@/guides/accessories-and-menus/column-menu/column-menu.md#filter-menu-items).
 
 The table above lists every key you can use. A key that is not on it is skipped, and Handsontable
-logs a console warning naming it. A key is also skipped when the plugin it needs is not enabled, so
-check the "Requires" column when an item does not appear.
-
-### Command names are not menu item keys
-
-Some commands are addressed with a `parent:child` name, such as `alignment:left`. Those names work
-with [`executeCommand()`](@/api/contextMenu.md#executecommand), which runs a command directly:
-
-::: only-for javascript
-```js
-hot.getPlugin('contextMenu').executeCommand('alignment:left');
-```
-:::
-
-::: only-for react
-```jsx
-hotRef.current.hotInstance.getPlugin('contextMenu').executeCommand('alignment:left');
-```
-:::
-
-They are not menu item keys. Listing `alignment:left` in `contextMenu` does not create a "Left"
-item, because only the keys in the table above are resolved.
-
-To show part of a submenu, keep the predefined submenu items and filter out the ones you don't
-want. The items you keep carry their own actions, so they keep working:
-
-::: only-for javascript
-```js
-const hot = new Handsontable(container, {
-  contextMenu: true,
-  afterContextMenuDefaultOptions(options) {
-    const alignment = options.items.find(item => item.key === 'alignment');
-    const verticalKeys = ['alignment:top', 'alignment:middle', 'alignment:bottom'];
-
-    alignment.submenu.items = alignment.submenu.items
-      .filter(item => !verticalKeys.includes(item.key));
-  },
-});
-```
-:::
-
-::: only-for react
-```jsx
-<HotTable
-  contextMenu={true}
-  afterContextMenuDefaultOptions={(options) => {
-    const alignment = options.items.find(item => item.key === 'alignment');
-    const verticalKeys = ['alignment:top', 'alignment:middle', 'alignment:bottom'];
-
-    alignment.submenu.items = alignment.submenu.items
-      .filter(item => !verticalKeys.includes(item.key));
-  }}
-/>
-```
-:::
-
-The alignment submenu then offers only the horizontal options. For the column menu, use
-`afterDropdownMenuDefaultOptions` instead.
-
-To build a submenu item of your own, give it a `name` and a `callback`. A custom item runs only the
-`callback` you write — it does not inherit an action from a predefined key of the same name.
+logs a console warning naming it. A key is also skipped when the plugin that provides it is not
+enabled, so check the required plugin named beside the key when an item does not appear.
 
 To see the context menu, right-click on a cell. On touch devices, long-press a cell to open the context menu.
 
@@ -232,6 +173,133 @@ To see the context menu, right-click on a cell. On touch devices, long-press a c
 :::
 
 :::
+
+### Command names are not menu item keys
+
+Some commands are addressed with a `parent:child` name, such as `alignment:left`. Those names work
+with [`executeCommand()`](@/api/contextMenu.md#executecommand), which runs a command directly:
+
+::: only-for javascript
+```javascript
+hot.getPlugin('contextMenu').executeCommand('alignment:left');
+```
+:::
+
+::: only-for react
+```jsx
+hotRef.current.hotInstance.getPlugin('contextMenu').executeCommand('alignment:left');
+```
+:::
+
+::: only-for angular
+```typescript
+this.hotTable.hotInstance.getPlugin('contextMenu').executeCommand('alignment:left');
+```
+:::
+
+::: only-for vue
+```javascript
+hotTableRef.value.hotInstance.getPlugin('contextMenu').executeCommand('alignment:left');
+```
+:::
+
+They are not menu item keys. Listing `alignment:left` in `contextMenu` does not create a "Left"
+item, because only the keys in the table above are resolved.
+
+To show part of a submenu, keep the predefined submenu items and filter out the ones you don't
+want. The items you keep carry their own actions, so they keep working:
+
+::: only-for javascript
+```javascript
+const verticalKeys = ['alignment:top', 'alignment:middle', 'alignment:bottom'];
+
+const hot = new Handsontable(container, {
+  licenseKey: 'non-commercial-and-evaluation',
+  contextMenu: true,
+  afterContextMenuDefaultOptions(options) {
+    const alignment = options.items.find(item => item.key === 'alignment');
+
+    if (!alignment) {
+      return;
+    }
+
+    alignment.submenu.items = alignment.submenu.items
+      .filter(item => !verticalKeys.includes(item.key));
+  },
+});
+```
+:::
+
+::: only-for react
+```jsx
+const verticalKeys = ['alignment:top', 'alignment:middle', 'alignment:bottom'];
+
+const trimAlignment = (options) => {
+  const alignment = options.items.find(item => item.key === 'alignment');
+
+  if (!alignment) {
+    return;
+  }
+
+  alignment.submenu.items = alignment.submenu.items
+    .filter(item => !verticalKeys.includes(item.key));
+};
+
+<HotTable
+  licenseKey="non-commercial-and-evaluation"
+  contextMenu={true}
+  afterContextMenuDefaultOptions={trimAlignment}
+/>
+```
+:::
+
+::: only-for angular
+```typescript
+const verticalKeys = ['alignment:top', 'alignment:middle', 'alignment:bottom'];
+
+readonly gridSettings: GridSettings = {
+  licenseKey: 'non-commercial-and-evaluation',
+  contextMenu: true,
+  afterContextMenuDefaultOptions(options) {
+    const alignment = options.items.find(item => item.key === 'alignment');
+
+    if (!alignment) {
+      return;
+    }
+
+    alignment.submenu.items = alignment.submenu.items
+      .filter(item => !verticalKeys.includes(item.key));
+  },
+};
+```
+:::
+
+::: only-for vue
+```javascript
+const verticalKeys = ['alignment:top', 'alignment:middle', 'alignment:bottom'];
+
+const settings = {
+  licenseKey: 'non-commercial-and-evaluation',
+  contextMenu: true,
+  afterContextMenuDefaultOptions(options) {
+    const alignment = options.items.find(item => item.key === 'alignment');
+
+    if (!alignment) {
+      return;
+    }
+
+    alignment.submenu.items = alignment.submenu.items
+      .filter(item => !verticalKeys.includes(item.key));
+  },
+};
+```
+:::
+
+The alignment submenu then offers only the horizontal options. For the column menu, use
+`afterDropdownMenuDefaultOptions` instead.
+
+To build a submenu item of your own, give it a `name` and a `callback`. A custom item runs only the
+`callback` you write -- it does not inherit an action from a predefined key of the same name.
 
 ::: only-for react
 

--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -125,9 +125,15 @@ The `filter_by_condition`, `filter_by_condition2`, `filter_operators`, `filter_b
 `filter_action_bar` items build the filtering interface and take effect only in the dropdown (column)
 menu, not in the context menu. See [Filter menu items](@/guides/accessories-and-menus/column-menu/column-menu.md#filter-menu-items).
 
-The table above lists every key you can use. A key that is not on it is skipped, and Handsontable
-logs a console warning naming it. A key is also skipped when the plugin that provides it is not
-enabled, so check the required plugin named beside the key when an item does not appear.
+The table above lists every key you can use in the array form of `contextMenu`. An array key that
+matches no available item is skipped, and Handsontable logs a console warning naming it and the
+menu it came from. That covers a key with a typo in it, and a key whose plugin is not enabled --
+so check the required plugin named beside the key when an item does not appear.
+
+Two cases are skipped without a warning. A key for a built-in item that is turned off, such as
+`row_above` under `allowInsertRow: false`, is left out on purpose. And in the object form of
+`contextMenu`, a plain string value is the item's label rather than a key to look up, so nothing
+is resolved and nothing is reported.
 
 To see the context menu, right-click on a cell. On touch devices, long-press a cell to open the context menu.
 

--- a/handsontable/src/plugins/contextMenu/AGENTS.md
+++ b/handsontable/src/plugins/contextMenu/AGENTS.md
@@ -15,7 +15,7 @@
 
 ## A plugin contributing menu items must register on BOTH hooks
 
-The two menus build their item lists from separate hooks: `afterContextMenuDefaultOptions` and `afterDropdownMenuDefaultOptions`. A plugin that registers on only one is absent from the other, and **nothing raises**. Until DEV-2758 that was actively misleading: `ItemsFactory` turned a key it could not resolve into a bare `{ name, key }` placeholder, so the menu rendered a row labelled with the RAW KEY that did nothing when clicked. That was issue #5429 — `freeze_column` worked in `contextMenu` and rendered a dead row in `dropdownMenu` for seven years.
+The two menus build their item lists from separate hooks: `afterContextMenuDefaultOptions` and `afterDropdownMenuDefaultOptions`. A plugin that registers on only one is absent from the other, and **nothing raises**. Until DEV-2758 that was actively misleading: `ItemsFactory` turned a key it could not resolve into a bare `{ name, key }` placeholder, so the menu rendered a row labeled with the RAW KEY that did nothing when clicked. That was issue #5429 — `freeze_column` worked in `contextMenu` and rendered a dead row in `dropdownMenu` for seven years.
 
 An unresolvable key is now **skipped**, with a `warnOnce()` naming it. So the failure is quiet in the UI and loud in the console instead of the other way round. It is still a failure: the item does not appear, so registering on both hooks remains the fix, not the warning.
 
@@ -27,11 +27,21 @@ Register one handler on both hooks, as `manualColumnFreeze.ts` does. Eight plugi
 
 An array entry can also be a full item definition **object** rather than a key string. Those are merged in further down and must never reach the unresolved-key path, which is why the skip is guarded by `!isObject(name)`.
 
-### `execute()` matches the whole command name before splitting on `:`
+### `execute()` resolves the PARENT name first, and the whole name only as a fallback
 
-Object-form `items` take their key verbatim, so `{ items: { 'alignment:left': … } }` registers a command under the full string. `CommandExecutor#execute()` therefore tries `this.commands[commandName]` first and only then splits — without that, the lookup searched for an `alignment` command that was never registered and threw `Menu command 'alignment' not exists.` on click (issue #5027). The split path still resolves a documented subcommand such as `executeCommand('alignment:left')` against the predefined `alignment` submenu, because nothing registers that key at the top level.
+Object-form `items` take their key verbatim, so `{ items: { 'alignment:left': … } }` registers a command under the full string, colon included. `CommandExecutor#execute()` used to split on `:` unconditionally and look up only the first segment, so that command was never found and a click threw `Menu command 'alignment' not exists.` (issue #5027). `#findCommand()` now falls back to the whole-name lookup — but **only where the split path used to throw**, and the order matters:
 
-Note what this does **not** do: it does not attach a predefined subcommand's callback to a user's item. `{ 'alignment:left': { name: 'Left' } }` renders and no longer throws, but it does nothing when clicked, because the user supplied no `callback`. Resolving predefined subcommand keys at any menu level is the open request in issue #5027 and was deliberately not built — it would mean changing the shallow `extend` merge that #9894 depends on.
+1. `commands[parent]` exists → walk its `submenu` for the subcommand, exactly as before.
+2. Otherwise `commands[<whole name>]` exists → return it.
+3. Otherwise throw.
+
+Reversing 1 and 2 looks equivalent and is not. Both entries exist at once whenever object-form `items` declare the parent *and* the colon key side by side (`{ items: { alignment: {}, 'alignment:left': {…} } }`): the parent carries the predefined submenu with the real callback, while the colon key is the caller's bare `{ name, key }`. Matching the whole name first hands back the bare entry, which has no `callback`, so an alignment that used to work silently stops running. Pinned by `__tests__/commandExecutor.unit.js`.
+
+Both lookups go through `hasOwnProperty()` — `commands` is a plain object, so a bare index answers `toString` and `constructor` with the inherited member, which then slips past every gate in `execute()` and runs the common callback instead of reporting an unknown command.
+
+A subcommand name that matches no submenu entry is a `warnOnce()` and a no-op. It previously read `disabled` off `undefined` and threw a `TypeError`; silence would have been worse than either, since a mistyped *parent* still throws.
+
+Note what none of this does: it does not attach a predefined subcommand's callback to a caller's item. `{ 'alignment:left': { name: 'Left' } }` renders and no longer throws, but it does nothing when clicked, because no `callback` was supplied. Resolving predefined subcommand keys at any menu level is the open request in issue #5027 and was deliberately not built — it would mean changing the shallow `extend` merge that #9894 depends on.
 
 Both menus now rebuild their item list on every `open()` (`prepareMenuItems()`), so the list tracks the current settings. Before that, `DropdownMenu` built its list once in `enablePlugin`, which left it frozen: a plugin enabled later through `updateSettings` never reached the menu, and one disabled later kept entries that still ran. Do not move item building back into `enablePlugin` — and note that the `Menu` instance and its local hooks are still created there, deliberately, so `prepareMenuItems()` stays safe to call repeatedly.
 

--- a/handsontable/src/plugins/contextMenu/AGENTS.md
+++ b/handsontable/src/plugins/contextMenu/AGENTS.md
@@ -15,9 +15,23 @@
 
 ## A plugin contributing menu items must register on BOTH hooks
 
-The two menus build their item lists from separate hooks: `afterContextMenuDefaultOptions` and `afterDropdownMenuDefaultOptions`. A plugin that registers on only one is absent from the other, and **nothing raises** — `ItemsFactory` turns a key it cannot resolve into a bare `{ name, key }` placeholder, so the menu renders a row labelled with the RAW KEY that does nothing when clicked. That was issue #5429: `freeze_column` worked in `contextMenu` and rendered a dead row in `dropdownMenu` for seven years.
+The two menus build their item lists from separate hooks: `afterContextMenuDefaultOptions` and `afterDropdownMenuDefaultOptions`. A plugin that registers on only one is absent from the other, and **nothing raises**. Until DEV-2758 that was actively misleading: `ItemsFactory` turned a key it could not resolve into a bare `{ name, key }` placeholder, so the menu rendered a row labelled with the RAW KEY that did nothing when clicked. That was issue #5429 — `freeze_column` worked in `contextMenu` and rendered a dead row in `dropdownMenu` for seven years.
 
-Register one handler on both hooks, as `manualColumnFreeze.ts` does. Eight plugins still register on the context menu hook only — `comments`, `customBorders`, `copyPaste`, `exportFile`, `mergeCells`, `hiddenRows`, `hiddenColumns`, `nestedRows` — so `copy`, `mergeCells`, `commentsAddEdit`, `borders` and the hiding keys are all still dead as dropdown menu keys.
+An unresolvable key is now **skipped**, with a `warnOnce()` naming it. So the failure is quiet in the UI and loud in the console instead of the other way round. It is still a failure: the item does not appear, so registering on both hooks remains the fix, not the warning.
+
+Register one handler on both hooks, as `manualColumnFreeze.ts` does. Eight plugins still register on the context menu hook only — `comments`, `customBorders`, `copyPaste`, `exportFile`, `mergeCells`, `hiddenRows`, `hiddenColumns`, `nestedRows` — so `copy`, `mergeCells`, `commentsAddEdit`, `borders` and the hiding keys are all still absent as dropdown menu keys.
+
+### The skip runs only AFTER the default-options hook — never move it into `getItems()`
+
+`prepareMenuItems()` calls `ItemsFactory#getItems()` **twice**: once to build the list handed to the hook, then `setPredefinedItems()`, then again. On the first pass every plugin key is unknown *by design*, and the placeholder emitted there is load-bearing — `nestedRows/ui/contextMenu.ts` runs `rangeEach(0, items.length - 1, …)` and inserts its entries only when the list is **non-empty**. Filtering inside `getItems()` unconditionally makes `contextMenu: ['add_child']` yield an empty first-pass list, nestedRows never inserts, and `add_child` vanishes — re-breaking issue #9894. The `#predefinedItemsSet` flag is what confines the skip to the second pass; `__tests__/itemsFactory.unit.js` pins both halves.
+
+An array entry can also be a full item definition **object** rather than a key string. Those are merged in further down and must never reach the unresolved-key path, which is why the skip is guarded by `!isObject(name)`.
+
+### `execute()` matches the whole command name before splitting on `:`
+
+Object-form `items` take their key verbatim, so `{ items: { 'alignment:left': … } }` registers a command under the full string. `CommandExecutor#execute()` therefore tries `this.commands[commandName]` first and only then splits — without that, the lookup searched for an `alignment` command that was never registered and threw `Menu command 'alignment' not exists.` on click (issue #5027). The split path still resolves a documented subcommand such as `executeCommand('alignment:left')` against the predefined `alignment` submenu, because nothing registers that key at the top level.
+
+Note what this does **not** do: it does not attach a predefined subcommand's callback to a user's item. `{ 'alignment:left': { name: 'Left' } }` renders and no longer throws, but it does nothing when clicked, because the user supplied no `callback`. Resolving predefined subcommand keys at any menu level is the open request in issue #5027 and was deliberately not built — it would mean changing the shallow `extend` merge that #9894 depends on.
 
 Both menus now rebuild their item list on every `open()` (`prepareMenuItems()`), so the list tracks the current settings. Before that, `DropdownMenu` built its list once in `enablePlugin`, which left it frozen: a plugin enabled later through `updateSettings` never reached the menu, and one disabled later kept entries that still ran. Do not move item building back into `enablePlugin` — and note that the `Menu` instance and its local hooks are still created there, deliberately, so `prepareMenuItems()` stays safe to call repeatedly.
 

--- a/handsontable/src/plugins/contextMenu/AGENTS.md
+++ b/handsontable/src/plugins/contextMenu/AGENTS.md
@@ -17,7 +17,11 @@
 
 The two menus build their item lists from separate hooks: `afterContextMenuDefaultOptions` and `afterDropdownMenuDefaultOptions`. A plugin that registers on only one is absent from the other, and **nothing raises**. Until DEV-2758 that was actively misleading: `ItemsFactory` turned a key it could not resolve into a bare `{ name, key }` placeholder, so the menu rendered a row labeled with the RAW KEY that did nothing when clicked. That was issue #5429 — `freeze_column` worked in `contextMenu` and rendered a dead row in `dropdownMenu` for seven years.
 
-An unresolvable key is now **skipped**, with a `warnOnce()` naming it. So the failure is quiet in the UI and loud in the console instead of the other way round. It is still a failure: the item does not appear, so registering on both hooks remains the fix, not the warning.
+An unresolvable key in the **array** form is now **skipped**, with a `warnOnce()` naming both the key and the menu it came from. So the failure is quiet in the UI and loud in the console instead of the other way round. It is still a failure: the item does not appear, so registering on both hooks remains the fix, not the warning.
+
+The menu name comes from `ItemsFactory`'s third constructor argument (each plugin passes its own `PLUGIN_KEY`). It is part of the `warnOnce` dedup key as well as the text, because both menus share one `hot.rootElement` scope — without it, a key unresolvable in *both* menus warns once and names neither.
+
+Two cases are deliberately outside the skip. A key naming a built-in `ITEMS` member with no current entry is dropped silently, exactly as before — `allowInsert*`/`allowRemove*` suppress theirs at render time. And the **object** form of `items` is untouched by this PR: there a plain string value is the item's *label*, not a key to resolve, so nothing is looked up and nothing is reported. Do not describe the skip as covering every unresolvable key.
 
 Register one handler on both hooks, as `manualColumnFreeze.ts` does. Eight plugins still register on the context menu hook only — `comments`, `customBorders`, `copyPaste`, `exportFile`, `mergeCells`, `hiddenRows`, `hiddenColumns`, `nestedRows` — so `copy`, `mergeCells`, `commentsAddEdit`, `borders` and the hiding keys are all still absent as dropdown menu keys.
 
@@ -38,6 +42,8 @@ Object-form `items` take their key verbatim, so `{ items: { 'alignment:left': �
 Reversing 1 and 2 looks equivalent and is not. Both entries exist at once whenever object-form `items` declare the parent *and* the colon key side by side (`{ items: { alignment: {}, 'alignment:left': {…} } }`): the parent carries the predefined submenu with the real callback, while the colon key is the caller's bare `{ name, key }`. Matching the whole name first hands back the bare entry, which has no `callback`, so an alignment that used to work silently stops running. Pinned by `__tests__/commandExecutor.unit.js`.
 
 Both lookups go through `hasOwnProperty()` — `commands` is a plain object, so a bare index answers `toString` and `constructor` with the inherited member, which then slips past every gate in `execute()` and runs the common callback instead of reporting an unknown command.
+
+`hasCommand()` is the boolean form of the same rule. `DropdownMenu#executeCommand` asks it rather than re-implementing the two lookups, because that method rebuilds the whole item list when a name looks unknown — so a copy of the rule that went stale would re-fire both item hooks on every colon-keyed command.
 
 A subcommand name that matches no submenu entry is a `warnOnce()` and a no-op. It previously read `disabled` off `undefined` and threw a `TypeError`; silence would have been worse than either, since a mistyped *parent* still throws.
 

--- a/handsontable/src/plugins/contextMenu/__tests__/commandExecutor.unit.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/commandExecutor.unit.js
@@ -1,0 +1,141 @@
+import { CommandExecutor } from 'handsontable/plugins/contextMenu/commandExecutor';
+
+describe('contextMenu/CommandExecutor', () => {
+  /** Stands in for the Handsontable instance every callback is applied against. */
+  const hot = {};
+
+  describe('a command registered under a key that contains a colon', () => {
+    // Object-form menu `items` take their key verbatim, so `{ items: { 'alignment:left': … } }`
+    // registers the command under the whole string. `execute()` used to split on `:` first and
+    // look up `alignment`, which was never registered — so a click threw
+    // `Menu command 'alignment' not exists.` instead of running anything (issue #5027).
+    it('is found by its full name instead of throwing', () => {
+      const executor = new CommandExecutor(hot);
+      const callback = jest.fn();
+
+      executor.registerCommand('alignment:left', { key: 'alignment:left', callback });
+
+      expect(() => executor.execute('alignment:left')).not.toThrow();
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('receives its own full name as the first callback argument', () => {
+      const executor = new CommandExecutor(hot);
+      const callback = jest.fn();
+
+      executor.registerCommand('alignment:left', { key: 'alignment:left', callback });
+      executor.execute('alignment:left', 'extra');
+
+      expect(callback).toHaveBeenCalledWith('alignment:left', 'extra');
+    });
+  });
+
+  describe('a subcommand of a registered parent', () => {
+    /**
+     * Mirrors how the predefined `alignment` item is shaped: a parent holding its own submenu.
+     *
+     * @param {Function} callback The submenu entry's callback.
+     * @returns {object}
+     */
+    function alignmentCommand(callback) {
+      return {
+        key: 'alignment',
+        submenu: {
+          items: [{ key: 'alignment:left', callback }],
+        },
+      };
+    }
+
+    it('still resolves through the parent when only the parent is registered', () => {
+      // The path the documented `executeCommand('alignment:left')` relies on. Matching the full
+      // name first must not shadow it — nothing registers `alignment:left` at the top level here.
+      const executor = new CommandExecutor(hot);
+      const callback = jest.fn();
+
+      executor.registerCommand('alignment', alignmentCommand(callback));
+      executor.execute('alignment:left');
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith('alignment:left');
+    });
+
+    it('does nothing when the subcommand name matches no submenu entry', () => {
+      // Previously this read `disabled` off `undefined` and threw a TypeError.
+      const executor = new CommandExecutor(hot);
+      const callback = jest.fn();
+
+      executor.registerCommand('alignment', alignmentCommand(callback));
+
+      expect(() => executor.execute('alignment:nonexistent')).not.toThrow();
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('does not run the parent as a fallback', () => {
+      // A parent that owns a submenu is a container, never an action.
+      const executor = new CommandExecutor(hot);
+      const parentCallback = jest.fn();
+      const command = alignmentCommand(jest.fn());
+
+      command.callback = parentCallback;
+      executor.registerCommand('alignment', command);
+      executor.execute('alignment:nonexistent');
+
+      expect(parentCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('a command nobody registered', () => {
+    it('still reports the missing name', () => {
+      const executor = new CommandExecutor(hot);
+
+      expect(() => executor.execute('not_a_command')).toThrow(/not_a_command/);
+    });
+
+    it('reports the parent name when a subcommand of an unknown parent is executed', () => {
+      const executor = new CommandExecutor(hot);
+
+      expect(() => executor.execute('nothing:here')).toThrow(/'nothing'/);
+    });
+  });
+
+  describe('the disabled gate', () => {
+    it('skips a command disabled by value, matched by its full name', () => {
+      const executor = new CommandExecutor(hot);
+      const callback = jest.fn();
+
+      executor.registerCommand('alignment:left', { key: 'alignment:left', callback, disabled: true });
+      executor.execute('alignment:left');
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('skips a command whose disabled function returns true', () => {
+      const executor = new CommandExecutor(hot);
+      const callback = jest.fn();
+
+      executor.registerCommand('alignment:left', {
+        key: 'alignment:left',
+        callback,
+        disabled: () => true,
+      });
+      executor.execute('alignment:left');
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the common callback', () => {
+    it('runs for a command matched by its full name', () => {
+      // The menu closes through this callback, so a command found on the new exact-match path
+      // must not bypass it.
+      const executor = new CommandExecutor(hot);
+      const commonCallback = jest.fn();
+
+      executor.registerCommand('alignment:left', { key: 'alignment:left' });
+      executor.setCommonCallback(commonCallback);
+      executor.execute('alignment:left');
+
+      expect(commonCallback).toHaveBeenCalledWith('alignment:left');
+    });
+  });
+});

--- a/handsontable/src/plugins/contextMenu/__tests__/commandExecutor.unit.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/commandExecutor.unit.js
@@ -1,8 +1,22 @@
 import { CommandExecutor } from 'handsontable/plugins/contextMenu/commandExecutor';
 
 describe('contextMenu/CommandExecutor', () => {
-  /** Stands in for the Handsontable instance every callback is applied against. */
-  const hot = {};
+  /**
+   * Stands in for the Handsontable instance every callback is applied against. `rootElement` is
+   * the scope the "warn once" state binds to, and it must be an object — a real instance always
+   * has one. Rebuilt per test so one test's warning cannot silence another's.
+   */
+  let hot;
+  let warnSpy;
+
+  beforeEach(() => {
+    hot = { rootElement: {} };
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
 
   describe('a command registered under a key that contains a colon', () => {
     // Object-form menu `items` take their key verbatim, so `{ items: { 'alignment:left': … } }`
@@ -59,6 +73,23 @@ describe('contextMenu/CommandExecutor', () => {
       expect(callback).toHaveBeenCalledWith('alignment:left');
     });
 
+    it('wins over a top-level command registered under the same colon key', () => {
+      // Both can be registered at once: `{ items: { alignment: {}, 'alignment:left': {…} } }`
+      // produces a rich `alignment` parent AND a bare top-level `alignment:left`. Resolving the
+      // whole name first would hand back the bare entry, whose lack of a callback would silently
+      // disable an alignment that used to work. The parent's submenu keeps precedence.
+      const executor = new CommandExecutor(hot);
+      const submenuCallback = jest.fn();
+      const topLevelCallback = jest.fn();
+
+      executor.registerCommand('alignment', alignmentCommand(submenuCallback));
+      executor.registerCommand('alignment:left', { key: 'alignment:left', callback: topLevelCallback });
+      executor.execute('alignment:left');
+
+      expect(submenuCallback).toHaveBeenCalledTimes(1);
+      expect(topLevelCallback).not.toHaveBeenCalled();
+    });
+
     it('does nothing when the subcommand name matches no submenu entry', () => {
       // Previously this read `disabled` off `undefined` and threw a TypeError.
       const executor = new CommandExecutor(hot);
@@ -68,6 +99,18 @@ describe('contextMenu/CommandExecutor', () => {
 
       expect(() => executor.execute('alignment:nonexistent')).not.toThrow();
       expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('warns about the unmatched subcommand so the typo is findable', () => {
+      // A mistyped PARENT throws. Without this, a mistyped CHILD was completely silent — no
+      // throw, no output, no return value — which is the worst of the two for debugging.
+      const executor = new CommandExecutor(hot);
+
+      executor.registerCommand('alignment', alignmentCommand(jest.fn()));
+      executor.execute('alignment:lefft');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('alignment:lefft');
     });
 
     it('does not run the parent as a fallback', () => {
@@ -95,6 +138,21 @@ describe('contextMenu/CommandExecutor', () => {
       const executor = new CommandExecutor(hot);
 
       expect(() => executor.execute('nothing:here')).toThrow(/'nothing'/);
+    });
+
+    it('does not resolve a name inherited from Object.prototype', () => {
+      // `commands` is a plain object, so a bare `this.commands[name]` lookup answers `toString`
+      // and `constructor` with the inherited member. That has no callback and no own `submenu`,
+      // so it slipped past every gate in `execute()` and quietly ran the common callback rather
+      // than reporting an unknown command.
+      const executor = new CommandExecutor(hot);
+      const commonCallback = jest.fn();
+
+      executor.setCommonCallback(commonCallback);
+
+      expect(() => executor.execute('toString')).toThrow(/toString/);
+      expect(() => executor.execute('constructor')).toThrow(/constructor/);
+      expect(commonCallback).not.toHaveBeenCalled();
     });
   });
 

--- a/handsontable/src/plugins/contextMenu/__tests__/commandExecutor.unit.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/commandExecutor.unit.js
@@ -156,6 +156,50 @@ describe('contextMenu/CommandExecutor', () => {
     });
   });
 
+  describe('hasCommand', () => {
+    // The boolean form of the same resolution rule `execute()` applies. `DropdownMenu#executeCommand`
+    // asks it instead of re-implementing the two lookups, so the two cannot drift apart.
+    it('finds a command registered under its plain name', () => {
+      const executor = new CommandExecutor(hot);
+
+      executor.registerCommand('freeze_column', { key: 'freeze_column' });
+
+      expect(executor.hasCommand('freeze_column')).toBe(true);
+    });
+
+    it('finds a subcommand through its registered parent', () => {
+      const executor = new CommandExecutor(hot);
+
+      executor.registerCommand('alignment', { key: 'alignment', submenu: { items: [] } });
+
+      expect(executor.hasCommand('alignment:left')).toBe(true);
+    });
+
+    it('finds a command registered under its whole colon key', () => {
+      // The case the plain primary-name check misses, which is what made every such call rebuild
+      // the whole item list.
+      const executor = new CommandExecutor(hot);
+
+      executor.registerCommand('alignment:left', { key: 'alignment:left' });
+
+      expect(executor.hasCommand('alignment:left')).toBe(true);
+    });
+
+    it('rejects a name nobody registered', () => {
+      const executor = new CommandExecutor(hot);
+
+      expect(executor.hasCommand('not_a_command')).toBe(false);
+      expect(executor.hasCommand('nothing:here')).toBe(false);
+    });
+
+    it('rejects a name inherited from Object.prototype', () => {
+      const executor = new CommandExecutor(hot);
+
+      expect(executor.hasCommand('toString')).toBe(false);
+      expect(executor.hasCommand('constructor')).toBe(false);
+    });
+  });
+
   describe('the disabled gate', () => {
     it('skips a command disabled by value, matched by its full name', () => {
       const executor = new CommandExecutor(hot);

--- a/handsontable/src/plugins/contextMenu/__tests__/itemsFactory.unit.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/itemsFactory.unit.js
@@ -1,0 +1,151 @@
+import { ItemsFactory } from 'handsontable/plugins/contextMenu/itemsFactory';
+
+/**
+ * `ItemsFactory` only needs `hot.rootElement` — it is the scope the "warn once" state binds to.
+ *
+ * @returns {object} A minimal Handsontable stand-in.
+ */
+function hotMock() {
+  return { rootElement: {} };
+}
+
+/**
+ * Describes every produced item so a resolved entry is distinguishable from a placeholder, which
+ * is the whole subject of these tests.
+ *
+ * A resolved item carries a `name` FUNCTION returning the translated phrase, and is reported as
+ * `<its key>`. A placeholder carries the raw key string as its `name` — the value that used to be
+ * rendered into the menu verbatim — and is reported as that string.
+ *
+ * @param {object[]} items The produced menu items.
+ * @returns {string[]}
+ */
+function namesOf(items) {
+  return items.map(item => (typeof item.name === 'function' ? `<${item.key}>` : item.name));
+}
+
+describe('contextMenu/ItemsFactory', () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('the pass before the default-options hook has run', () => {
+    // This is the pass whose output is handed to `afterContextMenuDefaultOptions`. Plugin keys are
+    // legitimately unknown here, so a placeholder MUST still be emitted for a plugin to merge its
+    // rich entry into. See the merge comment in `setPredefinedItems` and issue #9894.
+    it('emits a placeholder for a key it cannot resolve yet', () => {
+      const factory = new ItemsFactory(hotMock());
+
+      const items = factory.getItems(['row_above', 'borders']);
+
+      expect(namesOf(items)).toEqual(['<row_above>', 'borders']);
+    });
+
+    it('does not warn, because the key may still be contributed', () => {
+      const factory = new ItemsFactory(hotMock());
+
+      factory.getItems(['borders']);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('keeps the list non-empty, which plugins that splice by index depend on', () => {
+      // `nestedRows/ui/contextMenu.ts` runs `rangeEach(0, items.length - 1, …)` and inserts its
+      // entries only when the list is NOT empty. Dropping unknown keys on this pass would make
+      // `contextMenu: ['add_child']` produce an empty list, nestedRows would never insert, and
+      // `add_child` would vanish — re-breaking issue #9894.
+      const factory = new ItemsFactory(hotMock());
+
+      expect(factory.getItems(['add_child'])).toHaveLength(1);
+    });
+  });
+
+  describe('the pass after the default-options hook has run', () => {
+    it('skips a key that still resolves to nothing', () => {
+      const factory = new ItemsFactory(hotMock());
+
+      // What the plugins contributed. `borders` was never among them, so it stays unresolvable.
+      factory.setPredefinedItems(factory.getItems(['row_above', 'borders']));
+
+      const items = factory.getItems(['row_above', 'borders']);
+
+      // Before this fix the unresolved key became `{ name: 'borders', key: '0' }` and the menu
+      // rendered a row reading `borders` that did nothing when clicked (issues #5429, #5027).
+      expect(namesOf(items)).toEqual(['<row_above>']);
+    });
+
+    it('warns once per unresolved key so a typo is findable', () => {
+      const factory = new ItemsFactory(hotMock());
+
+      factory.setPredefinedItems(factory.getItems(['row_abvoe']));
+      factory.getItems(['row_abvoe']);
+      factory.getItems(['row_abvoe']);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('row_abvoe');
+    });
+
+    it('warns separately for each distinct unresolved key', () => {
+      const factory = new ItemsFactory(hotMock());
+
+      factory.setPredefinedItems(factory.getItems(['row_abvoe', 'col_lfet']));
+      factory.getItems(['row_abvoe', 'col_lfet']);
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('still resolves a key a plugin did contribute', () => {
+      const factory = new ItemsFactory(hotMock());
+      const contributed = factory.getItems(['borders']);
+
+      // Stand in for what `customBorders` pushes from the hook when it is enabled.
+      contributed.push({ key: 'borders', name: 'Borders', submenu: { items: [] } });
+      factory.setPredefinedItems(contributed);
+
+      // Resolved to the rich entry, so it keeps its translated name rather than being skipped.
+      expect(namesOf(factory.getItems(['borders']))).toEqual(['Borders']);
+    });
+
+    it('never skips an array entry that is a full item definition object', () => {
+      const factory = new ItemsFactory(hotMock());
+      const custom = { name: 'My own item', callback() {} };
+
+      factory.setPredefinedItems(factory.getItems([custom]));
+
+      // An object entry is a definition, not a key to look up, so the unresolved-key path must
+      // not touch it.
+      expect(namesOf(factory.getItems([custom]))).toEqual(['My own item']);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('leaves the object form of `items` alone', () => {
+      const factory = new ItemsFactory(hotMock());
+      const pattern = { items: { 'alignment:left': { name: 'Left' } } };
+
+      factory.setPredefinedItems(factory.getItems(pattern));
+
+      // Only the array form looks a bare string up in the registry. The object form declares the
+      // item inline, so its key is taken verbatim and the entry is kept.
+      expect(namesOf(factory.getItems(pattern))).toEqual(['Left']);
+    });
+  });
+
+  describe('keys that name a built-in item with no entry', () => {
+    it('are dropped without a warning, as they always were', () => {
+      const factory = new ItemsFactory(hotMock());
+
+      // `ITEMS` members are known names, so an absent entry is an availability question, not a
+      // mistake — the `allowInsert*`/`allowRemove*` options hide these at render time instead.
+      factory.setPredefinedItems([]);
+
+      expect(factory.getItems(['row_above'])).toEqual([]);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/handsontable/src/plugins/contextMenu/commandExecutor.ts
+++ b/handsontable/src/plugins/contextMenu/commandExecutor.ts
@@ -67,17 +67,30 @@ export class CommandExecutor {
    * @param {*} params Arguments passed to command task.
    */
   execute(commandName: string, ...params: unknown[]) {
-    const commandSplit = commandName.split(':');
-    const commandNamePrimary = commandSplit[0];
-
-    const subCommandName = commandSplit.length === 2 ? commandSplit[1] : null;
-    let command = this.commands[commandNamePrimary];
+    // A command can be registered under a key that itself contains a colon, because object-form
+    // menu `items` use their key verbatim. Match the whole name first, so such a command is found
+    // instead of the split below looking up a parent command that was never registered — which
+    // threw `Menu command '<parent>' not exists.` on click.
+    let command = this.commands[commandName];
 
     if (!command) {
-      throwWithCause(`Menu command '${commandNamePrimary}' not exists.`);
-    }
-    if (subCommandName && command.submenu) {
-      command = findSubCommand(subCommandName, command.submenu.items)!;
+      const commandSplit = commandName.split(':');
+      const commandNamePrimary = commandSplit[0];
+      const subCommandName = commandSplit.length === 2 ? commandSplit[1] : null;
+
+      command = this.commands[commandNamePrimary];
+
+      if (!command) {
+        throwWithCause(`Menu command '${commandNamePrimary}' not exists.`);
+      }
+      if (subCommandName && command.submenu) {
+        command = findSubCommand(subCommandName, command.submenu.items)!;
+
+        // A subcommand name that matches no submenu entry leaves nothing to run.
+        if (!command) {
+          return;
+        }
+      }
     }
     if (command.disabled === true) {
       return;
@@ -96,7 +109,7 @@ export class CommandExecutor {
     if (typeof this.commonCallback === 'function') {
       callbacks.push(this.commonCallback);
     }
-    params.unshift(commandSplit.join(':'));
+    params.unshift(commandName);
     arrayEach(callbacks, callback => callback.apply(this.hot, params));
   }
 }

--- a/handsontable/src/plugins/contextMenu/commandExecutor.ts
+++ b/handsontable/src/plugins/contextMenu/commandExecutor.ts
@@ -67,30 +67,11 @@ export class CommandExecutor {
    * @param {*} params Arguments passed to command task.
    */
   execute(commandName: string, ...params: unknown[]) {
-    // A command can be registered under a key that itself contains a colon, because object-form
-    // menu `items` use their key verbatim. Match the whole name first, so such a command is found
-    // instead of the split below looking up a parent command that was never registered — which
-    // threw `Menu command '<parent>' not exists.` on click.
-    let command = this.commands[commandName];
+    const command = this.#findCommand(commandName);
 
+    // A subcommand name that matches no submenu entry leaves nothing to run.
     if (!command) {
-      const commandSplit = commandName.split(':');
-      const commandNamePrimary = commandSplit[0];
-      const subCommandName = commandSplit.length === 2 ? commandSplit[1] : null;
-
-      command = this.commands[commandNamePrimary];
-
-      if (!command) {
-        throwWithCause(`Menu command '${commandNamePrimary}' not exists.`);
-      }
-      if (subCommandName && command.submenu) {
-        command = findSubCommand(subCommandName, command.submenu.items)!;
-
-        // A subcommand name that matches no submenu entry leaves nothing to run.
-        if (!command) {
-          return;
-        }
-      }
+      return;
     }
     if (command.disabled === true) {
       return;
@@ -111,6 +92,39 @@ export class CommandExecutor {
     }
     params.unshift(commandName);
     arrayEach(callbacks, callback => callback.apply(this.hot, params));
+  }
+
+  /**
+   * Resolves a command name to the descriptor that should run.
+   *
+   * @param {string} commandName Command id, optionally a `parent:child` subcommand name.
+   * @returns {object|undefined} The command, or `undefined` when a subcommand name matches no
+   *                             entry in its parent's submenu.
+   */
+  #findCommand(commandName: string): CommandDescriptor | undefined {
+    // A command can be registered under a key that itself contains a colon, because object-form
+    // menu `items` use their key verbatim. Match the whole name first, so such a command is found
+    // instead of the split below looking up a parent command that was never registered — which
+    // threw `Menu command '<parent>' not exists.` on click.
+    const exactMatch = this.commands[commandName];
+
+    if (exactMatch) {
+      return exactMatch;
+    }
+
+    const commandSplit = commandName.split(':');
+    const commandNamePrimary = commandSplit[0];
+    const subCommandName = commandSplit.length === 2 ? commandSplit[1] : null;
+    const command = this.commands[commandNamePrimary];
+
+    if (!command) {
+      throwWithCause(`Menu command '${commandNamePrimary}' not exists.`);
+    }
+    if (subCommandName && command.submenu) {
+      return findSubCommand(subCommandName, command.submenu.items);
+    }
+
+    return command;
   }
 }
 

--- a/handsontable/src/plugins/contextMenu/commandExecutor.ts
+++ b/handsontable/src/plugins/contextMenu/commandExecutor.ts
@@ -2,6 +2,7 @@ import type { HotInstance } from '../../core/types';
 import { arrayEach } from '../../helpers/array';
 import { throwWithCause } from '../../helpers/errors';
 import { hasOwnProperty } from '../../helpers/object';
+import { warnOnce } from '../../helpers/console';
 
 interface CommandDescriptor {
   key?: string;
@@ -102,29 +103,47 @@ export class CommandExecutor {
    *                             entry in its parent's submenu.
    */
   #findCommand(commandName: string): CommandDescriptor | undefined {
-    // A command can be registered under a key that itself contains a colon, because object-form
-    // menu `items` use their key verbatim. Match the whole name first, so such a command is found
-    // instead of the split below looking up a parent command that was never registered — which
-    // threw `Menu command '<parent>' not exists.` on click.
-    const exactMatch = this.commands[commandName];
-
-    if (exactMatch) {
-      return exactMatch;
-    }
-
     const commandSplit = commandName.split(':');
     const commandNamePrimary = commandSplit[0];
     const subCommandName = commandSplit.length === 2 ? commandSplit[1] : null;
-    const command = this.commands[commandNamePrimary];
 
-    if (!command) {
-      throwWithCause(`Menu command '${commandNamePrimary}' not exists.`);
-    }
-    if (subCommandName && command.submenu) {
-      return findSubCommand(subCommandName, command.submenu.items);
+    // The primary name is resolved FIRST so a parent's submenu keeps precedence over a top-level
+    // command registered under the same `parent:child` key. Both exist whenever object-form
+    // `items` declare the parent and the colon key side by side, and the submenu entry is the one
+    // that carries the action — matching the whole name first would hand back the caller's bare
+    // entry and silently stop running it.
+    if (hasOwnProperty(this.commands, commandNamePrimary)) {
+      const command = this.commands[commandNamePrimary];
+
+      if (!subCommandName || !command.submenu) {
+        return command;
+      }
+
+      const subCommand = findSubCommand(subCommandName, command.submenu.items);
+
+      // Nothing to run. Reported rather than thrown, so a mistyped subcommand is as findable as
+      // a mistyped parent (which throws below) without crashing a click handler.
+      if (!subCommand) {
+        warnOnce(
+          this.hot.rootElement,
+          `menu-unknown-subcommand:${commandName}`,
+          `Handsontable: the menu command "${commandName}" matches no entry in the ` +
+          `"${commandNamePrimary}" submenu, so it did nothing.`
+        );
+      }
+
+      return subCommand;
     }
 
-    return command;
+    // No such parent. A command can still be registered under a key that itself contains a colon,
+    // because object-form menu `items` use their key verbatim — matching the whole name here is
+    // what stops `{ items: { 'alignment:left': … } }` throwing on click. Reached only where the
+    // lookup above used to throw, so it takes nothing away from the split path.
+    if (hasOwnProperty(this.commands, commandName)) {
+      return this.commands[commandName];
+    }
+
+    return throwWithCause(`Menu command '${commandNamePrimary}' not exists.`);
   }
 }
 

--- a/handsontable/src/plugins/contextMenu/commandExecutor.ts
+++ b/handsontable/src/plugins/contextMenu/commandExecutor.ts
@@ -96,7 +96,22 @@ export class CommandExecutor {
   }
 
   /**
-   * Resolves a command name to the descriptor that should run.
+   * Checks whether a name resolves to a registered command, using the same two lookups
+   * `execute()` makes — the parent name first, then the whole name.
+   *
+   * @param {string} commandName Command id, optionally a `parent:child` subcommand name.
+   * @returns {boolean}
+   */
+  hasCommand(commandName: string): boolean {
+    const [commandNamePrimary] = commandName.split(':');
+
+    return hasOwnProperty(this.commands, commandNamePrimary) ||
+      hasOwnProperty(this.commands, commandName);
+  }
+
+  /**
+   * Resolves a command name to the descriptor that should run. Throws when the name resolves to
+   * no registered command at all.
    *
    * @param {string} commandName Command id, optionally a `parent:child` subcommand name.
    * @returns {object|undefined} The command, or `undefined` when a subcommand name matches no

--- a/handsontable/src/plugins/contextMenu/contextMenu.ts
+++ b/handsontable/src/plugins/contextMenu/contextMenu.ts
@@ -403,7 +403,7 @@ export class ContextMenu extends BasePlugin {
    * @fires Hooks#beforeContextMenuSetItems
    */
   prepareMenuItems() {
-    this.itemsFactory = new ItemsFactory(this.hot, ContextMenu.DEFAULT_ITEMS);
+    this.itemsFactory = new ItemsFactory(this.hot, ContextMenu.DEFAULT_ITEMS, PLUGIN_KEY);
 
     const settings = this.hot.getSettings()[PLUGIN_KEY];
     const predefinedItems = {

--- a/handsontable/src/plugins/contextMenu/itemsFactory.ts
+++ b/handsontable/src/plugins/contextMenu/itemsFactory.ts
@@ -1,6 +1,7 @@
 import type { HotInstance } from '../../core/types';
 import { objectEach, isObject, extend } from '../../helpers/object';
 import { arrayEach } from '../../helpers/array';
+import { warnOnce } from '../../helpers/console';
 import {
   SEPARATOR,
   ITEMS,
@@ -26,6 +27,13 @@ export class ItemsFactory {
    * @type {Array}
    */
   declare defaultOrderPattern: string[];
+  /**
+   * Whether `setPredefinedItems()` has already run. Until it has, the registry holds only the
+   * built-in items, so a key contributed by a plugin is legitimately still unresolvable.
+   *
+   * @type {boolean}
+   */
+  #predefinedItemsSet = false;
 
   /**
    * Initializes the items factory with a Handsontable instance and an optional default ordering pattern for menu items.
@@ -84,6 +92,7 @@ export class ItemsFactory {
       this.defaultOrderPattern.push(menuItemKey);
     });
     this.predefinedItems = items;
+    this.#predefinedItemsSet = true;
   }
 
   /**
@@ -94,7 +103,27 @@ export class ItemsFactory {
    * @returns {Array}
    */
   getItems(pattern: unknown = null) {
-    return getItems(pattern, this.defaultOrderPattern, this.predefinedItems);
+    return getItems(
+      pattern,
+      this.defaultOrderPattern,
+      this.predefinedItems,
+      this.#predefinedItemsSet ? (name: string) => this.#warnUnresolvedKey(name) : null
+    );
+  }
+
+  /**
+   * Reports a menu item key that names nothing, once per grid instance per key.
+   *
+   * @param {string} name The unresolved menu item key.
+   */
+  #warnUnresolvedKey(name: string) {
+    warnOnce(
+      this.hot.rootElement,
+      `menu-unresolved-item-key:${name}`,
+      `Handsontable: the menu item key "${name}" does not match any available menu item, so it ` +
+      'was skipped. Check the key for typos, and make sure the plugin that provides it is ' +
+      'enabled and contributes items to this menu.'
+    );
   }
 }
 
@@ -102,10 +131,16 @@ export class ItemsFactory {
  * @param {object[]} itemsPattern The user defined menu items collection.
  * @param {object[]} defaultPattern The menu default items collection.
  * @param {object} items Additional options.
+ * @param {Function|null} reportUnresolvedKey When given, a string key that names no available item
+ *                                            is skipped and passed to this callback instead of
+ *                                            being turned into a placeholder item.
  * @returns {object[]} Returns parsed and merged menu items collection ready to render.
  */
 function getItems(
-  itemsPattern: unknown = null, defaultPattern: string[] = [], items: Record<string, Record<string, unknown>> = {}
+  itemsPattern: unknown = null,
+  defaultPattern: string[] = [],
+  items: Record<string, Record<string, unknown>> = {},
+  reportUnresolvedKey: ((name: string) => void) | null = null
 ) {
   const result: Record<string, unknown>[] = [];
   let pattern: unknown = itemsPattern;
@@ -138,10 +173,24 @@ function getItems(
     arrayEach(pattern as string[], (name: string, key: number) => {
       let item: Record<string, unknown> = items[name];
 
-      // A predefined item name with no entry in the items map. The `allowInsert*`/`allowRemove*`
-      // options do not reach here – they hide their items at render time via `hidden()`.
-      if (!item && ITEMS.indexOf(name) >= 0) {
-        return;
+      // An array entry may be a full item definition object instead of a key. It is merged in
+      // below, so it must never be treated as an unresolved key.
+      if (!item && !isObject(name)) {
+        // A predefined item name with no entry in the items map. The `allowInsert*`/`allowRemove*`
+        // options do not reach here – they hide their items at render time via `hidden()`.
+        if (ITEMS.indexOf(name) >= 0) {
+          return;
+        }
+
+        // The key names nothing available. Before the default-options hook has run that is
+        // expected – plugin entries are still missing and need a placeholder to merge into (see
+        // `setPredefinedItems` and issue #9894) – so only the post-hook pass skips them. Emitting
+        // a placeholder there is what rendered the raw key string as a dead menu row (issue #5429).
+        if (reportUnresolvedKey) {
+          reportUnresolvedKey(name);
+
+          return;
+        }
       }
       if (!item) {
         item = { name, key: `${key}` };

--- a/handsontable/src/plugins/contextMenu/itemsFactory.ts
+++ b/handsontable/src/plugins/contextMenu/itemsFactory.ts
@@ -34,13 +34,22 @@ export class ItemsFactory {
    * @type {boolean}
    */
   #predefinedItemsSet = false;
+  /**
+   * Which menu this factory builds, used to make an unresolved-key warning name its own menu.
+   * Both menus share one grid element, so without it the first to warn silences the other.
+   *
+   * @type {string}
+   */
+  #menuName = 'menu';
 
   /**
-   * Initializes the items factory with a Handsontable instance and an optional default ordering pattern for menu items.
+   * Initializes the items factory with a Handsontable instance, an optional default ordering
+   * pattern for menu items, and the name of the menu it builds.
    */
-  constructor(hotInstance: HotInstance, orderPattern: string[] | null = null) {
+  constructor(hotInstance: HotInstance, orderPattern: string[] | null = null, menuName = 'menu') {
     this.hot = hotInstance;
     this.defaultOrderPattern = orderPattern || [];
+    this.#menuName = menuName;
   }
 
   /**
@@ -119,10 +128,10 @@ export class ItemsFactory {
   #warnUnresolvedKey(name: string) {
     warnOnce(
       this.hot.rootElement,
-      `menu-unresolved-item-key:${name}`,
-      `Handsontable: the menu item key "${name}" does not match any available menu item, so it ` +
-      'was skipped. Check the key for typos, and make sure the plugin that provides it is ' +
-      'enabled and contributes items to this menu.'
+      `menu-unresolved-item-key:${this.#menuName}:${name}`,
+      `Handsontable: the "${this.#menuName}" item key "${name}" does not match any available ` +
+      'menu item, so it was skipped. Check the key for typos, and make sure the plugin that ' +
+      'provides it is enabled and contributes items to this menu.'
     );
   }
 }

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
@@ -1,7 +1,7 @@
 import type { HotInstance } from '../../core/types';
 import { BasePlugin } from '../base';
 import { arrayEach } from '../../helpers/array';
-import { objectEach } from '../../helpers/object';
+import { objectEach, hasOwnProperty } from '../../helpers/object';
 import { CommandExecutor } from '../contextMenu/commandExecutor';
 import { getDocumentOffsetByElement } from '../contextMenu/utils';
 import {
@@ -598,9 +598,16 @@ export class DropdownMenu extends BasePlugin {
     // Only an unknown one: rebuilding on every call would fire both item hooks per command, which
     // a listener would see as noise. And never while the menu is open — it was just built, and a
     // rebuild would swap the items out from under the click that is running this command.
+    // A command can also be registered under a key that itself contains a colon, so both names
+    // count as known here — the same two lookups `CommandExecutor#execute()` makes. Testing only
+    // the primary name would rebuild the list on every colon-keyed command, which is exactly the
+    // per-call hook noise this check exists to avoid.
     const [primaryCommandName] = commandName.split(':');
+    const { commands } = this.commandExecutor;
+    const isCommandKnown = hasOwnProperty(commands, primaryCommandName) ||
+      hasOwnProperty(commands, commandName);
 
-    if (!this.commandExecutor.commands[primaryCommandName] && !this.menu?.isOpened()) {
+    if (!isCommandKnown && !this.menu?.isOpened()) {
       this.prepareMenuItems();
     }
 

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
@@ -1,7 +1,7 @@
 import type { HotInstance } from '../../core/types';
 import { BasePlugin } from '../base';
 import { arrayEach } from '../../helpers/array';
-import { objectEach, hasOwnProperty } from '../../helpers/object';
+import { objectEach } from '../../helpers/object';
 import { CommandExecutor } from '../contextMenu/commandExecutor';
 import { getDocumentOffsetByElement } from '../contextMenu/utils';
 import {
@@ -273,7 +273,7 @@ export class DropdownMenu extends BasePlugin {
       return;
     }
 
-    this.itemsFactory = new ItemsFactory(this.hot, DropdownMenu.DEFAULT_ITEMS);
+    this.itemsFactory = new ItemsFactory(this.hot, DropdownMenu.DEFAULT_ITEMS, PLUGIN_KEY);
 
     const settings = this.hot.getSettings()[PLUGIN_KEY];
     const predefinedItems = {
@@ -599,15 +599,11 @@ export class DropdownMenu extends BasePlugin {
     // a listener would see as noise. And never while the menu is open — it was just built, and a
     // rebuild would swap the items out from under the click that is running this command.
     // A command can also be registered under a key that itself contains a colon, so both names
-    // count as known here — the same two lookups `CommandExecutor#execute()` makes. Testing only
-    // the primary name would rebuild the list on every colon-keyed command, which is exactly the
-    // per-call hook noise this check exists to avoid.
-    const [primaryCommandName] = commandName.split(':');
-    const { commands } = this.commandExecutor;
-    const isCommandKnown = hasOwnProperty(commands, primaryCommandName) ||
-      hasOwnProperty(commands, commandName);
-
-    if (!isCommandKnown && !this.menu?.isOpened()) {
+    // count as known here. `hasCommand()` is the boolean form of the resolution rule `execute()`
+    // applies, and asking it keeps the two from drifting apart. Testing only the primary name
+    // would rebuild the list on every colon-keyed command, which is exactly the per-call hook
+    // noise this check exists to avoid.
+    if (!this.commandExecutor.hasCommand(commandName) && !this.menu?.isOpened()) {
       this.prepareMenuItems();
     }
 

--- a/tests/e2e/dropdown-menu-freeze-column.spec.ts
+++ b/tests/e2e/dropdown-menu-freeze-column.spec.ts
@@ -8,7 +8,7 @@ import { DropdownMenuFreezeColumnPage } from '../fixtures/pages/DropdownMenuFree
  * The two menus build their item lists from separate hooks — `afterContextMenuDefaultOptions` and
  * `afterDropdownMenuDefaultOptions` — and ManualColumnFreeze registered only the first. A key the
  * dropdown menu had never heard of raised nothing: `ItemsFactory` turned it into a bare
- * `{ name, key }` placeholder. So the menu rendered a row labelled with the RAW KEY, carrying no
+ * `{ name, key }` placeholder. So the menu rendered a row labeled with the RAW KEY, carrying no
  * callback and no `hidden()`, and clicking it closed the menu without freezing anything.
  *
  * That placeholder is gone as of DEV-2758 — an unresolvable key is skipped and warned about
@@ -296,7 +296,7 @@ test.describe('freeze_column / unfreeze_column as dropdown menu keys', () => {
 
   test.describe('manualColumnFreeze disabled', () => {
     // The entries belong to the plugin, so with it off nothing resolves either key. ItemsFactory
-    // used to emit a `{ name, key }` placeholder for each, and the menu rendered a row labelled
+    // used to emit a `{ name, key }` placeholder for each, and the menu rendered a row labeled
     // with the RAW KEY that did nothing when clicked — the shape #5429 reported. Those rows are
     // now skipped, which is what this block pins (DEV-2758).
     test('skips the unresolvable keys instead of rendering raw-key rows', async () => {
@@ -312,12 +312,14 @@ test.describe('freeze_column / unfreeze_column as dropdown menu keys', () => {
       expect(items).not.toContain('unfreeze_column');
     });
 
-    test('freezes nothing, since there is no row left to click', async () => {
-      await grid.openColumnMenu(PLUGIN_OFF, 'Charlie');
-      await grid.closeDropdownMenu();
+    test('reports the key as an unknown command through the API', async () => {
+      // The skipped row is never registered as a command either, so the API path the placeholder
+      // used to leave open now answers plainly instead of accepting the call and doing nothing.
+      // Driving `executeCommand` is the only way to reach that path — opening and closing the
+      // menu would assert nothing, since no build freezes a column just for being opened.
+      const error = await grid.executeDropdownCommand(PLUGIN_OFF, 'freeze_column', 2);
 
-      // The placeholder row used to be clickable and carried no callback. Dropping it must not
-      // leave some other path that still freezes through a disabled plugin.
+      expect(error).toContain('freeze_column');
       expect(await grid.fixedColumnsStart(PLUGIN_OFF)).toBe(0);
       expect(await grid.columnHeaders(PLUGIN_OFF)).toEqual(
         DropdownMenuFreezeColumnPage.COLUMN_HEADERS
@@ -335,8 +337,11 @@ test.describe('freeze_column / unfreeze_column as dropdown menu keys', () => {
 
       await grid.goto();
 
-      expect(warnings.join('\n')).toContain('freeze_column');
-      expect(warnings.join('\n')).toContain('unfreeze_column');
+      // Console events arrive over CDP independently of `goto()` resolving, so the wait has to be
+      // a contract rather than luck — a late message would otherwise fail the run, and a spec
+      // that only passes on retry still fails the job on CI.
+      await expect.poll(() => warnings.join('\n')).toContain('freeze_column');
+      await expect.poll(() => warnings.join('\n')).toContain('unfreeze_column');
     });
   });
 });

--- a/tests/e2e/dropdown-menu-freeze-column.spec.ts
+++ b/tests/e2e/dropdown-menu-freeze-column.spec.ts
@@ -7,9 +7,12 @@ import { DropdownMenuFreezeColumnPage } from '../fixtures/pages/DropdownMenuFree
  *
  * The two menus build their item lists from separate hooks — `afterContextMenuDefaultOptions` and
  * `afterDropdownMenuDefaultOptions` — and ManualColumnFreeze registered only the first. A key the
- * dropdown menu has never heard of does not raise anything: `ItemsFactory` turns it into a bare
+ * dropdown menu had never heard of raised nothing: `ItemsFactory` turned it into a bare
  * `{ name, key }` placeholder. So the menu rendered a row labelled with the RAW KEY, carrying no
  * callback and no `hidden()`, and clicking it closed the menu without freezing anything.
+ *
+ * That placeholder is gone as of DEV-2758 — an unresolvable key is skipped and warned about
+ * instead — so the `manualColumnFreeze disabled` block at the bottom now pins the skip.
  *
  * That failure mode is why the label assertions below check the translated text rather than just
  * "a row is there" — the broken build rendered a row too.
@@ -292,22 +295,48 @@ test.describe('freeze_column / unfreeze_column as dropdown menu keys', () => {
   });
 
   test.describe('manualColumnFreeze disabled', () => {
-    // Not coverage of this fix: it pins ItemsFactory's unknown-key fallback, which is what #5429
-    // reported seeing. The assertion holds on the unfixed build too, by design.
-    test('renders ItemsFactory placeholder rows, since nothing resolves the keys', async () => {
+    // The entries belong to the plugin, so with it off nothing resolves either key. ItemsFactory
+    // used to emit a `{ name, key }` placeholder for each, and the menu rendered a row labelled
+    // with the RAW KEY that did nothing when clicked — the shape #5429 reported. Those rows are
+    // now skipped, which is what this block pins (DEV-2758).
+    test('skips the unresolvable keys instead of rendering raw-key rows', async () => {
       await grid.openColumnMenu(PLUGIN_OFF, 'Charlie');
 
       const items = await grid.visibleDropdownMenuItems();
 
-      // The entries belong to the plugin, so with it off nothing resolves the keys and ItemsFactory
-      // emits its placeholder for each — the very rows the whole bug consisted of. Pinned as the
-      // real behavior rather than asserting the translated label is absent, which would pass on the
-      // broken build too and prove nothing.
-      expect(items).toEqual(['freeze_column', 'unfreeze_column']);
+      // Every item was dropped, so the menu falls back to its empty-list entry. Asserted as an
+      // exact list, because a build that skipped only one of the two keys would still satisfy
+      // the absence checks below.
+      expect(items).toEqual(['No available options']);
+      expect(items).not.toContain('freeze_column');
+      expect(items).not.toContain('unfreeze_column');
+    });
 
-      await grid.clickDropdownMenuItem('freeze_column');
+    test('freezes nothing, since there is no row left to click', async () => {
+      await grid.openColumnMenu(PLUGIN_OFF, 'Charlie');
+      await grid.closeDropdownMenu();
 
+      // The placeholder row used to be clickable and carried no callback. Dropping it must not
+      // leave some other path that still freezes through a disabled plugin.
       expect(await grid.fixedColumnsStart(PLUGIN_OFF)).toBe(0);
+      expect(await grid.columnHeaders(PLUGIN_OFF)).toEqual(
+        DropdownMenuFreezeColumnPage.COLUMN_HEADERS
+      );
+    });
+
+    test('warns on the console so the developer can find the key', async () => {
+      // Dropping the row silently would trade a visible defect for an invisible one. The warning
+      // is the replacement signal, and it names the key that could not be resolved.
+      //
+      // `prepareMenuItems()` runs once from `enablePlugin`, so the warning is emitted while the
+      // grid is being built — the developer sees it without opening the menu at all. That is
+      // before the `beforeEach` navigation returns, hence the listener plus a second visit.
+      const warnings = grid.collectUnresolvedKeyWarnings();
+
+      await grid.goto();
+
+      expect(warnings.join('\n')).toContain('freeze_column');
+      expect(warnings.join('\n')).toContain('unfreeze_column');
     });
   });
 });

--- a/tests/e2e/dropdown-menu-freeze-column.spec.ts
+++ b/tests/e2e/dropdown-menu-freeze-column.spec.ts
@@ -22,7 +22,7 @@ test.describe('freeze_column / unfreeze_column as dropdown menu keys', () => {
 
   const {
     CUSTOM_KEYS, DEFAULT_MENU, CONTEXT_CONTROL, PLUGIN_OFF, TOGGLE, TOGGLE_OFF_START,
-    FILTERS_ORDER, OTHER_KEYS, FREEZE_LABEL, UNFREEZE_LABEL,
+    FILTERS_ORDER, OTHER_KEYS, COLON_KEY, FREEZE_LABEL, UNFREEZE_LABEL,
   } = DropdownMenuFreezeColumnPage;
 
   /** How many rows carry exactly this label. */
@@ -291,6 +291,35 @@ test.describe('freeze_column / unfreeze_column as dropdown menu keys', () => {
       expect(await grid.columnHeaders(CONTEXT_CONTROL)).toEqual(
         ['Charlie', 'Alpha', 'Bravo', 'Delta', 'Echo', 'Foxtrot']
       );
+    });
+  });
+
+  test.describe('a command registered under a whole `parent:child` key', () => {
+    // `executeCommand` rebuilds the item list when the name looks unknown, so that a command
+    // contributed by a plugin enabled since the last build is still reachable. Asking only about
+    // the parent name reports every colon-keyed command as unknown, and each call then re-fires
+    // both item hooks — the noise the check exists to avoid. Never open the menu in here: opening
+    // rebuilds the list by design and would mask the difference.
+    test('is executed without rebuilding the item list', async () => {
+      // Zero to start with. The enable-time build runs before a hook supplied through the
+      // settings is attached, so it is not counted here — which leaves the counter measuring
+      // exactly the rebuilds `executeCommand` triggers, and nothing else.
+      expect(await grid.dropdownDefaultOptionsCalls()).toBe(0);
+
+      await grid.executeDropdownCommand(COLON_KEY, 'alignment:left', 0);
+      await grid.executeDropdownCommand(COLON_KEY, 'alignment:left', 0);
+
+      // Still zero. Asking only about the parent name reports this command as unknown every
+      // time, and each call then rebuilds the list — making this 2.
+      expect(await grid.dropdownDefaultOptionsCalls()).toBe(0);
+    });
+
+    test('runs without throwing', async () => {
+      // The #5027 symptom: the whole name is what the command was registered under, so a lookup
+      // that only ever split on ':' reported `Menu command 'alignment' not exists.`
+      const error = await grid.executeDropdownCommand(COLON_KEY, 'alignment:left', 0);
+
+      expect(error).toBeNull();
     });
   });
 

--- a/tests/fixtures/demo/dropdown-menu-freeze-column.html
+++ b/tests/fixtures/demo/dropdown-menu-freeze-column.html
@@ -131,7 +131,8 @@
         contextMenu: MENU_KEYS,
       }),
       // Same keys, plugin OFF. Nothing contributes the entries, so both keys stay unknown to the
-      // menu and render as the raw-key placeholder rows ItemsFactory emits for any unknown key.
+      // menu. They used to render as the raw-key placeholder rows ItemsFactory emitted for any
+      // unknown key; they are now skipped, leaving the menu's empty-list entry (DEV-2758).
       'plugin-off': build('plugin-off', {
         manualColumnFreeze: false,
         dropdownMenu: MENU_KEYS,

--- a/tests/fixtures/demo/dropdown-menu-freeze-column.html
+++ b/tests/fixtures/demo/dropdown-menu-freeze-column.html
@@ -50,6 +50,7 @@
   <div id="toggle-off-start" class="grid" data-testid="toggle-off-start"></div>
   <div id="filters-order" class="grid" data-testid="filters-order"></div>
   <div id="other-keys" class="grid" data-testid="other-keys"></div>
+  <div id="colon-key" class="grid" data-testid="colon-key"></div>
 
   <script>
     // The bundle under test, selected above from the sanitized allowlist. The
@@ -112,6 +113,10 @@
       }
     }
 
+    // How many times the `colon-key` grid has run `afterDropdownMenuDefaultOptions`. Set before
+    // any grid is built, because the hook fires once during construction.
+    window.dropdownDefaultOptionsCalls = 0;
+
     window.hots = {
       // The reported config: the two keys listed explicitly as dropdown menu items.
       'custom-keys': build('custom-keys', {
@@ -160,6 +165,22 @@
       'other-keys': build('other-keys', {
         manualColumnFreeze: true,
         dropdownMenu: ['col_left', 'col_right'],
+      }),
+      // Object-form `items` keyed by a whole `parent:child` string, which registers the command
+      // under that key verbatim. `executeCommand('alignment:left')` must then find it WITHOUT
+      // rebuilding the item list — the counter below is what proves the list was not rebuilt.
+      'colon-key': build('colon-key', {
+        dropdownMenu: {
+          items: {
+            'alignment:left': {
+              name: 'Left',
+              callback() {},
+            },
+          },
+        },
+        afterDropdownMenuDefaultOptions() {
+          window.dropdownDefaultOptionsCalls += 1;
+        },
       }),
     };
 

--- a/tests/fixtures/pages/DropdownMenuFreezeColumnPage.ts
+++ b/tests/fixtures/pages/DropdownMenuFreezeColumnPage.ts
@@ -166,6 +166,24 @@ export class DropdownMenuFreezeColumnPage {
     }, menuSelector);
   }
 
+  /**
+   * Start collecting console warnings, and return the live array they land in.
+   *
+   * Filtered to the unresolved-key warning so unrelated console noise (a license notice, say)
+   * cannot make the assertion pass on its own.
+   */
+  collectUnresolvedKeyWarnings(): string[] {
+    const warnings: string[] = [];
+
+    this.page.on('console', (message) => {
+      if (message.type() === 'warning' && message.text().includes('does not match any available')) {
+        warnings.push(message.text());
+      }
+    });
+
+    return warnings;
+  }
+
   /** Pick one entry from the open column header menu. */
   async clickDropdownMenuItem(label: string): Promise<void> {
     await this.menuItem('.htDropdownMenu', label).click();

--- a/tests/fixtures/pages/DropdownMenuFreezeColumnPage.ts
+++ b/tests/fixtures/pages/DropdownMenuFreezeColumnPage.ts
@@ -1,4 +1,4 @@
-import { type Page, type Locator, expect } from '@playwright/test';
+import { type Page, type Locator, type ConsoleMessage, expect } from '@playwright/test';
 
 /**
  * Page Object for the "freeze_column / unfreeze_column as dropdown menu keys" fixture
@@ -170,16 +170,19 @@ export class DropdownMenuFreezeColumnPage {
    * Start collecting console warnings, and return the live array they land in.
    *
    * Filtered to the unresolved-key warning so unrelated console noise (a license notice, say)
-   * cannot make the assertion pass on its own.
+   * cannot make the assertion pass on its own. The listener is removed when the test ends, so it
+   * cannot outlive the spec that asked for it.
    */
   collectUnresolvedKeyWarnings(): string[] {
     const warnings: string[] = [];
-
-    this.page.on('console', (message) => {
+    const onConsole = (message: ConsoleMessage) => {
       if (message.type() === 'warning' && message.text().includes('does not match any available')) {
         warnings.push(message.text());
       }
-    });
+    };
+
+    this.page.on('console', onConsole);
+    this.page.once('close', () => this.page.off('console', onConsole));
 
     return warnings;
   }

--- a/tests/fixtures/pages/DropdownMenuFreezeColumnPage.ts
+++ b/tests/fixtures/pages/DropdownMenuFreezeColumnPage.ts
@@ -26,6 +26,8 @@ export class DropdownMenuFreezeColumnPage {
   static readonly FILTERS_ORDER = 'filters-order';
   /** A custom item list that does not name the freeze keys, with the plugin enabled. */
   static readonly OTHER_KEYS = 'other-keys';
+  /** Object-form `items` keyed by a whole `parent:child` string, with a hook-call counter. */
+  static readonly COLON_KEY = 'colon-key';
 
   /** Every grid the fixture builds. */
   static readonly ALL_GRIDS = [
@@ -37,6 +39,7 @@ export class DropdownMenuFreezeColumnPage {
     DropdownMenuFreezeColumnPage.TOGGLE_OFF_START,
     DropdownMenuFreezeColumnPage.FILTERS_ORDER,
     DropdownMenuFreezeColumnPage.OTHER_KEYS,
+    DropdownMenuFreezeColumnPage.COLON_KEY,
   ];
 
   /** The fixture's named column headers, in their starting order. */
@@ -297,6 +300,18 @@ export class DropdownMenuFreezeColumnPage {
         return null;
       },
       [gridId, command, visualColumn] as [string, string, number]
+    );
+  }
+
+  /**
+   * How many times the `colon-key` grid has run `afterDropdownMenuDefaultOptions`.
+   *
+   * Building the item list fires that hook, so this counter is what separates "the command was
+   * found" from "the list was rebuilt to look for it".
+   */
+  async dropdownDefaultOptionsCalls(): Promise<number> {
+    return this.page.evaluate(
+      () => (window as unknown as { dropdownDefaultOptionsCalls: number }).dropdownDefaultOptionsCalls
     );
   }
 


### PR DESCRIPTION
### Context

The PR fixes a `contextMenu` / `dropdownMenu` item key that cannot be resolved being rendered as a menu row labelled with the **raw key string**, on a row that does nothing when clicked.

The sympathetic case needs no unusual config at all:

```js
contextMenu: ['row_above', 'borders'] // customBorders not enabled
```

That renders a row reading `borders`. The user took a documented key straight from the [context menu keys table](https://handsontable.com/docs/javascript-data-grid/context-menu/#context-menu-with-selected-options) and did not enable its plugin — and that table itself says *"Requires: CustomBorders"*, so the docs fully expect people to land here. Any typo does the same (`row_abvoe` renders a row reading `row_abvoe`), and so does a `parent:child` command name used as an item key (`alignment:left`).

This is the failure mode already documented in `handsontable/src/plugins/contextMenu/AGENTS.md` as the shape of #5429, where `freeze_column` rendered a dead row in `dropdownMenu` for seven years. #5429 was closed by fixing that one plugin; the placeholder that made it invisible stayed. Eight plugins still register on the context menu hook only, so their keys are all exposed the same way.

An unresolvable key is now **skipped**, with a `warnOnce()` naming it — quiet in the UI, loud in the console, instead of the other way round.

Two smaller defects in the same area go with it:

- `CommandExecutor#execute()` split the command name on `:` and looked up only the first segment, so a command registered under a full `a:b` key — which is what object-form `items` produce — was never found and threw `Menu command 'alignment' not exists.` on click. It now matches the whole name first, then falls back to the split.
- A subcommand name matching no submenu entry read `disabled` off `undefined` and threw a `TypeError`. It is now a no-op.

#### Scoping constraint worth knowing before review

The skip **must not** live inside `getItems()`. `prepareMenuItems()` calls it **twice** — once to build the list handed to `afterContextMenuDefaultOptions`, then `setPredefinedItems()`, then again. On the first pass every plugin key is unknown *by design*, and the placeholder emitted there is load-bearing: `nestedRows/ui/contextMenu.ts` runs `rangeEach(0, items.length - 1, …)` and inserts its entries only when the list is **non-empty**. Filtering unconditionally makes `contextMenu: ['add_child']` yield an empty first-pass list, nestedRows never inserts, and `add_child` vanishes — re-breaking #9894. The `#predefinedItemsSet` flag confines the skip to the second pass, and `itemsFactory.unit.js` pins both halves.

An array entry can also be a full item definition **object** rather than a key string, so the skip is guarded by `!isObject(name)`.

#### What this deliberately does not do

It does not resolve predefined subcommand keys at any menu level, which is the open request in [#5027](https://github.com/handsontable/handsontable/issues/5027). `alignment:left` is documented only as an `executeCommand()` **command name** — and it works there — while the documented list of *menu item keys* contains only top-level keys, so that expectation was an assumption rather than a broken promise. Building it would mean changing the shallow `extend` merge that #9894 depends on. Instead the docs now state the distinction and give the supported way to trim a submenu, which is what #5027 actually asked for:

```js
contextMenu: true,
afterContextMenuDefaultOptions(options) {
  const alignment = options.items.find(item => item.key === 'alignment');
  const verticalKeys = ['alignment:top', 'alignment:middle', 'alignment:bottom'];

  alignment.submenu.items = alignment.submenu.items
    .filter(item => !verticalKeys.includes(item.key));
}
```

`{ items: { 'alignment:left': { name: 'Left' } } }` therefore still does nothing on click — it just no longer throws.

### How has this been tested?

New unit coverage for both halves of the fix. Each new test was run against the **unfixed** source first: 3 of 10 `itemsFactory` tests and 7 of 10 `commandExecutor` tests fail there, and the ones that pass on both are the pre-existing behaviors they pin.

```bash
npm --prefix handsontable run test:unit -- --testPathPattern=itemsFactory      # 10 passed
npm --prefix handsontable run test:unit -- --testPathPattern=commandExecutor   # 10 passed
```

The Playwright spec for #5429 contained a test that **pinned the old placeholder behavior** (`expect(items).toEqual(['freeze_column', 'unfreeze_column'])`, commented as holding on the unfixed build by design). That block now pins the skip instead, plus the console warning:

```bash
cd tests && HOT_TEST_PORT=8213 npx playwright test --project=e2e-main e2e/dropdown-menu-freeze-column.spec.ts   # 21 passed
```

Regression runs over everything that contributes menu items, `nestedRows` first as the #9894 risk:

```bash
npm --prefix handsontable run test:e2e -- --testPathPattern=nestedRows      # 175 specs, 0 failures
npm --prefix handsontable run test:e2e -- --testPathPattern=contextMenu     # 596 specs, 0 failures
npm --prefix handsontable run test:e2e -- --testPathPattern=dropdownMenu    # 196 specs, 0 failures
npm --prefix handsontable run test:e2e -- --testPathPattern=filters         # 284 specs, 0 failures
npm --prefix handsontable run test:e2e -- --testPathPattern=customBorders   # 141 specs, 0 failures
npm --prefix handsontable run test:unit                                     # 4331 passed, 342 suites
npm --prefix handsontable run eslint                                        # 0 errors
npm --prefix handsontable run test:types                                    # clean
npm --prefix handsontable run build                                         # clean, incl. strict postbuild
```

Note for anyone re-running the Playwright leg: pass `HOT_TEST_PORT`. On the default 8123 `reuseExistingServer` attaches to whatever already listens, and another checkout's server silently serves its own build — that produced two confusing red runs here before the port was pinned.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

Behavior does change for a grid configured with a key that resolves to nothing: the row disappears instead of showing the raw key. Nothing can depend on clicking it — it carried no callback — so this is treated as a bug fix rather than a breaking change. The only conceivable reliance is abusing an arbitrary string as a static label, which is undocumented and better served by `{ name: '…', disabled: true }`.

### Related issue(s):

1. DEV-2758
2. Same defect class as #5429, which was closed by fixing one plugin rather than the placeholder.
3. Addresses the symptom in #5027 and documents its answer; the feature request in that thread is deliberately not built (see above).

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2758

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared context/dropdown menu item building and command execution paths used on every menu open; behavior is intentionally different when keys are invalid, but regression coverage is strong around the two-pass hook contract and nestedRows.
> 
> **Overview**
> **Fixes dead menu rows** that showed the raw configuration key (e.g. `borders` without CustomBorders, or `freeze_column` in the column menu when the plugin does not contribute). After plugin hooks run, `ItemsFactory` now **drops** keys that still do not resolve and logs a **one-time console warning** instead of emitting a no-op placeholder. The skip is limited to the second `getItems()` pass via `#predefinedItemsSet`, so the first pass still keeps placeholders plugins like nestedRows need (#9894).
> 
> **`CommandExecutor`** gains `#findCommand()`: parent `parent:child` submenu lookup stays first; whole-name lookup fixes object-form keys like `'alignment:left'` (#5027). Misspelled subcommands warn and no-op; lookups use `hasOwnProperty` to avoid `Object.prototype` names. **DropdownMenu** treats colon-keyed commands as known when deciding whether to rebuild before `executeCommand`.
> 
> Docs add guidance on invalid keys, plugin requirements, and that `alignment:left` is a command name—not a menu key—with `afterContextMenuDefaultOptions` examples for trimming submenus. Unit and e2e tests cover both passes, command precedence, and the updated skip behavior (DEV-2758 / #5429 class).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fec8684727cbb5ac94f0f82ad23806527b1513ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->