### PR TITLE
Docs assistant: adopt the in-band thread id (18.1 cherry-pick)

### DIFF
--- a/docs/src/components/DocsAssistant/useAssistant.ts
+++ b/docs/src/components/DocsAssistant/useAssistant.ts
@@ -122,7 +122,7 @@ function uid() {
 async function* readSSE(
   body: ReadableStream<Uint8Array>,
   signal: AbortSignal
-): AsyncGenerator<{ type: string; delta?: { content?: string } }> {
+): AsyncGenerator<{ type: string; delta?: { content?: string }; thread_id?: string }> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buf = '';
@@ -242,18 +242,29 @@ export function useAssistant() {
         }
         if (!res.body) throw new Error('No response body');
 
-        // Capture the thread id returned by the first successful turn so the
-        // backend can correlate subsequent turns to the same conversation. The
-        // server returns the same value on every turn of a conversation; the
-        // `!current` guard avoids redundant writes.
-        const returnedId = res.headers.get('X-Thread-Id');
-        if (returnedId && !threadIdRef.current) {
-          threadIdRef.current = returnedId;
-          writeThreadId(returnedId);
-        }
+        // Adopt the conversation id returned by the backend so it can
+        // correlate subsequent turns. The id arrives twice: as `thread_id` on
+        // the SSE `message_start` frame (primary — some client environments,
+        // e.g. corporate TLS-inspection proxies, strip custom response
+        // headers, but anything that delivers the stream delivers the frame)
+        // and as the `X-Thread-Id` response header (fallback). The server
+        // returns the RESOLVED id every turn — a fresh one when it discarded
+        // a stale echoed id — so always adopt it rather than keeping what we
+        // hold. Skip adoption once this request has been aborted or replaced
+        // (stop / clear / clearAndSend), so a late frame can't resurrect an
+        // id the user just cleared.
+        const adoptThreadId = (id: string | null | undefined) => {
+          if (!id || controller.signal.aborted) return;
+          if (threadIdRef.current === id) return;
+          threadIdRef.current = id;
+          writeThreadId(id);
+        };
+        adoptThreadId(res.headers.get('X-Thread-Id'));
 
         for await (const event of readSSE(res.body, controller.signal)) {
-          if (event.type === 'content_chunk') {
+          if (event.type === 'message_start') {
+            adoptThreadId(event.thread_id);
+          } else if (event.type === 'content_chunk') {
             const delta = event.delta?.content ?? '';
             if (delta) dispatch({ type: 'APPEND', id: assistantId, delta });
           } else if (event.type === 'message_end') {


### PR DESCRIPTION
## Summary
- Cherry-pick of #13352 (develop, `3e345133`) onto `prod-docs/18.1` so the live docs site ships the widget change: the assistant widget now takes its Slack thread id from the `thread_id` field on the SSE `message_start` frame, falling back to the `X-Thread-Id` header. ~40% of real-browser follow-ups were arriving with the header stripped (e.g. corporate TLS-inspection proxies), each one fragmenting the conversation into a new Slack thread — the in-band field survives anything that delivers the stream.
- Applied clean, no conflicts; one file (`docs/src/components/DocsAssistant/useAssistant.ts`).
- Backend support is already merged on the Worker's dev branch and its `dev → main` promotion is open (handsontable/docs-assistant#129); the widget change is inert-but-harmless until that ships (the header fallback keeps working either way).

[skip changelog]

## Test plan
- [x] Verified on develop via #13352 (merged 2026-09-03)
- [ ] Docs preview builds green on this PR
- [ ] After merge + docs-production deploy: a chat turn on handsontable.com/docs keeps one Slack thread across follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only docs widget threading logic; header fallback preserves prior behavior until the backend emits in-band `thread_id`.
> 
> **Overview**
> The docs assistant widget now keeps Slack conversations on one thread when **`X-Thread-Id`** is stripped (e.g. corporate TLS proxies) by reading **`thread_id`** from the SSE **`message_start`** frame, with the response header as fallback.
> 
> **`adoptThreadId`** centralizes persistence: it updates **`threadIdRef`** and localStorage whenever the backend sends a resolved id (including replacements for stale echoed ids), not only on the first turn. Adoption is skipped if the request was aborted so a late frame cannot restore an id after **stop**, **clear**, or **clearAndSend**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9af84c065cde4264fac03ff4359663714e776ea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->