### PR TITLE
DEV-443: Count spare rows instead of assuming them when sorting a filtered grid

### DIFF
--- a/.changelogs/5983.json
+++ b/.changelogs/5983.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed sorting leaving the last rows of a filtered grid unsorted when `minSpareRows` was set.",
+  "type": "fixed",
+  "issueOrPR": 5983,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/columnSorting/AGENTS.md
+++ b/handsontable/src/plugins/columnSorting/AGENTS.md
@@ -73,6 +73,30 @@ same place.
 The sorted rows are arrays of the form `[rowIndex, ...values]`, so the only sorted column's value sits at
 index **1**.
 
+## Spare rows are counted, not assumed (#5983)
+
+`getNumberOfRowsToSort()` keeps the trailing spare rows out of the sortable range, and it decides
+how many there are with `hot.countEmptyRows(true)` capped at `minSpareRows`, never from the option
+alone. `minSpareRows` says how many trailing empty rows the Core tops the grid up to, not how many
+are on screen: a filter trims an empty spare row exactly like any other non-matching row, and
+nothing re-creates it while the filter is on (`adjustRowsAndCols()` runs after alters, data changes
+and `updateSettings`, never on `trimmedIndexesChanged`). Subtracting the option from a filtered
+row count therefore excluded the last N **real data rows** from the sort and re-appended them
+unsorted at the bottom. The cap matters in the other direction too: trailing empty rows beyond
+`minSpareRows` are ordinary data and stay in the sort.
+
+`MultiColumnSorting` does not override the method, so both plugins share this and any change to it.
+
+**Known overlap, deliberately left alone.** The count and `fixedRowsBottom` are subtracted
+independently, but a spare row is appended at the end of the data, so it sits *inside* the band
+`fixedRowsBottom` already reserves. With `minSpareRows: 1, fixedRowsBottom: 1` and no filter both
+terms describe the same row, two rows leave the sortable range, and the last real data row is left
+unsorted, which is the #5983 symptom reached through a different option. The fix above did not
+change that (the counted value is never larger than `minSpareRows`, so the subtraction is exactly
+what it always was), and `__tests__/columnSorting.spec.js`'s "should respect `fixedRowsTop`,
+`fixedRowsBottom`, and `minSpareRows` together" currently passes *because* of the double
+subtraction - anyone correcting the overlap has to revisit that expectation first.
+
 ## The sort indicator reserves room on the header *container*
 
 `has-sort-indicator` goes on the header container, not the label. Padding on the label would enlarge the

--- a/handsontable/src/plugins/columnSorting/AGENTS.md
+++ b/handsontable/src/plugins/columnSorting/AGENTS.md
@@ -76,8 +76,10 @@ index **1**.
 ## Spare rows are counted, not assumed (#5983)
 
 `getNumberOfRowsToSort()` keeps the trailing spare rows out of the sortable range, and it decides
-how many there are with `hot.countEmptyRows(true)` capped at `minSpareRows`, never from the option
-alone. `minSpareRows` says how many trailing empty rows the Core tops the grid up to, not how many
+how many there are by counting them with `isEmptyRow()`, capped at `minSpareRows`, never from the
+option alone. The walk stops at the cap on purpose, so do not swap it for `countEmptyRows(true)`:
+that one is uncapped, reads every column of every row it visits, and this runs on every sort.
+`minSpareRows` says how many trailing empty rows the Core tops the grid up to, not how many
 are on screen: a filter trims an empty spare row exactly like any other non-matching row, and
 nothing re-creates it while the filter is on (`adjustRowsAndCols()` runs after alters, data changes
 and `updateSettings`, never on `trimmedIndexesChanged`). Subtracting the option from a filtered
@@ -92,10 +94,17 @@ independently, but a spare row is appended at the end of the data, so it sits *i
 `fixedRowsBottom` already reserves. With `minSpareRows: 1, fixedRowsBottom: 1` and no filter both
 terms describe the same row, two rows leave the sortable range, and the last real data row is left
 unsorted, which is the #5983 symptom reached through a different option. The fix above did not
-change that (the counted value is never larger than `minSpareRows`, so the subtraction is exactly
-what it always was), and `__tests__/columnSorting.spec.js`'s "should respect `fixedRowsTop`,
-`fixedRowsBottom`, and `minSpareRows` together" currently passes *because* of the double
-subtraction - anyone correcting the overlap has to revisit that expectation first.
+change that: the counted value is never larger than `minSpareRows`, so the subtraction is exactly
+what it always was.
+
+Nothing in either sorting suite covers the overlap. `__tests__/columnSorting.spec.js`'s "should
+respect `fixedRowsTop`, `fixedRowsBottom`, and `minSpareRows` together" is the only test in
+`columnSorting/__tests__` or `multiColumnSorting/__tests__` that sets both options, and it is
+blind to it - its `Total` row holds the largest value in the sorted column, so it lands on the
+same row whether or not it took part in the sort, and all four assertions hold either way
+(verified by removing the spare-row term from a built bundle: identical output). Whoever fixes
+the overlap has to give that spec a `Total` value that is not the extreme one before it can say
+anything.
 
 ## The sort indicator reserves room on the header *container*
 

--- a/handsontable/src/plugins/columnSorting/columnSorting.ts
+++ b/handsontable/src/plugins/columnSorting/columnSorting.ts
@@ -673,7 +673,31 @@ export class ColumnSorting extends BasePlugin {
       return Math.max(0, (settings.maxRows ?? 0) - fixedRowsBottom);
     }
 
-    return Math.max(0, numberOfRows - (settings.minSpareRows ?? 0) - fixedRowsBottom);
+    const minSpareRows = settings.minSpareRows ?? 0;
+    // The spare rows are COUNTED, never assumed from the option. `minSpareRows` says how many
+    // trailing empty rows the Core tops the grid up to, not how many are on screen right now:
+    // a filter trims an empty spare row away like any other non-matching row, and nothing
+    // re-creates it while the filter is on. Subtracting the option there pinned the last N real
+    // data rows below the sortable range and left them unsorted (#5983). Counting also caps the
+    // other direction - trailing empty rows beyond `minSpareRows` are ordinary data and stay in
+    // the sort.
+    //
+    // The count stops at `minSpareRows` rather than going through `countEmptyRows(true)`, whose
+    // walk is uncapped: verifying that a row is empty reads every column of it, and this runs on
+    // every sort, so a grid with a large block of trailing empty rows (`minRows`, or a dataset
+    // that simply ends blank) would pay for rows the cap then discards. `adjustRowsAndCols()`
+    // caps its `minSpareCols` count the same way, for the same reason.
+    let spareRows = 0;
+
+    for (let row = numberOfRows - 1; row >= 0 && spareRows < minSpareRows; row--) {
+      if (!this.hot.isEmptyRow(row)) {
+        break;
+      }
+
+      spareRows += 1;
+    }
+
+    return Math.max(0, numberOfRows - spareRows - fixedRowsBottom);
   }
 
   /**

--- a/tests/e2e/sorting-filtered-spare-rows.spec.ts
+++ b/tests/e2e/sorting-filtered-spare-rows.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '../fixtures/test';
+import { SortingFilteredSpareRowsPage, type SortingPlugin } from '../fixtures/pages/SortingFilteredSpareRowsPage';
+
+/**
+ * Regression coverage for GH #5983 - sorting a FILTERED grid that has `minSpareRows` set.
+ *
+ * A filter trims every row failing its conditions, and a spare row is empty, so an ordinary
+ * condition trims the spare rows away too. Nothing re-creates them while the filter is on, so
+ * the filtered view has no spare rows at all. Sorting nevertheless subtracted `minSpareRows`
+ * from the visible row count, which pinned the last N REAL data rows below the sortable range
+ * and left them in their pre-sort order - "the sort is off by however many extra blank rows
+ * you want added", as the report puts it.
+ *
+ * The `minSpareRows` rows still have to stay out of the sort whenever they are actually there,
+ * which is what the unfiltered cases below pin.
+ */
+const SORTING_PLUGINS: SortingPlugin[] = ['columnSorting', 'multiColumnSorting'];
+
+// `multiColumnSorting` extends `ColumnSorting` and inherits the range calculation untouched,
+// so every case has to hold for both.
+for (const plugin of SORTING_PLUGINS) {
+  test.describe(`sorting a filtered grid with minSpareRows (${plugin})`, () => {
+    let grid: SortingFilteredSpareRowsPage;
+
+    test.beforeEach(async({ page, theme, bundle }) => {
+      grid = new SortingFilteredSpareRowsPage(page, theme, bundle);
+      await grid.goto();
+      await grid.useSortingPlugin(plugin);
+    });
+
+    test('sorts every visible row once the filter has trimmed the spare row away', async() => {
+      // Column D `contains '1'` keeps D1 and D10..D13, and trims the empty spare row with them.
+      await grid.applyContainsFilter(3, '1');
+
+      await expect.poll(() => grid.columnValues(0)).toEqual(['A1', 'A10', 'A11', 'A12', 'A13']);
+      // The premise of the whole bug: no spare row survives the filter, so nothing may be
+      // subtracted from the sortable range.
+      await expect.poll(() => grid.trailingEmptyRowCount()).toBe(0);
+
+      await grid.sortByHeader(0);
+
+      await expect.poll(() => grid.columnValues(0)).toEqual(['A1', 'A10', 'A11', 'A12', 'A13']);
+
+      await grid.sortByHeader(0);
+
+      // A13 was the row left behind at the bottom, unsorted, before the fix.
+      await expect.poll(() => grid.columnValues(0)).toEqual(['A13', 'A12', 'A11', 'A10', 'A1']);
+      await expect(grid.cell(0, 0)).toHaveText('A13');
+      await expect(grid.cell(4, 0)).toHaveText('A1');
+
+      expect(grid.pageErrors).toEqual([]);
+    });
+
+    test('sorts every visible row when several spare rows were trimmed', async() => {
+      // The report describes the offset scaling with the option, so the three-row case is what
+      // distinguishes a real fix from one that happens to work for a single row.
+      await grid.useSortingPlugin(plugin, { minSpareRows: 3 });
+      await grid.applyContainsFilter(3, '1');
+
+      await expect.poll(() => grid.trailingEmptyRowCount()).toBe(0);
+
+      await grid.sortByHeader(0);
+      await grid.sortByHeader(0);
+
+      await expect.poll(() => grid.columnValues(0)).toEqual(['A13', 'A12', 'A11', 'A10', 'A1']);
+
+      expect(grid.pageErrors).toEqual([]);
+    });
+
+    test('keeps the spare row out of the sort when there is no filter', async() => {
+      // The complement of the fix: a spare row that IS present must still stay at the bottom,
+      // rather than being sorted in among the data as an empty value.
+      //
+      // `sortEmptyCells: true` is what makes this assertion able to fail at all. Under the
+      // default (`false`) the compare function pushes empty values to the end in BOTH orders, so
+      // the spare row lands last whether or not it was inside the sortable range - the test would
+      // pass with the spare-row guard deleted. With the option on, an empty value sorts FIRST
+      // ascending, so the `null` staying last is evidence of the guard and nothing else.
+      await grid.useSortingPlugin(plugin, { [plugin]: { sortEmptyCells: true } });
+
+      await expect.poll(() => grid.trailingEmptyRowCount()).toBe(1);
+
+      await grid.sortByHeader(0);
+
+      // Ascending, sorted as text: `A1` leads, the `A1x` block follows, and the spare row is
+      // still the `null` at the end instead of the first row.
+      await expect.poll(() => grid.columnValues(0)).toEqual([
+        'A1', 'A10', 'A11', 'A12', 'A13', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', null,
+      ]);
+
+      expect(grid.pageErrors).toEqual([]);
+    });
+
+    test('sorts trailing empty rows that are data rather than spare rows', async() => {
+      // The cap, in the direction the bug report does not cover: only `minSpareRows` trailing
+      // empty rows are spare, and any beyond that are ordinary data that has to take part in the
+      // sort. Three trailing blanks with `minSpareRows: 1` means two of them sort to the top
+      // ascending and exactly one stays pinned below the data.
+      await grid.useSortingPlugin(plugin, {
+        data: [['b'], ['a'], ['c'], [null], [null], [null]],
+        colHeaders: true,
+        minSpareRows: 1,
+        [plugin]: { sortEmptyCells: true },
+      });
+
+      await expect.poll(() => grid.trailingEmptyRowCount()).toBe(3);
+
+      await grid.sortByHeader(0);
+
+      await expect.poll(() => grid.columnValues(0)).toEqual([null, null, 'a', 'b', 'c', null]);
+
+      expect(grid.pageErrors).toEqual([]);
+    });
+
+    test('restores the spare row below the data when the filter is cleared', async() => {
+      // This one's subject is the round trip, not the sortable range: the spare row has to come
+      // back below the data once the filter that trimmed it is gone. The guard itself is pinned
+      // by the two tests above, which fail without it - a trailing `null` here does not prove it.
+      await grid.useSortingPlugin(plugin, { [plugin]: { sortEmptyCells: true } });
+
+      await grid.applyContainsFilter(3, '1');
+      await grid.sortByHeader(0);
+      await grid.sortByHeader(0);
+
+      await grid.clearFilter();
+
+      // The spare row is back, and it is still the last row - the sort must not have dragged it
+      // up among the data while it was trimmed.
+      await expect.poll(() => grid.rowCount()).toBe(14);
+      await expect.poll(() => grid.trailingEmptyRowCount()).toBe(1);
+      await expect.poll(async() => (await grid.columnValues(0)).at(-1)).toBeNull();
+
+      expect(grid.pageErrors).toEqual([]);
+    });
+  });
+}

--- a/tests/e2e/sorting-filtered-spare-rows.spec.ts
+++ b/tests/e2e/sorting-filtered-spare-rows.spec.ts
@@ -22,13 +22,16 @@ for (const plugin of SORTING_PLUGINS) {
   test.describe(`sorting a filtered grid with minSpareRows (${plugin})`, () => {
     let grid: SortingFilteredSpareRowsPage;
 
+    // Each test builds the grid exactly once, with its own settings. Selecting the plugin here
+    // instead would build a grid that every test then throws away.
     test.beforeEach(async({ page, theme, bundle }) => {
       grid = new SortingFilteredSpareRowsPage(page, theme, bundle);
       await grid.goto();
-      await grid.useSortingPlugin(plugin);
     });
 
     test('sorts every visible row once the filter has trimmed the spare row away', async() => {
+      await grid.useSortingPlugin(plugin);
+
       // Column D `contains '1'` keeps D1 and D10..D13, and trims the empty spare row with them.
       await grid.applyContainsFilter(3, '1');
 
@@ -37,11 +40,11 @@ for (const plugin of SORTING_PLUGINS) {
       // subtracted from the sortable range.
       await expect.poll(() => grid.trailingEmptyRowCount()).toBe(0);
 
-      await grid.sortByHeader(0);
+      await grid.sortByHeader(0, 'ascending');
 
       await expect.poll(() => grid.columnValues(0)).toEqual(['A1', 'A10', 'A11', 'A12', 'A13']);
 
-      await grid.sortByHeader(0);
+      await grid.sortByHeader(0, 'descending');
 
       // A13 was the row left behind at the bottom, unsorted, before the fix.
       await expect.poll(() => grid.columnValues(0)).toEqual(['A13', 'A12', 'A11', 'A10', 'A1']);
@@ -59,8 +62,8 @@ for (const plugin of SORTING_PLUGINS) {
 
       await expect.poll(() => grid.trailingEmptyRowCount()).toBe(0);
 
-      await grid.sortByHeader(0);
-      await grid.sortByHeader(0);
+      await grid.sortByHeader(0, 'ascending');
+      await grid.sortByHeader(0, 'descending');
 
       await expect.poll(() => grid.columnValues(0)).toEqual(['A13', 'A12', 'A11', 'A10', 'A1']);
 
@@ -80,7 +83,7 @@ for (const plugin of SORTING_PLUGINS) {
 
       await expect.poll(() => grid.trailingEmptyRowCount()).toBe(1);
 
-      await grid.sortByHeader(0);
+      await grid.sortByHeader(0, 'ascending');
 
       // Ascending, sorted as text: `A1` leads, the `A1x` block follows, and the spare row is
       // still the `null` at the end instead of the first row.
@@ -105,7 +108,7 @@ for (const plugin of SORTING_PLUGINS) {
 
       await expect.poll(() => grid.trailingEmptyRowCount()).toBe(3);
 
-      await grid.sortByHeader(0);
+      await grid.sortByHeader(0, 'ascending');
 
       await expect.poll(() => grid.columnValues(0)).toEqual([null, null, 'a', 'b', 'c', null]);
 
@@ -119,8 +122,8 @@ for (const plugin of SORTING_PLUGINS) {
       await grid.useSortingPlugin(plugin, { [plugin]: { sortEmptyCells: true } });
 
       await grid.applyContainsFilter(3, '1');
-      await grid.sortByHeader(0);
-      await grid.sortByHeader(0);
+      await grid.sortByHeader(0, 'ascending');
+      await grid.sortByHeader(0, 'descending');
 
       await grid.clearFilter();
 

--- a/tests/fixtures/demo/sorting-filtered-spare-rows.html
+++ b/tests/fixtures/demo/sorting-filtered-spare-rows.html
@@ -65,8 +65,10 @@
         colHeaders: true,
         rowHeaders: true,
         columnSorting: true,
+        // No `dropdownMenu`: the spec drives filtering through the plugin API, the way the
+        // reported repro's button does, and the menu's `.changeType` button would sit right
+        // next to the `span.colHeader` the sort clicks on a 50px column.
         filters: true,
-        dropdownMenu: true,
         minSpareRows: 1,
         // Stamped from a hook rather than a renderer so every cell type keeps its own
         // renderer and still gets an id.

--- a/tests/fixtures/demo/sorting-filtered-spare-rows.html
+++ b/tests/fixtures/demo/sorting-filtered-spare-rows.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable e2e fixture - sorting a filtered grid with minSpareRows</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back — a
+    // typo in the project config must be one red leg, never a silently
+    // mislabeled green one (nothing else asserts which file actually loaded).
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    // Written into <head> so the themed stylesheet is present before first render.
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    // 1:1 with the Puppeteer legs (umd = handsontable.js, full-min =
+    // handsontable.full.min.js, the exact file `test:production` loads).
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } </style>
+</head>
+<body>
+  <!--
+    E2E fixture for GH #5983: sorting a FILTERED grid that has `minSpareRows` set.
+
+    A filter trims every row that fails its conditions, and a spare row is empty, so an
+    ordinary condition trims the spare rows away too - nothing re-creates them while the
+    filter is on. ColumnSorting used to subtract `minSpareRows` from the visible row count
+    regardless, so the last N real data rows were pinned below the sort range.
+
+    The grid is rebuilt per test through `window.initSortingSpareRowsGrid`, so one test
+    cannot leak its sort or filter state into the next, and the `multiColumnSorting`
+    variant (which inherits the same range calculation) is one override rather than a
+    second fixture.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    var container = document.querySelector('[data-testid="grid"]');
+
+    container.className = 'ht-theme-' + window.htTheme;
+
+    window.initSortingSpareRowsGrid = function(overrides) {
+      if (window.hot) {
+        window.hot.destroy();
+      }
+
+      window.hot = new Handsontable(container, Object.assign({
+        // 13 rows, so a plain-text sort of column A puts A13 first descending - the value
+        // the report names as stuck at the bottom.
+        data: Handsontable.helper.createSpreadsheetData(13, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        columnSorting: true,
+        filters: true,
+        dropdownMenu: true,
+        minSpareRows: 1,
+        // Stamped from a hook rather than a renderer so every cell type keeps its own
+        // renderer and still gets an id.
+        afterRenderer: function(td, row, col) {
+          td.setAttribute('data-testid', 'cell-' + row + '-' + col);
+        },
+        afterGetColHeader: function(col, TH) {
+          if (col >= 0) {
+            TH.setAttribute('data-testid', 'col-header-' + col);
+          }
+        },
+        licenseKey: 'non-commercial-and-evaluation',
+      }, overrides || {}));
+
+      return true;
+    };
+
+    window.initSortingSpareRowsGrid();
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/SortingFilteredSpareRowsPage.ts
+++ b/tests/fixtures/pages/SortingFilteredSpareRowsPage.ts
@@ -1,0 +1,139 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+import { type CellValue } from './windowTypes';
+
+/** Which sorting plugin the grid is built with. Both share the sortable-range calculation. */
+export type SortingPlugin = 'columnSorting' | 'multiColumnSorting';
+
+/**
+ * Page object for the GH #5983 fixture: sorting a filtered grid that has `minSpareRows` set.
+ *
+ * Filtering is driven through the Filters plugin API rather than the dropdown menu, because
+ * that is what the bug report does (a button beside the grid calling `addCondition` +
+ * `filter`), and it keeps the spec's subject the sort rather than the menu. Sorting is driven
+ * by clicking the header label, which is the user gesture the report describes.
+ *
+ * `window.hot` and `window.initSortingSpareRowsGrid` are declared in `windowTypes.ts` - the
+ * single home of the `Window` augmentation shared by every page object in this directory.
+ */
+export class SortingFilteredSpareRowsPage {
+  /** The Playwright page the fixture is driven through. */
+  readonly page: Page;
+  /** The active theme, passed through to the fixture URL. */
+  readonly theme: string;
+  /** The active bundle, passed through to the fixture URL. */
+  readonly bundle: string;
+  /** Column headers live in several overlay layers, so every header locator is scoped to the top one. */
+  readonly headerOverlay: Locator;
+  /** Uncaught page errors seen since construction, in the order they fired. */
+  readonly pageErrors: string[] = [];
+
+  /**
+   * Wires up the page object for one theme/bundle leg and starts collecting uncaught page
+   * errors immediately, so a spec that never calls `goto()` before an assertion still sees them.
+   */
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.headerOverlay = page.locator('.ht_clone_top');
+    page.on('pageerror', (error) => { this.pageErrors.push(error.message); });
+  }
+
+  /**
+   * Navigate to the fixture and wait for the grid to render.
+   *
+   * The bundle is injected with `document.write`, so it loads separately from the block that
+   * builds the grid. Wait for `Handsontable` itself first, and with `waitForFunction` rather
+   * than `expect`: the plain UMD bundle is ~6 MB and every worker pulls its own copy, so a cold
+   * or busy server outlasts the 10s `expect` timeout while `waitForFunction` polls against the
+   * test budget.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(
+      `/tests/fixtures/demo/sorting-filtered-spare-rows.html?theme=${this.theme}&bundle=${this.bundle}`);
+    await this.page.waitForFunction(() => 'Handsontable' in window);
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /** Rebuilds the grid with the given setting overrides, so one test cannot leak into the next. */
+  async rebuild(overrides: Record<string, unknown> = {}): Promise<void> {
+    await this.page.evaluate(settings => window.initSortingSpareRowsGrid(settings), overrides);
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /**
+   * Rebuilds the grid with the given sorting plugin. `multiColumnSorting` extends
+   * `ColumnSorting` and the two refuse to run together, so the single-column plugin has to be
+   * switched off explicitly.
+   */
+  async useSortingPlugin(plugin: SortingPlugin, overrides: Record<string, unknown> = {}): Promise<void> {
+    await this.rebuild({
+      columnSorting: plugin === 'columnSorting',
+      multiColumnSorting: plugin === 'multiColumnSorting',
+      ...overrides,
+    });
+  }
+
+  /** A single data cell, by visual row/column, via its stable test id. */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /** A column header, scoped to the top overlay so the match is unambiguous. */
+  header(col: number): Locator {
+    return this.headerOverlay.getByTestId(`col-header-${col}`);
+  }
+
+  /** The clickable sorting label inside a column header. */
+  sortLabel(col: number): Locator {
+    return this.header(col).locator('span.colHeader');
+  }
+
+  /**
+   * Click a column header's sorting label, the gesture the bug report describes, and wait for
+   * the indicator so the follow-up assertions run against a sorted grid.
+   */
+  async sortByHeader(col: number): Promise<void> {
+    await this.sortLabel(col).click();
+    await expect(this.sortLabel(col)).toHaveClass(/ascending|descending/);
+  }
+
+  /**
+   * Apply a "contains" condition through the Filters plugin API - what the reported repro's
+   * button does. The condition takes a VISUAL column index, as every public `Filters` method
+   * does.
+   */
+  async applyContainsFilter(col: number, value: string): Promise<void> {
+    await this.page.evaluate(({ column, needle }) => {
+      const filters = window.hot.getPlugin('filters');
+
+      filters.addCondition(column, 'contains', [needle]);
+      filters.filter();
+    }, { column: col, needle: value });
+  }
+
+  /** Drop every condition and re-run the filter, bringing the trimmed rows back. */
+  async clearFilter(): Promise<void> {
+    await this.page.evaluate(() => {
+      const filters = window.hot.getPlugin('filters');
+
+      filters.clearConditions();
+      filters.filter();
+    });
+  }
+
+  /** The values the grid currently holds in a column, top to bottom, spare rows included. */
+  async columnValues(col: number): Promise<CellValue[]> {
+    return this.page.evaluate(column => window.hot.getDataAtCol(column), col);
+  }
+
+  /** The number of rows the grid currently renders, spare rows included. */
+  async rowCount(): Promise<number> {
+    return this.page.evaluate(() => window.hot.countRows());
+  }
+
+  /** The number of empty rows at the bottom of the grid - what `minSpareRows` is measured against. */
+  async trailingEmptyRowCount(): Promise<number> {
+    return this.page.evaluate(() => window.hot.countEmptyRows(true));
+  }
+}

--- a/tests/fixtures/pages/SortingFilteredSpareRowsPage.ts
+++ b/tests/fixtures/pages/SortingFilteredSpareRowsPage.ts
@@ -92,10 +92,15 @@ export class SortingFilteredSpareRowsPage {
   /**
    * Click a column header's sorting label, the gesture the bug report describes, and wait for
    * the indicator so the follow-up assertions run against a sorted grid.
+   *
+   * The expected order is required rather than optional: a second click lands on a label that
+   * already carries `ascending`, so waiting for "either indicator" would resolve the instant the
+   * click is dispatched and never wait for anything. Naming the order makes a lost click fail
+   * here, where it happened, instead of surfacing as a value mismatch further down the test.
    */
-  async sortByHeader(col: number): Promise<void> {
+  async sortByHeader(col: number, expectedOrder: 'ascending' | 'descending'): Promise<void> {
     await this.sortLabel(col).click();
-    await expect(this.sortLabel(col)).toHaveClass(/ascending|descending/);
+    await expect(this.sortLabel(col)).toHaveClass(new RegExp(`\\b${expectedOrder}\\b`));
   }
 
   /**

--- a/tests/fixtures/pages/windowTypes.ts
+++ b/tests/fixtures/pages/windowTypes.ts
@@ -23,6 +23,7 @@ interface FixtureCellRange {
  */
 export interface FixtureHotInstance {
   getDataAtCell(row: number, col: number): CellValue;
+  getDataAtCol(col: number): CellValue[];
   getSourceDataAtCell(row: number, col: number): CellValue;
   getSourceData(): unknown[];
   setDataAtCell(row: number, col: number, value: CellValue): void;
@@ -54,6 +55,11 @@ export interface FixtureHotInstance {
   getPlugin(name: 'manualColumnFreeze'): {
     freezeColumn(column: number): void,
     unfreezeColumn(column: number): void,
+  };
+  getPlugin(name: 'filters'): {
+    addCondition(column: number, name: string, args: unknown[]): void,
+    clearConditions(column?: number): void,
+    filter(): void,
   };
   getPlugin(name: 'dragToScroll'): { isListening(): boolean };
   getPlugin(name: 'multipleSelectionHandles'): { isDragged(): boolean };
@@ -166,6 +172,8 @@ declare global {
     initFragmentSelectionGrid(overrides?: Record<string, unknown>): boolean;
     /** Rebuilds the GH #5069 nested-`dataSchema` + `minSpareRows` fixture grid. */
     initNestedSchemaGrid(overrides?: Record<string, unknown>): boolean;
+    /** Rebuilds the GH #5983 sorting-a-filtered-grid-with-`minSpareRows` fixture grid. */
+    initSortingSpareRowsGrid(overrides?: Record<string, unknown>): boolean;
     /** Returns the text the browser currently reports as selected (fragmentSelection fixture). */
     readTextSelection(): string;
     /** Drops any existing text selection (fragmentSelection fixture). */


### PR DESCRIPTION
### Context

The PR fixes sorting a filtered grid that has `minSpareRows` set. With `columnSorting` (or `multiColumnSorting`), `filters` and `minSpareRows: N`, applying a filter and then sorting left the last N rows unsorted at the bottom of the grid — "the sort is off by however many extra blank rows you want added", as the report puts it.

`ColumnSorting#getNumberOfRowsToSort()` subtracted `minSpareRows` from the visible row count to keep the trailing spare rows out of the sortable range. That assumed the spare rows are on screen. They are not once a filter is applied: a spare row is empty, so an ordinary condition trims it away like any other non-matching row, and nothing re-creates it while the filter is on (`grid.adjustRowsAndCols()` runs after alters, data changes and `updateSettings`, never on `trimmedIndexesChanged`). The subtraction then excluded that many **real data rows**, which `sortByPresetSortStates()` re-appended below the sorted block in their original order.

The fix counts the trailing empty rows actually present instead of trusting the option, capping both the result and the walk at `minSpareRows`. The count can never exceed what was subtracted before, so behavior with the spare rows present is unchanged; the walk is capped rather than going through `countEmptyRows(true)`, whose scan is unbounded and reads every column of each row it visits — `adjustRowsAndCols()` caps its own `minSpareCols` count the same way, for the same reason.

`MultiColumnSorting` extends `ColumnSorting` and does not override the method, so both plugins were affected and both are covered.

One related overlap is **deliberately left alone**: a spare row sits inside the band `fixedRowsBottom` reserves, so with `minSpareRows: 1, fixedRowsBottom: 1` both terms describe the same row and two rows leave the sortable range. That is pre-existing, untouched by this change, and the existing `fixedRowsTop`/`fixedRowsBottom`/`minSpareRows` spec passes because of it. It is now recorded in the plugin's `AGENTS.md` so whoever corrects it knows that expectation has to be revisited first.

### How has this been tested?

New Playwright coverage in `tests/e2e/sorting-filtered-spare-rows.spec.ts` — 5 cases run against both sorting plugins (10 tests): the reported filter-then-sort flow, the same with `minSpareRows: 3`, a present spare row staying out of the sort, trailing empty rows beyond `minSpareRows` taking part in it, and the spare row returning below the data once the filter is cleared.

The two complement cases use `sortEmptyCells: true` with a single ascending click on purpose. Under the default (`false`) the compare function pushes empty values to the end in both sort orders, so a spare row lands last whether or not the guard excluded it — assertions written that way pass with the guard deleted and prove nothing. With the option on, an empty value sorts first ascending, so the spare row staying last is evidence of the guard. Verified by patching the guard out of the built bundle: those cases fail without it and pass with it.

```bash
npm run build --prefix handsontable

# new coverage, all four local legs
cd tests && npx playwright test sorting-filtered-spare-rows \
  --project=e2e-main --project=e2e-main-min --project=e2e-horizon --project=e2e-classic

# full functional leg
cd tests && npx playwright test --project=e2e-main

# the frozen Jasmine suites for the touched plugins
npm run test:e2e --prefix handsontable -- --testPathPattern='columnSorting'
npm run test:e2e --prefix handsontable -- --testPathPattern='multiColumnSorting'
npm run test:e2e --prefix handsontable -- --testPathPattern='filters'

npm run test:unit --prefix handsontable
npm run test:types --prefix handsontable
npm run eslint --prefix handsontable
npm run stylelint --prefix handsontable
```

Results: new spec 40 passed across the four legs; full `e2e-main` 837 passed / 1 skipped; Jasmine columnSorting 274, multiColumnSorting 137, filters 284, all 0 failures; unit 4374 passed; types, ESLint and Stylelint clean.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #5983
2. DEV-443

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sortable row-range logic used on every sort for columnSorting and multiColumnSorting; behavior is well covered by new e2e tests but touches core grid interaction with filters and spare rows.
> 
> **Overview**
> Fixes **#5983**: on a **filtered** grid with `minSpareRows`, column/multi-column sorting left the last N visible data rows unsorted at the bottom.
> 
> **`getNumberOfRowsToSort()`** no longer subtracts the `minSpareRows` setting from the row count. It now walks from the bottom and counts trailing empty rows with `isEmptyRow()`, stopping at `minSpareRows`, because filters remove empty spare rows from the view and they are not recreated until the filter clears. Only rows actually present as spare are excluded from the sort; extra trailing empty rows beyond the cap still participate in sorting.
> 
> Adds Playwright regression coverage (both sorting plugins), a demo fixture and page object, a changelog entry, and **AGENTS.md** notes on the counting rule and an existing `minSpareRows` + `fixedRowsBottom` overlap left unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21558c1ef2290962a7fe91f212ea7d9b1d73e847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->