### PR TITLE
Docs: clarify legacy license keys keep working after 18.1 upgrade

### DIFF
--- a/docs/content/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md
@@ -39,6 +39,10 @@ An expired key still does not block anything. Neither does a lapsed subscription
 expiration date the console reports an error and every feature keeps working, so a paying customer
 is never locked out.
 
+**If you already have a valid license key**, no action is needed: an existing key that is valid
+under 18.0 continues to work unchanged after upgrading to 18.1. Key validity depends only on the
+key's own expiration date, not on the Handsontable version you run.
+
 ### Who is affected
 
 You are affected if a Handsontable instance runs anywhere without a valid key. In practice that


### PR DESCRIPTION
### Context
The public v18.1 migration guide's license-enforcement section never states whether a license key that was already valid under 18.0 keeps working after upgrading to 18.1. Adds one paragraph confirming it does, and that validity depends only on the key's own expiration date. 

[skip changelog]

### Test evidence (required for source changes)
- Unit tests added/modified (`*.unit.js`): none — docs only
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none — docs only
- Type tests (`*.types.ts`) updated if public API changed: n/a
- For a bug fix — the spec that fails without this fix: n/a
- Demo page / recorded trace (for UI changes): n/a

### Commands run
- `git diff -- docs/content/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md` (reviewed manually, docs-only change, no build/test run)

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://app.clickup.com/t/9015210959/DEV-2773

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.
- [ ] MANUAL QA NEEDED

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification with no runtime or API impact.
> 
> **Overview**
> The **18.0 → 18.1 migration guide** now states explicitly that customers who already run a **valid license key** do not need to change anything when upgrading: keys that worked on 18.0 keep working on 18.1, and validity is tied to the **key’s expiration date**, not the Handsontable version.
> 
> The new paragraph sits in section 1 (license enforcement / blocking modal) so readers are not left wondering whether 18.1’s stricter missing-or-invalid-key behavior forces a new key for existing licensees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebd243818a0910bf540fd8b7810a0ff4e877ad53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->