### PR TITLE
DEV-2629: Force a GC between perf iterations and record the live heap

### DIFF
--- a/.claude/skills/performance-testing/SKILL.md
+++ b/.claude/skills/performance-testing/SKILL.md
@@ -204,7 +204,7 @@ These combine `scrollViewportTo()` with a deterministic `waitForFunction` that c
 | initial-load | 100000x100 | `new Handsontable(...)` | Grid construction only |
 | source-data-validator-load | 100000x100 | `new Handsontable(...)` with `sourceDataValidator` | initial-load's fixture plus the one option |
 
-Iterations: 3 for the scroll and cell-editing scenarios, 5 for filtering, sorting, initial-load and source-data-validator-load. Those four have 50 to 150 ms windows on a 300 MB heap, where one GC pause inside the window moves a mean of three by 10 to 20%, and their iterations are cheap next to the fixture load. Do not raise the scroll scenarios: each iteration is 500 wheel round trips.
+Iterations: 3 for the scroll and cell-editing scenarios, 5 for filtering, sorting, initial-load and source-data-validator-load. Each of those four states its own reason in its `scenario.config.mjs` (short windows on a 300 to 350 MB heap where one GC pause moves a mean of three by 10 to 20%; for `source-data-validator-load`, a 20% run-to-run spread after removing the runner factor), and their iterations are cheap next to the fixture load. `lib/__tests__/scenario-configs.test.mjs` pins the counts, so change the config and the test together. Do not raise the scroll scenarios: each iteration is 500 wheel round trips.
 
 ## Run Commands
 
@@ -266,8 +266,9 @@ Everything published describes the slice between the two `performance.mark`s tha
   `scrollToRow`/`scrollToColumn` report trimming, not scroll position, so their
   `waitForFunction` returns before the scroll has rendered.
 
-A category measured as exactly `0`, or a CV of `141.42%` (the CV of `{x, 0, 0}` at three
-iterations), means the window is wrong -- not that the operation was cheap.
+A category measured as exactly `0`, or a CV of `sqrt(n - 1) × 100%` (one nonzero iteration among
+zeros: `141.42%` at three iterations, `200%` at five), means the window is wrong -- not that the
+operation was cheap.
 
 1. **Spec** calls `runTracedScenario()` -> forced GC (over a control CDP session), CDP `Tracing.start`, start mark, action, settle, end mark, `afterActionFn`, forced GC + `Runtime.getHeapUsage` readback, `Tracing.end` -> raw JSON per iteration, plus `heap-after-gc.json` for the scenario. The GC before tracing keeps the previous reset's garbage out of the window (initial-load's third iteration read ~50% slower than its first two before it); the readback after the end mark is the live set, recorded as `updateCounters.jsHeapAfterGcBytes`. Both are part of `HARNESS_VERSION` 2.
 2. **Teardown** (`lib/teardown.mjs`) discovers `output/*/iteration-*.json`, calls `parseTrace()` from `trace-parser.mjs`

--- a/.claude/skills/performance-testing/SKILL.md
+++ b/.claude/skills/performance-testing/SKILL.md
@@ -204,6 +204,8 @@ These combine `scrollViewportTo()` with a deterministic `waitForFunction` that c
 | initial-load | 100000x100 | `new Handsontable(...)` | Grid construction only |
 | source-data-validator-load | 100000x100 | `new Handsontable(...)` with `sourceDataValidator` | initial-load's fixture plus the one option |
 
+Iterations: 3 for the scroll and cell-editing scenarios, 5 for filtering, sorting, initial-load and source-data-validator-load. Those four have 50 to 150 ms windows on a 300 MB heap, where one GC pause inside the window moves a mean of three by 10 to 20%, and their iterations are cheap next to the fixture load. Do not raise the scroll scenarios: each iteration is 500 wheel round trips.
+
 ## Run Commands
 
 ```bash
@@ -267,7 +269,7 @@ Everything published describes the slice between the two `performance.mark`s tha
 A category measured as exactly `0`, or a CV of `141.42%` (the CV of `{x, 0, 0}` at three
 iterations), means the window is wrong -- not that the operation was cheap.
 
-1. **Spec** calls `runTracedScenario()` -> CDP `Tracing.start`, start mark, action, settle, end mark, `Tracing.end` -> raw JSON per iteration
+1. **Spec** calls `runTracedScenario()` -> forced GC (over a control CDP session), CDP `Tracing.start`, start mark, action, settle, end mark, `afterActionFn`, forced GC + `Runtime.getHeapUsage` readback, `Tracing.end` -> raw JSON per iteration, plus `heap-after-gc.json` for the scenario. The GC before tracing keeps the previous reset's garbage out of the window (initial-load's third iteration read ~50% slower than its first two before it); the readback after the end mark is the live set, recorded as `updateCounters.jsHeapAfterGcBytes`. Both are part of `HARNESS_VERSION` 2.
 2. **Teardown** (`lib/teardown.mjs`) discovers `output/*/iteration-*.json`, calls `parseTrace()` from `trace-parser.mjs`
 3. **trace-parser.mjs** categorizes events into DevTools categories (scripting, rendering, painting, loading, system, idle), measures the window `runTracedScenario()` marked around the action (falling back to the auto-zoomed window only for traces recorded without marks), synthesizes ProfileCall scripting from CPU profile data
 4. **Teardown** averages across iterations via `averageParsedTraces()`, collects per-iteration values for CV% calculation, strips internal fields (`_iterationValues`, `_debug`) from saved snapshots

--- a/.claude/skills/performance-testing/SKILL.md
+++ b/.claude/skills/performance-testing/SKILL.md
@@ -59,11 +59,14 @@ export default {
   name: 'my-scenario',
   warmupRuns: 1,
   iterations: 3,
-  // Bump when this spec changes what the marked window contains: the median baseline only draws on
-  // develop goldens recorded at the same version (see lib/environment.mjs).
+  // Bump when this spec changes what the marked window contains, or when `iterations` changes: the
+  // median baseline only draws on develop goldens recorded at the same version (see
+  // lib/environment.mjs).
   measurementVersion: 1,
 };
 ```
+
+`measurementVersion` covers everything scenario-local that changes the published number or its spread: the window's contents, and the iteration count (a mean of five and a mean of three have the same expected value but different spreads, and `CV run` would mean something different per row). `HARNESS_VERSION` covers runner-wide changes. When both change in one PR, the harness bump already restarts the whole golden pool and the scenario bump is not needed on top; say so in the config comment.
 
 The `name` must match the directory name -- it determines the `output/<name>/` subdirectory, and the teardown reads `measurementVersion` from the config by that name. Add a comment documenting the grid size and why it was chosen.
 
@@ -266,9 +269,9 @@ Everything published describes the slice between the two `performance.mark`s tha
   `scrollToRow`/`scrollToColumn` report trimming, not scroll position, so their
   `waitForFunction` returns before the scroll has rendered.
 
-A category measured as exactly `0`, or a CV of `sqrt(n - 1) × 100%` (one nonzero iteration among
-zeros: `141.42%` at three iterations, `200%` at five), means the window is wrong -- not that the
-operation was cheap.
+A category measured as exactly `0`, or a CV of `sqrt(n) × 100%` (one nonzero iteration among
+zeros, with the sample standard deviation `calcCv` uses: `173.21%` at three iterations, `223.61%`
+at five), means the window is wrong -- not that the operation was cheap.
 
 1. **Spec** calls `runTracedScenario()` -> forced GC (over a control CDP session), CDP `Tracing.start`, start mark, action, settle, end mark, `afterActionFn`, forced GC + `Runtime.getHeapUsage` readback, `Tracing.end` -> raw JSON per iteration, plus `heap-after-gc.json` for the scenario. The GC before tracing keeps the previous reset's garbage out of the window (initial-load's third iteration read ~50% slower than its first two before it); the readback after the end mark is the live set, recorded as `updateCounters.jsHeapAfterGcBytes`. Both are part of `HARNESS_VERSION` 2.
 2. **Teardown** (`lib/teardown.mjs`) discovers `output/*/iteration-*.json`, calls `parseTrace()` from `trace-parser.mjs`

--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -158,9 +158,9 @@ Two rules follow for anyone writing or changing a scenario:
   `scrollToColumn` wait on trimming, not scroll position, so they return before the scroll
   has rendered; the settle is what makes those resets deterministic.
 
-A category measured as exactly `0`, or a CV of `sqrt(n - 1) × 100%` (one nonzero iteration among
-zeros: `141.42%` at three iterations, `200%` at five), means the window is wrong -- not that the
-operation was cheap.
+A category measured as exactly `0`, or a CV of `sqrt(n) × 100%` (one nonzero iteration among
+zeros, with the sample standard deviation `calcCv` uses: `173.21%` at three iterations, `223.61%`
+at five), means the window is wrong -- not that the operation was cheap.
 
 ### Golden baseline workflow
 

--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -83,7 +83,7 @@ Each scenario measures a specific user interaction pattern:
 | **initial-load** | 100000 x 100 | `new Handsontable(...)` | Grid construction only |
 | **source-data-validator-load** | 100000 x 100 | `new Handsontable(...)` with `sourceDataValidator` | Same fixture as initial-load plus the one option |
 
-Each scenario runs **1 warmup iteration** (discarded) followed by **3 measured iterations** with CDP tracing. The four short-window scenarios (filtering, sorting, initial-load, source-data-validator-load) run **5**: their windows are 50 to 150 ms on a 300 MB heap, where one GC pause moves a mean of three by 10 to 20%, and their iterations cost seconds next to the fixture load. The runner forces a full GC before every measured iteration, so garbage from the previous reset is never collected inside the next window, and reads the live heap after every end mark (`jsHeapAfterGcBytes`, recorded beside the windowed extrema).
+Each scenario runs **1 warmup iteration** (discarded) followed by **3 measured iterations** with CDP tracing. Four scenarios (filtering, sorting, initial-load, source-data-validator-load) run **5**; each states its own reason in its `scenario.config.mjs` (short windows on a 300 to 350 MB heap where one GC pause moves a mean of three by 10 to 20%; for `source-data-validator-load`, a 20% run-to-run spread after removing the runner factor), and their iterations cost seconds next to the fixture load. The runner forces a full GC before every measured iteration, so garbage from the previous reset is never collected inside the next window, and reads the live heap after every end mark (`jsHeapAfterGcBytes`, recorded beside the windowed extrema).
 
 ## Project structure
 
@@ -158,8 +158,9 @@ Two rules follow for anyone writing or changing a scenario:
   `scrollToColumn` wait on trimming, not scroll position, so they return before the scroll
   has rendered; the settle is what makes those resets deterministic.
 
-A category measured as exactly `0`, or a CV of `141.42%` (the CV of `{x, 0, 0}` at three
-iterations), means the window is wrong -- not that the operation was cheap.
+A category measured as exactly `0`, or a CV of `sqrt(n - 1) × 100%` (one nonzero iteration among
+zeros: `141.42%` at three iterations, `200%` at five), means the window is wrong -- not that the
+operation was cheap.
 
 ### Golden baseline workflow
 

--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -83,7 +83,7 @@ Each scenario measures a specific user interaction pattern:
 | **initial-load** | 100000 x 100 | `new Handsontable(...)` | Grid construction only |
 | **source-data-validator-load** | 100000 x 100 | `new Handsontable(...)` with `sourceDataValidator` | Same fixture as initial-load plus the one option |
 
-Each scenario runs **1 warmup iteration** (discarded) followed by **3 measured iterations** with CDP tracing.
+Each scenario runs **1 warmup iteration** (discarded) followed by **3 measured iterations** with CDP tracing. The four short-window scenarios (filtering, sorting, initial-load, source-data-validator-load) run **5**: their windows are 50 to 150 ms on a 300 MB heap, where one GC pause moves a mean of three by 10 to 20%, and their iterations cost seconds next to the fixture load. The runner forces a full GC before every measured iteration, so garbage from the previous reset is never collected inside the next window, and reads the live heap after every end mark (`jsHeapAfterGcBytes`, recorded beside the windowed extrema).
 
 ## Project structure
 
@@ -185,7 +185,7 @@ The report includes these categories (matching the DevTools Performance panel):
 | **Idle** | Time between tasks |
 
 Additional metrics from `UpdateCounters`:
-- JS heap size (min/max)
+- JS heap size (min/max), plus the live heap after a forced GC once the end mark is down (`JS heap after GC` in the HTML memory table; informational until enough goldens carry it to derive a threshold, the gate stays on the max)
 - DOM node count (min/max)
 - Event listener count (min/max)
 
@@ -197,7 +197,7 @@ of variation over the sample standard deviation, and both are flagged above `CV_
 
 | Column | What it measures | Typical value |
 |---|---|---|
-| **CV run** | How much the three iterations of this one run disagreed | under 4% on most scenarios |
+| **CV run** | How much the iterations of this one run disagreed | under 4% on most scenarios |
 | **CV base** | How far apart the develop runs behind the median baseline sit | 11-19% |
 
 A tight `CV run` says the run measured itself consistently. It says nothing about whether the run is

--- a/performance-tests/lib/__tests__/heap-after-gc.test.mjs
+++ b/performance-tests/lib/__tests__/heap-after-gc.test.mjs
@@ -1,0 +1,66 @@
+// Unit tests for the live-heap reading the runner takes after each end mark.
+//
+// The gate today is jsHeapMaxBytes, the highest sample inside the window, which on the scroll
+// scenarios tracks where V8 scheduled a GC rather than what the grid retains. The post-GC reading is
+// meant to replace it once enough goldens carry it. These cases pin the summary shape the teardown
+// folds into updateCounters, and that a scenario with no successful readback writes nothing -- so it
+// looks like one recorded before the field existed rather than one that measured zero.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { rm, mkdtemp, readFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { HEAP_AFTER_GC_FILE, saveHeapAfterGc, summarizeHeapAfterGc } from '../heap-after-gc.mjs';
+
+describe('summarizeHeapAfterGc', () => {
+  test('averages the finite readings and keeps every per-iteration value, nulls included', () => {
+    const summary = summarizeHeapAfterGc([100, null, 200]);
+
+    assert.equal(summary.averageBytes, 150);
+    assert.deepEqual(summary.values, [100, null, 200]);
+  });
+
+  test('has no average when nothing was read', () => {
+    assert.equal(summarizeHeapAfterGc([null, null]).averageBytes, null);
+    assert.equal(summarizeHeapAfterGc([]).averageBytes, null);
+    assert.equal(summarizeHeapAfterGc(undefined).averageBytes, null);
+  });
+
+  test('does not share the caller\'s array', () => {
+    const values = [1, 2];
+    const summary = summarizeHeapAfterGc(values);
+
+    values.push(3);
+    assert.deepEqual(summary.values, [1, 2]);
+  });
+});
+
+describe('saveHeapAfterGc', () => {
+  test('writes the summary beside the traces', async() => {
+    const dir = await mkdtemp(join(tmpdir(), 'perf-heap-'));
+
+    try {
+      await saveHeapAfterGc(dir, [3_000_000, 3_500_000]);
+
+      const saved = JSON.parse(await readFile(join(dir, HEAP_AFTER_GC_FILE), 'utf8'));
+
+      assert.equal(saved.averageBytes, 3_250_000);
+      assert.deepEqual(saved.values, [3_000_000, 3_500_000]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('writes nothing when every readback failed', async() => {
+    const dir = await mkdtemp(join(tmpdir(), 'perf-heap-'));
+
+    try {
+      await saveHeapAfterGc(dir, [null, null, null]);
+
+      assert.deepEqual(await readdir(dir), []);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/performance-tests/lib/__tests__/heap-after-gc.test.mjs
+++ b/performance-tests/lib/__tests__/heap-after-gc.test.mjs
@@ -14,15 +14,19 @@ import { join } from 'node:path';
 import { HEAP_AFTER_GC_FILE, saveHeapAfterGc, summarizeHeapAfterGc } from '../heap-after-gc.mjs';
 
 describe('summarizeHeapAfterGc', () => {
-  test('averages the finite readings and keeps every per-iteration value, nulls included', () => {
+  test('averages the finite readings, counts them, and keeps every per-iteration value, nulls included', () => {
     const summary = summarizeHeapAfterGc([100, null, 200]);
 
     assert.equal(summary.averageBytes, 150);
+    // Two of three: a consumer can tell this from a three-sample average, which the average alone
+    // cannot say.
+    assert.equal(summary.readCount, 2);
     assert.deepEqual(summary.values, [100, null, 200]);
   });
 
-  test('has no average when nothing was read', () => {
+  test('has no average and a zero count when nothing was read', () => {
     assert.equal(summarizeHeapAfterGc([null, null]).averageBytes, null);
+    assert.equal(summarizeHeapAfterGc([null, null]).readCount, 0);
     assert.equal(summarizeHeapAfterGc([]).averageBytes, null);
     assert.equal(summarizeHeapAfterGc(undefined).averageBytes, null);
   });
@@ -46,6 +50,7 @@ describe('saveHeapAfterGc', () => {
       const saved = JSON.parse(await readFile(join(dir, HEAP_AFTER_GC_FILE), 'utf8'));
 
       assert.equal(saved.averageBytes, 3_250_000);
+      assert.equal(saved.readCount, 2);
       assert.deepEqual(saved.values, [3_000_000, 3_500_000]);
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/performance-tests/lib/__tests__/html-report-builder-provenance.test.mjs
+++ b/performance-tests/lib/__tests__/html-report-builder-provenance.test.mjs
@@ -158,6 +158,79 @@ describe('buildHtmlReport -- environment and refusal', () => {
   });
 });
 
+describe('buildHtmlReport -- JS heap after GC', () => {
+  const withAfterGc = (bytes, label) => current(100, {
+    updateCounters: {
+      jsHeapMaxBytes: 100_000_000, jsHeapMaxLabel: '100 MB', jsHeapAfterGcBytes: bytes, jsHeapAfterGcLabel: label,
+    },
+  });
+
+  test('renders the live-heap row with its delta when both sides carry it', () => {
+    const data = payloadOf(buildHtmlReport(
+      { a: withAfterGc(55_000_000, '55.0 MB') },
+      {
+        timestamp: 't',
+        scenarios: {
+          a: golden({
+            updateCounters: {
+              jsHeapMaxBytes: 100_000_000,
+              jsHeapMaxLabel: '100 MB',
+              jsHeapAfterGcBytes: 50_000_000,
+              jsHeapAfterGcLabel: '50.0 MB',
+            },
+          }),
+        },
+      },
+      {}
+    ));
+    const row = data.scenarios[0].memory.find(r => r.label === 'JS heap after GC');
+
+    assert.equal(row.currentDisplay, '55.0 MB');
+    assert.equal(row.baselineDisplay, '50.0 MB');
+    assert.ok(Math.abs(row.change - 10) < 1e-9);
+  });
+
+  test('renders the row without a delta against a baseline recorded before the field existed', () => {
+    const data = payloadOf(buildHtmlReport(
+      { a: withAfterGc(55_000_000, '55.0 MB') }, { timestamp: 't', scenarios: { a: golden() } }, {}
+    ));
+    const row = data.scenarios[0].memory.find(r => r.label === 'JS heap after GC');
+
+    assert.equal(row.currentDisplay, '55.0 MB');
+    assert.equal(row.baselineDisplay, '--');
+    assert.equal(row.change, null);
+  });
+
+  test('omits the row when neither side carries it', () => {
+    const data = payloadOf(buildHtmlReport({ a: current(100) }, { timestamp: 't', scenarios: { a: golden() } }, {}));
+
+    assert.equal(data.scenarios[0].memory.some(r => r.label === 'JS heap after GC'), false);
+  });
+
+  test('the gate still runs on the windowed maximum, not on the live heap', () => {
+    // Live heap doubled, max flat: no regression is called.
+    const data = payloadOf(buildHtmlReport(
+      { a: withAfterGc(100_000_000, '100 MB') },
+      {
+        timestamp: 't',
+        scenarios: {
+          a: golden({
+            updateCounters: {
+              jsHeapMaxBytes: 100_000_000,
+              jsHeapMaxLabel: '100 MB',
+              jsHeapAfterGcBytes: 50_000_000,
+              jsHeapAfterGcLabel: '50.0 MB',
+            },
+          }),
+        },
+      },
+      {}
+    ));
+
+    assert.equal(data.scenarios[0].isRegression, false);
+  });
+});
+
 describe('buildHtmlReport -- per-scenario heap threshold', () => {
   test('each scenario carries its own heap threshold and is gated on it', () => {
     const between = (heapThresholdFor('scroll-left') + REGRESSION_CALLOUT_THRESHOLD_HEAP) / 2;

--- a/performance-tests/lib/__tests__/html-report-builder-provenance.test.mjs
+++ b/performance-tests/lib/__tests__/html-report-builder-provenance.test.mjs
@@ -7,7 +7,7 @@ import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import { buildHtmlReport } from '../html-report-builder.mjs';
 import { buildReport } from '../report-builder.mjs';
-import { REGRESSION_CALLOUT_THRESHOLD_HEAP, heapThresholdFor } from '../thresholds.mjs';
+import { INCOMPARABLE_LABELS, REGRESSION_CALLOUT_THRESHOLD_HEAP, heapThresholdFor } from '../thresholds.mjs';
 
 /**
  * @param {string} html
@@ -199,6 +199,60 @@ describe('buildHtmlReport -- JS heap after GC', () => {
     assert.equal(row.currentDisplay, '55.0 MB');
     assert.equal(row.baselineDisplay, '--');
     assert.equal(row.change, null);
+  });
+
+  test('the row is informational: it states its delta without a verdict', () => {
+    const data = payloadOf(buildHtmlReport(
+      { a: withAfterGc(57_000_000, '57.0 MB') },
+      {
+        timestamp: 't',
+        scenarios: {
+          a: golden({
+            updateCounters: {
+              jsHeapMaxBytes: 100_000_000,
+              jsHeapMaxLabel: '100 MB',
+              jsHeapAfterGcBytes: 50_000_000,
+              jsHeapAfterGcLabel: '50.0 MB',
+            },
+          }),
+        },
+      },
+      {}
+    ));
+    const rows = data.scenarios[0].memory;
+
+    // +14% on the live set, well past every heap band, and still neutral; the max row is not.
+    assert.equal(rows.find(r => r.label === 'JS heap after GC').neutral, true);
+    assert.equal(rows.find(r => r.label === 'Max JS heap').neutral, false);
+  });
+
+  test('a baseline that carries the field while this run does not is a failed capture, not a blank', () => {
+    const data = payloadOf(buildHtmlReport(
+      { a: current(100) },
+      {
+        timestamp: 't',
+        scenarios: {
+          a: golden({
+            updateCounters: {
+              jsHeapMaxBytes: 100_000_000,
+              jsHeapMaxLabel: '100 MB',
+              jsHeapAfterGcBytes: 50_000_000,
+              jsHeapAfterGcLabel: '50.0 MB',
+            },
+          }),
+        },
+      },
+      {}
+    ));
+    const row = data.scenarios[0].memory.find(r => r.label === 'JS heap after GC');
+
+    assert.equal(row.baselineDisplay, '50.0 MB');
+    assert.equal(row.currentDisplay, '--');
+    assert.equal(row.change, null);
+    assert.equal(row.incomplete, true);
+    assert.equal(row.incompleteLabel, INCOMPARABLE_LABELS['current-incomplete']);
+    // The scenario itself is still comparable: only this row's capture failed.
+    assert.equal(data.scenarios[0].baselineIncomplete, false);
   });
 
   test('omits the row when neither side carries it', () => {

--- a/performance-tests/lib/__tests__/median-snapshot.test.mjs
+++ b/performance-tests/lib/__tests__/median-snapshot.test.mjs
@@ -145,6 +145,31 @@ describe('computeMedianSnapshot', () => {
     assert.equal(result.scenarios.sorting.updateCounters.jsHeapMaxBytes, 2_000_002);
   });
 
+  test('medians the post-GC heap over the entries that carry it, and omits it when none do', () => {
+    const withField = computeMedianSnapshot([
+      snapshot('2026-08-28T00:00:00Z', {
+        sorting: { updateCounters: { ...DEFAULT_UPDATE_COUNTERS, jsHeapAfterGcBytes: 1_500_000 } },
+      }),
+      snapshot('2026-08-29T00:00:00Z', {
+        sorting: { updateCounters: { ...DEFAULT_UPDATE_COUNTERS, jsHeapAfterGcBytes: 1_700_000 } },
+      }),
+      // Recorded before the runner read the live heap: contributes to min/max, not to this field.
+      snapshot('2026-08-30T00:00:00Z'),
+    ]);
+
+    assert.equal(withField.scenarios.sorting.updateCounters.jsHeapAfterGcBytes, 1_600_000);
+    assert.equal(withField.scenarios.sorting.updateCounters.jsHeapAfterGcLabel, '1.6 MB');
+    assert.equal(withField.scenarios.sorting.updateCounters.jsHeapMaxBytes, 2_000_000);
+
+    const without = computeMedianSnapshot([
+      snapshot('2026-08-28T00:00:00Z'),
+      snapshot('2026-08-29T00:00:00Z'),
+    ]);
+
+    assert.equal('jsHeapAfterGcBytes' in without.scenarios.sorting.updateCounters, false);
+    assert.equal('jsHeapAfterGcLabel' in without.scenarios.sorting.updateCounters, false);
+  });
+
   test('regenerates the heap labels from the medianed bytes', () => {
     const result = computeMedianSnapshot([
       snapshot('2026-08-28T00:00:00Z'),

--- a/performance-tests/lib/__tests__/median-snapshot.test.mjs
+++ b/performance-tests/lib/__tests__/median-snapshot.test.mjs
@@ -170,6 +170,21 @@ describe('computeMedianSnapshot', () => {
     assert.equal('jsHeapAfterGcLabel' in without.scenarios.sorting.updateCounters, false);
   });
 
+  test('applies the MIN_VALID_SNAPSHOTS floor to the post-GC heap per field', () => {
+    // Four of five windowed goldens had failing readbacks: one run's live heap must not sit beside a
+    // true median of five for the max under a "median of 5" label.
+    const one = computeMedianSnapshot([
+      snapshot('2026-08-28T00:00:00Z', {
+        sorting: { updateCounters: { ...DEFAULT_UPDATE_COUNTERS, jsHeapAfterGcBytes: 1_500_000 } },
+      }),
+      snapshot('2026-08-29T00:00:00Z'),
+      snapshot('2026-08-30T00:00:00Z'),
+    ]);
+
+    assert.equal('jsHeapAfterGcBytes' in one.scenarios.sorting.updateCounters, false);
+    assert.equal(one.scenarios.sorting.updateCounters.jsHeapMaxBytes, 2_000_000);
+  });
+
   test('regenerates the heap labels from the medianed bytes', () => {
     const result = computeMedianSnapshot([
       snapshot('2026-08-28T00:00:00Z'),

--- a/performance-tests/lib/__tests__/scenario-configs.test.mjs
+++ b/performance-tests/lib/__tests__/scenario-configs.test.mjs
@@ -1,0 +1,95 @@
+// Pins the scenario configs against what the docs and the teardown assume about them.
+//
+// The config `name` must match its directory (the teardown resolves `output/<name>/` back to
+// `scenarios/<name>/scenario.config.mjs` to read `measurementVersion`), every scenario declares a
+// numeric `measurementVersion`, and the iteration counts the skill and the README quote are the ones
+// in force -- a fifth scenario at five iterations, or a count changed in one place, fails here rather
+// than drifting the prose.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ROOT = join(import.meta.dirname, '..', '..');
+const SCENARIOS_DIR = join(ROOT, 'scenarios');
+const SKILL_DOC = join(ROOT, '..', '.claude', 'skills', 'performance-testing', 'SKILL.md');
+const README = join(ROOT, 'README.md');
+
+// The short-window scenarios that run five iterations; everything else runs three.
+const FIVE_ITERATIONS = ['filtering', 'initial-load', 'sorting', 'source-data-validator-load'];
+
+/**
+ * @returns {Promise<Array<{ dir: string, config: object }>>}
+ */
+async function loadConfigs() {
+  const dirs = (await readdir(SCENARIOS_DIR, { withFileTypes: true }))
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .sort();
+
+  return Promise.all(dirs.map(async(dir) => {
+    const { default: config } = await import(
+      pathToFileURL(join(SCENARIOS_DIR, dir, 'scenario.config.mjs')).href
+    );
+
+    return { dir, config };
+  }));
+}
+
+describe('scenario configs', () => {
+  test('every config names its own directory and declares a numeric measurementVersion', async() => {
+    const configs = await loadConfigs();
+
+    assert.ok(configs.length >= 9);
+
+    for (const { dir, config } of configs) {
+      assert.equal(config.name, dir, `${dir}/scenario.config.mjs names "${config.name}"`);
+      assert.equal(typeof config.measurementVersion, 'number', `${dir} declares measurementVersion`);
+      assert.ok(Number.isInteger(config.measurementVersion) && config.measurementVersion >= 1, dir);
+    }
+  });
+
+  test('the four short-window scenarios run five iterations and the rest run three', async() => {
+    const configs = await loadConfigs();
+
+    for (const { dir, config } of configs) {
+      const expected = FIVE_ITERATIONS.includes(dir) ? 5 : 3;
+
+      assert.equal(config.iterations, expected, `${dir} runs ${expected} iterations`);
+      assert.equal(config.warmupRuns, 1, `${dir} runs one warmup`);
+    }
+  });
+
+  test('the docs name exactly the five-iteration scenarios', async() => {
+    for (const path of [SKILL_DOC, README]) {
+      const text = await readFile(path, 'utf8');
+      const sentence = text.split('\n').find(line => /run \*\*5\*\*|Iterations: 3 for/.test(line));
+
+      assert.ok(sentence, `${path} states the iteration counts`);
+
+      // Only the clause that lists the five-iteration scenarios: the skill sentence also names the
+      // three-iteration ones ("3 for the scroll and cell-editing scenarios, 5 for ..."), and the
+      // README lists the four in the parentheses right before "run **5**".
+      const fiveMarker = sentence.includes('Iterations: 3 for') ? '5 for ' : 'run **5**';
+      const markerAt = sentence.indexOf(fiveMarker);
+      const fiveClause = fiveMarker === '5 for '
+        ? sentence.slice(markerAt, sentence.indexOf('.', markerAt))
+        : sentence.slice(sentence.lastIndexOf('(', markerAt), markerAt);
+
+      for (const name of FIVE_ITERATIONS) {
+        assert.ok(fiveClause.includes(name), `${path} lists ${name} among the five-iteration scenarios`);
+      }
+
+      // No other scenario is claimed to run five.
+      const configs = await loadConfigs();
+
+      for (const { dir } of configs) {
+        if (!FIVE_ITERATIONS.includes(dir)) {
+          assert.ok(!fiveClause.includes(dir), `${path} does not list ${dir} among the five-iteration scenarios`);
+        }
+      }
+    }
+  });
+});

--- a/performance-tests/lib/__tests__/sidecar.test.mjs
+++ b/performance-tests/lib/__tests__/sidecar.test.mjs
@@ -1,0 +1,34 @@
+// The one writer and reader for the per-scenario sidecar files (hook-timing.json, heap-after-gc.json).
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { rm, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readSidecar, writeSidecar } from '../sidecar.mjs';
+
+describe('writeSidecar / readSidecar', () => {
+  test('round-trips a document, creating the directory on the way', async() => {
+    const dir = await mkdtemp(join(tmpdir(), 'perf-sidecar-'));
+
+    try {
+      const nested = join(dir, 'scenario');
+
+      await writeSidecar(nested, 'thing.json', { a: 1, values: [1, null] });
+
+      assert.deepEqual(await readSidecar(nested, 'thing.json'), { a: 1, values: [1, null] });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('reads null, not an error, for a sidecar that was never written', async() => {
+    const dir = await mkdtemp(join(tmpdir(), 'perf-sidecar-'));
+
+    try {
+      assert.equal(await readSidecar(dir, 'missing.json'), null);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/performance-tests/lib/heap-after-gc.mjs
+++ b/performance-tests/lib/heap-after-gc.mjs
@@ -1,0 +1,45 @@
+// The JS heap that survives a forced garbage collection after the action -- the live set.
+//
+// `jsHeapMaxBytes` (the gate today) is the highest sample inside the window, which on the scroll
+// scenarios depends on where V8 scheduled a GC during 500 renders rather than on what the grid
+// retains. The live set has no such dependence: the runner forces a full GC once the end mark is
+// down and reads the heap that is left, per iteration. Recorded alongside the max for now; it can
+// become the gate once enough goldens carry it to derive a threshold from (scripts/replay-goldens.mjs).
+
+import { writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export const HEAP_AFTER_GC_FILE = 'heap-after-gc.json';
+
+/**
+ * @param {Array<number | null>} values -- per-iteration used heap after GC, in bytes; null where
+ *   the readback failed for that iteration
+ * @returns {{ averageBytes: number | null, values: Array<number | null> }}
+ */
+export function summarizeHeapAfterGc(values) {
+  const finite = (values || []).filter(v => typeof v === 'number' && Number.isFinite(v));
+
+  return {
+    averageBytes: finite.length > 0 ? finite.reduce((a, b) => a + b, 0) / finite.length : null,
+    values: [...(values || [])],
+  };
+}
+
+/**
+ * Persists the per-iteration readings alongside the traces, for the teardown to fold into the
+ * scenario's `updateCounters`. Nothing is written when no iteration produced a reading, so a
+ * scenario whose readback failed throughout looks like one recorded before the field existed.
+ *
+ * @param {string} outputDir -- scenario output directory
+ * @param {Array<number | null>} values
+ */
+export async function saveHeapAfterGc(outputDir, values) {
+  const summary = summarizeHeapAfterGc(values);
+
+  if (summary.averageBytes === null) {
+    return;
+  }
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(join(outputDir, HEAP_AFTER_GC_FILE), JSON.stringify(summary, null, 2), 'utf8');
+}

--- a/performance-tests/lib/heap-after-gc.mjs
+++ b/performance-tests/lib/heap-after-gc.mjs
@@ -2,25 +2,27 @@
 //
 // `jsHeapMaxBytes` (the gate today) is the highest sample inside the window, which on the scroll
 // scenarios depends on where V8 scheduled a GC during 500 renders rather than on what the grid
-// retains. The live set has no such dependence: the runner forces a full GC once the end mark is
-// down and reads the heap that is left, per iteration. Recorded alongside the max for now; it can
+// retains. The live set has no such dependence: the runner forces a full GC once the trace is
+// stopped and reads the heap that is left, per iteration. Recorded alongside the max for now; it can
 // become the gate once enough goldens carry it to derive a threshold from (scripts/replay-goldens.mjs).
 
-import { writeFile, mkdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { writeSidecar } from './sidecar.mjs';
 
 export const HEAP_AFTER_GC_FILE = 'heap-after-gc.json';
 
 /**
  * @param {Array<number | null>} values -- per-iteration used heap after GC, in bytes; null where
  *   the readback failed for that iteration
- * @returns {{ averageBytes: number | null, values: Array<number | null> }}
+ * @returns {{ averageBytes: number | null, readCount: number, values: Array<number | null> }}
+ *   `readCount` is how many iterations produced a reading, so a consumer can tell a five-sample
+ *   average from a one-sample one
  */
 export function summarizeHeapAfterGc(values) {
   const finite = (values || []).filter(v => typeof v === 'number' && Number.isFinite(v));
 
   return {
     averageBytes: finite.length > 0 ? finite.reduce((a, b) => a + b, 0) / finite.length : null,
+    readCount: finite.length,
     values: [...(values || [])],
   };
 }
@@ -40,6 +42,5 @@ export async function saveHeapAfterGc(outputDir, values) {
     return;
   }
 
-  await mkdir(outputDir, { recursive: true });
-  await writeFile(join(outputDir, HEAP_AFTER_GC_FILE), JSON.stringify(summary, null, 2), 'utf8');
+  await writeSidecar(outputDir, HEAP_AFTER_GC_FILE, summary);
 }

--- a/performance-tests/lib/hook-timing.mjs
+++ b/performance-tests/lib/hook-timing.mjs
@@ -3,8 +3,10 @@
  * to measure the elapsed time between a "before" and "after" hook pair.
  */
 
-import { writeFile, mkdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { writeSidecar } from './sidecar.mjs';
+
+// The sidecar the teardown reads the hook deltas from, next to the scenario's traces.
+export const HOOK_TIMING_FILE = 'hook-timing.json';
 
 /**
  * Inject timing listeners for a before/after hook pair.
@@ -76,10 +78,5 @@ export async function saveHookTimings(outputDir, deltas) {
 
   const avgDelta = deltas.reduce((a, b) => a + b, 0) / deltas.length;
 
-  await mkdir(outputDir, { recursive: true });
-  await writeFile(
-    join(outputDir, 'hook-timing.json'),
-    JSON.stringify({ deltas, averageDeltaMs: avgDelta }, null, 2),
-    'utf8',
-  );
+  await writeSidecar(outputDir, HOOK_TIMING_FILE, { deltas, averageDeltaMs: avgDelta });
 }

--- a/performance-tests/lib/html-report-builder.mjs
+++ b/performance-tests/lib/html-report-builder.mjs
@@ -5,6 +5,7 @@
 import {
   REGRESSION_CALLOUT_THRESHOLD_TIMING,
   CV_WARNING_THRESHOLD,
+  INCOMPARABLE_LABELS,
   TRACE_MISMATCH_REASONS,
   activeTotalsPerIteration,
   calcCv,
@@ -365,21 +366,24 @@ function buildMemoryMetrics(current, golden, isCrossWindow = false) {
     return [];
   }
 
+  // [label, display key, numeric key, informational]. An informational row states its delta without
+  // a verdict on it: no threshold has been derived for the live set yet, and colouring it on the
+  // heap band would paint a 7% move red beside a flat jsHeapMaxBytes.
   const pairs = [
-    ['Min JS heap', 'jsHeapMinLabel', 'jsHeapMinBytes'],
-    ['Max JS heap', 'jsHeapMaxLabel', 'jsHeapMaxBytes'],
+    ['Min JS heap', 'jsHeapMinLabel', 'jsHeapMinBytes', false],
+    ['Max JS heap', 'jsHeapMaxLabel', 'jsHeapMaxBytes', false],
     // The live set after a forced GC (lib/heap-after-gc.mjs). Informational until enough goldens
     // carry it to derive a threshold; the row is skipped for runs recorded before it existed.
-    ['JS heap after GC', 'jsHeapAfterGcLabel', 'jsHeapAfterGcBytes'],
-    ['Min Nodes', 'nodesMin', 'nodesMin'],
-    ['Max Nodes', 'nodesMax', 'nodesMax'],
-    ['Min Listeners', 'listenersMin', 'listenersMin'],
-    ['Max Listeners', 'listenersMax', 'listenersMax'],
+    ['JS heap after GC', 'jsHeapAfterGcLabel', 'jsHeapAfterGcBytes', true],
+    ['Min Nodes', 'nodesMin', 'nodesMin', false],
+    ['Max Nodes', 'nodesMax', 'nodesMax', false],
+    ['Min Listeners', 'listenersMin', 'listenersMin', false],
+    ['Max Listeners', 'listenersMax', 'listenersMax', false],
   ];
 
   const rows = [];
 
-  for (const [label, displayKey, numKey] of pairs) {
+  for (const [label, displayKey, numKey, neutral] of pairs) {
     const cDisplay = cUc[displayKey];
     const gDisplay = gUc?.[displayKey];
 
@@ -387,12 +391,22 @@ function buildMemoryMetrics(current, golden, isCrossWindow = false) {
       continue;
     }
 
+    // The baseline carries the metric and this run does not: a capture that failed, which must not
+    // look like a metric nobody measured. Named for the side that missed it, like the timing rows.
+    const currentMissing = cDisplay == null && gDisplay != null;
+    const incomplete = isCrossWindow || currentMissing;
+
     rows.push({
       label,
       currentDisplay: cDisplay != null ? String(cDisplay) : '--',
       baselineDisplay: gDisplay != null ? String(gDisplay) : '--',
-      change: isCrossWindow ? null : pctChange(gUc?.[numKey], cUc[numKey]),
-      incomplete: isCrossWindow,
+      change: incomplete ? null : pctChange(gUc?.[numKey], cUc[numKey]),
+      incomplete,
+      // The row's own label when the row, not the scenario, is what is incomplete.
+      incompleteLabel: currentMissing && !isCrossWindow
+        ? INCOMPARABLE_LABELS['current-incomplete']
+        : null,
+      neutral,
     });
   }
 
@@ -1304,12 +1318,15 @@ function buildScript() {
         tr.appendChild(elText('td', row.baselineDisplay, 'num'));
         tr.appendChild(elText('td', row.currentDisplay, 'num'));
         const changeTd = elText(
-          'td', row.incomplete ? scenario.incompleteLabel : fmtPct(row.change), 'num'
+          'td',
+          row.incomplete ? (row.incompleteLabel || scenario.incompleteLabel) : fmtPct(row.change),
+          'num'
         );
         // Memory is banded on the scenario's heap threshold, which is an order of magnitude tighter
         // than the timing one because heap barely moves run to run -- except on the scenarios whose
-        // peak heap depends on GC timing, which carry a wider band (heapThresholdFor).
-        changeTd.style.color = row.incomplete
+        // peak heap depends on GC timing, which carry a wider band (heapThresholdFor). An
+        // informational row (the live heap, no threshold derived yet) states its delta unbanded.
+        changeTd.style.color = row.incomplete || row.neutral
           ? statusColor('neutral')
           : statusColor(classifyChangeCss(row.change, scenario.heapThreshold));
         tr.appendChild(changeTd);

--- a/performance-tests/lib/html-report-builder.mjs
+++ b/performance-tests/lib/html-report-builder.mjs
@@ -368,6 +368,9 @@ function buildMemoryMetrics(current, golden, isCrossWindow = false) {
   const pairs = [
     ['Min JS heap', 'jsHeapMinLabel', 'jsHeapMinBytes'],
     ['Max JS heap', 'jsHeapMaxLabel', 'jsHeapMaxBytes'],
+    // The live set after a forced GC (lib/heap-after-gc.mjs). Informational until enough goldens
+    // carry it to derive a threshold; the row is skipped for runs recorded before it existed.
+    ['JS heap after GC', 'jsHeapAfterGcLabel', 'jsHeapAfterGcBytes'],
     ['Min Nodes', 'nodesMin', 'nodesMin'],
     ['Max Nodes', 'nodesMax', 'nodesMax'],
     ['Min Listeners', 'listenersMin', 'listenersMin'],

--- a/performance-tests/lib/median-snapshot.mjs
+++ b/performance-tests/lib/median-snapshot.mjs
@@ -91,6 +91,9 @@ function medianScenario(entries) {
   if (updateCounterEntries.length > 0) {
     const jsHeapMinBytes = median(updateCounterEntries.map(uc => uc.jsHeapMinBytes));
     const jsHeapMaxBytes = median(updateCounterEntries.map(uc => uc.jsHeapMaxBytes));
+    // Absent on goldens recorded before the runner read the live heap; median() skips those, so a
+    // window mixing old and new entries medians only the ones that have it.
+    const jsHeapAfterGcBytes = median(updateCounterEntries.map(uc => uc.jsHeapAfterGcBytes));
 
     updateCounters = {
       sampleCount: medianRounded(updateCounterEntries.map(uc => uc.sampleCount)) ?? 0,
@@ -98,6 +101,10 @@ function medianScenario(entries) {
       jsHeapMaxBytes,
       jsHeapMinLabel: jsHeapMinBytes === null ? null : formatHeapMinBytesLabel(jsHeapMinBytes),
       jsHeapMaxLabel: jsHeapMaxBytes === null ? null : formatHeapMaxBytesLabel(jsHeapMaxBytes),
+      ...(jsHeapAfterGcBytes === null ? {} : {
+        jsHeapAfterGcBytes,
+        jsHeapAfterGcLabel: formatHeapMaxBytesLabel(jsHeapAfterGcBytes),
+      }),
       documentsMin: medianRounded(updateCounterEntries.map(uc => uc.documentsMin)),
       documentsMax: medianRounded(updateCounterEntries.map(uc => uc.documentsMax)),
       nodesMin: medianRounded(updateCounterEntries.map(uc => uc.nodesMin)),

--- a/performance-tests/lib/median-snapshot.mjs
+++ b/performance-tests/lib/median-snapshot.mjs
@@ -91,9 +91,14 @@ function medianScenario(entries) {
   if (updateCounterEntries.length > 0) {
     const jsHeapMinBytes = median(updateCounterEntries.map(uc => uc.jsHeapMinBytes));
     const jsHeapMaxBytes = median(updateCounterEntries.map(uc => uc.jsHeapMaxBytes));
-    // Absent on goldens recorded before the runner read the live heap; median() skips those, so a
-    // window mixing old and new entries medians only the ones that have it.
-    const jsHeapAfterGcBytes = median(updateCounterEntries.map(uc => uc.jsHeapAfterGcBytes));
+    // Absent on goldens recorded before the runner read the live heap. Medianed only when at least
+    // MIN_VALID_SNAPSHOTS entries carry it -- the same floor the whole median has, applied per field,
+    // so a baseline labelled "median of 5" never carries one run's live heap beside a true median of
+    // five for the max.
+    const afterGcValues = updateCounterEntries
+      .map(uc => uc.jsHeapAfterGcBytes)
+      .filter(v => typeof v === 'number' && Number.isFinite(v));
+    const jsHeapAfterGcBytes = afterGcValues.length >= MIN_VALID_SNAPSHOTS ? median(afterGcValues) : null;
 
     updateCounters = {
       sampleCount: medianRounded(updateCounterEntries.map(uc => uc.sampleCount)) ?? 0,

--- a/performance-tests/lib/sidecar.mjs
+++ b/performance-tests/lib/sidecar.mjs
@@ -1,0 +1,34 @@
+// Per-scenario sidecar files: small JSON documents a spec or the runner writes next to the traces
+// (`hook-timing.json`, `heap-after-gc.json`) for the teardown to fold into the scenario's result.
+// One writer and one reader, so the two files cannot drift on encoding or on how a missing file is
+// reported.
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { exists } from './fs-utils.mjs';
+
+/**
+ * @param {string} outputDir -- scenario output directory
+ * @param {string} file -- the sidecar's file name
+ * @param {object} data
+ */
+export async function writeSidecar(outputDir, file, data) {
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(join(outputDir, file), JSON.stringify(data, null, 2), 'utf8');
+}
+
+/**
+ * @param {string} outputDir
+ * @param {string} file
+ * @returns {Promise<object | null>} null when the sidecar was never written
+ */
+export async function readSidecar(outputDir, file) {
+  const path = join(outputDir, file);
+
+  if (!await exists(path)) {
+    return null;
+  }
+
+  return JSON.parse(await readFile(path, 'utf8'));
+}

--- a/performance-tests/lib/teardown.mjs
+++ b/performance-tests/lib/teardown.mjs
@@ -160,13 +160,14 @@ async function collectScenarioResults() {
       const heapData = JSON.parse(await readFile(heapAfterGcPath, 'utf8'));
       const bytes = typeof heapData.averageBytes === 'number' ? heapData.averageBytes : null;
 
+      // The per-iteration readings stay in heap-after-gc.json (uploaded with the artifact); no
+      // report reads them yet, so they are not carried on _iterationValues.
       if (bytes !== null) {
         averaged.updateCounters = {
           ...(averaged.updateCounters || {}),
           jsHeapAfterGcBytes: bytes,
           jsHeapAfterGcLabel: formatHeapMaxBytesLabel(bytes),
         };
-        averaged._iterationValues.heapAfterGc = heapData.values ?? [];
       }
     }
 

--- a/performance-tests/lib/teardown.mjs
+++ b/performance-tests/lib/teardown.mjs
@@ -5,8 +5,9 @@ import { readdir, readFile, writeFile, mkdir, copyFile } from 'node:fs/promises'
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { parseTrace, averageParsedTraces } from '../trace-parser.mjs';
+import { parseTrace, averageParsedTraces, formatHeapMaxBytesLabel } from '../trace-parser.mjs';
 import { exists } from './fs-utils.mjs';
+import { HEAP_AFTER_GC_FILE } from './heap-after-gc.mjs';
 import { saveSnapshots, loadBaseline } from './snapshot-store.mjs';
 import { assessReport, buildReport, collectRegressions } from './report-builder.mjs';
 import { buildHtmlReport } from './html-report-builder.mjs';
@@ -149,6 +150,24 @@ async function collectScenarioResults() {
 
       averaged.hookTiming = hookData.averageDeltaMs ?? null;
       averaged._iterationValues.hookTiming = hookData.deltas ?? [];
+    }
+
+    // The live heap the runner read after each end mark (lib/heap-after-gc.mjs). Folded into
+    // updateCounters beside the windowed extrema it is meant to eventually replace as the gate.
+    const heapAfterGcPath = join(scenarioDir, HEAP_AFTER_GC_FILE);
+
+    if (await exists(heapAfterGcPath)) {
+      const heapData = JSON.parse(await readFile(heapAfterGcPath, 'utf8'));
+      const bytes = typeof heapData.averageBytes === 'number' ? heapData.averageBytes : null;
+
+      if (bytes !== null) {
+        averaged.updateCounters = {
+          ...(averaged.updateCounters || {}),
+          jsHeapAfterGcBytes: bytes,
+          jsHeapAfterGcLabel: formatHeapMaxBytesLabel(bytes),
+        };
+        averaged._iterationValues.heapAfterGc = heapData.values ?? [];
+      }
     }
 
     results[entry.name] = averaged;

--- a/performance-tests/lib/teardown.mjs
+++ b/performance-tests/lib/teardown.mjs
@@ -8,6 +8,8 @@ import { pathToFileURL } from 'node:url';
 import { parseTrace, averageParsedTraces, formatHeapMaxBytesLabel } from '../trace-parser.mjs';
 import { exists } from './fs-utils.mjs';
 import { HEAP_AFTER_GC_FILE } from './heap-after-gc.mjs';
+import { HOOK_TIMING_FILE } from './hook-timing.mjs';
+import { readSidecar } from './sidecar.mjs';
 import { saveSnapshots, loadBaseline } from './snapshot-store.mjs';
 import { assessReport, buildReport, collectRegressions } from './report-builder.mjs';
 import { buildHtmlReport } from './html-report-builder.mjs';
@@ -143,31 +145,37 @@ async function collectScenarioResults() {
     averaged.measurementVersion = await measurementVersionOf(entry.name);
 
     // Load hook timing if saved alongside traces
-    const hookTimingPath = join(scenarioDir, 'hook-timing.json');
+    const hookData = await readSidecar(scenarioDir, HOOK_TIMING_FILE);
 
-    if (await exists(hookTimingPath)) {
-      const hookData = JSON.parse(await readFile(hookTimingPath, 'utf8'));
-
+    if (hookData) {
       averaged.hookTiming = hookData.averageDeltaMs ?? null;
       averaged._iterationValues.hookTiming = hookData.deltas ?? [];
     }
 
-    // The live heap the runner read after each end mark (lib/heap-after-gc.mjs). Folded into
-    // updateCounters beside the windowed extrema it is meant to eventually replace as the gate.
-    const heapAfterGcPath = join(scenarioDir, HEAP_AFTER_GC_FILE);
+    // The live heap the runner read after each iteration's trace (lib/heap-after-gc.mjs). Folded
+    // into updateCounters beside the windowed extrema it is meant to eventually replace as the
+    // gate -- only when there are windowed extrema: a window that caught no UpdateCounters sample
+    // leaves updateCounters null, and a two-field object in its place would grow the memory table
+    // and stamp a zero sampleCount on the median.
+    const heapData = await readSidecar(scenarioDir, HEAP_AFTER_GC_FILE);
+    const afterGcBytes = typeof heapData?.averageBytes === 'number' ? heapData.averageBytes : null;
 
-    if (await exists(heapAfterGcPath)) {
-      const heapData = JSON.parse(await readFile(heapAfterGcPath, 'utf8'));
-      const bytes = typeof heapData.averageBytes === 'number' ? heapData.averageBytes : null;
+    if (afterGcBytes !== null && averaged.updateCounters) {
+      const readCount = typeof heapData.readCount === 'number' ? heapData.readCount : null;
 
       // The per-iteration readings stay in heap-after-gc.json (uploaded with the artifact); no
-      // report reads them yet, so they are not carried on _iterationValues.
-      if (bytes !== null) {
-        averaged.updateCounters = {
-          ...(averaged.updateCounters || {}),
-          jsHeapAfterGcBytes: bytes,
-          jsHeapAfterGcLabel: formatHeapMaxBytesLabel(bytes),
-        };
+      // report reads them yet, so they are not carried on _iterationValues. The count is, so a
+      // one-sample average is distinguishable from a five-sample one once this becomes a gate.
+      averaged.updateCounters = {
+        ...averaged.updateCounters,
+        jsHeapAfterGcBytes: afterGcBytes,
+        jsHeapAfterGcLabel: formatHeapMaxBytesLabel(afterGcBytes),
+        jsHeapAfterGcSamples: readCount,
+      };
+
+      if (readCount !== null && readCount < parsedResults.length) {
+        console.warn(`  WARN: ${entry.name} read the live heap on ${readCount} of ` +
+          `${parsedResults.length} iterations; jsHeapAfterGcBytes averages only those.`);
       }
     }
 

--- a/performance-tests/lib/trace-runner.mjs
+++ b/performance-tests/lib/trace-runner.mjs
@@ -4,6 +4,7 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { MEASURE_START_MARK, MEASURE_END_MARK } from '../trace-parser.mjs';
+import { saveHeapAfterGc } from './heap-after-gc.mjs';
 
 /**
  * Version of the measurement contract this runner implements: what the marked window contains,
@@ -15,8 +16,47 @@ import { MEASURE_START_MARK, MEASURE_END_MARK } from '../trace-parser.mjs';
  * value (see lib/environment.mjs), so the window restarts cleanly instead of averaging two
  * definitions of the same scenario for five develop pushes. A scenario-level redefinition that
  * leaves the runner alone bumps `measurementVersion` in its own scenario.config.mjs instead.
+ *
+ * History:
+ *   1 -- marked window, settle after action and after setup/reset (the first stamped version).
+ *   2 -- a full GC is forced before every measured iteration and after every end mark. The first
+ *        keeps garbage from the previous iteration's reset (a destroyed 100000x100 grid, a reloaded
+ *        dataset) from being collected inside the next window, which is why initial-load's third
+ *        iteration read ~50% slower than its first two; the second reads the live heap.
  */
-export const HARNESS_VERSION = 1;
+export const HARNESS_VERSION = 2;
+
+/**
+ * Forces a full garbage collection in the page's renderer.
+ *
+ * Over a CDP session of its own, never the tracing one: the tracing session is created per
+ * iteration and torn down with `Tracing.end`, while this runs between iterations.
+ *
+ * @param {import('playwright-core').CDPSession} control
+ */
+async function collectGarbage(control) {
+  await control.send('HeapProfiler.collectGarbage');
+}
+
+/**
+ * The used JS heap once everything collectable is gone -- the live set.
+ *
+ * @param {import('playwright-core').CDPSession} control
+ * @returns {Promise<number | null>} bytes, or null when the readback failed
+ */
+async function heapUsedAfterGc(control) {
+  try {
+    await collectGarbage(control);
+
+    const { usedSize } = await control.send('Runtime.getHeapUsage');
+
+    return typeof usedSize === 'number' && Number.isFinite(usedSize) ? usedSize : null;
+  } catch (err) {
+    console.warn(`\n  WARN: heap-after-GC readback failed (${err.message}); recording null for this iteration.`);
+
+    return null;
+  }
+}
 
 /**
  * @param {import('@playwright/test').Page} page
@@ -224,46 +264,65 @@ export async function runTracedScenario({
     }
   }
 
-  // Measured iterations
-  for (let i = 1; i <= iterations; i++) {
-    process.stdout.write(`  Iteration ${i}/${iterations}: tracing`);
+  // One session for the GC calls across all iterations; the tracing session is per iteration.
+  const control = await page.context().newCDPSession(page);
+  const heapAfterGc = [];
 
-    const cdp = await startTracing(page);
+  try {
+    // Measured iterations
+    for (let i = 1; i <= iterations; i++) {
+      // Clean slate: whatever the warmup or the previous reset left behind is collected here, on
+      // no one's clock, rather than inside the window as a major GC billed to the action.
+      await collectGarbage(control);
 
-    // Heartbeat: print dots during actionFn to keep GH Actions log alive
-    const heartbeat = setInterval(() => process.stdout.write('.'), 5000);
+      process.stdout.write(`  Iteration ${i}/${iterations}: tracing`);
 
-    // The mark is taken after CDP has already entered the isolate once, so the
-    // interrupt that carries it stays outside the window it opens.
-    await mark(page, MEASURE_START_MARK);
+      const cdp = await startTracing(page);
 
-    await actionFn(true);
+      // Heartbeat: print dots during actionFn to keep GH Actions log alive
+      const heartbeat = setInterval(() => process.stdout.write('.'), 5000);
 
-    // Inside the window on purpose: the frame this waits for is the work being measured.
-    if (!skipSettle) {
-      await settle(`iteration ${i}`);
+      // The mark is taken after CDP has already entered the isolate once, so the
+      // interrupt that carries it stays outside the window it opens.
+      await mark(page, MEASURE_START_MARK);
+
+      await actionFn(true);
+
+      // Inside the window on purpose: the frame this waits for is the work being measured.
+      if (!skipSettle) {
+        await settle(`iteration ${i}`);
+      }
+
+      await mark(page, MEASURE_END_MARK);
+
+      // Outside the window: a readback here is harness overhead, not measured work.
+      if (afterActionFn) {
+        await afterActionFn();
+      }
+
+      // Also outside the window (the UpdateCounters extrema are taken over the marked samples
+      // only), and after the readbacks so the GC does not compete with them: what the action left
+      // alive, per iteration.
+      heapAfterGc.push(await heapUsedAfterGc(control));
+
+      clearInterval(heartbeat);
+
+      process.stdout.write(' stopping');
+      const traceJson = await stopTracing(cdp);
+
+      const outPath = join(outputDir, `iteration-${i}.json`);
+
+      await writeFile(outPath, traceJson);
+      console.log(` saved (${(traceJson.length / 1024).toFixed(0)} KB)`);
+
+      if (resetFn && i < iterations) {
+        await resetFn();
+        await settleAfterPrepare('reset');
+      }
     }
-
-    await mark(page, MEASURE_END_MARK);
-
-    // Outside the window: a readback here is harness overhead, not measured work.
-    if (afterActionFn) {
-      await afterActionFn();
-    }
-
-    clearInterval(heartbeat);
-
-    process.stdout.write(' stopping');
-    const traceJson = await stopTracing(cdp);
-
-    const outPath = join(outputDir, `iteration-${i}.json`);
-
-    await writeFile(outPath, traceJson);
-    console.log(` saved (${(traceJson.length / 1024).toFixed(0)} KB)`);
-
-    if (resetFn && i < iterations) {
-      await resetFn();
-      await settleAfterPrepare('reset');
-    }
+  } finally {
+    await control.detach().catch(() => {});
   }
+
+  await saveHeapAfterGc(outputDir, heapAfterGc);
 }

--- a/performance-tests/lib/trace-runner.mjs
+++ b/performance-tests/lib/trace-runner.mjs
@@ -273,39 +273,45 @@ export async function runTracedScenario({
     for (let i = 1; i <= iterations; i++) {
       // Clean slate: whatever the warmup or the previous reset left behind is collected here, on
       // no one's clock, rather than inside the window as a major GC billed to the action.
+      // Unguarded on purpose, unlike the readback below: this GC is part of what the timing
+      // numbers mean under HARNESS_VERSION 2, so a run that could not perform it must fail rather
+      // than publish numbers recorded under a different contract.
       await collectGarbage(control);
 
       process.stdout.write(`  Iteration ${i}/${iterations}: tracing`);
 
       const cdp = await startTracing(page);
 
-      // Heartbeat: print dots during actionFn to keep GH Actions log alive
+      // Heartbeat: print dots during actionFn to keep GH Actions log alive. Cleared in a finally
+      // so a throwing actionFn does not leave the interval printing into a dead run.
       const heartbeat = setInterval(() => process.stdout.write('.'), 5000);
 
-      // The mark is taken after CDP has already entered the isolate once, so the
-      // interrupt that carries it stays outside the window it opens.
-      await mark(page, MEASURE_START_MARK);
+      try {
+        // The mark is taken after CDP has already entered the isolate once, so the
+        // interrupt that carries it stays outside the window it opens.
+        await mark(page, MEASURE_START_MARK);
 
-      await actionFn(true);
+        await actionFn(true);
 
-      // Inside the window on purpose: the frame this waits for is the work being measured.
-      if (!skipSettle) {
-        await settle(`iteration ${i}`);
+        // Inside the window on purpose: the frame this waits for is the work being measured.
+        if (!skipSettle) {
+          await settle(`iteration ${i}`);
+        }
+
+        await mark(page, MEASURE_END_MARK);
+
+        // Outside the window: a readback here is harness overhead, not measured work.
+        if (afterActionFn) {
+          await afterActionFn();
+        }
+
+        // Also outside the window (the UpdateCounters extrema are taken over the marked samples
+        // only), and after the readbacks so the GC does not compete with them: what the action left
+        // alive, per iteration. Informational, so a failed readback records null and moves on.
+        heapAfterGc.push(await heapUsedAfterGc(control));
+      } finally {
+        clearInterval(heartbeat);
       }
-
-      await mark(page, MEASURE_END_MARK);
-
-      // Outside the window: a readback here is harness overhead, not measured work.
-      if (afterActionFn) {
-        await afterActionFn();
-      }
-
-      // Also outside the window (the UpdateCounters extrema are taken over the marked samples
-      // only), and after the readbacks so the GC does not compete with them: what the action left
-      // alive, per iteration.
-      heapAfterGc.push(await heapUsedAfterGc(control));
-
-      clearInterval(heartbeat);
 
       process.stdout.write(' stopping');
       const traceJson = await stopTracing(cdp);
@@ -321,6 +327,9 @@ export async function runTracedScenario({
       }
     }
   } finally {
+    // Swallowed on purpose: a detach that fails because the page or browser is already gone is
+    // exactly the case where an error is propagating out of the loop, and a second one here would
+    // replace it.
     await control.detach().catch(() => {});
   }
 

--- a/performance-tests/lib/trace-runner.mjs
+++ b/performance-tests/lib/trace-runner.mjs
@@ -281,40 +281,50 @@ export async function runTracedScenario({
       process.stdout.write(`  Iteration ${i}/${iterations}: tracing`);
 
       const cdp = await startTracing(page);
-
-      // Heartbeat: print dots during actionFn to keep GH Actions log alive. Cleared in a finally
-      // so a throwing actionFn does not leave the interval printing into a dead run.
-      const heartbeat = setInterval(() => process.stdout.write('.'), 5000);
+      let traceJson;
 
       try {
-        // The mark is taken after CDP has already entered the isolate once, so the
-        // interrupt that carries it stays outside the window it opens.
-        await mark(page, MEASURE_START_MARK);
+        // Heartbeat: print dots during actionFn to keep GH Actions log alive. Cleared in a finally
+        // so a throwing actionFn does not leave the interval printing into a dead run.
+        const heartbeat = setInterval(() => process.stdout.write('.'), 5000);
 
-        await actionFn(true);
+        try {
+          // The mark is taken after CDP has already entered the isolate once, so the
+          // interrupt that carries it stays outside the window it opens.
+          await mark(page, MEASURE_START_MARK);
 
-        // Inside the window on purpose: the frame this waits for is the work being measured.
-        if (!skipSettle) {
-          await settle(`iteration ${i}`);
+          await actionFn(true);
+
+          // Inside the window on purpose: the frame this waits for is the work being measured.
+          if (!skipSettle) {
+            await settle(`iteration ${i}`);
+          }
+
+          await mark(page, MEASURE_END_MARK);
+
+          // Outside the window: a readback here is harness overhead, not measured work.
+          if (afterActionFn) {
+            await afterActionFn();
+          }
+        } finally {
+          clearInterval(heartbeat);
         }
 
-        await mark(page, MEASURE_END_MARK);
-
-        // Outside the window: a readback here is harness overhead, not measured work.
-        if (afterActionFn) {
-          await afterActionFn();
-        }
-
-        // Also outside the window (the UpdateCounters extrema are taken over the marked samples
-        // only), and after the readbacks so the GC does not compete with them: what the action left
-        // alive, per iteration. Informational, so a failed readback records null and moves on.
-        heapAfterGc.push(await heapUsedAfterGc(control));
+        process.stdout.write(' stopping');
+        traceJson = await stopTracing(cdp);
       } finally {
-        clearInterval(heartbeat);
+        // The session that held the recording, released whether or not the iteration completed.
+        // Swallowed on purpose: a detach that fails because the page is already gone is exactly
+        // the case where an error is propagating out of the loop, and a second one would replace it.
+        await cdp.detach().catch(() => {});
       }
 
-      process.stdout.write(' stopping');
-      const traceJson = await stopTracing(cdp);
+      // After the trace is stopped, so the forced major GC on a 300 to 350 MB heap is in no saved
+      // trace: the marked window would exclude it anyway, but an iteration that lost its marks falls
+      // back to the auto-zoomed window, and a major GC is exactly the busiest region that fallback
+      // would pick. Stopping the trace does not touch page state, so the reading is the same. What
+      // the action left alive, per iteration; informational, so a failed readback records null.
+      heapAfterGc.push(await heapUsedAfterGc(control));
 
       const outPath = join(outputDir, `iteration-${i}.json`);
 

--- a/performance-tests/scenarios/cell-editing/scenario.config.mjs
+++ b/performance-tests/scenarios/cell-editing/scenario.config.mjs
@@ -3,7 +3,7 @@ export default {
   name: 'cell-editing',
   warmupRuns: 1,
   iterations: 3,
-  // Bump when this spec changes what the marked window contains: the median baseline only draws on
-  // develop goldens recorded at the same version (see lib/environment.mjs).
+  // Bump when this spec changes what the marked window contains, or when `iterations` changes: the
+  // median baseline only draws on develop goldens recorded at the same version (see lib/environment.mjs).
   measurementVersion: 1,
 };

--- a/performance-tests/scenarios/filtering/scenario.config.mjs
+++ b/performance-tests/scenarios/filtering/scenario.config.mjs
@@ -2,7 +2,9 @@
 export default {
   name: 'filtering',
   warmupRuns: 1,
-  iterations: 3,
+  // Five, not three: the filter runs in a 50-100 ms window on a 300 MB heap, where one GC pause
+  // moves a mean of three by 10-20%. The iterations are cheap next to the fixture load.
+  iterations: 5,
   // Bump when this spec changes what the marked window contains: the median baseline only draws on
   // develop goldens recorded at the same version (see lib/environment.mjs).
   measurementVersion: 1,

--- a/performance-tests/scenarios/filtering/scenario.config.mjs
+++ b/performance-tests/scenarios/filtering/scenario.config.mjs
@@ -5,7 +5,8 @@ export default {
   // Five, not three: the filter runs in a 50-100 ms window on a 300 MB heap, where one GC pause
   // moves a mean of three by 10-20%. The iterations are cheap next to the fixture load.
   iterations: 5,
-  // Bump when this spec changes what the marked window contains: the median baseline only draws on
-  // develop goldens recorded at the same version (see lib/environment.mjs).
+  // Bump when this spec changes what the marked window contains, or when `iterations` changes. Not
+  // bumped for the 3 -> 5 change above: HARNESS_VERSION 2 landed in the same change and already
+  // restarts the whole golden pool (see lib/environment.mjs).
   measurementVersion: 1,
 };

--- a/performance-tests/scenarios/initial-load/scenario.config.mjs
+++ b/performance-tests/scenarios/initial-load/scenario.config.mjs
@@ -4,7 +4,9 @@
 export default {
   name: 'initial-load',
   warmupRuns: 1,
-  iterations: 3,
+  // Five, not three: the build runs in a 50-100 ms window on a 300 MB heap, where one GC pause moves
+  // a mean of three by 10-20%. The iterations are cheap next to the fixture load.
+  iterations: 5,
   // Bump when this spec changes what the marked window contains: the median baseline only draws on
   // develop goldens recorded at the same version (see lib/environment.mjs).
   measurementVersion: 1,

--- a/performance-tests/scenarios/initial-load/scenario.config.mjs
+++ b/performance-tests/scenarios/initial-load/scenario.config.mjs
@@ -7,7 +7,8 @@ export default {
   // Five, not three: the build runs in a 50-100 ms window on a 300 MB heap, where one GC pause moves
   // a mean of three by 10-20%. The iterations are cheap next to the fixture load.
   iterations: 5,
-  // Bump when this spec changes what the marked window contains: the median baseline only draws on
-  // develop goldens recorded at the same version (see lib/environment.mjs).
+  // Bump when this spec changes what the marked window contains, or when `iterations` changes. Not
+  // bumped for the 3 -> 5 change above: HARNESS_VERSION 2 landed in the same change and already
+  // restarts the whole golden pool (see lib/environment.mjs).
   measurementVersion: 1,
 };

--- a/performance-tests/scenarios/scroll-down/scenario.config.mjs
+++ b/performance-tests/scenarios/scroll-down/scenario.config.mjs
@@ -3,7 +3,7 @@ export default {
   name: 'scroll-down',
   warmupRuns: 1,
   iterations: 3,
-  // Bump when this spec changes what the marked window contains: the median baseline only draws on
-  // develop goldens recorded at the same version (see lib/environment.mjs).
+  // Bump when this spec changes what the marked window contains, or when `iterations` changes: the
+  // median baseline only draws on develop goldens recorded at the same version (see lib/environment.mjs).
   measurementVersion: 1,
 };

--- a/performance-tests/scenarios/scroll-left/scenario.config.mjs
+++ b/performance-tests/scenarios/scroll-left/scenario.config.mjs
@@ -3,7 +3,7 @@ export default {
   name: 'scroll-left',
   warmupRuns: 1,
   iterations: 3,
-  // Bump when this spec changes what the marked window contains: the median baseline only draws on
-  // develop goldens recorded at the same version (see lib/environment.mjs).
+  // Bump when this spec changes what the marked window contains, or when `iterations` changes: the
+  // median baseline only draws on develop goldens recorded at the same version (see lib/environment.mjs).
   measurementVersion: 1,
 };

--- a/performance-tests/scenarios/scroll-right/scenario.config.mjs
+++ b/performance-tests/scenarios/scroll-right/scenario.config.mjs
@@ -3,7 +3,7 @@ export default {
   name: 'scroll-right',
   warmupRuns: 1,
   iterations: 3,
-  // Bump when this spec changes what the marked window contains: the median baseline only draws on
-  // develop goldens recorded at the same version (see lib/environment.mjs).
+  // Bump when this spec changes what the marked window contains, or when `iterations` changes: the
+  // median baseline only draws on develop goldens recorded at the same version (see lib/environment.mjs).
   measurementVersion: 1,
 };

--- a/performance-tests/scenarios/scroll-up/scenario.config.mjs
+++ b/performance-tests/scenarios/scroll-up/scenario.config.mjs
@@ -3,7 +3,7 @@ export default {
   name: 'scroll-up',
   warmupRuns: 1,
   iterations: 3,
-  // Bump when this spec changes what the marked window contains: the median baseline only draws on
-  // develop goldens recorded at the same version (see lib/environment.mjs).
+  // Bump when this spec changes what the marked window contains, or when `iterations` changes: the
+  // median baseline only draws on develop goldens recorded at the same version (see lib/environment.mjs).
   measurementVersion: 1,
 };

--- a/performance-tests/scenarios/sorting/scenario.config.mjs
+++ b/performance-tests/scenarios/sorting/scenario.config.mjs
@@ -2,7 +2,9 @@
 export default {
   name: 'sorting',
   warmupRuns: 1,
-  iterations: 3,
+  // Five, not three: the sort runs in a 100-150 ms window on a 350 MB heap, where one GC pause moves
+  // a mean of three by 10-20%. The iterations are cheap next to the fixture load.
+  iterations: 5,
   // Bump when this spec changes what the marked window contains: the median baseline only draws on
   // develop goldens recorded at the same version (see lib/environment.mjs).
   measurementVersion: 1,

--- a/performance-tests/scenarios/sorting/scenario.config.mjs
+++ b/performance-tests/scenarios/sorting/scenario.config.mjs
@@ -5,7 +5,8 @@ export default {
   // Five, not three: the sort runs in a 100-150 ms window on a 350 MB heap, where one GC pause moves
   // a mean of three by 10-20%. The iterations are cheap next to the fixture load.
   iterations: 5,
-  // Bump when this spec changes what the marked window contains: the median baseline only draws on
-  // develop goldens recorded at the same version (see lib/environment.mjs).
+  // Bump when this spec changes what the marked window contains, or when `iterations` changes. Not
+  // bumped for the 3 -> 5 change above: HARNESS_VERSION 2 landed in the same change and already
+  // restarts the whole golden pool (see lib/environment.mjs).
   measurementVersion: 1,
 };

--- a/performance-tests/scenarios/source-data-validator-load/scenario.config.mjs
+++ b/performance-tests/scenarios/source-data-validator-load/scenario.config.mjs
@@ -5,7 +5,9 @@
 export default {
   name: 'source-data-validator-load',
   warmupRuns: 1,
-  iterations: 3,
+  // Five, not three: run-to-run spread of the validator pass over 10 million cells was 20% after
+  // removing the runner factor. The iterations are cheap next to the fixture load.
+  iterations: 5,
   // Bump when this spec changes what the marked window contains: the median baseline only draws on
   // develop goldens recorded at the same version (see lib/environment.mjs).
   measurementVersion: 1,

--- a/performance-tests/scenarios/source-data-validator-load/scenario.config.mjs
+++ b/performance-tests/scenarios/source-data-validator-load/scenario.config.mjs
@@ -8,7 +8,8 @@ export default {
   // Five, not three: run-to-run spread of the validator pass over 10 million cells was 20% after
   // removing the runner factor. The iterations are cheap next to the fixture load.
   iterations: 5,
-  // Bump when this spec changes what the marked window contains: the median baseline only draws on
-  // develop goldens recorded at the same version (see lib/environment.mjs).
+  // Bump when this spec changes what the marked window contains, or when `iterations` changes. Not
+  // bumped for the 3 -> 5 change above: HARNESS_VERSION 2 landed in the same change and already
+  // restarts the whole golden pool (see lib/environment.mjs).
   measurementVersion: 1,
 };


### PR DESCRIPTION
### Context

**Stacked on #13383.** Base is `feature/DEV-2629_Perf-baseline-provenance`; retarget to `develop` once that PR merges. Review only the commits above the base.

The PR changes what the performance runner does between and after iterations, so the four short-window scenarios stop reporting GC timing as grid time.

The 2026-09-04 replay of develop goldens left filtering, sorting, initial-load and sourceDataValidator with a run-to-run CV of 11 to 20% **after** removing the CI runner speed factor, against 2.5 to 3.6% on the scroll scenarios. Their windows are 50 to 150 ms on a 300 MB heap; GC lands under `scripting`, and a single pause moves a mean of three by 10 to 20%. initial-load's third iteration read about 50% slower than its first two on every run because two destroyed 100000x100 grids were still uncollected when it started.

What ships:

- **Forced GC before every measured iteration** (`HeapProfiler.collectGarbage` over a control CDP session, separate from the per-iteration tracing session). Garbage from the previous reset is collected on nobody's clock instead of inside the next window.
- **Live heap after every end mark.** After `afterActionFn`, the runner forces a GC and reads `Runtime.getHeapUsage`, records it per iteration to `heap-after-gc.json` (new `lib/heap-after-gc.mjs`, same pattern as `hook-timing.json`), and the teardown folds the average into `updateCounters.jsHeapAfterGcBytes`. The median baseline medians it over the entries that carry it; the HTML memory table shows it as `JS heap after GC`. Informational for now: the gate stays on the windowed maximum until enough goldens carry the field to derive a threshold from with `scripts/replay-goldens.mjs`. It is the metric that should eventually replace `jsHeapMaxBytes`, whose peak on the scroll scenarios depends on where V8 scheduled a GC rather than on what the grid retains.
- **Iterations 3 → 5** for filtering, sorting, initial-load and source-data-validator-load. Their iterations cost seconds next to the fixture load; the scroll scenarios stay at 3 because each iteration is 500 wheel round trips.
- **`HARNESS_VERSION` 1 → 2**, with a history block in `trace-runner.mjs`. Both changes alter the number a scenario publishes for the same grid code, so the median window restarts cleanly through the compatibility key from #13383 instead of averaging two harness definitions for five develop pushes.

Aggregation stays the arithmetic mean: median-of-3 would change the published number on exactly the noisy scenarios and buys little at n=5 once GC is controlled.

**Operational note.** After merge, PR comments read "no comparable baseline: the develop goldens were recorded on a different environment (harness 1 -> 2)" until two develop pushes on a perf-scoped path have recorded harness-2 goldens. Expected. Re-derive `REGRESSION_CALLOUT_THRESHOLD_TIMING` with `node performance-tests/scripts/replay-goldens.mjs --since <date>` once about ten harness-2 goldens exist; 15 was measured against harness-1 noise and is likely too permissive now.

### How has this been tested?

- `node --test performance-tests/lib/__tests__/*.test.mjs` — 230 pass (10 new: `heap-after-gc.test.mjs`, a median case for `jsHeapAfterGcBytes`, four HTML memory-table cases including one pinning that the gate still runs on the windowed maximum).
- `cd performance-tests && npm run lint && npm run typecheck` — clean.
- End to end on this machine, `PERF_MODE=golden npx playwright test --grep sorting`: 5 `iteration-N.json` files plus `heap-after-gc.json` with five readings (269.1 to 269.5 MB, spread 0.15%); the saved snapshot carries `harnessVersion: 2`, `runs: 5`, and `jsHeapAfterGcBytes` beside the windowed min and max; scripting CV across the five iterations 3.4%; the report refuses the harness-1 history with the reason "harness 1 -> 2".

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2629

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Tooling only: `performance-tests/`, the `performance-testing` skill, `performance-tests/README.md`. No shipped package changes, so no changelog entry.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2629

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes published perf numbers and baseline compatibility (harness bump), affecting CI comparisons and golden history until new develop goldens accumulate; no product runtime impact.
> 
> **Overview**
> Bumps the performance harness to **`HARNESS_VERSION` 2** so short-window scenarios stop billing **GC from the previous reset** into the traced action. Before each measured iteration the runner **forces a full GC** (separate control CDP session); after the end mark it GCs again and records **`jsHeapAfterGcBytes`** via `heap-after-gc.json`, folded into snapshots and shown in the HTML report as **“JS heap after GC”** (informational only—the regression gate stays on windowed **max** heap).
> 
> **Filtering, sorting, initial-load, and source-data-validator-load** go from **3 → 5** measured iterations to tame run-to-run spread on ~50–150 ms windows; scroll scenarios stay at 3. Shared **`sidecar.mjs`** unifies hook-timing and heap sidecars; median baselines **median the post-GC heap** when enough goldens carry it. Docs and **`scenario-configs.test.mjs`** pin iteration counts and versioning rules (`measurementVersion` now covers iteration-count changes).
> 
> Until two develop runs record harness-2 goldens, PR compare mode will report **no comparable baseline** (harness 1 → 2)—expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a098fd3d0f7ff9bffa928cad9d798c5b28abd2ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->