### PR TITLE
Docs assistant: adopt the thread id from the SSE message_start frame

### DIFF
--- a/docs/src/components/DocsAssistant/useAssistant.ts
+++ b/docs/src/components/DocsAssistant/useAssistant.ts
@@ -122,7 +122,7 @@ function uid() {
 async function* readSSE(
   body: ReadableStream<Uint8Array>,
   signal: AbortSignal
-): AsyncGenerator<{ type: string; delta?: { content?: string } }> {
+): AsyncGenerator<{ type: string; delta?: { content?: string }; thread_id?: string }> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buf = '';
@@ -242,18 +242,29 @@ export function useAssistant() {
         }
         if (!res.body) throw new Error('No response body');
 
-        // Capture the thread id returned by the first successful turn so the
-        // backend can correlate subsequent turns to the same conversation. The
-        // server returns the same value on every turn of a conversation; the
-        // `!current` guard avoids redundant writes.
-        const returnedId = res.headers.get('X-Thread-Id');
-        if (returnedId && !threadIdRef.current) {
-          threadIdRef.current = returnedId;
-          writeThreadId(returnedId);
-        }
+        // Adopt the conversation id returned by the backend so it can
+        // correlate subsequent turns. The id arrives twice: as `thread_id` on
+        // the SSE `message_start` frame (primary — some client environments,
+        // e.g. corporate TLS-inspection proxies, strip custom response
+        // headers, but anything that delivers the stream delivers the frame)
+        // and as the `X-Thread-Id` response header (fallback). The server
+        // returns the RESOLVED id every turn — a fresh one when it discarded
+        // a stale echoed id — so always adopt it rather than keeping what we
+        // hold. Skip adoption once this request has been aborted or replaced
+        // (stop / clear / clearAndSend), so a late frame can't resurrect an
+        // id the user just cleared.
+        const adoptThreadId = (id: string | null | undefined) => {
+          if (!id || controller.signal.aborted) return;
+          if (threadIdRef.current === id) return;
+          threadIdRef.current = id;
+          writeThreadId(id);
+        };
+        adoptThreadId(res.headers.get('X-Thread-Id'));
 
         for await (const event of readSSE(res.body, controller.signal)) {
-          if (event.type === 'content_chunk') {
+          if (event.type === 'message_start') {
+            adoptThreadId(event.thread_id);
+          } else if (event.type === 'content_chunk') {
             const delta = event.delta?.content ?? '';
             if (delta) dispatch({ type: 'APPEND', id: assistantId, delta });
           } else if (event.type === 'message_end') {


### PR DESCRIPTION
## Summary
- Some client environments (corporate TLS-inspection proxies) strip custom response headers, so the `X-Thread-Id` header never reaches the docs-assistant widget — every follow-up turn then arrives at the backend with no conversation id and roots a new Slack thread, fragmenting the monitored conversation. Backend telemetry shows ~40% of real-browser follow-ups affected, all-or-nothing per session.
- The backend now also delivers the id in-band as `thread_id` on the SSE `message_start` frame (handsontable/docs-assistant#128, live on the dev Worker): anything that delivers the answer stream delivers the id. The widget adopts it from the frame, keeping the response header as fallback.
- Adoption is now always-adopt: the server returns the resolved id on every turn — including a fresh one after its stale-thread cutoff re-roots a conversation — so the widget follows it instead of keeping a stale value forever. Adoption skips aborted/replaced requests so a late frame can't resurrect an id the user just cleared.
- After merge this should be cherry-picked to the active `prod-docs` branch so the live docs pick it up, same as prior widget changes.

## Test plan
- [x] `npx tsc --noEmit` clean in `docs/`
- [x] `npm run docs:test:plugins` — 257 pass, 0 fail
- [x] Backend contract verified live against the dev Worker: `message_start` carries `thread_id` equal to the `X-Thread-Id` header on both streamed and canned turns
- [ ] On dev.handsontable.com after deploy: a two-turn widget conversation lands in one Slack thread; simulate header stripping (strip `X-Thread-Id` via a devtools local override or proxy) and confirm threading still works via the frame

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conversation correlation for the docs assistant widget; wrong adoption could split or merge Slack threads, but scope is limited to client-side thread id handling with abort guards.
> 
> **Overview**
> Fixes fragmented docs-assistant conversations when **`X-Thread-Id`** never reaches the browser (e.g. TLS-inspection proxies stripping custom headers).
> 
> The widget now picks up the backend conversation id from the SSE **`message_start`** frame’s **`thread_id`** as the primary source, with the response header kept as a fallback. **`readSSE`** is typed to expose **`thread_id`** on parsed events, and the stream loop handles **`message_start`** before **`content_chunk`**.
> 
> Thread adoption is no longer “first id only”: each turn can update **`threadIdRef`** / localStorage when the server returns a **resolved** id (including after stale-thread re-rooting). **`adoptThreadId`** ignores missing ids, unchanged ids, and any adoption after the request was aborted or replaced so a late frame cannot restore an id the user cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ec79038e5e9020846c2d67ed44291efd549f076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->