### PR TITLE
DEV-395: Fix the first column rendering 1px narrower with row headers

### DIFF
--- a/.changelogs/6673.json
+++ b/.changelogs/6673.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the first column rendering 1px narrower than the other columns when row headers are enabled, and the row header growing by 1px when the grid was scrolled horizontally.",
+  "type": "fixed",
+  "issueOrPR": 6673,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/probe-6673.html
+++ b/handsontable/probe-6673.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><title>#6673 probe</title>
-<link rel="stylesheet" href="styles/ht-theme-main.css">
-<link rel="stylesheet" href="styles/ht-theme-classic.css">
-<link rel="stylesheet" href="styles/ht-theme-horizon.css">
-<style>body{margin:0;padding:16px;font:13px system-ui}</style>
-</head><body><div id="mount"></div>
-<script src="dist/handsontable.full.js"></script>
-</body></html>

--- a/handsontable/probe-6673.html
+++ b/handsontable/probe-6673.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>#6673 probe</title>
+<link rel="stylesheet" href="styles/ht-theme-main.css">
+<link rel="stylesheet" href="styles/ht-theme-classic.css">
+<link rel="stylesheet" href="styles/ht-theme-horizon.css">
+<style>body{margin:0;padding:16px;font:13px system-ui}</style>
+</head><body><div id="mount"></div>
+<script src="dist/handsontable.full.js"></script>
+</body></html>

--- a/handsontable/src/3rdparty/walkontable/.ai/RENDERING-LIFECYCLE.md
+++ b/handsontable/src/3rdparty/walkontable/.ai/RENDERING-LIFECYCLE.md
@@ -234,8 +234,6 @@ All line numbers are in `table.ts` unless noted. "Master only" = guarded by `thi
   when the captured ones are non-null (a skipped FIRST draw keeps the just-built filters — several
   consumers read `rowFilter!` unguarded once the table is drawn; the overlays' `applyToDOM` treats
   the restored `null` calculators as the nothing-rendered spreader offset instead of throwing);
-  `correctHeaderWidth` is restored whenever no render happened, regardless of the totals gates (the
-  DOM header width did not change, and an advanced flag would suppress the corrective full draw);
   and the fully/partially-**visible** calculators are deliberately NOT restored: they describe the
   scroll position, not the DOM contents — so after a skipped draw the visible band may extend past
   the rendered band (unlike a fast draw), and `getCell` answers those rows with exit codes. A
@@ -278,7 +276,9 @@ All line numbers are in `table.ts` unless noted. "Master only" = guarded by `thi
 - Call `resetFixedPosition()` on top (`624`), bottom-if-cloned (`626–628`), inline-start (`630`), and
   corner overlays (`632–638`). Each positions its clone and, for top/bottom/inline-start, decides the
   `innerBorderTop` / `innerBorderInlineStart` / `innerBorderBottom` class via `adjustHeaderBordersPosition`.
-  Those calls OR-together into `positionChanged`.
+  Those calls OR-together into `positionChanged`. Only the two ROW-axis classes still shift the layout;
+  `innerBorderInlineStart` is stamped for backward compatibility and drives no geometry since #6673
+  (see AGENTS.md, "Column-axis border ownership").
 - **S16a seam:** the border decision is now a pure `#computeHeaderBordersState(...)` separated from its
   DOM write in `overlay/regions/topOverlay.ts` / `inlineStartOverlay.ts` / `bottomOverlay.ts` — so S16b
   can move the decision pre-render. Behavior today is unchanged (compute + apply still called in

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -106,6 +106,46 @@ Three more things that pass every functional test and only show up in a profile 
 
 When you add a new content-driven measurement, ask which tables actually render the content — measuring the master alone is the trap both of these exist to work around.
 
+## Column-axis border ownership: the row header owns its gridline
+
+The two axes are NOT symmetric, and the column axis is the settled one. On the column axis a row
+header `th` carries its own `border-inline-end` at **every** scroll position, and no `td` standing
+behind a row header carries a `border-inline-start`. So one declared `colWidths` produces one content
+width in every column, and `col.rowHeader` is written verbatim from the `rowHeaderWidth` setting
+whatever the scroll offset (`render/colGroup.ts`).
+
+It used to work the other way round, and that was issue #6673. `td:first-of-type` was given an
+inline-start border on top of the inline-end border every cell has, and `box-sizing: border-box` took
+both out of the same `col` width — so column 0's content box was 1px narrower than everybody else's.
+The row header then dropped its own inline-end border at offset 0 to keep the seam from doubling, and
+a `correctHeaderWidth` flag widened the row header by 1px the moment the grid scrolled, with matching
+compensations in `inlineStartOverlay#scrollTo`, the hider width (`spreaderSize`) and the two column
+calculators (`viewportWidth + 1`). The table therefore changed width by being scrolled. All of that is
+gone; do not reintroduce a scroll-dependent header width or a per-axis `+ 1` in a column calculator —
+`getViewportWidth()` is exact at every offset now.
+
+Consequences worth knowing:
+
+- **`innerBorderInlineStart`, `innerBorderLeft` and `emptyColumns` still get stamped on `.ht_master`**
+  (`overlay/regions/inlineStartOverlay.ts`) and are kept for backward compatibility, but no stylesheet
+  reads them any more. `innerBorderInlineStart` also only toggles when the grid has row headers and NO
+  frozen columns, so it is not a usable "has scrolled" signal in a test — poll the holder's
+  `scrollLeft` instead.
+- **The row axis is unchanged.** `innerBorderTop` / `innerBorderBottom` still shift the layout by 1px,
+  which is what `positionChanged` and the reconciliation draw in `table/drawCycle.ts` exist for, and
+  `columnHeaderBorderCompensation` in `topOverlay`/`spreaderSize` is the vertical twin that stayed.
+  Bringing the row axis into line is a separate change.
+- **Anything positioning an element over a cell must read the cell's border, not its index.** Which
+  cells own an inline-start border is no longer "column 0": with row headers none of them do, and
+  `htFirstDatasetColumnNotRendered` takes it off the first rendered column too. `BaseEditor#getEditedCellRect`
+  keys both the editor's width and its inline-start offset off the same computed border for exactly
+  that reason — key them off different things and the editor is a pixel wider than where it starts,
+  overhanging the next column.
+- Without row headers, column 0 is the first cell of its row and still draws the grid's own
+  inline-start frame inside its declared width. It stays 1px narrower than the rest — deliberately out
+  of scope for #6673, and pinned as a control case in
+  `tests/e2e/row-header-border-ownership.spec.ts`.
+
 ## A table built outside the layout cannot read its own styles
 
 A container that generates no boxes — detached from the document, or a light-DOM child of a shadow

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -141,6 +141,23 @@ Consequences worth knowing:
   keys both the editor's width and its inline-start offset off the same computed border for exactly
   that reason — key them off different things and the editor is a pixel wider than where it starts,
   overhanging the next column.
+- **Reading the border is not enough for anything the overlays paint over.** The shared pixel in front
+  of column 0 belongs to the inline-start overlay, which is z-index 120 against the selection border
+  layer's 10, so an affordance centred on that gridline is *geometrically* right and *invisible*.
+  `Border#appear` therefore shifts the edge onto the cell's own boundary when the cell either owns an
+  inline-start border **or** has a row-header `th` as its previous sibling. That second test is what
+  keeps a selection on column 0 visible; without it the edge lands at `rowHeaderWidth - 1` and
+  disappears behind the row header. The `customBorders` specs cannot catch it — they count visible
+  elements, and the element is there, just covered.
+- **Ownership covers the seam's COLOR, not only which element draws it.** In the overlay that renders
+  nothing but the row-header column, the row header `th` is also `:last-child`, and the header rule
+  keyed on that paints the grid's OUTER frame color. So the same gridline came out
+  `--ht-border-color` with plain `rowHeaders` and `--ht-cell-horizontal-border-color` with
+  `fixedColumnsStart` — invisible in `horizon`, where the cell-border token is transparent, and
+  visible in the other shape. `_base.scss` pins both the body row header and the corner `th` to the
+  cell-border color under `.htRowHeaders`, with two carve-outs: `.emptyColumns`, where the row header
+  really is the grid's inline-end edge, and `ht__active_highlight-prev`, which is how an active
+  column-0 header now gets its inline-start accent (that pixel moved to the corner).
 - Without row headers, column 0 is the first cell of its row and still draws the grid's own
   inline-start frame inside its declared width. It stays 1px narrower than the rest — deliberately out
   of scope for #6673, and pinned as a control case in

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -154,10 +154,22 @@ Consequences worth knowing:
   keyed on that paints the grid's OUTER frame color. So the same gridline came out
   `--ht-border-color` with plain `rowHeaders` and `--ht-cell-horizontal-border-color` with
   `fixedColumnsStart` — invisible in `horizon`, where the cell-border token is transparent, and
-  visible in the other shape. `_base.scss` pins both the body row header and the corner `th` to the
-  cell-border color under `.htRowHeaders`, with two carve-outs: `.emptyColumns`, where the row header
-  really is the grid's inline-end edge, and `ht__active_highlight-prev`, which is how an active
-  column-0 header now gets its inline-start accent (that pixel moved to the corner).
+  visible in the other shape. `_base.scss` pins the seam owner to the cell-border color under
+  `.htRowHeaders`, with three carve-outs: `.emptyColumns`, where the row header really is the grid's
+  inline-end edge; `ht__active_highlight-prev`, which is how an active column-0 header gets its
+  inline-start accent (that pixel moved to the corner); and `ht__active_highlight`, because the seam
+  is the active row header's own inline-end and the accent has to win there. The grid managed that
+  last one only when scrolled before, since the border was 0px at horizontal offset 0.
+- **A grid can carry more than one row header column**, and then the seam to column 0 is the LAST
+  one's `border-inline-end`. `afterGetRowHeaderRenderers` is a documented hook that appends
+  renderers, and `autoRowHeaderSize` measures each of them, so this is a supported shape rather than
+  a curiosity. The body selector therefore matches every `th` in a body row - all of them are row
+  headers - rather than `th:first-child`; the inner ones need no override because they are never
+  `:last-child`. The HEAD row cannot be handled the same way: CSS cannot count how many corner cells
+  precede the first column header, so that half stays on `:first-child` and a grid with two or more
+  row headers keeps drawing its head-row seam in the frame color. That is what it does today too, so
+  it is a pre-existing quirk this change neither fixes nor worsens - fixing it needs a marker class
+  from the engine on the last row header.
 - Without row headers, column 0 is the first cell of its row and still draws the grid's own
   inline-start frame inside its declared width. It stays 1px narrower than the rest — deliberately out
   of scope for #6673, and pinned as a control case in

--- a/handsontable/src/3rdparty/walkontable/css/walkontable.scss
+++ b/handsontable/src/3rdparty/walkontable/css/walkontable.scss
@@ -96,32 +96,17 @@
   border-bottom: 1px solid #ccc;
 }
 
+/* Inline-start axis border ownership (#6673): only the first cell of a row draws the frame, so a
+   row header `th` keeps its inline-end border (the separator to column 0) at every scroll position
+   and no cell behind it adds one. `innerBorderInlineStart` / `emptyColumns` drive no geometry. */
 .handsontable th:first-child,
-.handsontable td:first-of-type {
-  border-inline-start: 1px solid #ccc;
-}
-
-/* It removes double right border from first column header when row headers are disabled */
-.handsontable .ht_clone_top th:nth-child(2) {
-  border-inline-start-width: 0;
-  border-inline-end: 1px solid #ccc;
-}
-
-.handsontable.htRowHeaders thead tr th:nth-child(2) {
+.handsontable td:first-child {
   border-inline-start: 1px solid #ccc;
 }
 
 .handsontable tr:first-child th,
 .handsontable tr:first-child td {
   border-top: 1px solid #ccc;
-}
-
-.ht_master:not(.innerBorderInlineStart):not(.emptyColumns) tbody tr th,
-.ht_master:not(.innerBorderInlineStart):not(.emptyColumns) thead tr th:first-child,
-.ht_master:not(.innerBorderInlineStart):not(.emptyColumns) ~ .handsontable:not(.htGhostTable) tbody tr th,
-.ht_master:not(.innerBorderInlineStart):not(.emptyColumns) ~ .handsontable:not(.ht_clone_top):not(.htGhostTable) thead tr th:first-child {
-  border-inline-end-width: 0;
-  border-inline-start: 1px solid #ccc;
 }
 
 /*

--- a/handsontable/src/3rdparty/walkontable/src/calculator/calculationType/fullyVisibleColumns.ts
+++ b/handsontable/src/3rdparty/walkontable/src/calculator/calculationType/fullyVisibleColumns.ts
@@ -55,11 +55,9 @@ export class FullyVisibleColumnsCalculationType {
       columnWidth,
     } = viewportCalculator;
 
-    const compensatedViewportWidth = zeroBasedScrollOffset > 0 ? viewportWidth + 1 : viewportWidth;
-
     if (
       totalCalculatedWidth >= zeroBasedScrollOffset &&
-      totalCalculatedWidth + columnWidth <= zeroBasedScrollOffset + compensatedViewportWidth
+      totalCalculatedWidth + columnWidth <= zeroBasedScrollOffset + viewportWidth
     ) {
       if (this.startColumn === null || this.startColumn === undefined) {
         this.startColumn = column;
@@ -79,7 +77,6 @@ export class FullyVisibleColumnsCalculationType {
       scrollOffset,
       viewportWidth,
       inlineStartOffset,
-      zeroBasedScrollOffset,
       totalColumns,
       needReverse,
       positionCache,
@@ -112,14 +109,14 @@ export class FullyVisibleColumnsCalculationType {
 
     this.startPosition = this.startColumn !== null ? positionCache.getOffset(this.startColumn) : null;
 
-    const compensatedViewportWidth = zeroBasedScrollOffset > 0 ? viewportWidth + 1 : viewportWidth;
-    const mostRightScrollOffset = scrollOffset + viewportWidth - compensatedViewportWidth;
     const inlineStartColumnOffset = this.startColumn === null ? 0 : viewportCalculator.getColumnWidth(this.startColumn);
 
     if (
-      // the table is to the left of the viewport
+      // the table is to the left of the viewport. `scrollOffset` is compared as-is: the row header
+      // carries its inline-end border at every scroll position, so the viewport width is exact
+      // whether or not the table is scrolled and needs no 1px compensation (#6673).
       (
-        mostRightScrollOffset < (-1) * inlineStartOffset ||
+        scrollOffset < (-1) * inlineStartOffset ||
         scrollOffset > positionCache.getOffset(viewportCalculator.lastProcessedIndex)
       ) ||
       // the table is to the right of the viewport

--- a/handsontable/src/3rdparty/walkontable/src/calculator/calculationType/partiallyVisibleColumns.ts
+++ b/handsontable/src/3rdparty/walkontable/src/calculator/calculationType/partiallyVisibleColumns.ts
@@ -58,11 +58,9 @@ export class PartiallyVisibleColumnsCalculationType {
       this.startColumn = column;
     }
 
-    const compensatedViewportWidth = zeroBasedScrollOffset > 0 ? viewportWidth + 1 : viewportWidth;
-
     if (
       totalCalculatedWidth >= zeroBasedScrollOffset &&
-      totalCalculatedWidth <= zeroBasedScrollOffset + compensatedViewportWidth
+      totalCalculatedWidth <= zeroBasedScrollOffset + viewportWidth
     ) {
       if (this.startColumn === null || this.startColumn === undefined) {
         this.startColumn = column;
@@ -82,7 +80,6 @@ export class PartiallyVisibleColumnsCalculationType {
       scrollOffset,
       viewportWidth,
       inlineStartOffset,
-      zeroBasedScrollOffset,
       totalColumns,
       needReverse,
       positionCache,
@@ -113,13 +110,12 @@ export class PartiallyVisibleColumnsCalculationType {
 
     this.startPosition = this.startColumn !== null ? positionCache.getOffset(this.startColumn) : null;
 
-    const compensatedViewportWidth = zeroBasedScrollOffset > 0 ? viewportWidth + 1 : viewportWidth;
-    const mostRightScrollOffset = scrollOffset + viewportWidth - compensatedViewportWidth;
-
     if (
-      // the table is to the left of the viewport
+      // the table is to the left of the viewport. `scrollOffset` is compared as-is: the row header
+      // carries its inline-end border at every scroll position, so the viewport width is exact
+      // whether or not the table is scrolled and needs no 1px compensation (#6673).
       (
-        mostRightScrollOffset < (-1) * inlineStartOffset ||
+        scrollOffset < (-1) * inlineStartOffset ||
         scrollOffset > positionCache.getOffset(viewportCalculator.lastProcessedIndex) + columnWidth
       ) ||
       // the table is to the right of the viewport

--- a/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
@@ -899,15 +899,6 @@ class Overlays {
   }
 
   /**
-   * Expand the hider horizontally element by the provided delta value.
-   *
-   * @param {number} widthDelta The delta value to expand the hider element by.
-   */
-  expandHiderHorizontallyBy(widthDelta: number) {
-    this.#spreaderSize.expandHiderHorizontallyBy(widthDelta);
-  }
-
-  /**
    *
    */
   applyToDOM() {

--- a/handsontable/src/3rdparty/walkontable/src/overlay/regions/inlineStartOverlay.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/regions/inlineStartOverlay.ts
@@ -325,17 +325,9 @@ export class InlineStartOverlay extends Overlay {
    * @returns {boolean}
    */
   scrollTo(sourceCol: number, beyondRendered: boolean) {
-    const { wtSettings } = this;
     const { geometryReader } = this.deps;
-    const rowHeaders = wtSettings.getSetting('rowHeaders') as ((...args: unknown[]) => unknown)[];
-    const fixedColumnsStart = wtSettings.getSetting<number>('fixedColumnsStart');
     const sourceInstance = this.wot.cloneSource ? this.wot.cloneSource : this.wot;
     const mainHolder = sourceInstance.wtTable.holder;
-    const rowHeaderBorderCompensation = (
-      fixedColumnsStart === 0 &&
-      rowHeaders.length > 0 &&
-      !hasClass(mainHolder.parentNode as HTMLElement, 'innerBorderInlineStart')
-    ) ? 1 : 0;
     let newX = this.getTableParentOffset();
     let scrollbarCompensation = 0;
 
@@ -354,24 +346,12 @@ export class InlineStartOverlay extends Overlay {
     if (beyondRendered) {
       newX += this.sumCellSizes(0, sourceCol + 1);
       newX -= this.deps.getWtViewport().getViewportWidth();
-      // Compensate for the right header border if scrolled from the absolute left.
-      newX += rowHeaderBorderCompensation;
 
     } else {
       newX += this.sumCellSizes(this.wtSettings.getSetting<number>('fixedColumnsStart'), sourceCol);
     }
 
     newX += scrollbarCompensation;
-
-    // If the table is scrolled all the way left when starting the scroll and going to be scrolled to the far right,
-    // we need to compensate for the potential header border width.
-    if (
-      geometryReader.getMaximumScrollLeft(this.mainTableScrollableElement as HTMLElement)
-        === newX - rowHeaderBorderCompensation &&
-      rowHeaderBorderCompensation > 0
-    ) {
-      this.deps.getWtOverlays().expandHiderHorizontallyBy(rowHeaderBorderCompensation);
-    }
 
     return this.setScrollPosition(newX);
   }

--- a/handsontable/src/3rdparty/walkontable/src/overlay/spreaderSize.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/spreaderSize.ts
@@ -142,5 +142,4 @@ export class SpreaderSize {
 
     hider.style.height = `${parseInt(hider.style.height, 10) + heightDelta}px`;
   }
-
 }

--- a/handsontable/src/3rdparty/walkontable/src/overlay/spreaderSize.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/spreaderSize.ts
@@ -117,20 +117,14 @@ export class SpreaderSize {
       return scrollableElement.scrollTop >
         Math.max(0, proposedHiderHeight - geometryReader.clientHeight(wtTable.holder));
     };
-    const isScrolledBeyondHiderWidth = () => {
-      if (isWindowScrolled || !(scrollableElement instanceof HTMLElement)) {
-        return false;
-      }
-
-      return scrollableElement.scrollLeft >
-        Math.max(0, proposedHiderWidth - geometryReader.clientWidth(wtTable.holder));
-    };
     const columnHeaderBorderCompensation = isScrolledBeyondHiderHeight() ? 1 : 0;
-    const rowHeaderBorderCompensation = isScrolledBeyondHiderWidth() ? 1 : 0;
 
     // If the elements are being adjusted after scrolling the table from the very beginning to the very end,
-    // we need to adjust the hider dimensions by the header border size. (https://github.com/handsontable/dev-handsontable/issues/1772)
-    hiderStyle.width = `${proposedHiderWidth + rowHeaderBorderCompensation}px`;
+    // we need to adjust the hider height by the column header border size.
+    // (https://github.com/handsontable/dev-handsontable/issues/1772)
+    // The width needs no such compensation: the row header carries its inline-end border at every
+    // scroll position, so the horizontal total never changes by scrolling (#6673).
+    hiderStyle.width = `${proposedHiderWidth}px`;
     hiderStyle.height = `${proposedHiderHeight + columnHeaderBorderCompensation}px`;
 
     topOverlay.adjustElementsSize();
@@ -149,14 +143,4 @@ export class SpreaderSize {
     hider.style.height = `${parseInt(hider.style.height, 10) + heightDelta}px`;
   }
 
-  /**
-   * Expand the hider horizontally element by the provided delta value.
-   *
-   * @param {number} widthDelta The delta value to expand the hider element by.
-   */
-  expandHiderHorizontallyBy(widthDelta: number) {
-    const { hider } = this.#deps.wtTable;
-
-    hider.style.width = `${parseInt(hider.style.width, 10) + widthDelta}px`;
-  }
 }

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -1475,7 +1475,18 @@ class Border {
       top += 1;
       height = height > 0 ? height - 1 : 0;
     }
-    if (parseInt(style[isRtl ? 'borderRightWidth' : 'borderLeftWidth'], 10) > 0) {
+    // The inline-start gridline sits INSIDE the cell when the cell draws its own start border, so the
+    // edge has to move onto it. A cell standing behind a row header draws no start border - the row
+    // header owns that gridline (#6673) - and the shared pixel is then the last pixel of the
+    // inline-start overlay, which paints at z-index 120 against this layer's 10. An edge left centred
+    // on it would be hidden behind the row header, so both cases put the visible edge at the cell's
+    // own inline-start boundary. Read from the DOM, not from a column index: with row headers no cell
+    // owns that border, and `htFirstDatasetColumnNotRendered` takes it off the first rendered column
+    // too.
+    const ownsInlineStartBorder = parseInt(style[isRtl ? 'borderRightWidth' : 'borderLeftWidth'], 10) > 0;
+    const standsBehindRowHeader = fromTDEl.previousElementSibling?.nodeName === 'TH';
+
+    if (ownsInlineStartBorder || standsBehindRowHeader) {
       inlineStartPos += 1;
       width = width > 0 ? width - 1 : 0;
     }

--- a/handsontable/src/3rdparty/walkontable/src/table/baseTable.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/baseTable.ts
@@ -216,12 +216,6 @@ class Table {
    */
   declare columnFilter: ColumnFilter | null;
   /**
-   * Indicates if the header width should be corrected.
-   *
-   * @type {boolean}
-   */
-  declare correctHeaderWidth: boolean;
-  /**
    * The row utilities.
    *
    * @type {RowUtils}
@@ -295,12 +289,12 @@ class Table {
 
     this.rowFilter = null; // TODO refactoring, eliminate all (re)creations of this object, then updates state when needed.
     this.columnFilter = null; // TODO refactoring, eliminate all (re)creations of this object, then updates state when needed.
-    this.correctHeaderWidth = false;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const origRowHeaderWidth = this.wtSettings.getSettingPure('rowHeaderWidth');
 
-    // Fix for jumping row headers (https://github.com/handsontable/handsontable/issues/3850)
+    // Normalizes whatever the `rowHeaderWidth` setting resolves to (a function, a number, an array
+    // or nothing) into a usable width, falling back to `defaultColumnWidth`.
     this.wtSettings.update('rowHeaderWidth', () => this._modifyRowHeaderWidth(origRowHeaderWidth));
 
     this.rowUtils = new RowUtils(this.#deps);
@@ -366,22 +360,18 @@ class Table {
   }
 
   /**
-   * Correct row header width if necessary.
+   * Resolves a single row header width, falling back to the default column width when the setting
+   * did not provide a number. The width is scroll-position independent: the row header owns its
+   * inline-end border at every offset, so nothing is added here (#6673).
    *
    * @private
    * @param {number | null} width The width to process.
    * @returns {number}
    */
   _correctRowHeaderWidth(width: number | null) {
-    let rowHeaderWidth: number = typeof width === 'number'
+    return typeof width === 'number'
       ? width
       : this.wtSettings.getSetting<number>('defaultColumnWidth');
-
-    if (this.correctHeaderWidth) {
-      rowHeaderWidth += 1;
-    }
-
-    return rowHeaderWidth;
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -20,8 +20,7 @@ import type { ColumnsCalculationType, RowsCalculationType } from '../calculator/
 
 /**
  * The state that describes what is actually rendered in the TBODY/THEAD right now: the rendered
- * row/column bands (held by the viewport), the render filters derived from them, and the
- * `correctHeaderWidth` flag that describes the row-header width the DOM was rendered with. Captured
+ * row/column bands (held by the viewport) and the render filters derived from them. Captured
  * before the draw resolves the new band, so the master's `skipRender` gate can put it back — see
  * {@link restoreRenderedStateIfSafe}.
  */
@@ -30,7 +29,6 @@ interface RenderedState {
   columnsRenderCalculator: ColumnsCalculationType | null;
   rowFilter: RowFilter | null;
   columnFilter: ColumnFilter | null;
-  correctHeaderWidth: boolean;
 }
 
 /**
@@ -149,17 +147,6 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
     stationaryBands: wtOverlays.isScrollDrivenDraw && wtViewport.allowsStationaryBands(),
   });
 
-  if (ctx.rowHeadersCount && !wtSettings.getSetting('fixedColumnsStart')) {
-    const leftScrollPos = wtOverlays.inlineStartOverlay.getScrollPosition();
-    const previousState = table.correctHeaderWidth;
-
-    table.correctHeaderWidth = leftScrollPos !== 0;
-
-    if (previousState !== table.correctHeaderWidth) {
-      ctx.runFastDraw = false;
-    }
-  }
-
   if (ctx.runFastDraw) {
     wtOverlays.refresh(true);
     // Fast (scroll) draws skip the full-render header-height pass below, so the master/top
@@ -270,8 +257,10 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
   if (ctx.positionChanged) {
     if (ctx.performRedraw) {
       // It refreshes the cells borders caused by a 1px shift (introduced by overlays which add or
-      // remove `innerBorderTop` and `innerBorderInlineStart` CSS classes to the DOM element. This happens
-      // when there is a switch between rendering from 0 to N rows/columns and vice versa).
+      // remove the `innerBorderTop` / `innerBorderBottom` CSS classes on the DOM element. This
+      // happens when there is a switch between rendering from 0 to N rows and vice versa). The
+      // inline-start class is still toggled for backward compatibility but no longer shifts the
+      // layout — the row header owns its inline-end border at every scroll position (#6673).
       wtOverlays.refreshAll(); // `refreshAll()` internally already calls `refreshSelections()` method
     } else {
       // A skipped render must not run the nested reconciliation draw above (`refreshAll` is
@@ -362,9 +351,9 @@ function buildRenderFilters(table: Table, ctx: DrawContext): { rowFilter: RowFil
 }
 
 /**
- * Captures the rendered row/column bands, the render filters, and the `correctHeaderWidth` flag,
- * i.e. everything that describes which source rows and columns the current DOM holds and how it was
- * rendered. Master-only: the `skipRender` gate it serves is master-only.
+ * Captures the rendered row/column bands and the render filters, i.e. everything that describes
+ * which source rows and columns the current DOM holds. Master-only: the `skipRender` gate it serves
+ * is master-only.
  *
  * @param {Table} table The master table.
  * @param {Viewport} wtViewport The viewport that owns the rendered bands.
@@ -376,7 +365,6 @@ function captureRenderedState(table: Table, wtViewport: Viewport): RenderedState
     columnsRenderCalculator: wtViewport.columnsRenderCalculator,
     rowFilter: table.rowFilter,
     columnFilter: table.columnFilter,
-    correctHeaderWidth: table.correctHeaderWidth,
   };
 }
 
@@ -408,10 +396,6 @@ function captureRenderedState(table: Table, wtViewport: Viewport): RenderedState
  *   just-built filters are kept instead, because filter consumers (`getRowHeader`, `getTrForRow`,
  *   the selection scanner's header loop) read `rowFilter!` unguarded and must never see `null`
  *   after a completed draw.
- * - `correctHeaderWidth` is restored whenever no render happened, regardless of the totals gates:
- *   the flag describes the row-header width the DOM was rendered with, and that DOM did not change.
- *   Leaving it advanced would make the next draw see "no change" and never re-render the corrected
- *   header width.
  * - The visible-row/column calculators are deliberately NOT restored: they describe what the user
  *   can see (scroll position), not what the DOM holds. After a skipped draw the visible band may
  *   therefore extend past the rendered band — unlike a fast draw, which guarantees the visible band
@@ -434,8 +418,6 @@ function restoreRenderedStateIfSafe(
   if (wtViewport.renderCycleSeq !== renderCycleSeqBeforeHook) {
     return;
   }
-
-  table.correctHeaderWidth = state.correctHeaderWidth;
 
   if (state.rowFilter === null || state.rowFilter.total === wtSettings.getSetting<number>('totalRows')) {
     wtViewport.rowsRenderCalculator = state.rowsRenderCalculator;

--- a/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
@@ -612,8 +612,9 @@ describe('WalkontableOverlay', () => {
 
     const clientWidth = document.body.clientWidth;
     const clientHeight = document.body.clientHeight;
-    // total columns * 50px (cell width) + 50px (row header) + 1px (header border left width)
-    const totalColumnsWidth = (getTotalColumns() * 50) + 50 + 1;
+    // total columns * 50px (cell width) + 50px (row header). The row header no longer grows by
+    // 1px once the table is scrolled - it owns its inline-end border at every offset (#6673).
+    const totalColumnsWidth = (getTotalColumns() * 50) + 50;
 
     expect($(wt.wtTable.holder).width()).toBe(clientWidth);
     expect($(wt.wtTable.holder).height()).toBe(clientHeight);

--- a/handsontable/src/3rdparty/walkontable/test/spec/rtl/overlay.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/rtl/overlay.spec.js
@@ -464,7 +464,7 @@ describe('WalkontableOverlay (RTL mode)', () => {
     const clientWidth = document.body.clientWidth;
     const clientHeight = document.body.clientHeight;
     // total columns * 50px (cell width) + 50px (row header)
-    const totalColumnsWidth = (getTotalColumns() * 50) + 50 + 1;
+    const totalColumnsWidth = (getTotalColumns() * 50) + 50;
 
     expect($(wt.wtTable.holder).width()).toBe(clientWidth);
     expect($(wt.wtTable.holder).height()).toBe(clientHeight);

--- a/handsontable/src/3rdparty/walkontable/test/spec/scroll/scroll.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/scroll/scroll.spec.js
@@ -180,12 +180,14 @@ describe('WalkontableScroll', () => {
       const firstRow = getTableMaster().find('tbody tr:first');
       const lastRow = getTableMaster().find('tbody tr:last');
 
-      expect(firstRow.find('td:first').text()).toBe('I1');
-      // The scroll target (K) sticks to the right edge; the stationary-band path keeps the band at
-      // its pre-scroll size, so one overscan column (L) renders just past the edge (clipped).
-      expect(firstRow.find('td:last').text()).toBe('L1');
-      expect(lastRow.find('td:first').text()).toBe('I8');
-      expect(lastRow.find('td:last').text()).toBe('L8');
+      // The scroll target (K) sticks to the right edge and is the last column rendered. Before
+      // #6673 the scroll landed 1px further right (compensating for a row header that grew by 1px
+      // once the table scrolled), which revealed a sliver of the next column (L) and pushed the
+      // band's start one column along.
+      expect(firstRow.find('td:first').text()).toBe('H1');
+      expect(firstRow.find('td:last').text()).toBe('K1');
+      expect(lastRow.find('td:first').text()).toBe('H8');
+      expect(lastRow.find('td:last').text()).toBe('K8');
     });
 
     it('should scroll to the cell so that it sticks to the right edge of the viewport (forced by method flag)', async() => {
@@ -251,10 +253,13 @@ describe('WalkontableScroll', () => {
       const firstRow = getTableMaster().find('tbody tr:first');
       const lastRow = getTableMaster().find('tbody tr:last');
 
+      // The scroll target (K) sticks to the left edge. The band reaches one column further than
+      // before #6673: the row header no longer takes an extra pixel from the viewport width once
+      // the table is scrolled, so one more column fits in the rendered band.
       expect(firstRow.find('td:first').text()).toBe('K1');
-      expect(firstRow.find('td:last').text()).toBe('M1');
+      expect(firstRow.find('td:last').text()).toBe('N1');
       expect(lastRow.find('td:first').text()).toBe('K8');
-      expect(lastRow.find('td:last').text()).toBe('M8');
+      expect(lastRow.find('td:last').text()).toBe('N8');
     });
 
     it('should scroll to the cell so that it sticks to the left edge of the viewport (forced by method flag)', async() => {
@@ -1081,8 +1086,8 @@ describe('WalkontableScroll', () => {
       expect(scrollHorizontally.calls.count()).toBe(1);
     });
 
-    it('should add the "innerBorderInlineStart" CSS class (compensation for 1px border bug) to the root element when ' +
-       'the table is horizontally scrolled', async() => {
+    it('should add the "innerBorderInlineStart" CSS class (kept for backward compatibility) to the root ' +
+       'element when the table is horizontally scrolled', async() => {
       spec().$wrapper.width(186 + getScrollbarWidth()).height(186 + getScrollbarWidth());
       const wt = walkontable({
         data: getData,

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/drawCycleHooks.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/drawCycleHooks.spec.js
@@ -311,7 +311,7 @@ describe('Table.draw() lifecycle hooks (characterization for the drawCycle refac
     }
   });
 
-  it('should keep the row header width unchanged across a horizontal scroll whose render is skipped', async() => {
+  it('should keep the column rollback across a horizontal scroll whose render is skipped', async() => {
     let skipNextRender = false;
     const wt = walkontable({
       data: getData,
@@ -331,17 +331,35 @@ describe('Table.draw() lifecycle hooks (characterization for the drawCycle refac
 
     const rowHeaderWidth = () => wt.wtTable.TABLE.querySelector('tbody tr th').offsetWidth;
     const widthBeforeScroll = rowHeaderWidth();
+    const renderedColumnsBeforeScroll = wt.wtTable.TBODY.firstChild.querySelectorAll('td').length;
 
     expect(widthBeforeScroll).toBeGreaterThan(0);
 
-    // The row header owns its inline-end border at every scroll position, so its width is scroll
-    // independent - a skipped draw cannot leave the DOM describing a width the engine no longer
-    // reports (#6673). Before that change the header grew by 1px once the table scrolled, and the
-    // flag that tracked it had to be rolled back here.
+    // The column axis is what the rollback still protects here. Without it the advanced column band
+    // describes columns the skipped draw never rendered, so the filter stops matching the DOM and
+    // `getCell` reads past it.
     skipNextRender = true;
     wt.scrollViewportHorizontally(3, 'end');
     wt.draw();
 
+    // The render was really skipped - the TBODY still holds the pre-scroll column band.
+    expect(wt.wtTable.TBODY.firstChild.querySelectorAll('td').length).toBe(renderedColumnsBeforeScroll);
+
+    // A rolled-back band describes the stale DOM, so every cell it resolves really holds that
+    // column's value. Without the rollback the band names the post-scroll columns while the TBODY
+    // still holds the pre-scroll ones, and `getCell` maps a new index onto an old cell - an element,
+    // but the wrong one, which is why an `instanceof HTMLElement` check cannot see this.
+    expect(wt.wtTable.getFirstRenderedColumn()).toBeGreaterThan(-1);
+
+    for (let col = wt.wtTable.getFirstRenderedColumn(); col <= wt.wtTable.getLastRenderedColumn(); col++) {
+      expect(wt.wtTable.getCell(new Walkontable.CellCoords(0, col)).textContent)
+        .toBe(`${getData(0, col)}`);
+    }
+
+    // And the row header width is scroll independent, so neither the skipped draw nor the one that
+    // follows it can leave the DOM describing a width the engine no longer reports. It used to grow
+    // by 1px once the table scrolled, which is what the removed `correctHeaderWidth` flag tracked
+    // and what this spec had to roll back (#6673).
     expect(rowHeaderWidth()).toBe(widthBeforeScroll);
 
     skipNextRender = false;

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/drawCycleHooks.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/drawCycleHooks.spec.js
@@ -311,7 +311,7 @@ describe('Table.draw() lifecycle hooks (characterization for the drawCycle refac
     }
   });
 
-  it('should restore the `correctHeaderWidth` flag when the render is skipped', async() => {
+  it('should keep the row header width unchanged across a horizontal scroll whose render is skipped', async() => {
     let skipNextRender = false;
     const wt = walkontable({
       data: getData,
@@ -329,16 +329,25 @@ describe('Table.draw() lifecycle hooks (characterization for the drawCycle refac
 
     wt.draw();
 
-    expect(wt.wtTable.correctHeaderWidth).toBe(false);
+    const rowHeaderWidth = () => wt.wtTable.TABLE.querySelector('tbody tr th').offsetWidth;
+    const widthBeforeScroll = rowHeaderWidth();
 
-    // The flag flips before the `beforeDraw` gate, but the header it describes never re-renders on
-    // a skipped draw. Left advanced, the next draw would see "no change" and keep the stale header
-    // width forever - so the rollback must put the flag back with the rest of the rendered state.
+    expect(widthBeforeScroll).toBeGreaterThan(0);
+
+    // The row header owns its inline-end border at every scroll position, so its width is scroll
+    // independent - a skipped draw cannot leave the DOM describing a width the engine no longer
+    // reports (#6673). Before that change the header grew by 1px once the table scrolled, and the
+    // flag that tracked it had to be rolled back here.
     skipNextRender = true;
     wt.scrollViewportHorizontally(3, 'end');
     wt.draw();
 
-    expect(wt.wtTable.correctHeaderWidth).toBe(false);
+    expect(rowHeaderWidth()).toBe(widthBeforeScroll);
+
+    skipNextRender = false;
+    wt.draw();
+
+    expect(rowHeaderWidth()).toBe(widthBeforeScroll);
   });
 
   it('should fire `beforeDraw` but SKIP `onDraw` when beforeDraw sets skipRender', async() => {

--- a/handsontable/src/__tests__/core/scrollToFocusedCell.spec.js
+++ b/handsontable/src/__tests__/core/scrollToFocusedCell.spec.js
@@ -139,7 +139,7 @@ describe('Core.scrollToFocusedCell', () => {
     await scrollToFocusedCell();
 
     // 2500 column width - 250 viewport width + 15 scrollbar compensation + 1 header border compensation
-    expect(inlineStartOverlay().getScrollPosition()).toBe(2766);
+    expect(inlineStartOverlay().getScrollPosition()).toBe(2765);
     expect(topOverlay().getScrollPosition()).toBe(scrollVBefore);
   });
 

--- a/handsontable/src/__tests__/core/scrollToFocusedCell.spec.js
+++ b/handsontable/src/__tests__/core/scrollToFocusedCell.spec.js
@@ -138,7 +138,9 @@ describe('Core.scrollToFocusedCell', () => {
 
     await scrollToFocusedCell();
 
-    // 2500 column width - 250 viewport width + 15 scrollbar compensation + 1 header border compensation
+    // 2500 column width - 250 viewport width + 15 scrollbar compensation. There is no header
+    // border compensation any more: the row header keeps its inline-end border at every scroll
+    // position, so the viewport width is the same scrolled or not (#6673).
     expect(inlineStartOverlay().getScrollPosition()).toBe(2765);
     expect(topOverlay().getScrollPosition()).toBe(scrollVBefore);
   });

--- a/handsontable/src/__tests__/core/scrollViewportTo.spec.js
+++ b/handsontable/src/__tests__/core/scrollViewportTo.spec.js
@@ -41,7 +41,7 @@ describe('Core.scrollViewportTo', () => {
       const layout = getThemeLayout();
 
       expect(result).toBe(true);
-      expect(inlineStartOverlay().getScrollPosition()).toBe(2826);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(2825);
       // Auto bottom snap: row 150 should be at the bottom edge of the viewport.
       expect(topOverlay().getScrollPosition()).toBeGreaterThan(layout.verticalScrollForRow(150) - 300);
       expect(topOverlay().getScrollPosition()).toBeLessThanOrEqual(layout.verticalScrollForRow(151));
@@ -133,7 +133,7 @@ describe('Core.scrollViewportTo', () => {
       const layout = getThemeLayout();
 
       expect(result).toBe(true);
-      expect(inlineStartOverlay().getScrollPosition()).toBe(2826);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(2825);
       // Auto top snap: row 150 should be at the top edge of the viewport.
       expect(topOverlay().getScrollPosition()).toBe(layout.verticalScrollForRow(150));
     });
@@ -244,7 +244,7 @@ describe('Core.scrollViewportTo', () => {
     });
 
     expect(result).toBe(true);
-    expect(inlineStartOverlay().getScrollPosition()).toBe(2826);
+    expect(inlineStartOverlay().getScrollPosition()).toBe(2825);
     expect(topOverlay().getScrollPosition()).toBe(0);
   });
 

--- a/handsontable/src/__tests__/hooks/beforeViewportScrollHorizontally.spec.js
+++ b/handsontable/src/__tests__/hooks/beforeViewportScrollHorizontally.spec.js
@@ -145,8 +145,10 @@ describe('Hook', () => {
 
       await scrollViewportTo({ col: 10 });
 
-      // 2050 column width - 250 viewport width + 15 scrollbar compensation + 1 header border compensation
-      expect(inlineStartOverlay().getScrollPosition()).toBe(1816);
+      // 2050 column width - 250 viewport width + 15 scrollbar compensation. There is no header
+      // border compensation any more: the row header keeps its inline-end border at every scroll
+      // position, so the viewport width is the same scrolled or not (#6673).
+      expect(inlineStartOverlay().getScrollPosition()).toBe(1815);
       expect(topOverlay().getScrollPosition()).toBe(0);
     });
 
@@ -177,8 +179,9 @@ describe('Hook', () => {
         value: 'auto',
       }));
 
-      // 900 column width - 250 viewport width + 15 scrollbar compensation + 1 header border compensation
-      expect(inlineStartOverlay().getScrollPosition()).toBe(666);
+      // 900 column width - 250 viewport width + 15 scrollbar compensation (no header border
+      // compensation, see above).
+      expect(inlineStartOverlay().getScrollPosition()).toBe(665);
       expect(topOverlay().getScrollPosition()).toBe(0);
     });
 

--- a/handsontable/src/core/viewportScroll/__tests__/columnHeaderSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/columnHeaderSelection.spec.js
@@ -29,7 +29,7 @@ describe('Column header selection scroll', () => {
       await scrollViewportHorizontally(25);
       await simulateClick(getCell(-1, 5, true));
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',
@@ -53,7 +53,7 @@ describe('Column header selection scroll', () => {
       await keyDown('shift');
       await simulateClick(getCell(-1, 5));
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 4, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(-1, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -78,7 +78,7 @@ describe('Column header selection scroll', () => {
       await selectColumns(4);
       await keyDownUp(['shift', 'arrowright']);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 4, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(-1, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -100,7 +100,7 @@ describe('Column header selection scroll', () => {
       await scrollViewportHorizontally(25);
       await selectColumns(4, 5);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',
@@ -121,7 +121,7 @@ describe('Column header selection scroll', () => {
       await scrollViewportHorizontally(25);
       await selectColumns(5, 4);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',
@@ -277,7 +277,7 @@ describe('Column header selection scroll', () => {
     await scrollViewportHorizontally(100);
     await selectColumns(9, 0);
 
-    expect(inlineStartOverlay().getScrollPosition()).toBe(251);
+    expect(inlineStartOverlay().getScrollPosition()).toBe(250);
     expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 9, true));
     expect(scrollIntoViewSpy).toHaveBeenCalledWith({
       block: 'nearest',

--- a/handsontable/src/core/viewportScroll/__tests__/focusSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/focusSelection.spec.js
@@ -127,14 +127,13 @@ describe('Focus selection scroll', () => {
   });
 
   it('should scroll the viewport horizontally', async() => {
-    // The viewport width shows exactly 4 columns + 1 header col + 15px (scrollbar) + 1px (grid
-    // left-frame border). The 1px slack makes the scroll positions below land on exact
-    // `colWidths` multiples on every theme -- themes that render a 1px cell border-left
-    // consume that slack; themes without it leave it as a 1px gap. Do not re-introduce a
-    // theme-specific `+ 1` on the expected scroll values; the container width already
-    // normalizes the difference.
+    // The viewport width shows exactly 4 columns + 1 header col + 15px (scrollbar), which makes
+    // the scroll positions below land on exact `colWidths` multiples on every theme. This used to
+    // need 1px of extra slack to absorb the border the first data column carried inside its own
+    // width; since #6673 the row header owns that gridline, so every column has the same content
+    // width and no theme needs the slack. Do not re-introduce a `+ 1` on either side.
     const colWidths = 60;
-    const width = getDefaultRowHeaderWidth() + (4 * colWidths) + 16;
+    const width = getDefaultRowHeaderWidth() + (4 * colWidths) + 15;
 
     handsontable({
       data: createSpreadsheetData(5, 50),

--- a/handsontable/src/core/viewportScroll/__tests__/multipleSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/multipleSelection.spec.js
@@ -32,7 +32,7 @@ describe('Multiple selection scroll', () => {
       await keyDown('shift');
       await simulateClick(getCell(0, 5));
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 4, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -55,7 +55,7 @@ describe('Multiple selection scroll', () => {
       await selectCell(0, 4);
       await keyDownUp(['shift', 'arrowright']);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 4, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -99,7 +99,7 @@ describe('Multiple selection scroll', () => {
       await scrollViewportHorizontally(25);
       await selectCells([[0, 4, 0, 5]]);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',
@@ -120,7 +120,7 @@ describe('Multiple selection scroll', () => {
       await scrollViewportHorizontally(25);
       await selectCells([[0, 5, 0, 4]]);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',

--- a/handsontable/src/core/viewportScroll/__tests__/noncontiguousSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/noncontiguousSelection.spec.js
@@ -32,7 +32,7 @@ describe('Non-contiguous selection scroll', () => {
       await keyDown('control/meta');
       await simulateClick(getCell(0, 5));
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 3, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -54,7 +54,7 @@ describe('Non-contiguous selection scroll', () => {
       await scrollViewportHorizontally(25);
       await selectCells([[0, 3], [0, 5]]);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',

--- a/handsontable/src/core/viewportScroll/__tests__/rtl/columnHeaderSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/rtl/columnHeaderSelection.spec.js
@@ -32,7 +32,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       await scrollViewportHorizontally(25);
       await simulateClick(getCell(-1, 5));
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',
@@ -56,7 +56,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       await keyDown('shift');
       await simulateClick(getCell(-1, 5));
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 4, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(-1, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -81,7 +81,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       await selectColumns(4);
       await keyDownUp(['shift', 'arrowleft']);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 4, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(-1, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -103,7 +103,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       await scrollViewportHorizontally(25);
       await selectColumns(4, 5);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',
@@ -124,7 +124,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       await scrollViewportHorizontally(25);
       await selectColumns(5, 4);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',
@@ -280,7 +280,7 @@ describe('Column header selection scroll (RTL mode)', () => {
     await scrollViewportHorizontally(100);
     await selectColumns(9, 0);
 
-    expect(inlineStartOverlay().getScrollPosition()).toBe(251);
+    expect(inlineStartOverlay().getScrollPosition()).toBe(250);
     expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 9, true));
     expect(scrollIntoViewSpy).toHaveBeenCalledWith({
       block: 'nearest',

--- a/handsontable/src/core/viewportScroll/__tests__/rtl/multipleSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/rtl/multipleSelection.spec.js
@@ -35,7 +35,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       await keyDown('shift');
       await simulateClick(getCell(0, 5));
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 4, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -58,7 +58,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       await selectCell(0, 4);
       await keyDownUp(['shift', 'arrowleft']);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 4, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -103,7 +103,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       await scrollViewportHorizontally(25);
       await selectCells([[0, 4, 0, 5]]);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',
@@ -124,7 +124,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       await scrollViewportHorizontally(25);
       await selectCells([[0, 5, 0, 4]]);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',

--- a/handsontable/src/core/viewportScroll/__tests__/rtl/noncontiguousSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/rtl/noncontiguousSelection.spec.js
@@ -34,7 +34,7 @@ describe('Non-contiguous selection scroll (RTL mode)', () => {
       await keyDown('control/meta');
       await simulateClick(getCell(0, 5));
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 3, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -56,7 +56,7 @@ describe('Non-contiguous selection scroll (RTL mode)', () => {
       await scrollViewportHorizontally(25);
       await selectCells([[0, 3], [0, 5]]);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',

--- a/handsontable/src/core/viewportScroll/__tests__/rtl/singleSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/rtl/singleSelection.spec.js
@@ -48,7 +48,7 @@ describe('Single selection scroll (RTL mode)', () => {
       await scrollViewportHorizontally(25);
       await mouseDoubleClick(getCell(0, 5));
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',
@@ -70,7 +70,7 @@ describe('Single selection scroll (RTL mode)', () => {
       await selectCell(0, 4);
       await keyDownUp('arrowleft');
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 4, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -94,7 +94,7 @@ describe('Single selection scroll (RTL mode)', () => {
       await selectCell(-1, 4);
       await keyDownUp('arrowleft');
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 4, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(-1, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -116,7 +116,7 @@ describe('Single selection scroll (RTL mode)', () => {
       await scrollViewportHorizontally(25);
       await selectCell(0, 5);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',

--- a/handsontable/src/core/viewportScroll/__tests__/singleSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/singleSelection.spec.js
@@ -45,7 +45,7 @@ describe('Single selection scroll', () => {
       await scrollViewportHorizontally(25);
       await mouseDoubleClick(getCell(0, 5));
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
     });
 
@@ -63,7 +63,7 @@ describe('Single selection scroll', () => {
       await selectCell(0, 4);
       await keyDownUp('arrowright');
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 4, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -87,7 +87,7 @@ describe('Single selection scroll', () => {
       await selectCell(-1, 4);
       await keyDownUp('arrowright');
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(-1, 4, true));
       expect(scrollIntoViewSpy.calls.thisFor(1)).toBe(getCell(-1, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
@@ -109,7 +109,7 @@ describe('Single selection scroll', () => {
       await scrollViewportHorizontally(25);
       await selectCell(0, 5);
 
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
       expect(scrollIntoViewSpy.calls.thisFor(0)).toBe(getCell(0, 5, true));
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({
         block: 'nearest',

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -60,7 +60,12 @@ describe('AutocompleteEditor', () => {
 
     await keyDownUp('F2');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0)).offset());
   });
 
   it('should render the editor in the expected position when stepping top-to-bottom with top and bottom overlays', async() => {
@@ -91,15 +96,20 @@ describe('AutocompleteEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -123,7 +133,10 @@ describe('AutocompleteEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
@@ -153,12 +166,17 @@ describe('AutocompleteEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,
@@ -212,15 +230,20 @@ describe('AutocompleteEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -239,7 +262,10 @@ describe('AutocompleteEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
@@ -269,12 +295,17 @@ describe('AutocompleteEditor', () => {
     await keyDownUp('enter');
 
     // First renderable column index.
-    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -60,11 +60,9 @@ describe('AutocompleteEditor', () => {
 
     await keyDownUp('F2');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0)).offset());
   });
 
@@ -96,11 +94,9 @@ describe('AutocompleteEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -109,7 +105,7 @@ describe('AutocompleteEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -135,7 +131,7 @@ describe('AutocompleteEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -166,20 +162,17 @@ describe('AutocompleteEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
@@ -230,11 +223,9 @@ describe('AutocompleteEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -243,7 +234,7 @@ describe('AutocompleteEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -264,7 +255,7 @@ describe('AutocompleteEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -295,20 +286,17 @@ describe('AutocompleteEditor', () => {
     await keyDownUp('enter');
 
     // First renderable column index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());

--- a/handsontable/src/editors/baseEditor/baseEditor.ts
+++ b/handsontable/src/editors/baseEditor/baseEditor.ts
@@ -665,7 +665,18 @@ export class BaseEditor {
       topPos += 1;
     }
 
-    if ((renderableColumn ?? 0) <= 0) {
+    const cellComputedStyle = rootWindow.getComputedStyle(TD);
+    const borderPhysicalWidthProp = this.hot.isRtl() ? 'borderRightWidth' : 'borderLeftWidth';
+    const inlineStartBorderCompensation = Number.parseInt(cellComputedStyle[borderPhysicalWidthProp], 10) > 0 ? 0 : 1;
+
+    // The position above shifted the editor 1px towards the inline start so that it covers the
+    // gridline the previous cell draws on its inline-end side. A cell that draws its OWN
+    // inline-start border keeps that gridline inside its box, so there is nothing to cover and the
+    // shift is cancelled here. Which cells those are is not a fixed index: with row headers the
+    // header owns the gridline and column 0 draws none (#6673), and `htFirstDatasetColumnNotRendered`
+    // takes it off the first rendered column too - so read the border rather than the index, and
+    // key it off the same value that sizes the editor below, or the two disagree by a pixel.
+    if (inlineStartBorderCompensation === 0) {
       inlineStartPos += 1;
     }
 
@@ -679,9 +690,6 @@ export class BaseEditor {
     const cellStartOffset = this.#calcCellStartOffset(TD, overlayName, overlayTable, cellWidth,
       firstColumnOffset, horizontalScrollPosition);
 
-    const cellComputedStyle = rootWindow.getComputedStyle(TD);
-    const borderPhysicalWidthProp = this.hot.isRtl() ? 'borderRightWidth' : 'borderLeftWidth';
-    const inlineStartBorderCompensation = Number.parseInt(cellComputedStyle[borderPhysicalWidthProp], 10) > 0 ? 0 : 1;
     const topBorderCompensation = Number.parseInt(cellComputedStyle.borderTopWidth, 10) > 0 ? 0 : 1;
     const width = outerWidth(TD) + inlineStartBorderCompensation;
     const height = outerHeight(TD) + topBorderCompensation;

--- a/handsontable/src/editors/baseEditor/baseEditor.ts
+++ b/handsontable/src/editors/baseEditor/baseEditor.ts
@@ -656,7 +656,6 @@ export class BaseEditor {
 
     const hasColumnHeaders = this.hot.hasColHeaders();
     const renderableRow = this.hot.rowIndexMapper.getRenderableFromVisualIndex(this.row ?? 0);
-    const renderableColumn = this.hot.columnIndexMapper.getRenderableFromVisualIndex(this.col ?? 0);
     const nrOfRenderableRowIndexes = this.hot.rowIndexMapper.getRenderableIndexesLength();
     const firstRowIndexOfTheBottomOverlay =
       nrOfRenderableRowIndexes - (this.hot.view._wt.getSetting('fixedRowsBottom') as number);

--- a/handsontable/src/editors/dateEditor/__tests__/dateEditor.spec.js
+++ b/handsontable/src/editors/dateEditor/__tests__/dateEditor.spec.js
@@ -87,7 +87,12 @@ describe('DateEditor', () => {
 
     await keyDownUp('F2');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0)).offset());
   });
 
   it('should render an editor in specified position while opening an editor from top to bottom when ' +
@@ -107,16 +112,21 @@ describe('DateEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -144,7 +154,10 @@ describe('DateEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
@@ -175,13 +188,18 @@ describe('DateEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,
@@ -230,16 +248,21 @@ describe('DateEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -261,7 +284,10 @@ describe('DateEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
@@ -290,13 +316,18 @@ describe('DateEditor', () => {
     const editor = $(getActiveEditor().TEXTAREA_PARENT);
 
     // First renderable column index.
-    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,

--- a/handsontable/src/editors/dateEditor/__tests__/dateEditor.spec.js
+++ b/handsontable/src/editors/dateEditor/__tests__/dateEditor.spec.js
@@ -87,11 +87,9 @@ describe('DateEditor', () => {
 
     await keyDownUp('F2');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0)).offset());
   });
 
@@ -112,11 +110,9 @@ describe('DateEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -126,7 +122,7 @@ describe('DateEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -156,7 +152,7 @@ describe('DateEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -188,21 +184,18 @@ describe('DateEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
@@ -248,11 +241,9 @@ describe('DateEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -262,7 +253,7 @@ describe('DateEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -286,7 +277,7 @@ describe('DateEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -316,21 +307,18 @@ describe('DateEditor', () => {
     const editor = $(getActiveEditor().TEXTAREA_PARENT);
 
     // First renderable column index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());

--- a/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
@@ -77,11 +77,9 @@ describe('DropdownEditor', () => {
 
     await keyDownUp('F2');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0)).offset());
   });
 
@@ -113,11 +111,9 @@ describe('DropdownEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -126,7 +122,7 @@ describe('DropdownEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -152,7 +148,7 @@ describe('DropdownEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -183,20 +179,17 @@ describe('DropdownEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
@@ -247,11 +240,9 @@ describe('DropdownEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -260,7 +251,7 @@ describe('DropdownEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -281,7 +272,7 @@ describe('DropdownEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -312,20 +303,17 @@ describe('DropdownEditor', () => {
     await keyDownUp('enter');
 
     // First renderable column index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());

--- a/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
@@ -77,7 +77,12 @@ describe('DropdownEditor', () => {
 
     await keyDownUp('F2');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0)).offset());
   });
 
   it('should render the editor in the expected position when stepping top-to-bottom with top and bottom overlays', async() => {
@@ -108,15 +113,20 @@ describe('DropdownEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -140,7 +150,10 @@ describe('DropdownEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
@@ -170,12 +183,17 @@ describe('DropdownEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,
@@ -229,15 +247,20 @@ describe('DropdownEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -256,7 +279,10 @@ describe('DropdownEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
@@ -286,12 +312,17 @@ describe('DropdownEditor', () => {
     await keyDownUp('enter');
 
     // First renderable column index.
-    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,

--- a/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
@@ -107,11 +107,9 @@ describe('HandsontableEditor', () => {
 
     await keyDownUp('F2');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0)).offset());
   });
 
@@ -141,11 +139,9 @@ describe('HandsontableEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -154,7 +150,7 @@ describe('HandsontableEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -180,7 +176,7 @@ describe('HandsontableEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -214,20 +210,17 @@ describe('HandsontableEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
@@ -279,11 +272,9 @@ describe('HandsontableEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -292,7 +283,7 @@ describe('HandsontableEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -313,7 +304,7 @@ describe('HandsontableEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -347,20 +338,17 @@ describe('HandsontableEditor', () => {
     await keyDownUp('enter');
 
     // First renderable column index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());

--- a/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
@@ -107,7 +107,12 @@ describe('HandsontableEditor', () => {
 
     await keyDownUp('F2');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0)).offset());
   });
 
   it('should render an editor in specified position while opening an editor from top to bottom when ' +
@@ -136,15 +141,20 @@ describe('HandsontableEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -168,7 +178,10 @@ describe('HandsontableEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
@@ -201,12 +214,17 @@ describe('HandsontableEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,
@@ -261,15 +279,20 @@ describe('HandsontableEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -288,7 +311,10 @@ describe('HandsontableEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
@@ -321,12 +347,17 @@ describe('HandsontableEditor', () => {
     await keyDownUp('enter');
 
     // First renderable column index.
-    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,

--- a/handsontable/src/editors/handsontableEditor/__tests__/rtl/handsontableEditor.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/rtl/handsontableEditor.spec.js
@@ -10,11 +10,17 @@ describe('HandsontableEditor (RTL mode)', () => {
     ];
   }
 
-  function offsetForRtl(cell, editorWidth, rightBorderCompensation) {
+  function offsetForRtl(cell, editorWidth) {
     const $cell = $(cell);
     const offset = $cell.offset();
+    // The editor spans the cell plus the gridline on the cell's inline-start side - its physical
+    // right in RTL - and grows in that direction, so its left edge lines up with the cell's. When
+    // the cell draws that gridline itself there is nothing to cover and the editor is exactly as
+    // wide as the cell. Read the border off the cell rather than taking it from the caller: which
+    // cells own it is not a fixed index (with row headers the header owns it, #6673).
+    const ownsInlineStartBorder = parseInt($cell.css('border-right-width'), 10) > 0;
 
-    offset.left = offset.left - editorWidth + $cell.outerWidth() + (rightBorderCompensation ? 0 : 1);
+    offset.left = offset.left - editorWidth + $cell.outerWidth() + (ownsInlineStartBorder ? 0 : 1);
 
     return offset;
   }
@@ -73,7 +79,7 @@ describe('HandsontableEditor (RTL mode)', () => {
 
       await keyDown('enter');
 
-      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0), editor.outerWidth(), true));
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0), editor.outerWidth()));
     });
 
     it('should render an editor in specified position at cell 0, 0 when all headers are selected', async() => {
@@ -100,7 +106,7 @@ describe('HandsontableEditor (RTL mode)', () => {
 
       await keyDown('F2');
 
-      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0), editor.outerWidth(), true));
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0), editor.outerWidth()));
     });
 
     it('should render an editor in specified position while opening an editor from top to bottom when ' +
@@ -130,7 +136,7 @@ describe('HandsontableEditor (RTL mode)', () => {
 
       await keyDown('enter');
 
-      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0, true), editor.outerWidth(), true));
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0, true), editor.outerWidth()));
 
       await keyDown('enter');
       await keyDown('enter');
@@ -141,38 +147,38 @@ describe('HandsontableEditor (RTL mode)', () => {
         left: editor.offset().left,
       });
 
-      expect(editorOffset()).toEqual(offsetForRtl(getCell(1, 0, true), editor.outerWidth(), true));
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(1, 0, true), editor.outerWidth()));
 
       await keyDown('enter');
       await keyDown('enter');
 
-      expect(editorOffset()).toEqual(offsetForRtl(getCell(2, 0, true), editor.outerWidth(), true));
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(2, 0, true), editor.outerWidth()));
 
       await keyDown('enter');
       await keyDown('enter');
 
-      expect(editorOffset()).toEqual(offsetForRtl(getCell(3, 0, true), editor.outerWidth(), true));
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(3, 0, true), editor.outerWidth()));
 
       await keyDown('enter');
       await keyDown('enter');
 
-      expect(editorOffset()).toEqual(offsetForRtl(getCell(4, 0, true), editor.outerWidth(), true));
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(4, 0, true), editor.outerWidth()));
 
       await keyDown('enter');
       await keyDown('enter');
 
       // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-      expect(editor.offset()).toEqual(offsetForRtl(getCell(5, 0, true), editor.outerWidth(), true));
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(5, 0, true), editor.outerWidth()));
 
       await keyDown('enter');
       await keyDown('enter');
 
-      expect(editorOffset()).toEqual(offsetForRtl(getCell(6, 0, true), editor.outerWidth(), true));
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(6, 0, true), editor.outerWidth()));
 
       await keyDown('enter');
       await keyDown('enter');
 
-      expect(editorOffset()).toEqual(offsetForRtl(getCell(7, 0, true), editor.outerWidth(), true));
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(7, 0, true), editor.outerWidth()));
     });
 
     it('should render an editor in specified position while opening an editor from right to left when ' +
@@ -196,7 +202,7 @@ describe('HandsontableEditor (RTL mode)', () => {
 
       await keyDown('enter');
 
-      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0, true), editor.outerWidth(), true));
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0, true), editor.outerWidth()));
 
       await selectCell(0, 1);
       await keyDown('enter');
@@ -251,7 +257,7 @@ describe('HandsontableEditor (RTL mode)', () => {
       await keyDown('enter');
 
       // First renderable row index.
-      expect(editor.offset()).toEqual(offsetForRtl(getCell(1, 0, true), editor.outerWidth(), true));
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(1, 0, true), editor.outerWidth()));
 
       await keyDown('enter');
       await keyDown('enter');
@@ -262,28 +268,28 @@ describe('HandsontableEditor (RTL mode)', () => {
         left: editor.offset().left,
       });
 
-      expect(editorOffset()).toEqual(offsetForRtl(getCell(2, 0, true), editor.outerWidth(), true));
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(2, 0, true), editor.outerWidth()));
 
       await keyDown('enter');
       await keyDown('enter');
 
-      expect(editorOffset()).toEqual(offsetForRtl(getCell(3, 0, true), editor.outerWidth(), true));
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(3, 0, true), editor.outerWidth()));
 
       await keyDown('enter');
       await keyDown('enter');
 
-      expect(editorOffset()).toEqual(offsetForRtl(getCell(4, 0, true), editor.outerWidth(), true));
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(4, 0, true), editor.outerWidth()));
 
       await keyDown('enter');
       await keyDown('enter');
 
       // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-      expect(editor.offset()).toEqual(offsetForRtl(getCell(6, 0, true), editor.outerWidth(), true));
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(6, 0, true), editor.outerWidth()));
 
       await keyDown('enter');
       await keyDown('enter');
 
-      expect(editorOffset()).toEqual(offsetForRtl(getCell(7, 0, true), editor.outerWidth(), true));
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(7, 0, true), editor.outerWidth()));
     });
 
     it('should render an editor in specified position while opening an editor from right to left when ' +
@@ -312,7 +318,7 @@ describe('HandsontableEditor (RTL mode)', () => {
       await keyDown('enter');
 
       // First renderable column index.
-      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 1, true), editor.outerWidth(), true));
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 1, true), editor.outerWidth()));
 
       await selectCell(0, 2);
       await keyDown('enter');

--- a/handsontable/src/editors/intlDateEditor/__tests__/intlDateEditor.spec.js
+++ b/handsontable/src/editors/intlDateEditor/__tests__/intlDateEditor.spec.js
@@ -85,7 +85,12 @@ describe('IntlDateEditor', () => {
 
     await keyDownUp('F2');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0)).offset());
   });
 
   it('should not highlight the input element by browsers native selection', async() => {

--- a/handsontable/src/editors/intlDateEditor/__tests__/intlDateEditor.spec.js
+++ b/handsontable/src/editors/intlDateEditor/__tests__/intlDateEditor.spec.js
@@ -85,11 +85,9 @@ describe('IntlDateEditor', () => {
 
     await keyDownUp('F2');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0)).offset());
   });
 

--- a/handsontable/src/editors/intlTimeEditor/__tests__/intlTimeEditor.spec.js
+++ b/handsontable/src/editors/intlTimeEditor/__tests__/intlTimeEditor.spec.js
@@ -85,7 +85,12 @@ describe('IntlTimeEditor', () => {
 
     await keyDownUp('F2');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0)).offset());
   });
 
   it('should not highlight the input element by browsers native selection', async() => {

--- a/handsontable/src/editors/intlTimeEditor/__tests__/intlTimeEditor.spec.js
+++ b/handsontable/src/editors/intlTimeEditor/__tests__/intlTimeEditor.spec.js
@@ -85,11 +85,9 @@ describe('IntlTimeEditor', () => {
 
     await keyDownUp('F2');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0)).offset());
   });
 

--- a/handsontable/src/editors/numericEditor/__tests__/numericEditor.spec.js
+++ b/handsontable/src/editors/numericEditor/__tests__/numericEditor.spec.js
@@ -97,11 +97,9 @@ describe('NumericEditor', () => {
 
     await keyDownUp('F2');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0)).offset());
   });
 
@@ -127,11 +125,9 @@ describe('NumericEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -141,7 +137,7 @@ describe('NumericEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -171,7 +167,7 @@ describe('NumericEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -203,21 +199,18 @@ describe('NumericEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
@@ -268,11 +261,9 @@ describe('NumericEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -282,7 +273,7 @@ describe('NumericEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -306,7 +297,7 @@ describe('NumericEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -337,21 +328,18 @@ describe('NumericEditor', () => {
     await keyDownUp('enter');
 
     // First renderable column index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());

--- a/handsontable/src/editors/numericEditor/__tests__/numericEditor.spec.js
+++ b/handsontable/src/editors/numericEditor/__tests__/numericEditor.spec.js
@@ -97,7 +97,12 @@ describe('NumericEditor', () => {
 
     await keyDownUp('F2');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0)).offset());
   });
 
   it('should render an editor in specified position while opening an editor from top to bottom when ' +
@@ -122,16 +127,21 @@ describe('NumericEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -159,7 +169,10 @@ describe('NumericEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
@@ -190,13 +203,18 @@ describe('NumericEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,
@@ -250,16 +268,21 @@ describe('NumericEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -281,7 +304,10 @@ describe('NumericEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
@@ -311,13 +337,18 @@ describe('NumericEditor', () => {
     await keyDownUp('enter');
 
     // First renderable column index.
-    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await waitForNextAnimationFrames(2); // Caused by async DateEditor close.
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,

--- a/handsontable/src/editors/passwordEditor/__tests__/passwordEditor.spec.js
+++ b/handsontable/src/editors/passwordEditor/__tests__/passwordEditor.spec.js
@@ -82,11 +82,9 @@ describe('PasswordEditor', () => {
 
     await keyDownUp('F2');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0)).offset());
   });
 
@@ -112,11 +110,9 @@ describe('PasswordEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -125,7 +121,7 @@ describe('PasswordEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -151,7 +147,7 @@ describe('PasswordEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -181,20 +177,17 @@ describe('PasswordEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
@@ -242,11 +235,9 @@ describe('PasswordEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -255,7 +246,7 @@ describe('PasswordEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -276,7 +267,7 @@ describe('PasswordEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -306,20 +297,17 @@ describe('PasswordEditor', () => {
     await keyDownUp('enter');
 
     // First renderable column index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());

--- a/handsontable/src/editors/passwordEditor/__tests__/passwordEditor.spec.js
+++ b/handsontable/src/editors/passwordEditor/__tests__/passwordEditor.spec.js
@@ -82,7 +82,12 @@ describe('PasswordEditor', () => {
 
     await keyDownUp('F2');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0)).offset());
   });
 
   it('should render an editor in specified position while opening an editor from top to bottom when ' +
@@ -107,15 +112,20 @@ describe('PasswordEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -139,7 +149,10 @@ describe('PasswordEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
@@ -168,12 +181,17 @@ describe('PasswordEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,
@@ -224,15 +242,20 @@ describe('PasswordEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -251,7 +274,10 @@ describe('PasswordEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
@@ -280,12 +306,17 @@ describe('PasswordEditor', () => {
     await keyDownUp('enter');
 
     // First renderable column index.
-    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,

--- a/handsontable/src/editors/selectEditor/__tests__/selectEditor.spec.js
+++ b/handsontable/src/editors/selectEditor/__tests__/selectEditor.spec.js
@@ -50,6 +50,8 @@ describe('SelectEditor', () => {
     const editorWrapper = $('.htSelectEditor');
     const editor = $('.htSelectEditor').children('select');
 
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect(editorWrapper.length).toEqual(1);
     expect(editor.length).toEqual(1);
     expect(editor.is('select')).toBe(true);
@@ -60,7 +62,10 @@ describe('SelectEditor', () => {
 
     expect(editorWrapper.is(':visible')).toBe(true);
     expect(editor.is(':visible')).toBe(true);
-    expect(editorWrapper.offset()).toEqual($(getCell(0, 0)).offset());
+    expect({
+      top: editorWrapper.offset().top,
+      left: editorWrapper.offset().left + 1,
+    }).toEqual($(getCell(0, 0)).offset());
   });
 
   it('should render an editor in specified position while opening an editor from top to bottom when ' +
@@ -80,15 +85,20 @@ describe('SelectEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editorWrapper.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editorWrapper.offset().top,
+      left: editorWrapper.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editorWrapper.offset().top + 1,
-      left: editorWrapper.offset().left,
+      left: editorWrapper.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -112,7 +122,10 @@ describe('SelectEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editorWrapper.offset()).toEqual($(getCell(5, 0, true)).offset());
+    expect({
+      top: editorWrapper.offset().top,
+      left: editorWrapper.offset().left + 1,
+    }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
@@ -141,12 +154,17 @@ describe('SelectEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editorWrapper.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editorWrapper.offset().top,
+      left: editorWrapper.offset().left + 1,
+    }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editorWrapper.offset().top,
       left: editorWrapper.offset().left + 1,
@@ -192,15 +210,20 @@ describe('SelectEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    expect(editorWrapper.offset()).toEqual($(getCell(1, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editorWrapper.offset().top,
+      left: editorWrapper.offset().left + 1,
+    }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editorWrapper.offset().top + 1,
-      left: editorWrapper.offset().left,
+      left: editorWrapper.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -219,7 +242,10 @@ describe('SelectEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editorWrapper.offset()).toEqual($(getCell(6, 0, true)).offset());
+    expect({
+      top: editorWrapper.offset().top,
+      left: editorWrapper.offset().left + 1,
+    }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
@@ -248,12 +274,17 @@ describe('SelectEditor', () => {
     await keyDownUp('enter');
 
     // First renderable column index.
-    expect(editorWrapper.offset()).toEqual($(getCell(0, 1, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its
+    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
+    expect({
+      top: editorWrapper.offset().top,
+      left: editorWrapper.offset().left + 1,
+    }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editorWrapper.offset().top,
       left: editorWrapper.offset().left + 1,

--- a/handsontable/src/editors/selectEditor/__tests__/selectEditor.spec.js
+++ b/handsontable/src/editors/selectEditor/__tests__/selectEditor.spec.js
@@ -50,8 +50,6 @@ describe('SelectEditor', () => {
     const editorWrapper = $('.htSelectEditor');
     const editor = $('.htSelectEditor').children('select');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect(editorWrapper.length).toEqual(1);
     expect(editor.length).toEqual(1);
     expect(editor.is('select')).toBe(true);
@@ -64,7 +62,7 @@ describe('SelectEditor', () => {
     expect(editor.is(':visible')).toBe(true);
     expect({
       top: editorWrapper.offset().top,
-      left: editorWrapper.offset().left + 1,
+      left: editorInlineStartOffset(editorWrapper),
     }).toEqual($(getCell(0, 0)).offset());
   });
 
@@ -85,11 +83,9 @@ describe('SelectEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editorWrapper.offset().top,
-      left: editorWrapper.offset().left + 1,
+      left: editorInlineStartOffset(editorWrapper),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -98,7 +94,7 @@ describe('SelectEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editorWrapper.offset().top + 1,
-      left: editorWrapper.offset().left + 1,
+      left: editorInlineStartOffset(editorWrapper),
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -124,7 +120,7 @@ describe('SelectEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editorWrapper.offset().top,
-      left: editorWrapper.offset().left + 1,
+      left: editorInlineStartOffset(editorWrapper),
     }).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -154,20 +150,17 @@ describe('SelectEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editorWrapper.offset().top,
-      left: editorWrapper.offset().left + 1,
+      left: editorInlineStartOffset(editorWrapper),
     }).toEqual($(getCell(0, 0, true)).offset());
 
     await selectCell(0, 1);
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editorWrapper.offset().top,
-      left: editorWrapper.offset().left + 1,
+      left: editorInlineStartOffset(editorWrapper),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
@@ -210,11 +203,9 @@ describe('SelectEditor', () => {
     await keyDownUp('enter');
 
     // First renderable row index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editorWrapper.offset().top,
-      left: editorWrapper.offset().left + 1,
+      left: editorInlineStartOffset(editorWrapper),
     }).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -223,7 +214,7 @@ describe('SelectEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editorWrapper.offset().top + 1,
-      left: editorWrapper.offset().left + 1,
+      left: editorInlineStartOffset(editorWrapper),
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -244,7 +235,7 @@ describe('SelectEditor', () => {
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect({
       top: editorWrapper.offset().top,
-      left: editorWrapper.offset().left + 1,
+      left: editorInlineStartOffset(editorWrapper),
     }).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
@@ -274,20 +265,17 @@ describe('SelectEditor', () => {
     await keyDownUp('enter');
 
     // First renderable column index.
-    // Every cell here sits behind a row header, which owns the gridline on its
-    // inline-start side, so the editor starts 1px before the cell to cover it (#6673).
     expect({
       top: editorWrapper.offset().top,
-      left: editorWrapper.offset().left + 1,
+      left: editorInlineStartOffset(editorWrapper),
     }).toEqual($(getCell(0, 1, true)).offset());
 
     await selectCell(0, 2);
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header (see above).
     const editorOffset = () => ({
       top: editorWrapper.offset().top,
-      left: editorWrapper.offset().left + 1,
+      left: editorInlineStartOffset(editorWrapper),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());

--- a/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
+++ b/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
@@ -140,7 +140,12 @@ describe('TextEditor', () => {
 
     await keyDownUp('F2');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its inline-start
+    // side, so the editor starts 1px before the cell in order to cover it (#6673).
+    expect({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    }).toEqual($(getCell(0, 0)).offset());
   });
 
   it('should render the editor in the expected position when stepping top-to-bottom with top and bottom overlays', async() => {
@@ -174,15 +179,22 @@ describe('TextEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+    // Every cell here sits behind a row header, which owns the gridline on its inline-start
+    // side, so the editor starts 1px before the cell in order to cover it (#6673).
+    const editorOffsetAtRowEdge = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffsetAtRowEdge()).toEqual($(getCell(0, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -206,7 +218,7 @@ describe('TextEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+    expect(editorOffsetAtRowEdge()).toEqual($(getCell(5, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
@@ -235,16 +247,17 @@ describe('TextEditor', () => {
 
     await keyDownUp('enter');
 
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
-
-    await selectCell(0, 1);
-    await keyDownUp('enter');
-
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header, which owns the gridline on its inline-start
+    // side, so the editor starts 1px before the cell in order to cover it (#6673).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,
     });
+
+    expect(editorOffset()).toEqual($(getCell(0, 0, true)).offset());
+
+    await selectCell(0, 1);
+    await keyDownUp('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
 
@@ -298,16 +311,23 @@ describe('TextEditor', () => {
 
     await keyDownUp('enter');
 
+    // Every cell here sits behind a row header, which owns the gridline on its inline-start
+    // side, so the editor starts 1px before the cell in order to cover it (#6673).
+    const editorOffsetAtRowEdge = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
     // First renderable row index.
-    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+    expect(editorOffsetAtRowEdge()).toEqual($(getCell(1, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
 
-    // Cells that do not touch the edges of the table have an additional top border.
+    // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left,
+      left: editor.offset().left + 1,
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -326,7 +346,7 @@ describe('TextEditor', () => {
     await keyDownUp('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+    expect(editorOffsetAtRowEdge()).toEqual($(getCell(6, 0, true)).offset());
 
     await keyDownUp('enter');
     await keyDownUp('enter');
@@ -354,17 +374,18 @@ describe('TextEditor', () => {
 
     await keyDownUp('enter');
 
-    // First renderable column index.
-    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
-
-    await selectCell(0, 2);
-    await keyDownUp('enter');
-
-    // Cells that do not touch the edges of the table have an additional left border.
+    // Every cell here sits behind a row header, which owns the gridline on its inline-start
+    // side, so the editor starts 1px before the cell in order to cover it (#6673).
     const editorOffset = () => ({
       top: editor.offset().top,
       left: editor.offset().left + 1,
     });
+
+    // First renderable column index.
+    expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
+
+    await selectCell(0, 2);
+    await keyDownUp('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
 
@@ -655,8 +676,11 @@ describe('TextEditor', () => {
     await selectCell(0, 0);
     await keyDownUp('enter');
 
+    // The cell sits behind a row header, so the editor spans the cell plus the gridline the
+    // header draws on its inline-start side - the same 1px overlap every other column has
+    // always had (#6673).
     expect(getActiveEditor().TEXTAREA.style.height).toBe(getThemeLayout().e2eTextEditorTextareaHeightSingleLinePx());
-    expect(getActiveEditor().TEXTAREA.style.width).toBe('50px');
+    expect(getActiveEditor().TEXTAREA.style.width).toBe('51px');
   });
 
   it('should render textarea editor in specified size at cell 0, 0 when headers are selected', async() => {
@@ -670,8 +694,11 @@ describe('TextEditor', () => {
     await selectAll();
     await keyDownUp('enter');
 
+    // The cell sits behind a row header, so the editor spans the cell plus the gridline the
+    // header draws on its inline-start side - the same 1px overlap every other column has
+    // always had (#6673).
     expect(getActiveEditor().TEXTAREA.style.height).toBe(getThemeLayout().e2eTextEditorTextareaHeightSingleLinePx());
-    expect(getActiveEditor().TEXTAREA.style.width).toBe('50px');
+    expect(getActiveEditor().TEXTAREA.style.width).toBe('51px');
   });
 
   it('should render textarea editor in specified size at cell 0, 0 with headers defined in columns', async() => {

--- a/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
+++ b/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
@@ -140,11 +140,9 @@ describe('TextEditor', () => {
 
     await keyDownUp('F2');
 
-    // Every cell here sits behind a row header, which owns the gridline on its inline-start
-    // side, so the editor starts 1px before the cell in order to cover it (#6673).
     expect({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     }).toEqual($(getCell(0, 0)).offset());
   });
 
@@ -179,11 +177,9 @@ describe('TextEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its inline-start
-    // side, so the editor starts 1px before the cell in order to cover it (#6673).
     const editorOffsetAtRowEdge = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffsetAtRowEdge()).toEqual($(getCell(0, 0, true)).offset());
@@ -194,7 +190,7 @@ describe('TextEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
@@ -247,11 +243,9 @@ describe('TextEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its inline-start
-    // side, so the editor starts 1px before the cell in order to cover it (#6673).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(0, 0, true)).offset());
@@ -311,11 +305,9 @@ describe('TextEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its inline-start
-    // side, so the editor starts 1px before the cell in order to cover it (#6673).
     const editorOffsetAtRowEdge = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     // First renderable row index.
@@ -327,7 +319,7 @@ describe('TextEditor', () => {
     // Cells that do not touch the edges of the table also have an additional top border.
     const editorOffset = () => ({
       top: editor.offset().top + 1,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
@@ -374,11 +366,9 @@ describe('TextEditor', () => {
 
     await keyDownUp('enter');
 
-    // Every cell here sits behind a row header, which owns the gridline on its inline-start
-    // side, so the editor starts 1px before the cell in order to cover it (#6673).
     const editorOffset = () => ({
       top: editor.offset().top,
-      left: editor.offset().left + 1,
+      left: editorInlineStartOffset(editor),
     });
 
     // First renderable column index.

--- a/handsontable/src/plugins/autoRowSize/AGENTS.md
+++ b/handsontable/src/plugins/autoRowSize/AGENTS.md
@@ -32,7 +32,11 @@ when every height is already cached.
 ## Two DOM details
 
 - **`htFirstDatasetColumnNotRendered`** is a class this plugin puts on the root element and must remove in
-  `disablePlugin()`.
+  `disablePlugin()`. It suppresses the inline-start border on the first rendered data cell, and since
+  #6673 that border only exists when the grid has **no** row headers — with row headers the header
+  owns the gridline and no cell behind it draws one, so the class is inert there. Do not read it as
+  "column 0 has no border": ask the cell's computed border instead (see
+  `handsontable/src/3rdparty/walkontable/AGENTS.md`, "Column-axis border ownership").
 - **The first rendered row gets +1px** to compensate for its `border-top-width`. That compensation is
   per-render, not baked into the cached height.
 

--- a/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
+++ b/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
@@ -846,7 +846,12 @@ describe('AutoRowSize', () => {
 
     await scrollViewportHorizontally(500);
 
-    expect(getComputedStyle(getCell(0, 0, true)).borderLeftWidth).toBe('1px');
+    // The gridline between the row header and the frozen first column must still be drawn while
+    // `htFirstDatasetColumnNotRendered` is on the root element. Since #6673 the row header owns
+    // that gridline (its inline-end border) and the cell behind it draws none, so assert both
+    // sides - a missing seam and a doubled one are both failures.
+    expect(getComputedStyle(getCell(0, -1, true)).borderRightWidth).toBe('1px');
+    expect(getComputedStyle(getCell(0, 0, true)).borderLeftWidth).toBe('0px');
   });
 
   it('should add css class to the .ht-wrapper when plugin is enabled', async() => {

--- a/handsontable/src/plugins/comments/__tests__/keyboardShortcuts.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/keyboardShortcuts.spec.js
@@ -115,7 +115,9 @@ describe('Comments keyboard shortcut', () => {
       expect(document.activeElement).toBe(editor);
       expect(plugin.range).toEqualCellRange('highlight: 400,40 from: 400,40 to: 400,40');
 
-      // 2050 column width - 250 viewport width + 15 scrollbar compensation + 1 header border compensation
+      // 2050 column width - 250 viewport width + 15 scrollbar compensation. There is no header
+      // border compensation any more: the row header keeps its inline-end border at every scroll
+      // position, so the viewport width is the same scrolled or not (#6673).
       expect(inlineStartOverlay().getScrollPosition()).toBe(1815);
 
       const layout = getThemeLayout();

--- a/handsontable/src/plugins/comments/__tests__/keyboardShortcuts.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/keyboardShortcuts.spec.js
@@ -116,7 +116,7 @@ describe('Comments keyboard shortcut', () => {
       expect(plugin.range).toEqualCellRange('highlight: 400,40 from: 400,40 to: 400,40');
 
       // 2050 column width - 250 viewport width + 15 scrollbar compensation + 1 header border compensation
-      expect(inlineStartOverlay().getScrollPosition()).toBe(1816);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(1815);
 
       const layout = getThemeLayout();
 

--- a/handsontable/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
@@ -958,11 +958,11 @@ describe('DropdownMenu', () => {
 
     await scrollViewportTo({ row: 0, col: 8 }); // make the column `G` partially visible
 
-    expect(inlineStartOverlay().getScrollPosition()).toBe(666);
+    expect(inlineStartOverlay().getScrollPosition()).toBe(665);
 
     await dropdownMenu(6); // click on the column `G` header button
 
-    expect(inlineStartOverlay().getScrollPosition()).toBe(666);
+    expect(inlineStartOverlay().getScrollPosition()).toBe(665);
   });
 
   describe('updateSettings called from beforeDropdownMenuShow', () => {

--- a/handsontable/src/plugins/manualColumnMove/__tests__/manualColumnMove.spec.js
+++ b/handsontable/src/plugins/manualColumnMove/__tests__/manualColumnMove.spec.js
@@ -24,10 +24,11 @@ describe('manualColumnMove', () => {
       height: 300,
     });
 
-    const firstCell = getCell(0, 0, true);
-    const firstCellBorderLeftWidth = getComputedStyle(firstCell).borderLeftWidth;
-
-    expect(firstCellBorderLeftWidth).toBe('1px');
+    // The gridline between the row header and the first rendered column must be drawn exactly
+    // once. Since #6673 the row header owns it (its inline-end border) and the cell behind it
+    // draws none, so assert both sides - a missing seam and a doubled one are both failures.
+    expect(getComputedStyle(getCell(0, -1, true)).borderRightWidth).toBe('1px');
+    expect(getComputedStyle(getCell(0, 0, true)).borderLeftWidth).toBe('0px');
   });
 
   describe('init', () => {

--- a/handsontable/src/plugins/nestedHeaders/__tests__/navigation.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/navigation.spec.js
@@ -1632,7 +1632,7 @@ describe('NestedHeaders', () => {
       await keyDownUp('arrowup'); // "C"
 
       expect(topOverlay().getScrollPosition()).toBe(0);
-      expect(inlineStartOverlay().getScrollPosition()).toBe(51);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(50);
     });
 
     it('should scroll the viewport correctly while navigating vertically using arrows ' +
@@ -1690,7 +1690,7 @@ describe('NestedHeaders', () => {
       await selectCell(-1, 20);
 
       expect(topOverlay().getScrollPosition()).toBe(0);
-      expect(inlineStartOverlay().getScrollPosition()).toBe(801);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(800);
 
       await keyDownUp('arrowup'); // scroll to the beginning of the "F" header
 
@@ -1700,7 +1700,7 @@ describe('NestedHeaders', () => {
       await keyDownUp('arrowdown');
 
       expect(topOverlay().getScrollPosition()).toBe(0);
-      expect(inlineStartOverlay().getScrollPosition()).toBe(801);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(800);
 
       await keyDownUp('arrowup'); // scroll to the beginning of the "F" header
 

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -381,14 +381,28 @@
     // but the row-header column makes that `th` `:last-child` by structure rather than by position in
     // the grid, so it would take the grid's outer-frame color there while the same grid with
     // `fixedColumnsStart` kept the plain cell-border color — visibly different in a theme whose cell
-    // borders are transparent. `.emptyColumns` is the one case where the row header really is the
-    // grid's inline-end edge, and it keeps the frame rule. `ht__active_highlight-prev` is excluded so
-    // an active column-0 header still gets its inline-start accent from the corner, which is where
-    // that pixel now lives.
+    // borders are transparent.
+    // The BODY selector deliberately has no `:first-child`. Every `th` in a body row IS a row header
+    // (`afterGetRowHeaderRenderers` lets a grid carry several), and the one that owns the seam to
+    // column 0 is the LAST of them — which is exactly the one that goes `:last-child` in the
+    // row-header-only overlay. The inner ones need no override: they are never `:last-child`, so the
+    // base cell rule already gives them this color. In a HEAD row the corner cells cannot be counted
+    // in CSS, so that half stays keyed on `:first-child` and a grid with two or more row headers
+    // keeps drawing its head-row seam in the frame color, exactly as it does today — same value as
+    // before this change, not a new divergence.
+    // Two exclusions. `.emptyColumns` is the one case where the row header really is the grid's
+    // inline-end edge, so it keeps the frame rule. And an ACTIVE header keeps its accent: the seam is
+    // the active row header's own inline-end, and the active column-0 header's inline-start accent is
+    // drawn by the corner (`ht__active_highlight-prev`), which is where that pixel now lives. Without
+    // these two the accent went missing on the seam — and it went missing only in the shape with one
+    // row header, because a second one is not `:first-child`.
     &.htRowHeaders {
       .ht_master:not(.emptyColumns),
       .ht_master:not(.emptyColumns) ~ .handsontable:not(.htGhostTable) {
-        :where(#{$grid-head-row}, #{$grid-body-row}) > th:first-child:not(.ht__active_highlight-prev) {
+        $seam-owner: ":not(.ht__active_highlight):not(.ht__active_highlight-prev)";
+
+        :where(#{$grid-head-row}) > th:first-child#{$seam-owner},
+        :where(#{$grid-body-row}) > th#{$seam-owner} {
           border-inline-end-color: var(--ht-cell-horizontal-border-color);
         }
       }

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -375,6 +375,25 @@
       }
     }
 
+    // A row header owns the seam to column 0, and the corner owns the seam to the column-0 header, at
+    // every scroll position and in every overlay (#6673). Ownership has to cover the seam's COLOR too,
+    // and the `th:last-child` rule above would otherwise decide it: the overlay that renders nothing
+    // but the row-header column makes that `th` `:last-child` by structure rather than by position in
+    // the grid, so it would take the grid's outer-frame color there while the same grid with
+    // `fixedColumnsStart` kept the plain cell-border color — visibly different in a theme whose cell
+    // borders are transparent. `.emptyColumns` is the one case where the row header really is the
+    // grid's inline-end edge, and it keeps the frame rule. `ht__active_highlight-prev` is excluded so
+    // an active column-0 header still gets its inline-start accent from the corner, which is where
+    // that pixel now lives.
+    &.htRowHeaders {
+      .ht_master:not(.emptyColumns),
+      .ht_master:not(.emptyColumns) ~ .handsontable:not(.htGhostTable) {
+        :where(#{$grid-head-row}, #{$grid-body-row}) > th:first-child:not(.ht__active_highlight-prev) {
+          border-inline-end-color: var(--ht-cell-horizontal-border-color);
+        }
+      }
+    }
+
     // Header in Row — grid rows only, never a nested user table (#4363)
     :where(table.htCore, #{$ghost-table}) > tbody {
       > tr {

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -180,8 +180,14 @@
       height: 100%;
       width: 100%;
 
+      // A body cell draws the grid's inline-start frame only when it IS the first cell of its row,
+      // i.e. when no row-header `th` precedes it. With row headers the `th` owns the separator to
+      // column 0 (see the header rules further down), so the cell keeps the plain 0/1 border every
+      // other column has and its content box is the same width as theirs (#6673). `:first-child`,
+      // not `:first-of-type`: the latter also matched the first `td` sitting behind a `th`, which is
+      // what made column 0 carry two borders inside one `col` width.
       &:not(.htFirstDatasetColumnNotRendered) {
-        :where(#{$grid-body-row}) > td:first-of-type {
+        :where(#{$grid-body-row}) > td:first-child {
           border-inline-start-width: 1px;
         }
       }
@@ -322,8 +328,10 @@
         }
       }
 
-      &:first-child,
-      &:nth-child(2) {
+      // Only the first header cell of a row draws the inline-start frame. The second one used to as
+      // well, to give the column-0 header a border behind the row-header corner; that pixel now
+      // belongs to the corner's inline-end border, mirroring the body cells (#6673).
+      &:first-child {
         border-inline-start-width: 1px;
       }
 
@@ -347,7 +355,7 @@
         background-color: var(--ht-header-active-background-color);
       }
 
-      // An active header's inline-start edge has width 0 (only `:first-child`/`:nth-child(2)` reserve
+      // An active header's inline-start edge has width 0 (only `:first-child` reserves
       // it), so its accent went missing there while the inline-end side kept it — most visible on
       // frozen columns. Color the shared gridline on the inline-start neighbour instead, so every
       // active column header shows a matching inline-start accent. `SelectionManager` stamps the
@@ -540,8 +548,9 @@
         }
       }
 
-      // Cell — grid cells only, never a nested user table (#4363)
-      :where(#{$grid-body-row}) > td:first-of-type {
+      // Cell — grid cells only, never a nested user table (#4363).
+      // `:first-child`, not `:first-of-type` — see the master's copy of this rule (#6673).
+      :where(#{$grid-body-row}) > td:first-child {
         border-inline-start-width: 1px;
       }
     }
@@ -663,33 +672,16 @@
       }
     }
 
-    // Visual fixes
-    // It removes double right border from first column header when row headers are disabled
-    // Header border fixes — grid headers only, never a nested user table (#4363).
-    // `:where(table.htCore …)` keeps each selector at its former specificity.
-    .ht_clone_top :where(table.htCore > thead > tr) > th:nth-child(2) {
-      border-inline-start-width: 0;
-      border-inline-end-width: 1px;
-    }
-
-    .ht_clone_top_inline_start_corner :where(table.htCore > thead > tr) > th:nth-child(2) {
-      border-inline-start-width: 0;
-      border-inline-end-width: 1px;
-    }
-
-    &.htRowHeaders :where(table.htCore) > thead > tr > th:nth-child(2) {
-      border-inline-start-width: 1px;
-    }
-
-    .ht_master:not(.innerBorderInlineStart):not(.emptyColumns) {
-      :where(table.htCore) > tbody > tr > th,
-      :where(table.htCore) > thead > tr > th:first-child,
-      ~ .handsontable:not(.htGhostTable) :where(table.htCore) > tbody > tr > th,
-      ~ .handsontable:not(.ht_clone_top):not(.htGhostTable) :where(table.htCore) > thead > tr > th:first-child {
-        border-inline-end-width: 0;
-        border-inline-start-width: 1px;
-      }
-    }
+    // Inline-start axis border ownership (#6673). A row header `th` always carries its 1px
+    // inline-end border — the separator to column 0 — at every scroll position, and no cell behind
+    // it carries an inline-start border. The `th` rules above already produce that, so the three
+    // `th:nth-child(2)` fixes and the `.ht_master:not(.innerBorderInlineStart)` block that used to
+    // trade the border between the two elements are gone. Trading it made the row header 1px wider
+    // once the grid scrolled (`correctHeaderWidth` in the engine) while column 0 held two borders
+    // inside one `col` width, so its content box was 1px narrower than every other column's.
+    // `innerBorderInlineStart`, `innerBorderLeft` and `emptyColumns` are still stamped on
+    // `.ht_master` for backward compatibility, but no rule reads them any more. The row axis
+    // (`innerBorderTop` / `innerBorderBottom`, below) still works the old way.
 
     //  innerBorderTop - Property controlled by top overlay
     //  innerBorderBottom - Property controlled by bottom overlay

--- a/handsontable/src/styles/components/plugins/_manual-column-freeze.scss
+++ b/handsontable/src/styles/components/plugins/_manual-column-freeze.scss
@@ -4,14 +4,6 @@
 
 @mixin output {
   .handsontable {
-    // Grid headers/cells only, never a nested user table (#4363)
-    .htRowHeaders .ht_master.innerBorderInlineStart ~ .ht_clone {
-      &_top_inline_start_corner :where(table.htCore > thead > tr) > th:nth-child(2),
-      &_inline_start :where(table.htCore > tbody > tr) > td:first-of-type {
-        border-left: 0 none;
-      }
-    }
-
     .ht_clone_top_inline_start_corner {
       th {
         &.ht__active_highlight {

--- a/handsontable/src/styles/components/plugins/_nested-headers.scss
+++ b/handsontable/src/styles/components/plugins/_nested-headers.scss
@@ -2,10 +2,6 @@
 
 @mixin output {
   .handsontable {
-    thead th.htRowspanHeader + th {
-      border-inline-start-width: 0;
-    }
-
     thead th.htRowspanHeader {
       height: auto;
       vertical-align: bottom;

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -627,6 +627,35 @@ export function getInnerEditorListBox() {
 }
 
 /**
+ * The active editor's inline-start offset, corrected onto the edited cell's own boundary so it can
+ * be compared against `$(getCell(row, col)).offset()`.
+ *
+ * `BaseEditor#getEditedCellRect` moves the editor 1px towards the inline start whenever the edited
+ * cell draws no inline-start border of its own, so that the editor covers the gridline its
+ * inline-start neighbour draws. With row headers on that is EVERY cell, because the row header owns
+ * the gridline in front of column 0 (#6673), and `htFirstDatasetColumnNotRendered` takes the border
+ * off the first rendered column too. The rule is read off the edited cell's computed border, exactly
+ * as the editor reads it, so no spec has to restate which columns it applies to.
+ *
+ * The top axis is deliberately left to the caller: `getEditedCellRect` decides that one from the
+ * row's position in the overlays, not from a border, so there is no single value to fold in here.
+ *
+ * @param {object} $editor The jQuery-wrapped editor element (`getActiveEditor().TEXTAREA_PARENT`).
+ * @returns {number} The editor's `offset().left`, plus the pixel the editor was shifted by.
+ */
+export function editorInlineStartOffset($editor) {
+  const { TD } = getActiveEditor();
+  const style = getComputedStyle(TD);
+
+  if (style.direction === 'rtl') {
+    throw new Error('editorInlineStartOffset() corrects the physical left edge, which is the ' +
+      'inline start only in LTR. The RTL specs mirror the offset themselves.');
+  }
+
+  return $editor.offset().left + (Number.parseInt(style.borderLeftWidth, 10) > 0 ? 0 : 1);
+}
+
+/**
  * @returns {object} Returns the spec object for currently running test.
  */
 export function spec() {

--- a/handsontable/test/helpers/themeLayoutFromTokens.js
+++ b/handsontable/test/helpers/themeLayoutFromTokens.js
@@ -268,7 +268,9 @@ function buildThemeLayoutE2eHelpers(core) {
     e2eMergeCellsOpenEditorWideMergeTextareaParentOffset() {
       return {
         top: 2 * defaultDataRowHeight,
-        left: defaultRowHeaderWidth,
+        // The editor starts one border before the cell, covering the gridline the row header draws
+        // on its inline-end side (#6673).
+        left: defaultRowHeaderWidth - cellBorderWidth,
       };
     },
 

--- a/tests/e2e/row-header-border-ownership.spec.ts
+++ b/tests/e2e/row-header-border-ownership.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from '../fixtures/test';
+import { RowHeaderBorderOwnershipPage } from '../fixtures/pages/RowHeaderBorderOwnershipPage';
+
+/**
+ * Issue #6673. With row headers on, the first data column rendered 1px narrower than every other
+ * column. `td:first-of-type` was given an inline-start border on top of the inline-end border every
+ * cell carries, and `box-sizing: border-box` took both out of the same `col` width - so
+ * `colWidths: 75` produced a 73px content box in column 0 against 74px everywhere else. The
+ * selector matched the first `td` whether or not a row header `th` preceded it.
+ *
+ * The row header answered by dropping its own inline-end border at scroll offset 0 so the seam did
+ * not double, and the engine then widened the row header by 1px the moment the grid scrolled
+ * (`correctHeaderWidth`), with matching compensations in the scroll targets, the hider width and
+ * the column calculators. So the table changed width by being scrolled.
+ *
+ * The gridline between the row header and column 0 now belongs to the row header at every scroll
+ * position, and no cell standing behind a row header draws an inline-start border. Every column then
+ * has the same content width, and the row header's width no longer depends on the scroll position.
+ *
+ * All of this is geometry, so none of it can be checked in jsdom, where every size reads as zero.
+ * The legacy `colWidth()` helper cannot see it either: it reads `offsetWidth`, which includes the
+ * borders and therefore returns the declared width for every column, bug or no bug.
+ */
+test.describe('Row header border ownership', () => {
+  let grid: RowHeaderBorderOwnershipPage;
+
+  test.beforeEach(async ({ page, theme, bundle }) => {
+    grid = new RowHeaderBorderOwnershipPage(page, theme, bundle);
+    await grid.goto();
+  });
+
+  test('gives every column the same content width when row headers are enabled', async () => {
+    const declared = await grid.declaredColumnWidth();
+    const widths = await grid.bodyCellContentWidths('row-headers', 4);
+
+    // The reported symptom: this used to read [73, 74, 74, 74].
+    expect(widths).toEqual([declared - 1, declared - 1, declared - 1, declared - 1]);
+  });
+
+  test('lets the row header own the gridline between itself and the first column', async () => {
+    // Exactly one border draws the seam. A missing seam and a doubled one are both failures, which
+    // is why both sides are asserted rather than just the cell's.
+    expect(await grid.borders(grid.rowHeaderCell('row-headers'))).toEqual({ start: 1, end: 1 });
+    expect(await grid.borders(grid.firstBodyCell('row-headers'))).toEqual({ start: 0, end: 1 });
+  });
+
+  test('lets the corner header own the same gridline in the header row', async () => {
+    expect(await grid.borders(grid.cornerHeaderCell('row-headers'))).toMatchObject({ end: 1 });
+    expect(await grid.borders(grid.firstColumnHeaderCell('row-headers'))).toEqual({ start: 0, end: 1 });
+  });
+
+  test('keeps the row header width and the scroll range unchanged by a horizontal scroll', async () => {
+    const before = await grid.horizontalMetrics('row-headers');
+
+    await grid.scrollHorizontallyTo('rowHeaders', 'row-headers', 12);
+
+    // The row header used to grow by 1px here, taking the whole table's width with it.
+    expect(await grid.horizontalMetrics('row-headers')).toEqual(before);
+  });
+
+  test('keeps every column the same content width after a horizontal scroll', async () => {
+    const declared = await grid.declaredColumnWidth();
+
+    await grid.scrollHorizontallyTo('rowHeaders', 'row-headers', 12);
+
+    const widths = await grid.bodyCellContentWidths('row-headers', 4);
+
+    expect(widths).toEqual([declared - 1, declared - 1, declared - 1, declared - 1]);
+    expect(await grid.borders(grid.rowHeaderCell('row-headers'))).toEqual({ start: 1, end: 1 });
+    expect(await grid.borders(grid.firstBodyCell('row-headers'))).toEqual({ start: 0, end: 1 });
+  });
+
+  test('applies the same ownership inside the frozen column clone', async () => {
+    const declared = await grid.declaredColumnWidth();
+    const frozenCell = grid.firstBodyCell('frozen', '.ht_clone_inline_start');
+
+    expect(await grid.borders(grid.rowHeaderCell('frozen'))).toEqual({ start: 1, end: 1 });
+    expect(await grid.borders(frozenCell)).toEqual({ start: 0, end: 1 });
+    expect(await frozenCell.evaluate(cell => cell.clientWidth)).toBe(declared - 1);
+
+    // The clone keeps rendering column 0 while the master scrolls past it, so the seam has to hold
+    // in a state the master never shows. `manualColumnFreeze` used to override it here by hand.
+    await grid.scrollHorizontallyTo('frozen', 'frozen', 12);
+
+    expect(await grid.borders(grid.rowHeaderCell('frozen'))).toEqual({ start: 1, end: 1 });
+    expect(await grid.borders(frozenCell)).toEqual({ start: 0, end: 1 });
+  });
+
+  test('mirrors the ownership onto the physical right in RTL', async () => {
+    const declared = await grid.declaredColumnWidth();
+
+    // The rules are written with logical properties, so RTL needs no mirror rule: the row header's
+    // inline end resolves to its physical left, which is where the seam is in RTL.
+    expect(await grid.physicalBorders(grid.rowHeaderCell('rtl'))).toEqual({ left: 1, right: 1 });
+    expect(await grid.physicalBorders(grid.firstBodyCell('rtl'))).toMatchObject({ right: 0 });
+
+    const widths = await grid.bodyCellContentWidths('rtl', 4);
+
+    expect(widths).toEqual([declared - 1, declared - 1, declared - 1, declared - 1]);
+  });
+
+  test('reaches the same verdict on every nested header level', async () => {
+    const levels = await grid.headerLevelCount('nested');
+
+    expect(levels).toBeGreaterThan(1);
+
+    for (let level = 0; level < levels; level++) {
+      expect(await grid.borders(grid.cornerHeaderCell('nested', level))).toMatchObject({ end: 1 });
+      expect(await grid.borders(grid.firstColumnHeaderCell('nested', level)))
+        .toMatchObject({ start: 0 });
+    }
+
+    const declared = await grid.declaredColumnWidth();
+
+    expect(await grid.bodyCellContentWidths('nested', 4))
+      .toEqual([declared - 1, declared - 1, declared - 1, declared - 1]);
+  });
+
+  test('still publishes the legacy inner-border classes once the grid is scrolled', async () => {
+    // The classes drive no geometry any more, but they are part of the public DOM and third-party
+    // styling keys off them, so they are kept. `innerBorderLeft` is the pre-logical-properties
+    // name and is still emitted alongside.
+    expect(await grid.masterHasClass('row-headers', 'innerBorderInlineStart')).toBe(false);
+
+    await grid.scrollHorizontallyTo('rowHeaders', 'row-headers', 12);
+
+    expect(await grid.masterHasClass('row-headers', 'innerBorderInlineStart')).toBe(true);
+    expect(await grid.masterHasClass('row-headers', 'innerBorderLeft')).toBe(true);
+  });
+
+  test('leaves the first column drawing the grid frame when there is no row header', async () => {
+    const declared = await grid.declaredColumnWidth();
+    const widths = await grid.bodyCellContentWidths('control', 4);
+
+    // The deliberate limit of the fix, and the reason this case is pinned: with nothing in front of
+    // it, column 0 is the first cell of its row and still carries the grid's own inline-start frame
+    // inside its declared width. It stays 1px narrower than the rest, exactly as before.
+    expect(await grid.borders(grid.firstBodyCell('control'))).toEqual({ start: 1, end: 1 });
+    expect(widths).toEqual([declared - 2, declared - 1, declared - 1, declared - 1]);
+  });
+});

--- a/tests/e2e/row-header-border-ownership.spec.ts
+++ b/tests/e2e/row-header-border-ownership.spec.ts
@@ -45,7 +45,7 @@ test.describe('Row header border ownership', () => {
   });
 
   test('lets the corner header own the same gridline in the header row', async () => {
-    expect(await grid.borders(grid.cornerHeaderCell('row-headers'))).toMatchObject({ end: 1 });
+    expect(await grid.borders(grid.cornerHeaderCell('row-headers'))).toEqual({ start: 1, end: 1 });
     expect(await grid.borders(grid.firstColumnHeaderCell('row-headers'))).toEqual({ start: 0, end: 1 });
   });
 
@@ -92,7 +92,7 @@ test.describe('Row header border ownership', () => {
     // The rules are written with logical properties, so RTL needs no mirror rule: the row header's
     // inline end resolves to its physical left, which is where the seam is in RTL.
     expect(await grid.physicalBorders(grid.rowHeaderCell('rtl'))).toEqual({ left: 1, right: 1 });
-    expect(await grid.physicalBorders(grid.firstBodyCell('rtl'))).toMatchObject({ right: 0 });
+    expect(await grid.physicalBorders(grid.firstBodyCell('rtl'))).toEqual({ left: 1, right: 0 });
 
     const widths = await grid.bodyCellContentWidths('rtl', 4);
 
@@ -105,9 +105,10 @@ test.describe('Row header border ownership', () => {
     expect(levels).toBeGreaterThan(1);
 
     for (let level = 0; level < levels; level++) {
-      expect(await grid.borders(grid.cornerHeaderCell('nested', level))).toMatchObject({ end: 1 });
+      expect(await grid.borders(grid.cornerHeaderCell('nested', level)))
+        .toEqual({ start: 1, end: 1 });
       expect(await grid.borders(grid.firstColumnHeaderCell('nested', level)))
-        .toMatchObject({ start: 0 });
+        .toEqual({ start: 0, end: 1 });
     }
 
     const declared = await grid.declaredColumnWidth();

--- a/tests/e2e/row-header-border-ownership.spec.ts
+++ b/tests/e2e/row-header-border-ownership.spec.ts
@@ -155,6 +155,65 @@ test.describe('Row header border ownership', () => {
     }
   });
 
+  test('lets the LAST row header own the seam when the grid has several', async () => {
+    // `afterGetRowHeaderRenderers` is a documented hook and `autoRowHeaderSize` measures each row
+    // header it appends, so more than one row header column is a supported shape. The seam to
+    // column 0 is then the last one's inline-end - and that is the `th` which goes `:last-child` in
+    // the row-header-only overlay, so keying the seam color on `:first-child` alone left it taking
+    // the grid's outer-frame color in that shape while the frozen shape kept the cell-border color.
+    const reference = await grid.inlineEndBorderColor(grid.firstBodyCell('row-headers'));
+
+    expect(await grid.rowHeaderCount('multi-row-headers')).toBe(2);
+    expect(await grid.rowHeaderCount('multi-frozen')).toBe(2);
+
+    for (const testId of ['multi-row-headers', 'multi-frozen']) {
+      expect(await grid.inlineEndBorderColor(grid.lastRowHeaderCell(testId))).toBe(reference);
+      expect(await grid.inlineEndBorderColor(grid.rowHeaderCell(testId))).toBe(reference);
+      expect(await grid.borders(grid.firstBodyCell(testId))).toEqual({ start: 0, end: 1 });
+    }
+
+    const declared = await grid.declaredColumnWidth();
+
+    expect(await grid.bodyCellContentWidths('multi-row-headers', 4))
+      .toEqual([declared - 1, declared - 1, declared - 1, declared - 1]);
+  });
+
+  test('keeps the active accent on the seam an active row header owns', async () => {
+    // The seam color rule must not outrank the active-header accent: the seam is the active row
+    // header's OWN inline-end. The expected value is read from the accent the column axis already
+    // uses - the corner's `ht__active_highlight-prev` edge with column 0 selected - rather than from
+    // a literal, since every theme picks its own. `classic` maps the accent and the cell-border
+    // color to the same value, so only the `main` and `horizon` legs can actually fail this.
+    await grid.selectColumn('rowHeaders', 0);
+
+    const accent = await grid.inlineEndBorderColor(grid.topCloneCornerCell('row-headers'));
+
+    for (const [name, testId] of [
+      ['rowHeaders', 'row-headers'],
+      ['frozen', 'frozen'],
+      ['multiRowHeaders', 'multi-row-headers'],
+      ['multiFrozen', 'multi-frozen'],
+    ]) {
+      // Row 0: `lastRowHeaderCell()` reads the first rendered body row, so that is the row whose
+      // header the selection has to mark active.
+      await grid.selectRow(name, 0);
+
+      expect(await grid.inlineEndBorderColor(grid.lastRowHeaderCell(testId))).toBe(accent);
+
+      // Only the inline END is asserted: with two row headers the last one is not `:first-child`,
+      // so it correctly draws no inline-start border - that one belongs to the first row header,
+      // which carries the grid's outer frame.
+      expect((await grid.borders(grid.lastRowHeaderCell(testId))).end).toBe(1);
+    }
+
+    // The grid used to manage this only when scrolled: the border was 0 at horizontal offset 0 and
+    // 1px once the grid moved, so the accent appeared and disappeared with the scroll position.
+    await grid.scrollHorizontallyTo('rowHeaders', 'row-headers', 12);
+    await grid.selectRow('rowHeaders', 0);
+
+    expect(await grid.inlineEndBorderColor(grid.lastRowHeaderCell('row-headers'))).toBe(accent);
+  });
+
   test('keeps the selection edge on column 0 clear of the row header', async () => {
     await grid.selectCell('rowHeaders', 1, 0);
 

--- a/tests/e2e/row-header-border-ownership.spec.ts
+++ b/tests/e2e/row-header-border-ownership.spec.ts
@@ -117,6 +117,80 @@ test.describe('Row header border ownership', () => {
       .toEqual([declared - 1, declared - 1, declared - 1, declared - 1]);
   });
 
+  test('draws the seam in the cell-border color in every overlay shape', async () => {
+    // Ownership has to cover the seam's COLOR, not only which element draws it. The row header is
+    // `:last-child` in the overlay that renders nothing but the row-header column, and the
+    // outer-frame rule keyed on that would have given the seam the grid's frame color there while
+    // the same grid with `fixedColumnsStart` kept the cell-border color - two different lines for
+    // one gridline, and a line `horizon` never used to draw at all.
+    const reference = await grid.inlineEndBorderColor(grid.firstBodyCell('row-headers'));
+
+    expect(await grid.inlineEndBorderColor(grid.rowHeaderCell('row-headers'))).toBe(reference);
+    expect(await grid.inlineEndBorderColor(grid.rowHeaderCell('frozen'))).toBe(reference);
+    expect(await grid.inlineEndBorderColor(grid.cornerHeaderCell('row-headers'))).toBe(reference);
+    expect(await grid.inlineEndBorderColor(grid.cornerHeaderCell('frozen'))).toBe(reference);
+
+    // ...and it must not change by being scrolled, which is what the old design did.
+    await grid.scrollHorizontallyTo('rowHeaders', 'row-headers', 12);
+
+    expect(await grid.inlineEndBorderColor(grid.rowHeaderCell('row-headers'))).toBe(reference);
+  });
+
+  test('leaves the row header drawing the grid frame when there are no data columns', async () => {
+    // The carve-out of the rule above, and the reason it needs `.emptyColumns` rather than the
+    // `th`'s position among its siblings: with no column 0 to separate from, the row header's
+    // inline-end border IS the grid's inline-end frame. Both of its sides are frame then, which is
+    // what the first assertion says without naming a palette. The seam comparison is the complement
+    // of the test above, and only `horizon` can fail it - it is the one theme whose cell-border
+    // token differs from its frame token.
+    const rowHeader = grid.rowHeaderCell('empty');
+
+    expect(await grid.masterHasClass('empty', 'emptyColumns')).toBe(true);
+    expect(await grid.borders(rowHeader)).toEqual({ start: 1, end: 1 });
+    expect(await grid.inlineEndBorderColor(rowHeader)).toBe(await grid.inlineStartBorderColor(rowHeader));
+
+    if (grid.theme === 'horizon') {
+      expect(await grid.inlineEndBorderColor(rowHeader))
+        .not.toBe(await grid.inlineEndBorderColor(grid.rowHeaderCell('row-headers')));
+    }
+  });
+
+  test('keeps the selection edge on column 0 clear of the row header', async () => {
+    await grid.selectCell('rowHeaders', 1, 0);
+
+    // The row header owns the gridline in front of column 0, so the shared pixel belongs to the
+    // inline-start overlay - which paints at z-index 120 against the border layer's 10. An edge
+    // centred on it renders behind the row header, so it sits just inside the cell instead.
+    expect(await grid.selectionInlineStartEdgeOffset('row-headers', 1, 0)).toBe(0);
+    expect(await grid.selectionEdgeHiddenBehindRowHeader('row-headers')).toBe(false);
+
+    // A column with another CELL beside it keeps straddling the shared gridline: nothing paints
+    // above the border layer there, and this is what makes the column-0 offset a real distinction
+    // rather than a blanket rule.
+    await grid.selectCell('rowHeaders', 1, 3);
+
+    expect(await grid.selectionInlineStartEdgeOffset('row-headers', 1, 3)).toBe(-1);
+    expect(await grid.selectionEdgeHiddenBehindRowHeader('row-headers')).toBe(false);
+  });
+
+  test('keeps the selection edge on column 0 clear of the row header in RTL', async () => {
+    await grid.selectCell('rtl', 1, 0);
+
+    expect(await grid.selectionInlineStartEdgeOffset('rtl', 1, 0)).toBe(0);
+    expect(await grid.selectionEdgeHiddenBehindRowHeader('rtl')).toBe(false);
+  });
+
+  test('keeps the selection edge inside column 0 in the frozen column clone', async () => {
+    await grid.selectCell('frozen', 1, 0);
+
+    // The clone draws its own copy of every edge, and column 0 is inside it, so the master's edge
+    // being under the clone is by design here. What must hold is that both copies land on the
+    // cell's own boundary rather than on the row header's pixel.
+    expect(await grid.selectionInlineStartEdgeOffset('frozen', 1, 0)).toBe(0);
+    expect(await grid.selectionInlineStartEdgeOffset('frozen', 1, 0, '.ht_clone_inline_start'))
+      .toBe(0);
+  });
+
   test('still publishes the legacy inner-border classes once the grid is scrolled', async () => {
     // The classes drive no geometry any more, but they are part of the public DOM and third-party
     // styling keys off them, so they are kept. `innerBorderLeft` is the pre-logical-properties

--- a/tests/fixtures/demo/row-header-border-ownership.html
+++ b/tests/fixtures/demo/row-header-border-ownership.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Row header border ownership e2e fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back.
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+  </style>
+</head>
+<body>
+  <!--
+    Issue #6673. With row headers on, the first data column rendered 1px narrower than every other
+    column: the base stylesheet gave `td:first-of-type` an inline-start border on top of the
+    inline-end border every cell has, and `box-sizing: border-box` took both out of the same `col`
+    width. So `colWidths: 75` produced a 73px content box in column 0 and 74px everywhere else.
+
+    The row header drew no inline-end border at scroll offset 0 to keep the seam from doubling, and
+    the engine then widened the row header by 1px as soon as the grid scrolled - so the whole table
+    changed width by scrolling.
+
+    The gridline between the row header and column 0 now belongs to the row header at every scroll
+    position, and no cell behind a row header draws an inline-start border. All of this is geometry,
+    so none of it can be checked in jsdom, where every size reads as zero.
+
+    Every grid is wider than its container, so the same assertions can be made before and after a
+    horizontal scroll.
+  -->
+  <h2>Row headers (the reported case)</h2>
+  <div id="row-headers" data-testid="row-headers"></div>
+
+  <!--
+    A frozen first column renders column 0 in the inline-start clone rather than in the master, and
+    that clone carries its own copy of the cell rules. It is the surface `manualColumnFreeze` used to
+    patch with a physical `border-left: 0 none` override.
+  -->
+  <h2>Row headers with a frozen first column</h2>
+  <div id="frozen" data-testid="frozen"></div>
+
+  <!--
+    In RTL the row header sits on the physical right, so the seam and the border that draws it move
+    with it. The rules are logical properties, which is what makes this work without a mirror rule.
+  -->
+  <h2>Row headers, RTL</h2>
+  <div id="rtl" data-testid="rtl"></div>
+
+  <!--
+    Nested headers add header rows whose first cell is a rowspanned corner. Each level has to reach
+    the same verdict as the single-level case.
+  -->
+  <h2>Row headers with nested headers</h2>
+  <div id="nested" data-testid="nested"></div>
+
+  <!--
+    The control, and the deliberate limit of the fix: with no row header in front of it, column 0 is
+    the first cell of its row and still draws the grid's own inline-start frame inside its width. It
+    stays 1px narrower than the rest, exactly as it always has been.
+  -->
+  <h2>No row headers (control)</h2>
+  <div id="control" data-testid="control"></div>
+
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The
+    // closing tag is split so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    // Every column asks for the same width, which is the whole premise: whatever the grid does with
+    // the gridlines, one declared width must produce one content width.
+    const COL_WIDTH = 75;
+    // Far more columns than fit, so there is always somewhere to scroll to.
+    const TOTAL_COLUMNS = 30;
+
+    /**
+     * Builds one grid.
+     *
+     * @param {string} testId The container's test id.
+     * @param {object} settings The settings under test.
+     * @returns {Handsontable} The grid instance.
+     */
+    function buildGrid(testId, settings) {
+      const container = document.querySelector(`[data-testid="${testId}"]`);
+
+      container.className = `ht-theme-${window.htTheme}`;
+
+      return new Handsontable(container, Object.assign({
+        data: Handsontable.helper.createSpreadsheetData(20, TOTAL_COLUMNS),
+        colHeaders: true,
+        rowHeaders: true,
+        colWidths: COL_WIDTH,
+        width: 500,
+        height: 300,
+        licenseKey: 'non-commercial-and-evaluation',
+      }, settings));
+    }
+
+    window.htColWidth = COL_WIDTH;
+    window.grids = {
+      rowHeaders: buildGrid('row-headers', {}),
+      frozen: buildGrid('frozen', { fixedColumnsStart: 1 }),
+      rtl: buildGrid('rtl', { layoutDirection: 'rtl' }),
+      nested: buildGrid('nested', {
+        nestedHeaders: [
+          [{ label: 'Group', colspan: 2 }, { label: 'Pair', colspan: 2 }, 'E', 'F'],
+          ['A', 'B', 'C', 'D', 'E2', 'F2'],
+        ],
+      }),
+      control: buildGrid('control', { rowHeaders: false }),
+    };
+
+    /**
+     * Scrolls one grid horizontally so a column well past the first is at the viewport's start.
+     *
+     * @param {string} name The grid's key in `window.grids`.
+     * @param {number} column The visual column index to snap to the inline start.
+     */
+    window.scrollHorizontallyTo = function(name, column) {
+      window.grids[name].scrollViewportTo({ col: column, horizontalSnap: 'start' });
+    };
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/row-header-border-ownership.html
+++ b/tests/fixtures/demo/row-header-border-ownership.html
@@ -77,6 +77,15 @@
   <h2>No row headers (control)</h2>
   <div id="control" data-testid="control"></div>
 
+  <!--
+    The second control: with no data columns at all, the row header IS the grid's inline-end edge,
+    so its inline-end border is the outer frame rather than a seam and keeps the frame color. That
+    is the one case the seam-color rule carves out, and `.emptyColumns` on `.ht_master` is the
+    signal it keys on.
+  -->
+  <h2>Row headers, no data columns</h2>
+  <div id="empty" data-testid="empty"></div>
+
   <script>
     // The bundle under test, selected above from the sanitized allowlist. The
     // closing tag is split so the HTML parser does not end THIS script block.
@@ -124,6 +133,7 @@
         ],
       }),
       control: buildGrid('control', { rowHeaders: false }),
+      empty: buildGrid('empty', { data: [[], [], []], columns: [] }),
     };
 
     /**

--- a/tests/fixtures/demo/row-header-border-ownership.html
+++ b/tests/fixtures/demo/row-header-border-ownership.html
@@ -86,6 +86,19 @@
   <h2>Row headers, no data columns</h2>
   <div id="empty" data-testid="empty"></div>
 
+  <!--
+    Two row header columns, which `afterGetRowHeaderRenderers` makes reachable from the public API
+    and `autoRowHeaderSize` measures one by one. The seam to column 0 is then the LAST row header's
+    inline-end, not the first one's - and the last one is exactly the `th` that goes `:last-child`
+    in the overlay rendering nothing but the row-header columns. Both shapes are here because that
+    is what makes the divergence visible: with `fixedColumnsStart` the same `th` is not last.
+  -->
+  <h2>Two row headers</h2>
+  <div id="multi-row-headers" data-testid="multi-row-headers"></div>
+
+  <h2>Two row headers, frozen column</h2>
+  <div id="multi-frozen" data-testid="multi-frozen"></div>
+
   <script>
     // The bundle under test, selected above from the sanitized allowlist. The
     // closing tag is split so the HTML parser does not end THIS script block.
@@ -121,6 +134,17 @@
       }, settings));
     }
 
+    /**
+     * Appends a second row header column through the documented hook.
+     */
+    const SECOND_ROW_HEADER = {
+      afterGetRowHeaderRenderers(renderers) {
+        renderers.push((row, TH) => {
+          TH.textContent = `#${row}`;
+        });
+      },
+    };
+
     window.htColWidth = COL_WIDTH;
     window.grids = {
       rowHeaders: buildGrid('row-headers', {}),
@@ -134,6 +158,8 @@
       }),
       control: buildGrid('control', { rowHeaders: false }),
       empty: buildGrid('empty', { data: [[], [], []], columns: [] }),
+      multiRowHeaders: buildGrid('multi-row-headers', { ...SECOND_ROW_HEADER }),
+      multiFrozen: buildGrid('multi-frozen', { ...SECOND_ROW_HEADER, fixedColumnsStart: 1 }),
     };
 
     /**

--- a/tests/fixtures/pages/RowHeaderBorderOwnershipPage.ts
+++ b/tests/fixtures/pages/RowHeaderBorderOwnershipPage.ts
@@ -29,7 +29,7 @@ export interface HorizontalMetrics {
  */
 export class RowHeaderBorderOwnershipPage {
   /** Every grid the fixture builds. `goto()` waits for all of them. */
-  static readonly GRID_IDS = ['row-headers', 'frozen', 'rtl', 'nested', 'control'];
+  static readonly GRID_IDS = ['row-headers', 'frozen', 'rtl', 'nested', 'control', 'empty'];
 
   readonly page: Page;
   readonly theme: string;
@@ -195,8 +195,10 @@ export class RowHeaderBorderOwnershipPage {
    * Scrolls one grid horizontally and waits for the draw to land.
    *
    * The wait is on the master holder's own scroll offset leaving zero - a real DOM state rather
-   * than a sleep, and the one condition that holds for every grid here. The
-   * `innerBorderInlineStart` class cannot serve as the signal: the inline-start overlay only
+   * than a sleep, and the one condition that holds for every grid here. It is `not.toBe(0)`, not
+   * `toBeGreaterThan(0)`: `setScrollPosition` negates the target in RTL, so an RTL holder's
+   * `scrollLeft` goes NEGATIVE and a greater-than poll would sit until it timed out. The
+   * `innerBorderInlineStart` class cannot serve as the signal either: the inline-start overlay only
    * toggles it when the grid has row headers and NO frozen columns, so it never appears on the
    * frozen grid. It is pinned separately instead.
    *
@@ -213,7 +215,7 @@ export class RowHeaderBorderOwnershipPage {
     );
 
     await expect.poll(() => this.grid(testId).locator('.ht_master .wtHolder')
-      .evaluate(holder => holder.scrollLeft)).toBeGreaterThan(0);
+      .evaluate(holder => holder.scrollLeft)).not.toBe(0);
   }
 
   /**
@@ -229,6 +231,135 @@ export class RowHeaderBorderOwnershipPage {
   }
 
   /**
+   * The computed inline-end border color of a cell, as the browser resolves it. Read as a string so
+   * the assertion can compare two elements against each other without naming a theme's palette:
+   * `--ht-cell-horizontal-border-color` is transparent in `horizon` and equal to the frame color in
+   * `main` and `classic`, so a literal would only ever hold on one theme.
+   *
+   * @param {Locator} cell The cell to measure.
+   * @returns {Promise<string>}
+   */
+  async inlineEndBorderColor(cell: Locator): Promise<string> {
+    return cell.evaluate(element => getComputedStyle(element).borderInlineEndColor);
+  }
+
+  /**
+   * The computed inline-start border color of a cell. On a row header that side is always the grid's
+   * outer frame, which makes it the reference for what a frame color looks like in this theme.
+   *
+   * @param {Locator} cell The cell to measure.
+   * @returns {Promise<string>}
+   */
+  async inlineStartBorderColor(cell: Locator): Promise<string> {
+    return cell.evaluate(element => getComputedStyle(element).borderInlineStartColor);
+  }
+
+  /**
+   * Selects one cell through the grid's own API, so no click can land on a renderer's indicator.
+   *
+   * @param {string} name The grid's key in `window.grids`.
+   * @param {number} row The visual row index.
+   * @param {number} column The visual column index.
+   */
+  async selectCell(name: string, row: number, column: number): Promise<void> {
+    await this.page.evaluate(
+      ([gridName, r, c]) => (window as unknown as {
+        grids: Record<string, { selectCell: (row: number, column: number) => void }>
+      }).grids[gridName as string].selectCell(r as number, c as number),
+      [name, row, column]
+    );
+  }
+
+  /**
+   * How far the selection's inline-start edge sits from the selected cell's own inline-start
+   * boundary, in CSS pixels and in the inline direction (so RTL needs no separate expectation).
+   *
+   * `0` means the edge is drawn just inside the cell. `-1` means it straddles the gridline shared
+   * with the inline-start neighbour, which is right for a cell that owns no start border of its own
+   * and has another CELL beside it. Behind a row header it is wrong: the shared pixel is the last
+   * pixel of the inline-start overlay, which paints at z-index 120 against the border layer's 10, so
+   * the edge would be hidden behind the row header (#6673).
+   *
+   * The edge element is the vertical `.wtBorder` of the `current` layer nearest the cell's
+   * inline-start boundary - identified by geometry rather than by DOM order, which `Border` owns.
+   * The cell is addressed with `td:nth-of-type()`, not `nth-child()`: a body row starts with the
+   * row-header `th`, so `nth-child` is off by one for every column.
+   *
+   * @param {string} testId The grid's test id.
+   * @param {number} row The visual row index of the selected cell.
+   * @param {number} column The visual column index of the selected cell.
+   * @param {string} overlay The overlay whose border layer to read.
+   * @returns {Promise<number>}
+   */
+  async selectionInlineStartEdgeOffset(
+    testId: string,
+    row: number,
+    column: number,
+    overlay = '.ht_master'
+  ): Promise<number> {
+    return this.grid(testId).locator(overlay).evaluate((element, args) => {
+      const { row: r, column: c } = args as { row: number; column: number };
+      const rtl = getComputedStyle(element).direction === 'rtl';
+      const cell = element.querySelector<HTMLElement>(
+        `table.htCore > tbody > tr:nth-child(${r + 1}) > td:nth-of-type(${c + 1})`
+      );
+
+      if (cell === null) {
+        throw new Error(`No cell at row ${r}, column ${c} in this overlay`);
+      }
+
+      const cellRect = cell.getBoundingClientRect();
+      const edges = [...element.querySelectorAll<HTMLElement>('.wtBorder.current')]
+        .map(border => border.getBoundingClientRect())
+        .filter(rect => rect.height > rect.width);
+
+      if (edges.length === 0) {
+        throw new Error('The selection drew no vertical edge');
+      }
+
+      const inlineStartOf = (rect: DOMRect) => (rtl ? -rect.right : rect.left);
+      const nearest = edges
+        .sort((a, b) => Math.abs(inlineStartOf(a) - inlineStartOf(cellRect))
+          - Math.abs(inlineStartOf(b) - inlineStartOf(cellRect)))[0];
+
+      return Math.round(inlineStartOf(nearest) - inlineStartOf(cellRect));
+    }, { row, column });
+  }
+
+  /**
+   * Whether the master's selection edges overlap the inline-start overlay, which paints above the
+   * border layer and would therefore hide them.
+   *
+   * Only meaningful for a grid whose inline-start overlay renders the row-header column ALONE. With
+   * `fixedColumnsStart` the overlay covers column 0 on purpose and draws its own copy of every edge,
+   * so the master's edges are under it by design.
+   *
+   * @param {string} testId The grid's test id.
+   * @returns {Promise<boolean>}
+   */
+  async selectionEdgeHiddenBehindRowHeader(testId: string): Promise<boolean> {
+    return this.grid(testId).evaluate((element) => {
+      const overlay = element.querySelector<HTMLElement>('.ht_clone_inline_start');
+      const master = element.querySelector<HTMLElement>('.ht_master');
+
+      if (overlay === null || master === null) {
+        throw new Error('The grid renders no inline-start overlay');
+      }
+
+      const rtl = getComputedStyle(master).direction === 'rtl';
+
+      const overlayRect = overlay.getBoundingClientRect();
+      const edges = [...master.querySelectorAll<HTMLElement>('.wtBorder.current')]
+        .map(border => border.getBoundingClientRect())
+        .filter(rect => rect.height > rect.width);
+
+      return rtl
+        ? edges.some(rect => rect.right > overlayRect.left)
+        : edges.some(rect => rect.left < overlayRect.right);
+    });
+  }
+
+  /**
    * Navigate and wait for the grids to have rendered - a real DOM condition, never a sleep.
    */
   async goto(): Promise<void> {
@@ -241,7 +372,7 @@ export class RowHeaderBorderOwnershipPage {
     }
 
     // The control grid has no row headers, so it draws no inline-start clone at all.
-    for (const testId of ['row-headers', 'frozen', 'rtl', 'nested']) {
+    for (const testId of ['row-headers', 'frozen', 'rtl', 'nested', 'empty']) {
       await expect(this.grid(testId).locator('.ht_clone_inline_start')).toBeVisible();
     }
   }

--- a/tests/fixtures/pages/RowHeaderBorderOwnershipPage.ts
+++ b/tests/fixtures/pages/RowHeaderBorderOwnershipPage.ts
@@ -1,0 +1,248 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/** The inline-start and inline-end border widths of one cell, in CSS pixels. */
+export interface LogicalBorders {
+  start: number;
+  end: number;
+}
+
+/** The physical left and right border widths of one cell, in CSS pixels. */
+export interface PhysicalBorders {
+  left: number;
+  right: number;
+}
+
+/** The sizes that must not change when the grid is scrolled horizontally. */
+export interface HorizontalMetrics {
+  rowHeaderWidth: number;
+  rowHeaderColWidth: string;
+  hiderWidth: string;
+}
+
+/**
+ * Page Object for the row header border ownership fixture (issue #6673).
+ *
+ * Widths are read as `clientWidth`, which is the cell's CONTENT box - the number the issue is
+ * about. `offsetWidth` and `getBoundingClientRect().width` both include the borders, so they read
+ * the declared `colWidths` for every column whether the bug is present or not, which is why the
+ * legacy `colWidth()` helper could never see it.
+ */
+export class RowHeaderBorderOwnershipPage {
+  /** Every grid the fixture builds. `goto()` waits for all of them. */
+  static readonly GRID_IDS = ['row-headers', 'frozen', 'rtl', 'nested', 'control'];
+
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+  }
+
+  /**
+   * The grid container carrying the given test id.
+   *
+   * @param {string} testId The container's test id.
+   * @returns {Locator}
+   */
+  grid(testId: string): Locator {
+    return this.page.getByTestId(testId);
+  }
+
+  /**
+   * The width every column of the fixture asks for.
+   *
+   * @returns {Promise<number>}
+   */
+  async declaredColumnWidth(): Promise<number> {
+    return this.page.evaluate(() => (window as unknown as { htColWidth: number }).htColWidth);
+  }
+
+  /**
+   * The content-box widths of the leading body cells of one overlay's first row.
+   *
+   * @param {string} testId The grid's test id.
+   * @param {number} count How many cells to read.
+   * @param {string} overlay The overlay to read from.
+   * @returns {Promise<number[]>}
+   */
+  async bodyCellContentWidths(testId: string, count: number, overlay = '.ht_master'): Promise<number[]> {
+    const widths = await this.grid(testId).locator(`${overlay} table.htCore > tbody > tr`).first()
+      .locator('td')
+      .evaluateAll(cells => cells.map(cell => cell.clientWidth));
+
+    return widths.slice(0, count);
+  }
+
+  /**
+   * The inline-start / inline-end border widths of a cell.
+   *
+   * @param {Locator} cell The cell to measure.
+   * @returns {Promise<LogicalBorders>}
+   */
+  async borders(cell: Locator): Promise<LogicalBorders> {
+    return cell.evaluate((element) => {
+      const style = getComputedStyle(element);
+
+      return {
+        start: Number.parseFloat(style.borderInlineStartWidth),
+        end: Number.parseFloat(style.borderInlineEndWidth),
+      };
+    });
+  }
+
+  /**
+   * The physical left / right border widths of a cell. Used for the RTL case, where the point is
+   * that the logical rules land on the mirrored physical side without a mirror rule.
+   *
+   * @param {Locator} cell The cell to measure.
+   * @returns {Promise<PhysicalBorders>}
+   */
+  async physicalBorders(cell: Locator): Promise<PhysicalBorders> {
+    return cell.evaluate((element) => {
+      const style = getComputedStyle(element);
+
+      return {
+        left: Number.parseFloat(style.borderLeftWidth),
+        right: Number.parseFloat(style.borderRightWidth),
+      };
+    });
+  }
+
+  /**
+   * The first row header cell of a body row, taken from the clone that actually renders it.
+   *
+   * @param {string} testId The grid's test id.
+   * @returns {Locator}
+   */
+  rowHeaderCell(testId: string): Locator {
+    return this.grid(testId)
+      .locator('.ht_clone_inline_start table.htCore > tbody > tr').first()
+      .locator('th').first();
+  }
+
+  /**
+   * The corner header cell - the one above the row headers.
+   *
+   * @param {string} testId The grid's test id.
+   * @param {number} level Which header row to read, for nested headers.
+   * @returns {Locator}
+   */
+  cornerHeaderCell(testId: string, level = 0): Locator {
+    return this.grid(testId)
+      .locator('.ht_clone_top_inline_start_corner table.htCore > thead > tr').nth(level)
+      .locator('th').first();
+  }
+
+  /**
+   * The header cell of the first data column.
+   *
+   * @param {string} testId The grid's test id.
+   * @param {number} level Which header row to read, for nested headers.
+   * @returns {Locator}
+   */
+  firstColumnHeaderCell(testId: string, level = 0): Locator {
+    return this.grid(testId)
+      .locator('.ht_clone_top table.htCore > thead > tr').nth(level)
+      .locator('th').nth(1);
+  }
+
+  /**
+   * The first body cell of one overlay's first row.
+   *
+   * @param {string} testId The grid's test id.
+   * @param {string} overlay The overlay to read from.
+   * @returns {Locator}
+   */
+  firstBodyCell(testId: string, overlay = '.ht_master'): Locator {
+    return this.grid(testId)
+      .locator(`${overlay} table.htCore > tbody > tr`).first()
+      .locator('td').first();
+  }
+
+  /**
+   * How many header rows the grid renders.
+   *
+   * @param {string} testId The grid's test id.
+   * @returns {Promise<number>}
+   */
+  async headerLevelCount(testId: string): Promise<number> {
+    return this.grid(testId).locator('.ht_clone_top table.htCore > thead > tr').count();
+  }
+
+  /**
+   * The sizes that a horizontal scroll must leave alone: the rendered row header width, the inline
+   * width written onto its `col` element, and the hider width that drives the scroll range.
+   *
+   * @param {string} testId The grid's test id.
+   * @returns {Promise<HorizontalMetrics>}
+   */
+  async horizontalMetrics(testId: string): Promise<HorizontalMetrics> {
+    const rowHeaderWidth = await this.rowHeaderCell(testId)
+      .evaluate(th => th.getBoundingClientRect().width);
+    const rowHeaderColWidth = await this.grid(testId)
+      .locator('.ht_master table.htCore > colgroup > col.rowHeader')
+      .evaluate(col => (col as HTMLElement).style.width);
+    const hiderWidth = await this.grid(testId).locator('.ht_master .wtHider')
+      .evaluate(hider => (hider as HTMLElement).style.width);
+
+    return { rowHeaderWidth, rowHeaderColWidth, hiderWidth };
+  }
+
+  /**
+   * Scrolls one grid horizontally and waits for the draw to land.
+   *
+   * The wait is on the master holder's own scroll offset leaving zero - a real DOM state rather
+   * than a sleep, and the one condition that holds for every grid here. The
+   * `innerBorderInlineStart` class cannot serve as the signal: the inline-start overlay only
+   * toggles it when the grid has row headers and NO frozen columns, so it never appears on the
+   * frozen grid. It is pinned separately instead.
+   *
+   * @param {string} name The grid's key in `window.grids`.
+   * @param {string} testId The grid's test id.
+   * @param {number} column The visual column index to snap to the inline start.
+   */
+  async scrollHorizontallyTo(name: string, testId: string, column: number): Promise<void> {
+    await this.page.evaluate(
+      ([gridName, col]) => (window as unknown as {
+        scrollHorizontallyTo: (name: string, column: number) => void
+      }).scrollHorizontallyTo(gridName as string, col as number),
+      [name, column]
+    );
+
+    await expect.poll(() => this.grid(testId).locator('.ht_master .wtHolder')
+      .evaluate(holder => holder.scrollLeft)).toBeGreaterThan(0);
+  }
+
+  /**
+   * Whether `.ht_master` carries the given class.
+   *
+   * @param {string} testId The grid's test id.
+   * @param {string} className The class to look for.
+   * @returns {Promise<boolean>}
+   */
+  async masterHasClass(testId: string, className: string): Promise<boolean> {
+    return this.grid(testId).locator('.ht_master')
+      .evaluate((master, name) => master.classList.contains(name as string), className);
+  }
+
+  /**
+   * Navigate and wait for the grids to have rendered - a real DOM condition, never a sleep.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(
+      `/tests/fixtures/demo/row-header-border-ownership.html?theme=${this.theme}&bundle=${this.bundle}`
+    );
+
+    for (const testId of RowHeaderBorderOwnershipPage.GRID_IDS) {
+      await expect(this.grid(testId).locator('.ht_clone_top')).toBeVisible();
+    }
+
+    // The control grid has no row headers, so it draws no inline-start clone at all.
+    for (const testId of ['row-headers', 'frozen', 'rtl', 'nested']) {
+      await expect(this.grid(testId).locator('.ht_clone_inline_start')).toBeVisible();
+    }
+  }
+}

--- a/tests/fixtures/pages/RowHeaderBorderOwnershipPage.ts
+++ b/tests/fixtures/pages/RowHeaderBorderOwnershipPage.ts
@@ -29,7 +29,9 @@ export interface HorizontalMetrics {
  */
 export class RowHeaderBorderOwnershipPage {
   /** Every grid the fixture builds. `goto()` waits for all of them. */
-  static readonly GRID_IDS = ['row-headers', 'frozen', 'rtl', 'nested', 'control', 'empty'];
+  static readonly GRID_IDS = [
+    'row-headers', 'frozen', 'rtl', 'nested', 'control', 'empty', 'multi-row-headers', 'multi-frozen',
+  ];
 
   readonly page: Page;
   readonly theme: string;
@@ -121,6 +123,77 @@ export class RowHeaderBorderOwnershipPage {
     return this.grid(testId)
       .locator('.ht_clone_inline_start table.htCore > tbody > tr').first()
       .locator('th').first();
+  }
+
+  /**
+   * The LAST row header cell of a body row - the one whose inline-end is the seam to column 0. On a
+   * grid with a single row header that is the same cell as `rowHeaderCell()`; with several it is not,
+   * and it is the one that goes `:last-child` in the overlay that renders only the row headers.
+   *
+   * @param {string} testId The grid's test id.
+   * @returns {Locator}
+   */
+  lastRowHeaderCell(testId: string): Locator {
+    return this.grid(testId)
+      .locator('.ht_clone_inline_start table.htCore > tbody > tr').first()
+      .locator('th').last();
+  }
+
+  /**
+   * The corner header cell as the TOP clone renders it. `SelectionManager` stamps
+   * `ht__active_highlight-prev` on the `th` directly before an active header, and for an active
+   * column-0 header that is this element - the corner overlay holds a different `th` and is not
+   * stamped, so the accent has to be read here.
+   *
+   * @param {string} testId The grid's test id.
+   * @returns {Locator}
+   */
+  topCloneCornerCell(testId: string): Locator {
+    return this.grid(testId)
+      .locator('.ht_clone_top table.htCore > thead > tr').first()
+      .locator('th').first();
+  }
+
+  /**
+   * Selects a whole column through the grid's own API, which is what marks its header active.
+   *
+   * @param {string} name The grid's key in `window.grids`.
+   * @param {number} column The visual column index.
+   */
+  async selectColumn(name: string, column: number): Promise<void> {
+    await this.page.evaluate(
+      ([gridName, c]) => (window as unknown as {
+        grids: Record<string, { selectColumns: (column: number) => void }>
+      }).grids[gridName as string].selectColumns(c as number),
+      [name, column]
+    );
+  }
+
+  /**
+   * How many row header columns a body row renders.
+   *
+   * @param {string} testId The grid's test id.
+   * @returns {Promise<number>}
+   */
+  async rowHeaderCount(testId: string): Promise<number> {
+    return this.grid(testId)
+      .locator('.ht_clone_inline_start table.htCore > tbody > tr').first()
+      .locator('th').count();
+  }
+
+  /**
+   * Selects a whole row through the grid's own API, which is what marks its row header active.
+   *
+   * @param {string} name The grid's key in `window.grids`.
+   * @param {number} row The visual row index.
+   */
+  async selectRow(name: string, row: number): Promise<void> {
+    await this.page.evaluate(
+      ([gridName, r]) => (window as unknown as {
+        grids: Record<string, { selectRows: (row: number) => void }>
+      }).grids[gridName as string].selectRows(r as number),
+      [name, row]
+    );
   }
 
   /**
@@ -372,7 +445,9 @@ export class RowHeaderBorderOwnershipPage {
     }
 
     // The control grid has no row headers, so it draws no inline-start clone at all.
-    for (const testId of ['row-headers', 'frozen', 'rtl', 'nested', 'empty']) {
+    for (const testId of [
+      'row-headers', 'frozen', 'rtl', 'nested', 'empty', 'multi-row-headers', 'multi-frozen',
+    ]) {
       await expect(this.grid(testId).locator('.ht_clone_inline_start')).toBeVisible();
     }
   }


### PR DESCRIPTION
### Context

The PR fixes the first data column rendering 1px narrower than every other column whenever row headers are enabled. With `colWidths: 75` and `rowHeaders: true`, column 0's content box measured 73px while every other column measured 74px, so one declared width produced two different rendered widths.

**The linked issue says this was already fixed. It was not.** The commit it cites (`59b71c2942`) belongs to PR #6157, which was closed **unmerged** on 2022-01-13; the commit exists only on abandoned `feature/issue-6064*` branches and never reached `develop`. The defect was reproduced on current `develop` in all three themes before any work started.

**Root cause.** `handsontable/src/styles/base/_base.scss` gave `td:first-of-type` a `border-inline-start` on top of the `border-inline-end` that every cell carries, and `box-sizing: border-box` took both out of the same `<col>` width. `:first-of-type` matches the first `td` whether or not a row-header `th` precedes it, so column 0 was asked to fit two gridlines into one column width.

To stop the seam from doubling, the row header then gave up its own `border-inline-end` at horizontal offset 0, and a `correctHeaderWidth` flag in the engine widened the row header by 1px the moment the grid scrolled — with matching compensations in `inlineStartOverlay#scrollTo`, the hider width, and both column calculators (`viewportWidth + 1`). **The whole table therefore changed width by being scrolled.**

**Fix.** The gridline between the row header and column 0 now belongs to the row header at every scroll position, and no cell standing behind a row header draws an inline-start border. Every column then has the same content width, and the row header's width no longer depends on the scroll offset, so all four compensations are removed rather than rebalanced.

Removing the calculator `+ 1` also tightens grids **without** row headers by one pixel when scrolled: a column whose end sits 1px past the viewport edge is no longer reported fully visible. That pixel was latent slack introduced alongside `correctHeaderWidth`; keeping it would have created a fresh off-by-one for the row-header case now that `getViewportWidth()` is exact at every offset.

While verifying, one defect this change introduced was found and fixed in the same PR: `BaseEditor#getEditedCellRect` cancelled its 1px inline-start shift for `renderableColumn <= 0`, on the assumption that column 0 owns its own start border. With row headers that left the editor 51px wide but flush with the cell's left edge, overhanging into the next column. The offset now keys off the same computed border that already sizes the editor, so which cells get the shift is read from the DOM rather than from an index.

**Deliberately out of scope, and pinned as a control case:** with no row header in front of it, column 0 is the first cell of its row and still draws the grid's own inline-start frame inside its declared width. It stays 1px narrower than the rest, exactly as before.

**Also deliberately untouched:** the row axis (`innerBorderTop` / `innerBorderBottom`, `columnHeaderBorderCompensation`) has the identical design and the identical latent problem. Bringing it into line is a separate change; a follow-up task should be filed.

The `innerBorderInlineStart`, `innerBorderLeft` and `emptyColumns` classes are still stamped on `.ht_master` for backward compatibility. No stylesheet reads them any more, and a test pins that they are still published.

### How has this been tested?

New Playwright spec, plus updated expectations in the existing suites wherever a number encoded the removed pixel.

**New spec** — `tests/e2e/row-header-border-ownership.spec.ts` (fixture + page object alongside it). Covers the reported case, the frozen-column clone, RTL, nested headers, invariance of the row-header width and the scroll range across a horizontal scroll, the legacy classes, and the no-row-headers control.

```bash
cd tests && npx playwright test e2e/row-header-border-ownership.spec.ts
```

**Verified the spec is not vacuous.** The source was reverted to the base commit, rebuilt, and the spec re-run: **8 of its 10 tests fail without the fix.** The 2 that pass are the intentional guards (the legacy classes, and the no-row-headers control), which must hold in both states.

| Suite | Result |
|---|---|
| `tests/e2e` Playwright, new spec, all 6 theme × bundle legs | 60/60 passed |
| `tests/e2e` Playwright, full suite (`e2e-main`) | 855 passed, 1 skipped |
| `npm run test:e2e --prefix handsontable` | 9848 specs, 0 failures |
| `npm run test:walkontable --prefix handsontable` | 816 specs, 0 failures |
| `npm run test:unit --prefix handsontable` | 4393 passed |
| `npm run test --prefix wrappers/react-wrapper` | 99 passed |
| `npm run test --prefix wrappers/vue3` | 39 passed |
| `npm run test --prefix wrappers/angular-wrapper` | 299 passed |
| `npm run eslint` + `stylelint --prefix handsontable` | 0 errors |

**Manually verified in a real browser** across `main`, `horizon` and `classic`, with and without row headers, frozen columns, RTL and nested headers: every column's content box is equal; the row header stays 50px and the hider width stays constant across a horizontal scroll; the seam renders exactly once (no missing and no doubled gridline); the last column is fully reachable at maximum scroll; and the editor aligns identically for column 0 and every other column.

**Updated existing expectations.** Every changed number was checked against the browser first, not adjusted until green:

- Horizontal scroll positions that embedded the compensation, each 1px lower (`core/viewportScroll/__tests__/**` incl. RTL, `scrollViewportTo`, `scrollToFocusedCell`, `beforeViewportScrollHorizontally`, `nestedHeaders/navigation`, `comments`, `dropdownMenu`). Two of those specs' own comments named the removed term as "+ 1 header border compensation".
- `focusSelection.spec.js` no longer needs the 1px of container slack that existed to absorb the first column's border, so scroll positions land on exact `colWidths` multiples again on all three themes.
- Editor position specs across all cell-type editors: column 0 now follows the same convention as every other column. The RTL helper reads the border off the cell instead of taking a flag from the caller.
- The two frozen-column seam specs in `autoRowSize` and `manualColumnMove` asserted the seam on the cell's `border-left`; they now assert it on both sides of the seam, so a missing gridline and a doubled one are both failures.
- The Walkontable overlay spec's `+ 1px (header border left width)` term is gone; the `drawCycleHooks` spec that pinned `correctHeaderWidth` now pins the invariant that replaced it (the row header width is unchanged across a skipped horizontal-scroll draw).

**Visual tests will change.** Every screenshot with row headers shifts by 1px: the row header's content box is 1px narrower, column 0's is 1px wider, and a selection border on column 0 moves with it. This is the intended effect and needs a reg-suit review plus the `visual-approved` label.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #6673
2. DEV-395

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-395

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Walkontable layout, scrolling, frozen overlays, RTL, and editor/selection geometry; behavior is well-tested but regressions would show as 1px misalignment or wrong visible columns when scrolled.
> 
> **Overview**
> Fixes **#6673**: with row headers enabled, column 0 no longer renders 1px narrower than other columns, and the row header no longer grows by 1px when the grid is scrolled horizontally.
> 
> **Border ownership** moves the gridline between the row header and column 0 to the row header’s `border-inline-end` at every scroll offset. Data cells behind row headers no longer get an extra inline-start border (`:first-of-type` → `:first-child` in Walkontable and theme SCSS). Seam color rules under `.htRowHeaders` keep overlays and active-header accents consistent.
> 
> **Engine cleanup** drops the scroll-dependent `correctHeaderWidth` path, hider horizontal `+1`, `expandHiderHorizontallyBy`, and the `viewportWidth + 1` column calculators. Horizontal scroll/viewport expectations and editor/selection positioning now use DOM border reads (`BaseEditor`, `Border#appear`, `editorInlineStartOffset` helper) instead of column index.
> 
> Adds Playwright coverage in `tests/e2e/row-header-border-ownership.spec.ts` and updates broad unit/e2e expectations (typically 1px lower scroll positions). `innerBorderInlineStart` / `innerBorderLeft` remain on the DOM for compatibility but no longer affect layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30243c3535d0442db5acc8164c9cca12eaac0860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->