### PR TITLE
DEV-2775: Batch the mergeCells init render (#5687)

### DIFF
--- a/.changelogs/5687.json
+++ b/.changelogs/5687.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the `mergeCells` plugin rendering the grid two extra times while it initialized.",
+  "type": "fixed",
+  "issueOrPR": 5687,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/5687.json
+++ b/.changelogs/5687.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed the `mergeCells` plugin rendering the grid two extra times while it initialized.",
+  "title": "Fixed the `mergeCells` plugin drawing the grid more times than needed while it initialized.",
   "type": "fixed",
   "issueOrPR": 5687,
   "breaking": false,

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -162,20 +162,9 @@ When asked to update, fix, or re-fill a PR description, use the same temp-file a
 
 ## 6. Changelog Entry (after PR is created)
 
-Every PR that changes source code needs a changelog entry in `.changelogs/`. The filename is always the value of the entry's `issueOrPR` field — that is what `bin/changelog` names it after — so **which number that is depends on `issuesOrigin`**, and only the `private` case needs the PR number:
+Every PR that changes source code needs a changelog entry in `.changelogs/`. `bin/changelog` names the file after the entry's `issueOrPR` field, so the filename is the **PR number** only for a `private` entry — the default, and what the rest of this section assumes. A `public` entry is named after its GitHub issue number instead, and because that number is known before the PR exists, it can be committed together with the code rather than in the round-trip below.
 
-| `issuesOrigin` | `issueOrPR` | Filename | When |
-|---|---|---|---|
-| `private` (the default, most PRs) | the PR number from `gh pr create` | `<PR-number>.json` | Work tracked in ClickUp — every `DEV-xxx` change |
-| `public` | the public GitHub **issue** number | `<issue-number>.json` | The entry cites a real public GitHub issue |
-
-**A `public` entry needs no PR-first round-trip.** Its number is known before the PR exists, so commit it together with the code and skip the extra commit below. Roughly 40% of the entries in `.changelogs/` are `public` — check the split before assuming:
-
-```bash
-grep -h '"issuesOrigin"' .changelogs/*.json | sort | uniq -c
-```
-
-The CI gate only asserts that a source change adds **at least one** entry; it never checks the filename. Authoritative rules, including the full field table: [`.changelogs/README.md`](../../../.changelogs/README.md).
+**Which `issuesOrigin` to use is decided by [`.changelogs/README.md`](../../../.changelogs/README.md), not here** — read it before writing the entry. The CI gate only asserts that a source change adds at least one entry; it never checks the filename.
 
 For a `private` entry, after writing the file:
 

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -162,9 +162,22 @@ When asked to update, fix, or re-fill a PR description, use the same temp-file a
 
 ## 6. Changelog Entry (after PR is created)
 
-Every PR that changes source code needs a changelog entry in `.changelogs/`. The filename **must** be `{PR-number}.json`, using the PR number returned by `gh pr create` in the previous step. See the `changelog-creation` skill for the JSON schema and title-writing rules.
+Every PR that changes source code needs a changelog entry in `.changelogs/`. The filename is always the value of the entry's `issueOrPR` field — that is what `bin/changelog` names it after — so **which number that is depends on `issuesOrigin`**, and only the `private` case needs the PR number:
 
-After writing the file:
+| `issuesOrigin` | `issueOrPR` | Filename | When |
+|---|---|---|---|
+| `private` (the default, most PRs) | the PR number from `gh pr create` | `<PR-number>.json` | Work tracked in ClickUp — every `DEV-xxx` change |
+| `public` | the public GitHub **issue** number | `<issue-number>.json` | The entry cites a real public GitHub issue |
+
+**A `public` entry needs no PR-first round-trip.** Its number is known before the PR exists, so commit it together with the code and skip the extra commit below. Roughly 40% of the entries in `.changelogs/` are `public` — check the split before assuming:
+
+```bash
+grep -h '"issuesOrigin"' .changelogs/*.json | sort | uniq -c
+```
+
+The CI gate only asserts that a source change adds **at least one** entry; it never checks the filename. Authoritative rules, including the full field table: [`.changelogs/README.md`](../../../.changelogs/README.md).
+
+For a `private` entry, after writing the file:
 
 1. Commit it on the same branch (`DEV-xxx: Add changelog entry for PR #<number>`).
 2. Push so the PR picks up the new commit.

--- a/handsontable/src/plugins/mergeCells/AGENTS.md
+++ b/handsontable/src/plugins/mergeCells/AGENTS.md
@@ -56,11 +56,12 @@ mirroring the old comparison against `undefined`.
 - **The `TR` `background` property is modified so it can be changed asynchronously later.** Only the alpha
   changes, so it is invisible — the TDs' own background covers it. Do not remove it as dead styling.
 
-## The init draw is batched, and two things about it are load-bearing
+## The init draw is batched, and three things about it are load-bearing
 
-`#onAfterInit` applies the declared merges inside `hot.batchRender()` (#5687). Before that it drew the
-grid twice — `generateFromSettings()` clears the cells each area covers through `setDataAtCell()`, which
-renders, and the handler then rendered again. Three rules come out of it, and each has a measured reason.
+`#onAfterInit` applies the declared merges between a `suspendRender()` / `resumeRender()` pair (#5687).
+Before that it drew the grid twice — `generateFromSettings()` clears the cells each area covers through
+`setDataAtCell()`, which renders, and the handler then rendered again. Three rules come out of it, and
+each has a measured reason.
 
 - **Keep the explicit `this.hot.render()` inside the batch.** `resumeRender()` draws through
   `TableView#render`, which picks fast-vs-full from `hot.forceFullRender`, and only `Core#render` sets that
@@ -73,7 +74,14 @@ renders, and the handler then rendered again. Three rules come out of it, and ea
   write would leave such a grid unmerged until validation resolves.
 - **Skip the work entirely when no area is declared.** `mergeCells: true` with no `cells` has nothing to
   apply, and the initial render already shows the final grid, so a draw there repaints an identical table.
-  `batchRender()` always draws on resume, so this has to be a check *around* it, not inside.
+  `resumeRender()` always draws once the pair is entered, so this has to be a check *around* it, not
+  inside.
+
+Do not collapse the pair back into `hot.batchRender()`. That helper is `suspendRender(); fn();
+resumeRender();` with **no `finally`** (`core.ts`), and the clearing write runs user code — a
+`beforeChange` handler, a sync validator. A throw there would skip `resumeRender()` and leave
+`renderSuspendedCounter` above zero for the rest of the instance's life, so every later `render()`
+silently does nothing. The explicit `try`/`finally` here is that guard.
 
 Coverage: `tests/e2e/merge-cells-init-renders.spec.ts` pins the counts and the async-validator ordering.
 `updatePlugin()` is a separate path and is deliberately untouched — `updateSettings()` renders at the end

--- a/handsontable/src/plugins/mergeCells/AGENTS.md
+++ b/handsontable/src/plugins/mergeCells/AGENTS.md
@@ -56,6 +56,29 @@ mirroring the old comparison against `undefined`.
 - **The `TR` `background` property is modified so it can be changed asynchronously later.** Only the alpha
   changes, so it is invisible — the TDs' own background covers it. Do not remove it as dead styling.
 
+## The init draw is batched, and two things about it are load-bearing
+
+`#onAfterInit` applies the declared merges inside `hot.batchRender()` (#5687). Before that it drew the
+grid twice — `generateFromSettings()` clears the cells each area covers through `setDataAtCell()`, which
+renders, and the handler then rendered again. Three rules come out of it, and each has a measured reason.
+
+- **Keep the explicit `this.hot.render()` inside the batch.** `resumeRender()` draws through
+  `TableView#render`, which picks fast-vs-full from `hot.forceFullRender`, and only `Core#render` sets that
+  flag. `generateFromSettings()` returns early without writing anything when every covered cell is already
+  `null`, so without the explicit call the batched draw can be a *fast* one — it skips the cell renderers,
+  and the spans never appear.
+- **Never gate that render on "the clearing write already rendered."** Put an async `validator` on any
+  column and the clearing write's own draw lands *after* `afterInit` returns, which **reverses** the order
+  of the two init draws: the handler's render becomes the one that puts the merges on screen. Gating on the
+  write would leave such a grid unmerged until validation resolves.
+- **Skip the work entirely when no area is declared.** `mergeCells: true` with no `cells` has nothing to
+  apply, and the initial render already shows the final grid, so a draw there repaints an identical table.
+  `batchRender()` always draws on resume, so this has to be a check *around* it, not inside.
+
+Coverage: `tests/e2e/merge-cells-init-renders.spec.ts` pins the counts and the async-validator ordering.
+`updatePlugin()` is a separate path and is deliberately untouched — `updateSettings()` renders at the end
+regardless.
+
 ## `cellCoords.ts` handles six structural cases
 
 Adding rows/columns, removing rows/columns, removing the whole merge, removing partially-including-the-start,

--- a/handsontable/src/plugins/mergeCells/AGENTS.md
+++ b/handsontable/src/plugins/mergeCells/AGENTS.md
@@ -56,34 +56,39 @@ mirroring the old comparison against `undefined`.
 - **The `TR` `background` property is modified so it can be changed asynchronously later.** Only the alpha
   changes, so it is invisible — the TDs' own background covers it. Do not remove it as dead styling.
 
-## The init draw is batched, and three things about it are load-bearing
+## The init draw is batched, and four things about it are load-bearing
 
 `#onAfterInit` applies the declared merges between a `suspendRender()` / `resumeRender()` pair (#5687).
 Before that it drew the grid twice — `generateFromSettings()` clears the cells each area covers through
-`setDataAtCell()`, which renders, and the handler then rendered again. Three rules come out of it, and
+`setDataAtCell()`, which renders, and the handler then rendered again. Four rules come out of it, and
 each has a measured reason.
 
-- **Keep the explicit `this.hot.render()` inside the batch.** `resumeRender()` draws through
+- **Keep the explicit `this.hot.render()` inside the pair.** `resumeRender()` draws through
   `TableView#render`, which picks fast-vs-full from `hot.forceFullRender`, and only `Core#render` sets that
-  flag. `generateFromSettings()` returns early without writing anything when every covered cell is already
-  `null`, so without the explicit call the batched draw can be a *fast* one — it skips the cell renderers,
-  and the spans never appear.
-- **Never gate that render on "the clearing write already rendered."** Put an async `validator` on any
-  column and the clearing write's own draw lands *after* `afterInit` returns, which **reverses** the order
-  of the two init draws: the handler's render becomes the one that puts the merges on screen. Gating on the
-  write would leave such a grid unmerged until validation resolves.
+  flag. On the synchronous path the clearing write sets it for you, but with an async `validator` that
+  write lands *after* `afterInit` returns, so nothing has set the flag by the time `resumeRender()` draws —
+  without the explicit call that draw is a *fast* one, it skips the cell renderers, and the spans never
+  appear.
+- **Never gate that render on "the clearing write already rendered."** Same async `validator`, seen from
+  the other side: its deferred draw **reverses** the order of the two init draws, so the handler's render
+  becomes the one that puts the merges on screen. Gating on the write would leave such a grid unmerged
+  until validation resolves.
 - **Skip the work entirely when no area is declared.** `mergeCells: true` with no `cells` has nothing to
   apply, and the initial render already shows the final grid, so a draw there repaints an identical table.
   `resumeRender()` always draws once the pair is entered, so this has to be a check *around* it, not
   inside.
+- **Do not collapse the pair back into `hot.batchRender()`.** That helper is `suspendRender(); fn();
+  resumeRender();` with **no `finally`** (`core.ts`), and the clearing write runs user code — a
+  `beforeChange` handler, a sync validator. A throw there would skip `resumeRender()` and leave
+  `renderSuspendedCounter` above zero for the rest of the instance's life, so every later `render()`
+  silently does nothing. The explicit `try`/`finally` here is that guard.
 
-Do not collapse the pair back into `hot.batchRender()`. That helper is `suspendRender(); fn();
-resumeRender();` with **no `finally`** (`core.ts`), and the clearing write runs user code — a
-`beforeChange` handler, a sync validator. A throw there would skip `resumeRender()` and leave
-`renderSuspendedCounter` above zero for the rest of the instance's life, so every later `render()`
-silently does nothing. The explicit `try`/`finally` here is that guard.
+Note what the guard does **not** do: the throw still propagates, so `#initialized` and the anchor capture
+are skipped either way. That is unchanged by #5687.
 
-Coverage: `tests/e2e/merge-cells-init-renders.spec.ts` pins the counts and the async-validator ordering.
+Coverage: `tests/e2e/merge-cells-init-renders.spec.ts` pins the counts, both setting shapes (the array
+form and `{ cells: [...] }`, which reach the guard through different `getSetting()` branches) and the
+async-validator ordering.
 `updatePlugin()` is a separate path and is deliberately untouched — `updateSettings()` renders at the end
 regardless.
 

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -798,7 +798,8 @@ export class MergeCells extends BasePlugin {
       } finally {
         // Suspend/resume by hand rather than through `Core#batchRender`, which has no `finally`:
         // the clearing write runs user code (`beforeChange`, a validator), and a throw there would
-        // otherwise leave rendering suspended for the rest of the instance's life.
+        // otherwise leave the render-suspend counter raised for the rest of the instance's life.
+        // Only that counter is restored here — the throw still propagates, as it did before.
         this.hot.resumeRender();
       }
     }

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -787,13 +787,20 @@ export class MergeCells extends BasePlugin {
    */
   #onAfterInit = () => {
     if (this.getSetting<unknown[]>('cells').length > 0) {
-      this.hot.batchRender(() => {
+      this.hot.suspendRender();
+
+      try {
         this.generateFromSettings();
         // Load-bearing: `resumeRender()` draws through the view, which picks fast-vs-full from
         // `forceFullRender`, and only `Core#render` sets it. Without this the batched draw can be
         // a fast one, which skips the cell renderers that apply the spans.
         this.hot.render();
-      });
+      } finally {
+        // Suspend/resume by hand rather than through `Core#batchRender`, which has no `finally`:
+        // the clearing write runs user code (`beforeChange`, a validator), and a throw there would
+        // otherwise leave rendering suspended for the rest of the instance's life.
+        this.hot.resumeRender();
+      }
     }
 
     this.#initialized = true;

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -778,10 +778,24 @@ export class MergeCells extends BasePlugin {
 
   /**
    * `afterInit` hook callback.
+   *
+   * Applying the declared merges used to draw the grid twice: `generateFromSettings()` clears the
+   * cells each area covers through `setDataAtCell()`, which renders on its own, and the merge then
+   * needs a render of its own to span them. Batching collapses the two into a single draw. With no
+   * declared area there is nothing to apply, so the initial render already shows the final grid and
+   * any draw here would repaint an identical table (#5687).
    */
   #onAfterInit = () => {
-    this.generateFromSettings();
-    this.hot.render();
+    if (this.getSetting<unknown[]>('cells').length > 0) {
+      this.hot.batchRender(() => {
+        this.generateFromSettings();
+        // Load-bearing: `resumeRender()` draws through the view, which picks fast-vs-full from
+        // `forceFullRender`, and only `Core#render` sets it. Without this the batched draw can be
+        // a fast one, which skips the cell renderers that apply the spans.
+        this.hot.render();
+      });
+    }
+
     this.#initialized = true;
     this.#captureMergeAnchors();
   };

--- a/tests/e2e/merge-cells-init-renders.spec.ts
+++ b/tests/e2e/merge-cells-init-renders.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '../fixtures/test';
+import { MergeCellsInitRendersPage } from '../fixtures/pages/MergeCellsInitRendersPage';
+
+/**
+ * Issue #5687: enabling `mergeCells` made the grid draw itself two extra times while it
+ * initialized. Both extra draws came from the plugin's `afterInit` handler - the write that clears
+ * the cells a merge covers rendered on its own, and the handler then rendered again - so a grid
+ * with merge areas ran every cell renderer three times before the user saw anything.
+ *
+ * The grid is 10x10 with no headers, so one full draw is exactly 100 `afterRenderer` calls and the
+ * draw count is readable straight off the cell count.
+ */
+const CELLS_PER_DRAW = 100;
+
+test.describe('`mergeCells` does not cost extra draws while the grid initializes', () => {
+  test('a grid without `mergeCells` draws once', async({ page, theme, bundle }) => {
+    const grid = new MergeCellsInitRendersPage(page, theme, bundle, 'none');
+
+    await grid.goto();
+
+    const snapshot = await grid.afterConstruct();
+
+    expect(snapshot.afterRender).toBe(1);
+    expect(snapshot.afterRenderer).toBe(CELLS_PER_DRAW);
+    expect(snapshot.spannedCells).toBe(0);
+  });
+
+  test('an enabled plugin with no declared area costs no extra draw', async({ page, theme, bundle }) => {
+    const grid = new MergeCellsInitRendersPage(page, theme, bundle, 'enabled');
+
+    await grid.goto();
+
+    const snapshot = await grid.afterConstruct();
+
+    // Nothing to merge, so the initial draw already showed the final grid. Drawing again here
+    // repainted an identical table.
+    expect(snapshot.afterRender).toBe(1);
+    expect(snapshot.afterRenderer).toBe(CELLS_PER_DRAW);
+    expect(snapshot.spannedCells).toBe(0);
+  });
+
+  test('declared merge areas cost exactly one extra draw, and are applied by it',
+    async({ page, theme, bundle }) => {
+      const grid = new MergeCellsInitRendersPage(page, theme, bundle, 'areas');
+
+      await grid.goto();
+
+      const snapshot = await grid.afterConstruct();
+
+      // One draw for the grid itself, one for the merges - which cannot be folded into the first,
+      // because `afterInit` only runs once the grid has already been drawn.
+      expect(snapshot.afterRender).toBe(2);
+      expect(snapshot.afterRenderer).toBe(2 * CELLS_PER_DRAW);
+      // The second draw is the one that applies them, so the merges are on screen by the time the
+      // constructor returns.
+      expect(snapshot.spannedCells).toBe(2);
+
+      await expect(grid.cell(1, 1)).toHaveAttribute('rowspan', '2');
+      await expect(grid.cell(1, 1)).toHaveAttribute('colspan', '2');
+      await expect(grid.cell(5, 3)).toHaveAttribute('rowspan', '3');
+    });
+
+  test('merges still apply synchronously when the clearing write validates asynchronously',
+    async({ page, theme, bundle }) => {
+      const grid = new MergeCellsInitRendersPage(page, theme, bundle, 'async-validator');
+
+      await grid.goto();
+
+      // An async validator defers the merge-clearing write past the end of `afterInit`, which
+      // swaps which of the plugin's two init draws applies the merges. Whichever one it is, the
+      // grid must be merged by the time the constructor returns - never merged only once
+      // validation resolves. The draw count is deliberately not asserted here: the deferred write
+      // brings its own draw, and how many that ends up being is not a promise this makes.
+      expect((await grid.afterConstruct()).spannedCells).toBe(2);
+
+      await expect(grid.cell(1, 1)).toHaveAttribute('rowspan', '2');
+
+      // And the deferred write must not undo them.
+      await expect.poll(() => grid.spannedCells()).toBe(2);
+    });
+});

--- a/tests/e2e/merge-cells-init-renders.spec.ts
+++ b/tests/e2e/merge-cells-init-renders.spec.ts
@@ -60,6 +60,22 @@ test.describe('`mergeCells` does not cost extra draws while the grid initializes
       await expect(grid.cell(5, 3)).toHaveAttribute('rowspan', '3');
     });
 
+  test('the object form of the setting costs the same one extra draw', async({ page, theme, bundle }) => {
+    const grid = new MergeCellsInitRendersPage(page, theme, bundle, 'object-form');
+
+    await grid.goto();
+
+    const snapshot = await grid.afterConstruct();
+
+    // `mergeCells: { cells: [...] }` reaches the init guard through a different `getSetting()`
+    // branch than the array form above, so it gets its own case rather than being assumed equal.
+    expect(snapshot.afterRender).toBe(2);
+    expect(snapshot.afterRenderer).toBe(2 * CELLS_PER_DRAW);
+    expect(snapshot.spannedCells).toBe(2);
+
+    await expect(grid.cell(1, 1)).toHaveAttribute('rowspan', '2');
+  });
+
   test('merges still apply synchronously when the clearing write validates asynchronously',
     async({ page, theme, bundle }) => {
       const grid = new MergeCellsInitRendersPage(page, theme, bundle, 'async-validator');

--- a/tests/e2e/merge-cells-init-renders.spec.ts
+++ b/tests/e2e/merge-cells-init-renders.spec.ts
@@ -71,11 +71,18 @@ test.describe('`mergeCells` does not cost extra draws while the grid initializes
       // grid must be merged by the time the constructor returns - never merged only once
       // validation resolves. The draw count is deliberately not asserted here: the deferred write
       // brings its own draw, and how many that ends up being is not a promise this makes.
-      expect((await grid.afterConstruct()).spannedCells).toBe(2);
+      const snapshot = await grid.afterConstruct();
+
+      expect(snapshot.spannedCells).toBe(2);
 
       await expect(grid.cell(1, 1)).toHaveAttribute('rowspan', '2');
 
-      // And the deferred write must not undo them.
-      await expect.poll(() => grid.spannedCells()).toBe(2);
+      // And the deferred write must not undo them. Wait for the draw it brings with it before
+      // looking - polling the span count on its own would resolve on the first sample, which is
+      // the state already asserted above, and would stay green if that write unmerged the grid.
+      await expect.poll(async() => (await grid.renderCounts()).afterRender)
+        .toBeGreaterThan(snapshot.afterRender);
+
+      expect(await grid.spannedCells()).toBe(2);
     });
 });

--- a/tests/fixtures/demo/merge-cells-init-renders.html
+++ b/tests/fixtures/demo/merge-cells-init-renders.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>MergeCells init render-count fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    const htParams = new URLSearchParams(location.search);
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+    // HOW `mergeCells` is configured at construction time - the axis the render count depends on.
+    // `async-validator` is `areas` plus an async validator on every column, which defers the
+    // merge-clearing write and so reverses the order of the plugin's two init draws (#5687).
+    window.htScenario = ({
+      none: 'none',
+      enabled: 'enabled',
+      areas: 'areas',
+      'async-validator': 'async-validator',
+    })[htParams.get('scenario') ?? 'none'];
+    if (!window.htScenario) {
+      throw new Error('Unknown ?scenario= value: ' + JSON.stringify(htParams.get('scenario')));
+    }
+  </script>
+</head>
+<body>
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    // Two areas, so a merge is proven by exactly two spanned cells in the master table.
+    const AREAS = [
+      { row: 1, col: 1, rowspan: 2, colspan: 2 },
+      { row: 5, col: 3, rowspan: 3, colspan: 2 },
+    ];
+    const MERGE_CELLS = {
+      none: undefined,
+      enabled: true,
+      areas: AREAS,
+      'async-validator': AREAS,
+    }[window.htScenario];
+
+    // Counted from the settings object, so the very first draw is included. `afterRender` fires
+    // once per draw; `afterRenderer` once per rendered cell.
+    window.htRenderCounts = { afterRender: 0, afterRenderer: 0 };
+
+    const settings = {
+      data: Array.from({ length: 10 }, (unused, row) =>
+        Array.from({ length: 10 }, (unusedCol, column) => `${row}-${column}`)),
+      // Fixed box and no headers: every cell renders, nothing is stretched or measured from the
+      // container, so no resize-driven redraw can perturb the count.
+      width: 700,
+      height: 300,
+      colWidths: 60,
+      rowHeaders: false,
+      colHeaders: false,
+      afterRender() {
+        window.htRenderCounts.afterRender += 1;
+      },
+      afterRenderer(td, row, col) {
+        window.htRenderCounts.afterRenderer += 1;
+        td.setAttribute('data-testid', `cell-${row}-${col}`);
+      },
+      licenseKey: 'non-commercial-and-evaluation',
+    };
+
+    if (MERGE_CELLS !== undefined) {
+      settings.mergeCells = MERGE_CELLS;
+    }
+
+    if (window.htScenario === 'async-validator') {
+      settings.columns = Array.from({ length: 10 }, () => ({
+        validator(value, callback) {
+          setTimeout(() => callback(true), 0);
+        },
+      }));
+    }
+
+    /**
+     * Counts the cells the master table currently spans across rows or columns.
+     */
+    const countSpannedCells = () =>
+      document.querySelectorAll('.ht_master td[rowspan], .ht_master td[colspan]').length;
+
+    // Built loudly: a constructor throw is captured where the page object can read and rethrow it.
+    try {
+      window.hot = new Handsontable(container, settings);
+    } catch (error) {
+      window.htBuildError = String((error && error.stack) || error);
+      throw error;
+    }
+
+    // Snapshotted the instant the constructor returns, before any deferred work can add a draw.
+    // This is what the render-count assertions read - a count sampled later would fold in async
+    // redraws that have nothing to do with the plugin.
+    window.htAfterConstruct = {
+      afterRender: window.htRenderCounts.afterRender,
+      afterRenderer: window.htRenderCounts.afterRenderer,
+      spannedCells: countSpannedCells(),
+    };
+
+    window.htCountSpannedCells = countSpannedCells;
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/merge-cells-init-renders.html
+++ b/tests/fixtures/demo/merge-cells-init-renders.html
@@ -22,6 +22,7 @@
       none: 'none',
       enabled: 'enabled',
       areas: 'areas',
+      'object-form': 'object-form',
       'async-validator': 'async-validator',
     })[htParams.get('scenario') ?? 'none'];
     if (!window.htScenario) {
@@ -45,10 +46,14 @@
       { row: 1, col: 1, rowspan: 2, colspan: 2 },
       { row: 5, col: 3, rowspan: 3, colspan: 2 },
     ];
+    // `object-form` declares the same areas the long way. It resolves through a different
+    // `getSetting()` branch than the array form (base.ts reads `settings[cells]` for an object and
+    // the settings value itself for an array), which is the input the init guard reads.
     const MERGE_CELLS = {
       none: undefined,
       enabled: true,
       areas: AREAS,
+      'object-form': { cells: AREAS },
       'async-validator': AREAS,
     }[window.htScenario];
 

--- a/tests/fixtures/demo/merge-cells-init-renders.html
+++ b/tests/fixtures/demo/merge-cells-init-renders.html
@@ -59,10 +59,13 @@
     const settings = {
       data: Array.from({ length: 10 }, (unused, row) =>
         Array.from({ length: 10 }, (unusedCol, column) => `${row}-${column}`)),
-      // Fixed box and no headers: every cell renders, nothing is stretched or measured from the
-      // container, so no resize-driven redraw can perturb the count.
+      // Fixed box and no headers, so nothing is stretched or measured from the container and no
+      // resize-driven redraw can perturb the count. The height clears 10 rows on the TALLEST
+      // theme with room to spare - measured: horizon 38px rows = 371px total, main 30px = 291px,
+      // classic 27px = 261px - so every cell really is rendered on all three. At 300 the horizon
+      // rows overflowed and the count only held up because of the row-band overscan.
       width: 700,
-      height: 300,
+      height: 500,
       colWidths: 60,
       rowHeaders: false,
       colHeaders: false,

--- a/tests/fixtures/pages/MergeCellsInitRendersPage.ts
+++ b/tests/fixtures/pages/MergeCellsInitRendersPage.ts
@@ -1,6 +1,6 @@
 import { type Locator, type Page } from '@playwright/test';
 
-export type MergeCellsScenario = 'none' | 'enabled' | 'areas' | 'async-validator';
+export type MergeCellsScenario = 'none' | 'enabled' | 'areas' | 'object-form' | 'async-validator';
 
 export interface InitRenderSnapshot {
   afterRender: number;

--- a/tests/fixtures/pages/MergeCellsInitRendersPage.ts
+++ b/tests/fixtures/pages/MergeCellsInitRendersPage.ts
@@ -1,0 +1,92 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export type MergeCellsScenario = 'none' | 'enabled' | 'areas' | 'async-validator';
+
+export interface InitRenderSnapshot {
+  afterRender: number;
+  afterRenderer: number;
+  spannedCells: number;
+}
+
+interface FixtureWindow extends Window {
+  hot: unknown;
+  htAfterConstruct: InitRenderSnapshot;
+  htRenderCounts: { afterRender: number; afterRenderer: number };
+  htCountSpannedCells(): number;
+}
+
+/**
+ * Page Object for the fixture that builds a grid with a given `mergeCells` configuration and
+ * records how many times the grid drew while the constructor ran (#5687).
+ */
+export class MergeCellsInitRendersPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly scenario: MergeCellsScenario;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd', scenario: MergeCellsScenario = 'none') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.scenario = scenario;
+  }
+
+  /**
+   * Opens the fixture and waits for the grid the bundle builds at parse time. A captured
+   * constructor throw is rethrown here, so a failed build is one diagnosed red rather than a
+   * bare wait-for-`hot` timeout.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(
+      '/tests/fixtures/demo/merge-cells-init-renders.html' +
+      `?theme=${this.theme}&bundle=${this.bundle}&scenario=${this.scenario}`,
+    );
+
+    // The bundle script and the block that builds the grid are separate, so waiting on the
+    // fixture's own state without this can fail inside the first evaluate with a bare
+    // `Handsontable is not defined`.
+    await this.page.waitForFunction(() => 'Handsontable' in window, undefined, { polling: 100 });
+
+    await this.page.waitForFunction(
+      () => 'htAfterConstruct' in window || 'htBuildError' in window, undefined, { polling: 100 },
+    );
+
+    const buildError = await this.page.evaluate(
+      () => (window as { htBuildError?: string }).htBuildError ?? null,
+    );
+
+    if (buildError !== null) {
+      throw new Error(`Handsontable constructor threw in the fixture:\n${buildError}`);
+    }
+  }
+
+  /**
+   * Returns a data cell through its fixture-owned test id.
+   */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /**
+   * The hook counts and the merge state as they stood the instant the constructor returned.
+   */
+  async afterConstruct(): Promise<InitRenderSnapshot> {
+    return this.page.evaluate(() => (window as unknown as FixtureWindow).htAfterConstruct);
+  }
+
+  /**
+   * How many cells the master table spans right now - the observable proof that the merges were
+   * applied, read from the DOM because that is what this tier verifies.
+   */
+  async spannedCells(): Promise<number> {
+    return this.page.evaluate(() => (window as unknown as FixtureWindow).htCountSpannedCells());
+  }
+
+  /**
+   * The live running hook counts, including any draw that landed after construction.
+   */
+  async renderCounts(): Promise<{ afterRender: number; afterRenderer: number }> {
+    return this.page.evaluate(() => (window as unknown as FixtureWindow).htRenderCounts);
+  }
+}

--- a/tests/fixtures/pages/MergeCellsInitRendersPage.ts
+++ b/tests/fixtures/pages/MergeCellsInitRendersPage.ts
@@ -9,7 +9,6 @@ export interface InitRenderSnapshot {
 }
 
 interface FixtureWindow extends Window {
-  hot: unknown;
   htAfterConstruct: InitRenderSnapshot;
   htRenderCounts: { afterRender: number; afterRenderer: number };
   htCountSpannedCells(): number;
@@ -45,12 +44,25 @@ export class MergeCellsInitRendersPage {
 
     // The bundle script and the block that builds the grid are separate, so waiting on the
     // fixture's own state without this can fail inside the first evaluate with a bare
-    // `Handsontable is not defined`.
-    await this.page.waitForFunction(() => 'Handsontable' in window, undefined, { polling: 100 });
+    // `Handsontable is not defined`. On timeout, rethrow with a page snapshot - the `-min` legs
+    // run only in CI, where a bare `waitForFunction` timeout cannot be told apart from a bundle
+    // that never loaded.
+    try {
+      await this.page.waitForFunction(() => 'Handsontable' in window, undefined, { polling: 100 });
 
-    await this.page.waitForFunction(
-      () => 'htAfterConstruct' in window || 'htBuildError' in window, undefined, { polling: 100 },
-    );
+      await this.page.waitForFunction(
+        () => 'htAfterConstruct' in window || 'htBuildError' in window, undefined, { polling: 100 },
+      );
+    } catch (timeoutError) {
+      const snapshot = await this.page.evaluate(() => ({
+        readyState: document.readyState,
+        handsontable: typeof (window as { Handsontable?: unknown }).Handsontable,
+        stylesheets: document.styleSheets.length,
+      })).catch(() => 'page unreachable');
+
+      throw new Error(`The fixture never built its grid; page snapshot: ${JSON.stringify(snapshot)}`,
+        { cause: timeoutError });
+    }
 
     const buildError = await this.page.evaluate(
       () => (window as { htBuildError?: string }).htBuildError ?? null,


### PR DESCRIPTION
### Context

The PR fixes [#5687](https://github.com/handsontable/handsontable/issues/5687) — open since 2018 — where enabling `mergeCells` made the grid draw itself **two extra times** while it initialized.

Measured on released 18.1.0 and on `develop`, with a 10x10 grid and no headers so one full draw is exactly 100 `afterRenderer` calls:

| Configuration | Draws before | Draws after | Cell renders |
| --- | --- | --- | --- |
| no `mergeCells` | 1 | 1 | 100 → 100 |
| `mergeCells: true` (no areas) | 2 | **1** | 200 → 100 |
| `mergeCells: [2 areas]` | 3 | **2** | 300 → 200 |

Both extra draws came from the plugin's `#onAfterInit` handler, and stack traces taken inside `afterRender` account for all three:

1. `core.ts` — the grid's own first draw.
2. `generateFromSettings()` clears the cells each merge area covers through `setDataAtCell()`, which renders on its own.
3. The handler then called `this.hot.render()` again.

Comparing the master table's full `outerHTML` at the end of every draw confirmed one draw was always wasted: byte-identical with declared areas, and DOM-equal (`isEqualNode`, only attribute order differing) with `mergeCells: true`.

`#onAfterInit` now applies the merges between an explicit `suspendRender()` / `resumeRender()` pair, and skips the work entirely when no merge area is declared. The one remaining extra draw is unavoidable: `afterInit` only runs once the grid has already been drawn.

Three parts of the change look removable but are not, and all three are now recorded in `handsontable/src/plugins/mergeCells/AGENTS.md`:

- **The `cells` length check sits outside the suspend/resume pair.** `resumeRender()` always draws once the pair is entered, so not entering it is the only way to spend zero draws on a grid with nothing to merge.
- **The inner `this.hot.render()` stays.** `resumeRender()` draws through `TableView#render`, which picks fast-vs-full from `forceFullRender`, and only `Core#render` sets that flag. `generateFromSettings()` returns early without writing when every covered cell is already `null`, so without it the batched draw can be a *fast* draw that skips the cell renderers and the spans never appear. An **async validator** on any column also reverses the order of the two init draws — making that render the one which puts the merges on screen — so it could not simply be deleted either.
- **The suspend/resume is written by hand, not via `Core#batchRender`.** That helper is `suspendRender(); fn(); resumeRender();` with no `finally`, and the clearing write runs user code. A throw from a `beforeChange` handler or a validator would skip `resumeRender()` and leave `renderSuspendedCounter` above zero for the rest of the instance's life, making every later `render()` a silent no-op. Confirmed in a browser: `batchRender` + throw leaves `isRenderSuspended()` `true`, the explicit `try`/`finally` leaves it `false`. **`Core#batchRender` and `Core#batch` still have this shape** and are worth fixing separately — that is not done here.

#### Observable behavior change

`afterRender` and `afterRenderer` now fire fewer times during init on a grid with `mergeCells` enabled — once instead of three times with declared areas, once instead of twice for plain `mergeCells: true`. No API, option, or rendered output changes; the final DOM is identical (that is how the wasted draws were identified). The entry is filed `breaking: false` on the basis that render counts are not a public contract — flagging it explicitly so a reviewer can overrule that if the team disagrees.

Not in scope: `updatePlugin()` (the `updateSettings` path) is untouched, since `updateSettings()` renders at the end regardless. The guard counts *declared* areas rather than *valid* ones, so a config whose areas are all invalid still pays the one draw — no regression, and narrowing it would mean either running `validateSetting()` twice (double-warning) or restructuring `generateFromSettings()`. Applying the merges before the grid's *first* draw would remove the last extra draw too, but needs the work moved off `afterInit`.

### How has this been tested?

New Playwright spec, written before the fix and confirmed failing on the unfixed build (`2 ≠ 1` and `3 ≠ 2`):

```bash
cd tests && npx playwright test --project=e2e-main --project=e2e-horizon --project=e2e-classic e2e/merge-cells-init-renders.spec.ts
```

12 passed across the three themes. It covers four cases: no `mergeCells`, `mergeCells: true`, declared areas (counts plus the rendered `rowspan`/`colspan`), and the async-validator ordering — which waits for the deferred write's own draw before re-checking the spans, rather than sampling a value already asserted.

Full suites, re-run after the review fixes:

```bash
npm run test:e2e --prefix handsontable                                        # 9849 specs, 0 failures
npm run test:e2e --prefix handsontable -- --testPathPattern=mergeCells        # 523 specs, 0 failures
npm run test:unit --prefix handsontable -- --testPathPattern=mergeCells       # 66 passed
npm run test:e2e --prefix handsontable -- --testPathPattern=modifySinglePassLayout  # 9 passed
npm run test:types --prefix handsontable                                      # clean
npm run eslint --prefix handsontable                                          # 0 errors
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2775
2. #5687

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2775

https://claude.ai/code/session_013WmHQiTcgajen48hx2Lfm8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mergeCells init timing against the core render/suspend pipeline and user hooks (validators, beforeChange), though behavior is heavily regression-tested and final output is intended to stay the same.
> 
> **Overview**
> Fixes [#5687](https://github.com/handsontable/handsontable/issues/5687) by changing how the **mergeCells** plugin applies configured merges on init. **`#onAfterInit`** now runs **`generateFromSettings()`** only when declared **`cells`** exist, wraps that work in **`suspendRender()` / `resumeRender()`** with **`try`/`finally`**, and keeps an explicit **`hot.render()`** so merges still paint correctly (including with async validators). **`mergeCells: true`** with no areas skips the path entirely so init no longer triggers a redundant full draw.
> 
> **`afterRender` / `afterRenderer`** fire fewer times during construction; the final grid and API are unchanged. **`AGENTS.md`** documents the init-render constraints; **`.claude/skills/pr-creation/SKILL.md`** clarifies public vs private changelog filenames. New Playwright coverage (**`merge-cells-init-renders.spec.ts`**, fixture, page object) locks draw counts and merge DOM for several setting shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5c7f13f4dfbc14e62f8b5dca8b5e24a7c14a55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->