### PR TITLE
DEV-2771: Unify the branch-naming docs on the ClickUp DEV form

### DIFF
--- a/.ai/DOC-STANDARDS.md
+++ b/.ai/DOC-STANDARDS.md
@@ -12,7 +12,7 @@ The gating policy and a digest of the most-violated rules live in the root `AGEN
 
 ## Documentation branch conventions
 
-- Feature docs branches: `docs/issue-xxxx` (e.g., `docs/issue-9024`), branched from the feature branch or `develop`.
+- Feature docs branches: `docs/DEV-xxxx_Short-Description` (e.g., `docs/DEV-458_Clarify-undo-redo-docs`), branched from the feature branch or `develop`.
 - Release docs branches: `release/x.y.z-docs`, branched from `release/x.y.z`.
 
 ## Writing style rules

--- a/.ai/DOC-STANDARDS.md
+++ b/.ai/DOC-STANDARDS.md
@@ -12,7 +12,7 @@ The gating policy and a digest of the most-violated rules live in the root `AGEN
 
 ## Documentation branch conventions
 
-- Feature docs branches: `docs/DEV-xxxx_Short-Description` (e.g., `docs/DEV-458_Clarify-undo-redo-docs`), branched from the feature branch or `develop`.
+- Feature docs branches: `docs/<TASK-ID>_Short-Description` (e.g., `docs/DEV-458_Clarify-undo-redo-docs`), branched from the feature branch or `develop`. `<TASK-ID>` is the ClickUp custom ID, whose prefix follows the task's space (`DEV`, `SU`, `PRO`).
 - Release docs branches: `release/x.y.z-docs`, branched from `release/x.y.z`.
 
 ## Writing style rules

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -9,9 +9,9 @@ Choose the prefix that matches your work:
 
 | Type | Pattern | Example |
 |------|---------|---------|
-| Feature (ClickUp) | `feature/DEV-xxx_Short-Description` | `feature/DEV-627_Forum-Update` |
-| Feature (GitHub) | `feature/issue-xxxx` | `feature/issue-11832` |
-| Docs | `docs/issue-xxxx` | `docs/issue-9500` |
+| Feature (ClickUp, default) | `feature/DEV-xxxx_Short-Description` | `feature/DEV-627_Forum-Update` |
+| Docs (ClickUp) | `docs/DEV-xxxx_Short-Description` | `docs/DEV-458_Clarify-undo-redo-docs` |
+| Feature (public GitHub issue) | `feature/issue-xxxx` | `feature/issue-11832` |
 | Release | `release/x.y.z` | `release/16.1.0` |
 
 When working from a ClickUp task, the **human-readable custom ID** (e.g. `DEV-627`, `IT-42`) **must** appear in the branch name so ClickUp links automatically. Never use the internal ClickUp hash ID (e.g. `86c9j4fxj`) — it is not a valid task identifier for branch linking.

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -9,10 +9,13 @@ Choose the prefix that matches your work:
 
 | Type | Pattern | Example |
 |------|---------|---------|
-| Feature (ClickUp, default) | `feature/DEV-xxxx_Short-Description` | `feature/DEV-627_Forum-Update` |
-| Docs (ClickUp) | `docs/DEV-xxxx_Short-Description` | `docs/DEV-458_Clarify-undo-redo-docs` |
+| Feature (ClickUp, default) | `feature/<TASK-ID>_Short-Description` | `feature/DEV-627_Forum-Update` |
+| Docs (ClickUp) | `docs/<TASK-ID>_Short-Description` | `docs/DEV-458_Clarify-undo-redo-docs` |
 | Feature (public GitHub issue) | `feature/issue-xxxx` | `feature/issue-11832` |
+| Docs (public GitHub issue) | `docs/issue-xxxx` | `docs/issue-9500` |
 | Release | `release/x.y.z` | `release/16.1.0` |
+
+`<TASK-ID>` is the ClickUp custom ID. Its prefix follows the space the task lives in, so it is not always `DEV`: `docs/SU-833_BeforeKeyDown-Return-False-Note` and `feature/PRO-858_Theme-API-e2e-test-data-driven-for-each-theme` are both valid. Copy the prefix from the task, never assume one.
 
 When working from a ClickUp task, the **human-readable custom ID** (e.g. `DEV-627`, `IT-42`) **must** appear in the branch name so ClickUp links automatically. Never use the internal ClickUp hash ID (e.g. `86c9j4fxj`) — it is not a valid task identifier for branch linking.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,8 +146,12 @@ These standards apply to **all** documentation across the monorepo — guides, t
 
 ### Branch naming
 
-- Feature branches: `feature/issue-xxxx` (e.g., `feature/issue-9024`)
-- Documentation branches: `docs/issue-xxxx` (e.g., `docs/issue-9024`)
+Almost all work is tracked in ClickUp, so the ClickUp form is the default. Put the human-readable custom ID (`DEV-458`, never the internal ClickUp hash) in the branch name so ClickUp links the branch automatically. Separate the ID from the description with an underscore, and use hyphens inside the description.
+
+- Feature branches: `feature/DEV-xxxx_Short-Description` (e.g., `feature/DEV-2740_ResizeObserver-loop-guard`)
+- Documentation branches: `docs/DEV-xxxx_Short-Description` (e.g., `docs/DEV-458_Clarify-undo-redo-docs`)
+
+For the rarer case of work tracked in a public GitHub issue rather than ClickUp, use `feature/issue-xxxx` (e.g., `feature/issue-11832`).
 
 (Release and LTS branches are maintainer-managed; the `pr-creation` skill has the full convention.)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,12 +146,12 @@ These standards apply to **all** documentation across the monorepo — guides, t
 
 ### Branch naming
 
-Almost all work is tracked in ClickUp, so the ClickUp form is the default. Put the human-readable custom ID (`DEV-458`, never the internal ClickUp hash) in the branch name so ClickUp links the branch automatically. Separate the ID from the description with an underscore, and use hyphens inside the description.
+Almost all work is tracked in ClickUp, so the ClickUp form is the default. Put the human-readable custom ID (`DEV-458`, `SU-833`, `PRO-858`, never the internal ClickUp hash) in the branch name so ClickUp links the branch automatically. Most work sits in the `DEV` space, but other spaces keep their own prefix, so copy the ID the task actually carries rather than assuming `DEV`. Separate the ID from the description with an underscore, and use hyphens inside the description.
 
-- Feature branches: `feature/DEV-xxxx_Short-Description` (e.g., `feature/DEV-2740_ResizeObserver-loop-guard`)
-- Documentation branches: `docs/DEV-xxxx_Short-Description` (e.g., `docs/DEV-458_Clarify-undo-redo-docs`)
+- Feature branches: `feature/<TASK-ID>_Short-Description` (e.g., `feature/DEV-2740_ResizeObserver-loop-guard`)
+- Documentation branches: `docs/<TASK-ID>_Short-Description` (e.g., `docs/SU-833_BeforeKeyDown-Return-False-Note`)
 
-For the rarer case of work tracked in a public GitHub issue rather than ClickUp, use `feature/issue-xxxx` (e.g., `feature/issue-11832`).
+For the rarer case of work tracked in a public GitHub issue rather than ClickUp, use `feature/issue-xxxx` for code and `docs/issue-xxxx` for documentation (e.g., `feature/issue-11832`).
 
 (Release and LTS branches are maintainer-managed; the `pr-creation` skill has the full convention.)
 


### PR DESCRIPTION
### Context

The PR fixes a mismatch between the branch naming the repository documents and the branch naming the team actually uses.

The root `AGENTS.md` is loaded into every agent session, and its "Branch naming" section listed `feature/issue-xxxx` as the only feature form. An agent following it named a branch with a bare issue number for ClickUp-tracked work, against both the `pr-creation` skill and every recent remote branch, which use `feature/DEV-xxxx_Short-Description`.

Three files disagreed. This unifies them on the ClickUp form:

| File | Was | Now |
|---|---|---|
| `AGENTS.md` | `feature/issue-xxxx`, `docs/issue-xxxx` | `feature/DEV-xxxx_Short-Description`, `docs/DEV-xxxx_Short-Description` |
| `.ai/DOC-STANDARDS.md` | `docs/issue-xxxx` | `docs/DEV-xxxx_Short-Description` |
| `.claude/skills/pr-creation/SKILL.md` | docs row `docs/issue-xxxx`; ID placeholder `DEV-xxx` | docs row on the ClickUp form; placeholder `DEV-xxxx` |

The `AGENTS.md` section also now spells out the separator rule, which is the detail most often fumbled: an underscore between the ID and the description, hyphens inside the description. Every example in the change is a real branch from this repository rather than an invented number.

Two decisions worth a reviewer's attention:

1. **`docs/issue-xxxx` is replaced outright.** The newest branch in that shape dates from October 2022, so nothing in current use is losing its documented name.
2. **`feature/issue-xxxx` is kept**, relabeled as the non-default "public GitHub issue" case. A branch in that shape received a commit the day before this PR was opened, so it is still live. Deleting the row would leave a used form undocumented, which is the same defect in the other direction. The rows in the `pr-creation` table are reordered so both ClickUp forms come first, since "which form do I reach for" is exactly what went wrong.

The upstream source of the stale wording is the **Programming practices** page in the ClickUp *Development process* doc, whose Git flow bullets carried the same two `issue-xxxx` schemes almost verbatim. That page needs the same correction so the repository and the process doc stop contradicting each other. It is being fixed by hand in the ClickUp UI rather than through the API, which offers only whole-page replace and would flatten the page's link-bookmark embeds on a round trip.

[skip changelog]

### Test evidence (required for source changes)

Not applicable. Documentation only: three Markdown files, no change under `handsontable/src/**` or `wrappers/**`, so there is no behavior to cover with a test.

- Unit tests added/modified (`*.unit.js`): none required, no source change
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none required, no source change
- Type tests (`*.types.ts`) updated if public API changed: none, no public API change
- For a bug fix, the spec that fails without this fix: not applicable
- Demo page / recorded trace (for UI changes): not applicable

### Commands run

The check that matters is that no stale branch form survives anywhere in the repository's Markdown, and that the only remaining `issue-` matches are the two deliberately kept GitHub-issue rows:

```
$ grep -rnE "(feature|docs|fix)/issue-x{2,}" --include="*.md" .
./.claude/skills/pr-creation/SKILL.md:14:| Feature (public GitHub issue) | `feature/issue-xxxx` | `feature/issue-11832` |
./AGENTS.md:154:For the rarer case of work tracked in a public GitHub issue rather than ClickUp, use `feature/issue-xxxx` (e.g., `feature/issue-11832`).
```

Local gates on the commit and the push:

```
$ git commit
lefthook pre-commit: lint-staged
summary: (done in 0.10 seconds)
ok

$ git push
lefthook pre-push: test-gate
## Test-presence gate
Pass.
Test-weakening gate: no weakened specs detected.
pre-push: ok
```

`AGENTS.md` was edited by name rather than through its `CLAUDE.md` symlink, so the symlink is intact and the staged diff contains only the three intended files.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

None of the four apply. This is a documentation-only change to agent-facing convention docs.

### Related issue(s):

1. DEV-2771

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

No published package is affected. The change touches repository-level convention docs and one Claude Code skill.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign). One signature covers both Handsontable and HyperFormula, and the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation. This PR *is* the documentation change.
- [ ] This change needs a manual QA pass.

### Follow-ups left out of scope

Found while sweeping, not fixed here, so a reviewer can decide whether they want separate tasks:

1. Non-branch ID placeholders still read `DEV-xxx` in the `pr-creation` and `changelog-creation` skills, in commit-message, PR-title, and ClickUp-URL examples. Only the branch-form placeholder was aligned here, so the two shapes now coexist inside `pr-creation/SKILL.md`.
2. The `pr-creation` branch table has no `fix/` row, even though the skill's own description names `fix/*` and branches in both `fix/` shapes exist on the remote.
3. `.ai/DOC-STANDARDS.md` documents release docs branches as `release/x.y.z-docs`, but the remote carries `prod-docs/*` and no branch in the documented shape. Looks stale for the same reason, but it is a different convention and was left untouched.

ClickUp task: https://app.clickup.com/t/123kvxe9h3f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only convention updates; no runtime code, APIs, or build behavior changes.
> 
> **Overview**
> **Aligns agent-facing branch naming** so `AGENTS.md`, `.ai/DOC-STANDARDS.md`, and the `pr-creation` skill all treat ClickUp as the default instead of listing `feature/issue-xxxx` / `docs/issue-xxxx` as the primary pattern.
> 
> Feature and docs branches are documented as `feature/<TASK-ID>_Short-Description` and `docs/<TASK-ID>_Short-Description`, with `<TASK-ID>` as the ClickUp custom ID (prefix varies by space: `DEV`, `SU`, `PRO`). The docs spell out the separator rule: underscore after the ID, hyphens in the description. The `pr-creation` table is reordered so ClickUp rows come first and adds a short note not to assume every task is `DEV`.
> 
> `feature/issue-xxxx` and `docs/issue-xxxx` remain documented only for work tied to public GitHub issues, not ClickUp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65174ad6fad0e42002cc1d5ab78cac49c2dc275b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->