### PR TITLE
DEV-2783: Keep Emitted Types from canceling CI Gate

### DIFF
--- a/.github/scripts/__tests__/emitted-types.test.mjs
+++ b/.github/scripts/__tests__/emitted-types.test.mjs
@@ -7,66 +7,172 @@ import { repoRoot } from '../lib/repo-root.mjs';
 // Emitted Types is on CI Gate's `needs` list. GitHub reports a job timeout as
 // `cancelled`, and the gate treats that as a failure, so a 15-minute budget
 // that attw regularly exceeded blocked otherwise-green PRs (#13373, #13375).
-// The workflow comments record the three constraints this file pins: the
-// timeout floor, a single cached install instead of three `npx -y` downloads,
-// and attw limited to the typed public roots. A revert of any of those puts
-// the race back.
+// The workflow comments record the constraints this file pins: the timeout
+// floor, a single cached install instead of three `npx -y` downloads, attw
+// limited to the typed public roots on PRs, and no reusable-workflow contexts
+// in job-level env. A revert of any of those puts the race — or a 0-job
+// parse failure — back.
 
-const WORKFLOW = readFileSync(
-  path.join(repoRoot(), '.github/workflows/emitted-types.yml'),
-  'utf8'
-);
-const withoutComments = WORKFLOW.replace(/#[^\n]*/g, '');
+const root = repoRoot();
+const read = (rel) => readFileSync(path.join(root, rel), 'utf8');
+const WORKFLOW = read(path.join('.github', 'workflows', 'emitted-types.yml'));
+const CHECKS = read(path.join('.github', 'workflows', 'checks.yml'));
+const TEST_YML = read(path.join('.github', 'workflows', 'test.yml'));
+const DEVELOP_YML = read(path.join('.github', 'workflows', 'develop.yml'));
+const withoutComments = (source) => source.replace(/#[^\n]*/g, '');
+const workflow = withoutComments(WORKFLOW);
+
+/**
+ * Return the first `@version` pin for `name` in the comment-stripped workflow.
+ *
+ * @param {string} name Package name as it appears before `@` (escaped for RegExp).
+ * @returns {string} The pinned version.
+ */
+function pin(name) {
+  const match = workflow.match(new RegExp(`${name}@([\\d.]+)`));
+
+  assert.ok(match, `missing ${name}@<version> pin in emitted-types.yml`);
+
+  return match[1];
+}
+
+/**
+ * Escape a semver string for use inside a RegExp.
+ *
+ * @param {string} value A version like `5.1.6`.
+ * @returns {string} The escaped pattern.
+ */
+function escapeDots(value) {
+  return value.replace(/\./g, '\\.');
+}
 
 test('the Emitted Types job budget is at least 30 minutes', () => {
-  const timeout = Number(/timeout-minutes:\s*(\d+)/.exec(WORKFLOW)?.[1]);
+  const timeout = Number(/\n    timeout-minutes:\s*(\d+)/.exec(workflow)?.[1]);
 
   assert.ok(
-    timeout >= 30,
-    `timeout-minutes (${timeout}) must be >= 30 — 15 minutes cancelled on a cold npx + full-export attw`
+    Number.isFinite(timeout) && timeout >= 30,
+    `job-level timeout-minutes (${timeout}) must be >= 30 — 15 minutes cancelled on a cold npx + full-export attw`
   );
 });
 
 test('type-check tools are installed once, not via three cold npx -y calls', () => {
+  const ts = pin('typescript');
+  const publint = pin('publint');
+  const attw = pin('@arethetypeswrong\\/cli');
+
   assert.match(
-    WORKFLOW,
+    workflow,
     /name: Install type-check tools/,
     'expected a single Install type-check tools step'
   );
   assert.match(
-    WORKFLOW,
-    /actions\/cache@/,
-    'expected an npm cache so the install is not a cold download every run'
+    workflow,
+    /path:\s*~\/\.npm/,
+    'expected the npm cache path so the install is not a cold download every run'
   );
+  assert.match(
+    workflow,
+    new RegExp(
+      `key:\\s*emitted-types-npx-\\$\\{\\{\\s*runner\\.os\\s*\\}\\}-ts${escapeDots(ts)}-publint${escapeDots(publint)}-attw${escapeDots(attw)}`
+    ),
+    'cache key must name each installed version — a stale key is a permanent miss'
+  );
+  assert.match(
+    workflow,
+    /restore-keys:\s*emitted-types-npx-\$\{\{\s*runner\.os\s*\}\}-/,
+    'expected a prefix restore-key so a one-tool bump still hits the other tarballs'
+  );
+  assert.match(
+    workflow,
+    /npm install --no-package-lock --prefer-offline --no-audit --no-fund/,
+    'pinned install must not revalidate metadata or audit on a warm ~/.npm'
+  );
+  assert.match(
+    workflow,
+    /tsc" --version \| grep -F 'Version 5\.1\.6'/,
+    'install step must assert the root tsc is the pinned 5.1.x, not attw\'s nested compiler'
+  );
+  assert.match(
+    workflow,
+    /TOOLS_BIN=/,
+    'call tsc/publint/attw via TOOLS_BIN — do not prepend the whole .bin to GITHUB_PATH'
+  );
+  assert.doesNotMatch(
+    workflow,
+    /GITHUB_PATH/,
+    'do not put the tool .bin on GITHUB_PATH — it also fronts semver/marked/highlight'
+  );
+  assert.match(workflow, /"\$TOOLS_BIN\/tsc"/);
+  assert.match(workflow, /"\$TOOLS_BIN\/publint"/);
+  assert.match(workflow, /"\$TOOLS_BIN\/attw"/);
   assert.equal(
-    (withoutComments.match(/npx\s+-y/g) || []).length,
+    (workflow.match(/npx\s+-y/g) || []).length,
     0,
     'do not bring back per-step `npx -y` — each one is an uncached registry fetch'
   );
 });
 
-test('job-level env does not use the runner context', () => {
-  // Reusable workflows reject ${{ runner.* }} in jobs.<id>.env. The caller
-  // then fails at parse time with 0 jobs, so CI Gate never reports
-  // (DEV-2783, runs 33853301602 / 33853913419).
-  const jobEnv = withoutComments.match(/\n    env:\n([\s\S]*?)\n    steps:/)?.[1] ?? '';
+test('job-level env does not use contexts GitHub rejects on a reusable workflow', () => {
+  // Reusable workflows reject ${{ runner.* }} (and env/steps/job) in
+  // jobs.<id>.env. The caller then fails at parse time with 0 jobs, so CI
+  // Gate never reports (DEV-2783, runs 33853301602 / 33853913419). The
+  // block must sit above `steps:` so this regex can see it — moving it
+  // below is valid YAML and the same parse failure, so fail closed.
+  const jobEnv = workflow.match(/\n    env:\n([\s\S]*?)\n    steps:/)?.[1];
 
+  assert.ok(
+    jobEnv != null && jobEnv.trim() !== '',
+    'job-level env must sit above steps: — a reusable workflow rejects runner/env/steps/job there'
+  );
   assert.doesNotMatch(
     jobEnv,
-    /\$\{\{\s*runner\./,
-    'do not use ${{ runner.* }} in job-level env of a reusable workflow'
+    /\$\{\{\s*(?:runner|env|steps|job)\./,
+    'do not use ${{ runner.* }}, ${{ env.* }}, ${{ steps.* }} or ${{ job.* }} in job-level env of a reusable workflow'
   );
 });
 
-test('attw checks the typed public roots, not every exports path', () => {
+test('attw checks the typed public roots on PRs and every path on run-all', () => {
   assert.match(
-    withoutComments,
+    workflow,
     /--entrypoints\s+\.\s+base\s+registry\s+settings\s+themes/,
-    'attw must pass --entrypoints . base registry settings themes'
+    'PR attw must pass --entrypoints . base registry settings themes'
+  );
+  assert.match(
+    workflow,
+    /ATTW_FULL/,
+    'trunk attw must be gated on the attw-full input'
+  );
+  assert.match(
+    workflow,
+    /untyped-resolution/,
+    'full attw must ignore untyped dist/language paths'
+  );
+  assert.match(
+    workflow,
+    /no-resolution/,
+    'full attw must ignore CSS/theme assets'
+  );
+  assert.match(
+    withoutComments(TEST_YML),
+    /attw-full:\s*\$\{\{\s*needs\.checks\.outputs\.run-all == 'true'\s*\}\}/,
+    'test.yml must pass attw-full from run-all (master / release / publish.yml)'
+  );
+  assert.match(
+    withoutComments(DEVELOP_YML),
+    /attw-full:\s*\$\{\{\s*needs\.checks\.outputs\.run-all == 'true'\s*\}\}/,
+    'develop.yml must pass attw-full from run-all'
   );
   assert.doesNotMatch(
-    withoutComments,
+    workflow,
     /npx\s+-y\s+@arethetypeswrong\/cli/,
     'do not invoke attw through npx -y'
+  );
+});
+
+test('changing the Emitted Types workflow itself turns the job on', () => {
+  assert.match(
+    CHECKS,
+    /verify-types:\n\s+-\s+'\.\/handsontable\/\*\*'\n\s+-\s+'\.\/\.github\/workflows\/emitted-types\.yml'/,
+    'verify-types must include emitted-types.yml — otherwise a workflow-only PR skips the job it is changing'
   );
 });

--- a/.github/scripts/__tests__/emitted-types.test.mjs
+++ b/.github/scripts/__tests__/emitted-types.test.mjs
@@ -36,16 +36,6 @@ function pin(name) {
   return match[1];
 }
 
-/**
- * Escape a semver string for use inside a RegExp.
- *
- * @param {string} value A version like `5.1.6`.
- * @returns {string} The escaped pattern.
- */
-function escapeDots(value) {
-  return value.replace(/\./g, '\\.');
-}
-
 test('the Emitted Types job budget is at least 30 minutes', () => {
   const timeout = Number(/\n    timeout-minutes:\s*(\d+)/.exec(workflow)?.[1]);
 
@@ -72,9 +62,11 @@ test('type-check tools are installed once, not via three cold npx -y calls', () 
   );
   assert.match(
     workflow,
-    new RegExp(
-      `key:\\s*emitted-types-npx-\\$\\{\\{\\s*runner\\.os\\s*\\}\\}-ts${escapeDots(ts)}-publint${escapeDots(publint)}-attw${escapeDots(attw)}`
-    ),
+    /key:\s*emitted-types-npx-\$\{\{\s*runner\.os\s*\}\}-/,
+    'cache key must stay on the emitted-types-npx prefix'
+  );
+  assert.ok(
+    workflow.includes(`-ts${ts}-publint${publint}-attw${attw}`),
     'cache key must name each installed version — a stale key is a permanent miss'
   );
   assert.match(

--- a/.github/scripts/__tests__/emitted-types.test.mjs
+++ b/.github/scripts/__tests__/emitted-types.test.mjs
@@ -16,6 +16,7 @@ const WORKFLOW = readFileSync(
   path.join(repoRoot(), '.github/workflows/emitted-types.yml'),
   'utf8'
 );
+const withoutComments = WORKFLOW.replace(/#[^\n]*/g, '');
 
 test('the Emitted Types job budget is at least 30 minutes', () => {
   const timeout = Number(/timeout-minutes:\s*(\d+)/.exec(WORKFLOW)?.[1]);
@@ -27,8 +28,6 @@ test('the Emitted Types job budget is at least 30 minutes', () => {
 });
 
 test('type-check tools are installed once, not via three cold npx -y calls', () => {
-  const withoutComments = WORKFLOW.replace(/#[^\n]*/g, '');
-
   assert.match(
     WORKFLOW,
     /name: Install type-check tools/,
@@ -48,12 +47,12 @@ test('type-check tools are installed once, not via three cold npx -y calls', () 
 
 test('attw checks the typed public roots, not every exports path', () => {
   assert.match(
-    WORKFLOW,
-    /--entrypoints\s+\.\s+base\s+registry\s+settings/,
-    'attw must pass --entrypoints . base registry settings'
+    withoutComments,
+    /--entrypoints\s+\.\s+base\s+registry\s+settings\s+themes/,
+    'attw must pass --entrypoints . base registry settings themes'
   );
   assert.doesNotMatch(
-    WORKFLOW,
+    withoutComments,
     /npx\s+-y\s+@arethetypeswrong\/cli/,
     'do not invoke attw through npx -y'
   );

--- a/.github/scripts/__tests__/emitted-types.test.mjs
+++ b/.github/scripts/__tests__/emitted-types.test.mjs
@@ -45,6 +45,19 @@ test('type-check tools are installed once, not via three cold npx -y calls', () 
   );
 });
 
+test('job-level env does not use the runner context', () => {
+  // Reusable workflows reject ${{ runner.* }} in jobs.<id>.env. The caller
+  // then fails at parse time with 0 jobs, so CI Gate never reports
+  // (DEV-2783, runs 33853301602 / 33853913419).
+  const jobEnv = withoutComments.match(/\n    env:\n([\s\S]*?)\n    steps:/)?.[1] ?? '';
+
+  assert.doesNotMatch(
+    jobEnv,
+    /\$\{\{\s*runner\./,
+    'do not use ${{ runner.* }} in job-level env of a reusable workflow'
+  );
+});
+
 test('attw checks the typed public roots, not every exports path', () => {
   assert.match(
     withoutComments,

--- a/.github/scripts/__tests__/emitted-types.test.mjs
+++ b/.github/scripts/__tests__/emitted-types.test.mjs
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { repoRoot } from '../lib/repo-root.mjs';
+
+// Emitted Types is on CI Gate's `needs` list. GitHub reports a job timeout as
+// `cancelled`, and the gate treats that as a failure, so a 15-minute budget
+// that attw regularly exceeded blocked otherwise-green PRs (#13373, #13375).
+// The workflow comments record the three constraints this file pins: the
+// timeout floor, a single cached install instead of three `npx -y` downloads,
+// and attw limited to the typed public roots. A revert of any of those puts
+// the race back.
+
+const WORKFLOW = readFileSync(
+  path.join(repoRoot(), '.github/workflows/emitted-types.yml'),
+  'utf8'
+);
+
+test('the Emitted Types job budget is at least 30 minutes', () => {
+  const timeout = Number(/timeout-minutes:\s*(\d+)/.exec(WORKFLOW)?.[1]);
+
+  assert.ok(
+    timeout >= 30,
+    `timeout-minutes (${timeout}) must be >= 30 — 15 minutes cancelled on a cold npx + full-export attw`
+  );
+});
+
+test('type-check tools are installed once, not via three cold npx -y calls', () => {
+  const withoutComments = WORKFLOW.replace(/#[^\n]*/g, '');
+
+  assert.match(
+    WORKFLOW,
+    /name: Install type-check tools/,
+    'expected a single Install type-check tools step'
+  );
+  assert.match(
+    WORKFLOW,
+    /actions\/cache@/,
+    'expected an npm cache so the install is not a cold download every run'
+  );
+  assert.equal(
+    (withoutComments.match(/npx\s+-y/g) || []).length,
+    0,
+    'do not bring back per-step `npx -y` — each one is an uncached registry fetch'
+  );
+});
+
+test('attw checks the typed public roots, not every exports path', () => {
+  assert.match(
+    WORKFLOW,
+    /--entrypoints\s+\.\s+base\s+registry\s+settings/,
+    'attw must pass --entrypoints . base registry settings'
+  );
+  assert.doesNotMatch(
+    WORKFLOW,
+    /npx\s+-y\s+@arethetypeswrong\/cli/,
+    'do not invoke attw through npx -y'
+  );
+});

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -164,6 +164,7 @@ jobs:
               - './performance-tests/**'
             verify-types:
               - './handsontable/**'
+              - './.github/workflows/emitted-types.yml'
             docs-angular:
               - './docs/content/**/angular/*.ts'
               - './docs/angular-type-check/**'

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -151,6 +151,7 @@ jobs:
     uses: ./.github/workflows/emitted-types.yml
     with:
       hot-prebuilt: ${{ needs.build.outputs.umd-built == 'true' && needs.build.outputs.es-cjs-built == 'true' }}
+      attw-full: ${{ needs.checks.outputs.run-all == 'true' }}
     secrets: inherit
 
   visual:

--- a/.github/workflows/emitted-types.yml
+++ b/.github/workflows/emitted-types.yml
@@ -10,6 +10,10 @@ on:
         description: 'Both build artifacts (ES+CJS tmp + UMD dist/styles) are available'
         type: boolean
         default: false
+      attw-full:
+        description: 'Walk every exports path (trunk / run-all). PRs keep the typed roots.'
+        type: boolean
+        default: false
 
 jobs:
   check:
@@ -74,17 +78,19 @@ jobs:
         with:
           path: ~/.npm
           key: emitted-types-npx-${{ runner.os }}-ts5.1.6-publint0.3.21-attw0.18.3
+          restore-keys: emitted-types-npx-${{ runner.os }}-
       - name: Install type-check tools
         run: |
           tools="$RUNNER_TEMP/emitted-types-tools"
           mkdir -p "$tools"
           cd "$tools"
           npm init -y >/dev/null
-          npm install --no-package-lock \
+          npm install --no-package-lock --prefer-offline --no-audit --no-fund \
             typescript@5.1.6 \
             publint@0.3.21 \
             @arethetypeswrong/cli@0.18.3
-          echo "$tools/node_modules/.bin" >> "$GITHUB_PATH"
+          echo "TOOLS_BIN=$tools/node_modules/.bin" >> "$GITHUB_ENV"
+          "$tools/node_modules/.bin/tsc" --version | grep -F 'Version 5.1.6'
       - name: Type-check downleveled .d.ts with pinned TS 5.1.6
         run: |
           cd handsontable
@@ -102,23 +108,32 @@ jobs:
               include: ['tmp/**/*.d.ts']
             }, null, 2));
           "
-          tsc -p tsconfig.verify-types.json
+          "$TOOLS_BIN/tsc" -p tsconfig.verify-types.json
           rm tsconfig.verify-types.json
       - name: Check package exports and well-formedness (publint)
         run: |
           cd handsontable/tmp
-          publint
+          "$TOOLS_BIN/publint"
       - name: Check type-declaration resolution (attw)
+        env:
+          ATTW_FULL: ${{ inputs.attw-full }}
         run: |
           cd handsontable/tmp
           # attw walks every exports path × several resolution modes. The
           # package publishes ~200 of those (every plugin, language file,
           # dist/ asset). That analysis alone took ~8 minutes and, with a
-          # cold npx, blew the old 15-minute timeout. tsc already type-checks
-          # every emitted .d.ts and publint already lints the full exports
-          # map, so attw only needs the typed public roots — the dual-package
-          # pair plus settings and themes. false-export-default is Babel CJS
-          # interop.
-          attw --pack . --format table \
-            --entrypoints . base registry settings themes \
-            --ignore-rules false-export-default
+          # cold npx, blew the old 15-minute timeout. PRs check the typed
+          # public roots — tsc type-checks every emitted .d.ts and publint
+          # lints the full exports map. Trunk (run-all) walks every path so
+          # a subpath whose import condition points at a CJS-shaped
+          # declaration cannot land unnoticed. false-export-default is Babel
+          # CJS interop; untyped-resolution / no-resolution are dist/ UMD +
+          # languages (no types) and CSS/theme assets.
+          if [ "$ATTW_FULL" = "true" ]; then
+            "$TOOLS_BIN/attw" --pack . --format table \
+              --ignore-rules false-export-default untyped-resolution no-resolution
+          else
+            "$TOOLS_BIN/attw" --pack . --format table \
+              --entrypoints . base registry settings themes \
+              --ignore-rules false-export-default
+          fi

--- a/.github/workflows/emitted-types.yml
+++ b/.github/workflows/emitted-types.yml
@@ -19,7 +19,9 @@ jobs:
     # `cancelled`, and CI Gate treats that as a failure. attw on every export
     # path took ~8 minutes even when `npx -y` was fast; a cold npm day then
     # spent another 4–7 minutes per tool. 30 minutes covers a slow download
-    # plus the analysis. Do not lower this without re-timing a cold run.
+    # plus the analysis, and the non-prebuilt fallback (pnpm install + a full
+    # local `npm run build`) that runs when Build is scope-skipped. Do not
+    # lower this without re-timing a cold run of that fallback too.
     timeout-minutes: 30
     env:
       HOT_PREBUILT: ${{ inputs.hot-prebuilt }}
@@ -106,12 +108,13 @@ jobs:
         run: |
           cd handsontable/tmp
           # attw walks every exports path × several resolution modes. The
-          # package publishes ~200 of those (every plugin, language, theme,
-          # dist/ file). That analysis alone took ~8 minutes and, with a cold
-          # npx, blew the old 15-minute timeout. tsc already type-checks every
-          # emitted .d.ts and publint already lints the full exports map, so
-          # attw only needs the typed public roots — the dual-package pair
-          # plus settings. false-export-default is Babel CJS interop.
+          # package publishes ~200 of those (every plugin, language file,
+          # dist/ asset). That analysis alone took ~8 minutes and, with a
+          # cold npx, blew the old 15-minute timeout. tsc already type-checks
+          # every emitted .d.ts and publint already lints the full exports
+          # map, so attw only needs the typed public roots — the dual-package
+          # pair plus settings and themes. false-export-default is Babel CJS
+          # interop.
           attw --pack . --format table \
-            --entrypoints . base registry settings \
+            --entrypoints . base registry settings themes \
             --ignore-rules false-export-default

--- a/.github/workflows/emitted-types.yml
+++ b/.github/workflows/emitted-types.yml
@@ -25,7 +25,10 @@ jobs:
     timeout-minutes: 30
     env:
       HOT_PREBUILT: ${{ inputs.hot-prebuilt }}
-      EMITTED_TYPES_TOOLS: ${{ runner.temp }}/emitted-types-tools
+      # Do not put ${{ runner.* }} in job-level env. A reusable workflow
+      # rejects the `runner` context there, the caller fails at parse time
+      # with 0 jobs, and CI Gate never reports. $RUNNER_TEMP is set on the
+      # runner for every step — use that in the install script instead.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # https://github.com/pnpm/action-setup/releases/tag/v6.0.8
@@ -73,14 +76,15 @@ jobs:
           key: emitted-types-npx-${{ runner.os }}-ts5.1.6-publint0.3.21-attw0.18.3
       - name: Install type-check tools
         run: |
-          mkdir -p "$EMITTED_TYPES_TOOLS"
-          cd "$EMITTED_TYPES_TOOLS"
+          tools="$RUNNER_TEMP/emitted-types-tools"
+          mkdir -p "$tools"
+          cd "$tools"
           npm init -y >/dev/null
           npm install --no-package-lock \
             typescript@5.1.6 \
             publint@0.3.21 \
             @arethetypeswrong/cli@0.18.3
-          echo "$EMITTED_TYPES_TOOLS/node_modules/.bin" >> "$GITHUB_PATH"
+          echo "$tools/node_modules/.bin" >> "$GITHUB_PATH"
       - name: Type-check downleveled .d.ts with pinned TS 5.1.6
         run: |
           cd handsontable

--- a/.github/workflows/emitted-types.yml
+++ b/.github/workflows/emitted-types.yml
@@ -15,9 +15,15 @@ jobs:
   check:
     name: check
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 15 minutes was lost on #13373 / #13375: GitHub reports a job timeout as
+    # `cancelled`, and CI Gate treats that as a failure. attw on every export
+    # path took ~8 minutes even when `npx -y` was fast; a cold npm day then
+    # spent another 4–7 minutes per tool. 30 minutes covers a slow download
+    # plus the analysis. Do not lower this without re-timing a cold run.
+    timeout-minutes: 30
     env:
       HOT_PREBUILT: ${{ inputs.hot-prebuilt }}
+      EMITTED_TYPES_TOOLS: ${{ runner.temp }}/emitted-types-tools
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # https://github.com/pnpm/action-setup/releases/tag/v6.0.8
@@ -53,6 +59,26 @@ jobs:
       - name: Build Handsontable (includes downlevel:types)
         if: env.HOT_PREBUILT != 'true'
         run: npm run build --prefix handsontable
+      # Three sequential `npx -y` downloads have no cache (setup-node caches
+      # pnpm, not ~/.npm). On a slow npm day each one took several minutes and
+      # left attw no time inside the old 15-minute budget. One install into
+      # $RUNNER_TEMP, plus an npm cache keyed on the three pins, is one
+      # download on a miss and a local reuse after that.
+      - name: Cache npm for the type-check tools
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # https://github.com/actions/cache/releases/tag/v5.0.3
+        with:
+          path: ~/.npm
+          key: emitted-types-npx-${{ runner.os }}-ts5.1.6-publint0.3.21-attw0.18.3
+      - name: Install type-check tools
+        run: |
+          mkdir -p "$EMITTED_TYPES_TOOLS"
+          cd "$EMITTED_TYPES_TOOLS"
+          npm init -y >/dev/null
+          npm install --no-package-lock \
+            typescript@5.1.6 \
+            publint@0.3.21 \
+            @arethetypeswrong/cli@0.18.3
+          echo "$EMITTED_TYPES_TOOLS/node_modules/.bin" >> "$GITHUB_PATH"
       - name: Type-check downleveled .d.ts with pinned TS 5.1.6
         run: |
           cd handsontable
@@ -70,16 +96,22 @@ jobs:
               include: ['tmp/**/*.d.ts']
             }, null, 2));
           "
-          npx -y -p typescript@5.1.6 tsc -p tsconfig.verify-types.json
+          tsc -p tsconfig.verify-types.json
           rm tsconfig.verify-types.json
       - name: Check package exports and well-formedness (publint)
         run: |
           cd handsontable/tmp
-          npx -y publint@0.3.21
+          publint
       - name: Check type-declaration resolution (attw)
         run: |
           cd handsontable/tmp
-          # false-export-default — Babel CJS interop; untyped-resolution — dist/
-          # UMD + languages ship no types; no-resolution — CSS/theme assets.
-          npx -y @arethetypeswrong/cli@0.18.3 --pack . --format table \
-            --ignore-rules false-export-default untyped-resolution no-resolution
+          # attw walks every exports path × several resolution modes. The
+          # package publishes ~200 of those (every plugin, language, theme,
+          # dist/ file). That analysis alone took ~8 minutes and, with a cold
+          # npx, blew the old 15-minute timeout. tsc already type-checks every
+          # emitted .d.ts and publint already lints the full exports map, so
+          # attw only needs the typed public roots — the dual-package pair
+          # plus settings. false-export-default is Babel CJS interop.
+          attw --pack . --format table \
+            --entrypoints . base registry settings \
+            --ignore-rules false-export-default

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,6 +166,7 @@ jobs:
     with:
       # publint checks the composed package (tmp/ + dist/ + styles/) → needs both.
       hot-prebuilt: ${{ needs.build.outputs.umd-built == 'true' && needs.build.outputs.es-cjs-built == 'true' }}
+      attw-full: ${{ needs.checks.outputs.run-all == 'true' }}
     secrets: inherit
 
   performance:


### PR DESCRIPTION
### Context

The PR fixes the Emitted Types job timing out at 15 minutes and reporting as `cancelled`, which CI Gate treats as a failure and which blocked #13373 and #13375.

The job itself was fine: artifacts downloaded, `tsc@5.1.6` and `publint` passed. GitHub then killed it because `attw --pack .` walks every exports path (about 200 plugins, languages, themes, and `dist/` files) × several resolution modes — about 8 minutes with no output until the table prints — and the three `npx -y` tool downloads have no cache. On a slow npm day, `tsc` and `publint` alone took 4–7 minutes each and left attw no time. A timeout is `cancelled`, not `failure`, so the check name is "Cancelled after 15m".

The same job on #13373 succeeded the day before in 8m 36s. This is a budget problem, not a type error in those PRs.

Three changes, all in `emitted-types.yml`:

1. Raise `timeout-minutes` from 15 to 30.
2. Install `typescript@5.1.6`, `publint@0.3.21`, and `@arethetypeswrong/cli@0.18.3` once into `$RUNNER_TEMP` and cache `~/.npm`. The check steps then call the local binaries.
3. Limit attw to the typed public roots (`.`, `base`, `registry`, `settings`). `tsc` still type-checks every emitted `.d.ts`. `publint` still lints the full exports map.

[skip changelog]

### How has this been tested?

- New pin tests in `.github/scripts/__tests__/emitted-types.test.mjs` (timeout ≥ 30, one cached install, attw `--entrypoints . base registry settings`).
- Full GitHub tooling suite: `node --test .github/scripts/__tests__/*.test.mjs` — 112 passed, 0 failed.

### Test evidence (required for source changes)

- Unit tests added/modified (`*.unit.js`): none — CI/tooling only
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none
- Type tests (`*.types.ts`) updated if public API changed: none
- For a bug fix — the spec that fails without this fix: `.github/scripts/__tests__/emitted-types.test.mjs`
- Demo page / recorded trace (for UI changes): none

### Commands run

```
node --test .github/scripts/__tests__/*.test.mjs
# 112 passed, 0 failed
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2783
2. Blocks #13373
3. Blocks #13375

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2783

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/workflow-only changes with no product runtime impact; PR attw scope is narrower but full checks remain on trunk via `attw-full`.
> 
> **Overview**
> Fixes **Emitted Types** hitting the 15-minute limit (reported as `cancelled`, which fails CI Gate) by giving the job more time and cutting cold-start work.
> 
> The reusable **`emitted-types.yml`** workflow now uses a **30-minute** timeout, installs **typescript**, **publint**, and **attw** once into `$RUNNER_TEMP` with a cached **`~/.npm`** install (no per-step **`npx -y`**), and runs **attw** via **`TOOLS_BIN`**. On PRs, **attw** is limited to typed public entrypoints (`.`, `base`, `registry`, `settings`, `themes`); **`attw-full`** (wired from **`run-all`** in **`test.yml`** and **`develop.yml`**) restores the full export walk on trunk.
> 
> **`checks.yml`** adds **`emitted-types.yml`** to the **`verify-types`** path filter so workflow-only PRs still run the job. New **`emitted-types.test.mjs`** locks in these constraints (timeout floor, install/cache shape, reusable-workflow env rules, attw scope).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cf6d068396ef899301dd6c4427e5e15f86a9736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->