### PR TITLE
docs: enable moveCells in the events-and-hooks example

### DIFF
--- a/docs/content/guides/getting-started/events-and-hooks/javascript/example1.js
+++ b/docs/content/guides/getting-started/events-and-hooks/javascript/example1.js
@@ -26,6 +26,7 @@ const config = {
     comments: true,
     manualColumnMove: true,
     manualRowMove: true,
+    moveCells: true,
     licenseKey: 'non-commercial-and-evaluation',
 };
 const example1Events = document.getElementById('example1_events');

--- a/docs/content/guides/getting-started/events-and-hooks/javascript/example1.ts
+++ b/docs/content/guides/getting-started/events-and-hooks/javascript/example1.ts
@@ -28,6 +28,7 @@ const config: Handsontable.GridSettings = {
   comments: true,
   manualColumnMove: true,
   manualRowMove: true,
+  moveCells: true,
   licenseKey: 'non-commercial-and-evaluation',
 };
 


### PR DESCRIPTION
### Context
The "All available Handsontable hooks" example on the [Events and hooks](https://handsontable.com/docs/javascript-data-grid/events-and-hooks/) guide builds its hook checkbox list dynamically from every registered hook (`Handsontable.hooks.getRegistered()`), which includes `beforeMoveCells` and `afterMoveCells` (added in 18.1). But the demo grid's settings never set `moveCells: true`, so checking those two boxes and dragging a selection never logs anything — the hooks are wired up but the feature that would fire them is off.

Fix: add `moveCells: true` to the example's grid settings, matching how `manualColumnMove`/`manualRowMove` are already enabled there.

Related: DEV-2788 (ClickUp).

### Test evidence (required for source changes)
- none — docs only (example config change, no source under `handsontable/src` or `wrappers/`)

### Commands run
```
node scripts/transpile-doc-example.mjs content/guides/getting-started/events-and-hooks/javascript/example1.ts
# Wrote content/guides/getting-started/events-and-hooks/javascript/example1.js
git diff --stat
#  .../javascript/example1.js | 1 +
#  .../javascript/example1.ts | 1 +
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-2788

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.
- [x] MANUAL QA NEEDED

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only example config change with no runtime or library code impact.
> 
> **Overview**
> The **Events and hooks** “all registered hooks” demo now sets **`moveCells: true`** on the example grid (in both `example1.ts` and transpiled `example1.js`), alongside the existing row/column move options.
> 
> Without this, **`beforeMoveCells`** / **`afterMoveCells`** could be selected in the checklist but would never fire when dragging a selection, because the move-cells feature stayed disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddb43b2fd1624feaa7abd2e97253c3096d65975f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->