### PR TITLE
DEV-458: Correct and complete the undo/redo documentation

### DIFF
--- a/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
+++ b/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
@@ -31,9 +31,9 @@ Revert and restore your changes, using the undo and redo features.
 
 The [`UndoRedo`](@/api/undoRedo.md) plugin records supported grid operations and stores them in undo and redo stacks.
 
-You can use keyboard shortcuts or call API methods to move backward and forward through that history.
+You can use keyboard shortcuts, the context menu, or API methods to move backward and forward through that history.
 
-The plugin is enabled by default.
+The plugin is enabled by default. When the [context menu](@/guides/accessories-and-menus/context-menu/context-menu.md) is enabled, its default items include **Undo** and **Redo**.
 
 ## Basic demo
 
@@ -97,7 +97,8 @@ The built-in tracked actions include:
 - Row and column insertion/removal (`afterCreateRow`, `afterCreateCol`, `beforeRemoveRow`, `beforeRemoveCol`)
 - Column sorting (`beforeColumnSort`)
 - Filtering (`beforeFilter`)
-- Row and column moving (`beforeRowMove`, `beforeColumnMove`)
+- Row and column moving (`afterRowMove`, `afterColumnMove`)
+- Cell moving and copying (`beforeMoveCells`, `afterMoveCells`)
 - Merge and unmerge (`beforeMergeCells`, `afterUnmergeCells`)
 - Alignment changes (`beforeCellAlignment`)
 
@@ -120,7 +121,7 @@ UndoRedo exposes hooks for both stack updates and action execution:
 
 You can return `false` from `beforeUndoStackChange`, `beforeUndo`, or `beforeRedo` to block recording or execution.
 
-Calling `loadData()` clears both stacks.
+Calling [`loadData()`](@/api/core.md#loaddata) clears both stacks. Calling [`updateData()`](@/api/core.md#updatedata) does not, so an undo that runs after it can restore values from the previous dataset. Call [`clear()`](@/api/undoRedo.md#clear) yourself if you don't want that. Disabling the plugin or destroying the grid also clears both stacks.
 
 ## Programmatic control
 
@@ -182,6 +183,8 @@ The following operations are not tracked by default:
 - [Hiding columns](@/guides/columns/column-hiding/column-hiding.md) and [hiding rows](@/guides/rows/row-hiding/row-hiding.md)
 - [Trimming rows](@/guides/rows/row-trimming/row-trimming.md)
 - Generic cell metadata changes that don't register an UndoRedo action (for example, most direct `setCellMeta()` updates)
+- Merges applied from the [`mergeCells`](@/api/options.md#mergecells) setting. UndoRedo tracks the merges and unmerges that run through the context menu and the merge keyboard shortcut.
+- Rows and columns that Handsontable adds on its own to satisfy [`minRows`](@/api/options.md#minrows), [`minCols`](@/api/options.md#mincols), [`minSpareRows`](@/api/options.md#minsparerows), or [`minSpareCols`](@/api/options.md#minsparecols). These carry the `auto` source, which UndoRedo skips, along with the `UndoRedo.undo` and `UndoRedo.redo` sources that its own operations use.
 
 ## Related keyboard shortcuts
 

--- a/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
+++ b/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
@@ -98,7 +98,7 @@ The built-in tracked actions include:
 - Column sorting (`beforeColumnSort`)
 - Filtering (`beforeFilter`)
 - Row and column moving (`afterRowMove`, `afterColumnMove`)
-- Cell moving and copying (`beforeMoveCells`, `afterMoveCells`)
+- Cell moving and copying (`beforeMoveCells`, `afterMoveCells`), when the [`moveCells`](@/api/options.md#movecells) option is enabled
 - Merge and unmerge (`beforeMergeCells`, `afterUnmergeCells`)
 - Alignment changes (`beforeCellAlignment`)
 
@@ -183,8 +183,8 @@ The following operations are not tracked by default:
 - [Hiding columns](@/guides/columns/column-hiding/column-hiding.md) and [hiding rows](@/guides/rows/row-hiding/row-hiding.md)
 - [Trimming rows](@/guides/rows/row-trimming/row-trimming.md)
 - Generic cell metadata changes that don't register an UndoRedo action (for example, most direct `setCellMeta()` updates)
-- Merges applied from the [`mergeCells`](@/api/options.md#mergecells) setting. UndoRedo tracks the merges and unmerges that run through the context menu and the merge keyboard shortcut.
-- Rows and columns that Handsontable adds on its own to satisfy [`minRows`](@/api/options.md#minrows), [`minCols`](@/api/options.md#mincols), [`minSpareRows`](@/api/options.md#minsparerows), or [`minSpareCols`](@/api/options.md#minsparecols). These carry the `auto` source, which UndoRedo skips, along with the `UndoRedo.undo` and `UndoRedo.redo` sources that its own operations use.
+- Merges applied from the [`mergeCells`](@/api/options.md#mergecells) setting. UndoRedo tracks the merges and unmerges that run through the context menu, the merge keyboard shortcut, and the plugin's [`merge()`](@/api/mergeCells.md#merge) and [`unmerge()`](@/api/mergeCells.md#unmerge) methods.
+- Rows and columns that Handsontable adds on its own to satisfy [`minRows`](@/api/options.md#minrows), [`minCols`](@/api/options.md#mincols), [`minSpareRows`](@/api/options.md#minsparerows), or [`minSpareCols`](@/api/options.md#minsparecols). These carry the `auto` source, which UndoRedo skips. It also skips the `UndoRedo.undo` and `UndoRedo.redo` sources, so its own operations never re-enter the stack.
 
 ## Related keyboard shortcuts
 

--- a/handsontable/src/plugins/undoRedo/undoRedo.ts
+++ b/handsontable/src/plugins/undoRedo/undoRedo.ts
@@ -23,7 +23,9 @@ Hooks.getSingleton().register('afterRedo');
  * @description
  * Handsontable UndoRedo plugin allows to undo and redo certain actions done in the table.
  *
- * __Note__, that not all actions are currently undo-able. The UndoRedo plugin is enabled by default.
+ * The plugin is enabled by default. It doesn't track every grid operation. For the list of tracked
+ * actions and the known limitations, see
+ * [Undo and redo](@/guides/accessories-and-menus/undo-redo/undo-redo.md).
  * @example
  * ```js
  * undo: true


### PR DESCRIPTION
### Context

The PR corrects and completes the undo and redo documentation.

Issue #8463 asked a question the docs never answered: which grid operations are undoable and which are not. The guide was rewritten since then and now carries a tracked-actions list, but that list drifted from the source, and several behaviors that surprise users were still undocumented. This PR closes the remaining gaps.

Checked every entry against `handsontable/src/plugins/undoRedo/`:

1. **Wrong hook names.** The guide listed `beforeRowMove` and `beforeColumnMove`. The plugin registers on `afterRowMove` and `afterColumnMove`.
2. **Missing tracked action.** `MoveCellsAction` is registered in `actions/index.ts` but was absent from the guide. The `moveCells` plugin postdates the last guide rewrite.
3. **`updateData()` does not clear the stacks.** The guide only said that `loadData()` clears them. `#onAfterChange` matches `source === 'loadData'` only, so an undo that runs after `updateData()` can restore values from the previous dataset. Disabling the plugin and destroying the grid also clear both stacks.
4. **The context menu was never mentioned.** `UNDO` and `REDO` are in `ContextMenu.DEFAULT_ITEMS`, so right-click undo works out of the box.
5. **Two missing limitations.** Merges applied from the `mergeCells` setting are skipped (`beforeMergeCells` early-returns on `auto`), as are rows and columns that Handsontable adds itself to satisfy `minRows`, `minCols`, `minSpareRows`, or `minSpareCols` (those carry the `auto` source, which `done()` drops).
6. **Plugin JSDoc.** The `UndoRedo` class description still carried the exact sentence quoted in the issue: "Note, that not all actions are currently undo-able." Replaced with a pointer to the guide, matching how the `undo` option JSDoc already links it.

Two findings that are out of scope here and need their own tasks:

- **Plugin class JSDoc never reaches the API reference.** Verified by running `docs:api`. The generator globs `handsontable/tmp/**/*.js`, and swc's CJS transform drops the comment above `export class`, so the class description is missing from the CJS build for every plugin (`autoColumnSize`, `contextMenu`, `mergeCells`, `comments` all confirmed). The generator then falls back to the constructor JSDoc, which is why `/api/undo-redo` reads "Initializes the plugin and registers all built-in undo/redo action handlers". Pointing the parser at the `.mjs` build would add a Description section to dozens of API pages at once, so it needs its own review.
- **`unmergeSelection()` is not undoable.** `mergeSelection()` records to the undo stack; `unmergeSelection()` passes `auto = true` and does not. Both are public API. The context-menu path works because `toggleMerge()` calls `unmergeRange()` with the default `auto = false`. The guide wording here names the tracked path rather than claiming every user unmerge is tracked.

[skip changelog] — documentation only; the source change is a JSDoc comment with no runtime effect.

### How has this been tested?

Every claim was verified by reading the source rather than by assumption. No runtime code changed, so no new tests apply and the commit carries a `Refactor-only:` trailer.

```bash
npm run eslint --prefix handsontable   # 0 errors
npm run docs:lint --prefix docs        # no issues found
```

Rendering of the API reference was checked locally with `npm run docs:api --prefix docs`, which is how the JSDoc finding above was confirmed.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #8463
2. DEV-458

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-458

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a non-runtime JSDoc comment only; no behavioral code changes.
> 
> **Overview**
> **Updates the undo/redo guide and `UndoRedo` class JSDoc** so tracked operations, stack behavior, and limitations match the plugin implementation (DEV-458 / #8463).
> 
> The overview now mentions **context menu** undo/redo. The tracked-actions list fixes row/column move hooks to **`afterRowMove` / `afterColumnMove`**, adds **cell move/copy** when `moveCells` is on, and the stack-lifecycle section clarifies that **`loadData()`** clears history while **`updateData()`** does not (with guidance to call **`clear()`**), plus notes that disabling the plugin or destroying the grid clears stacks.
> 
> **Known limitations** now call out merges from the **`mergeCells` setting**, structural rows/cols added with the **`auto`** source, and that **`UndoRedo.undo` / `UndoRedo.redo`** sources are not re-recorded. Plugin JSDoc drops the vague “not all actions are undo-able” line in favor of a link to the guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c37b5ee859c17927cf9df48316a9cc51087f77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->