### PR TITLE
docs: cross-link getCellMetaTransient() from getCellMeta() JSDoc

### DIFF
--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -5328,6 +5328,9 @@ export default function Core(
    * (grid, column, and cell levels). To read global grid settings only, use {@link Core#getSettings}.
    * To read column-level meta, use {@link Core#getColumnMeta}.
    *
+   * For a read-only bulk scan over many cells, use {@link Core#getCellMetaTransient} instead: it
+   * returns the same data without permanently caching a meta object per cell.
+   *
    * @memberof Core#
    * @function getCellMeta
    * @param {number} row Visual row index.


### PR DESCRIPTION
### Context
`getCellMeta()` is the method people already know and reach for, but for a read-only bulk scan over many/all cells, the newer (18.1.0) `getCellMetaTransient()` is significantly faster and doesn't permanently cache a meta object per visited cell. People are unlikely to discover `getCellMetaTransient()` on their own, so this cross-links it from the method they'll actually land on first, `getCellMeta()`'s JSDoc.

The added sentence follows the `{@link Core#...}` cross-reference style already used in the same doc block (see `{@link Core#getSettings}`, `{@link Core#getColumnMeta}` just above it).

### Test evidence (required for source changes)
- Unit tests added/modified (`*.unit.js`): none, JSDoc-only comment change, no behavior change
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none
- Type tests (`*.types.ts`) updated if public API changed: none, no public API change
- For a bug fix — the spec that fails without this fix: n/a
- Demo page / recorded trace (for UI changes): n/a

### Commands run
none — comment-only change, no build/test run

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://app.clickup.com/t/9015210959/DEV-2729
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.
- [ ] MANUAL QA NEEDED

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc comment change only; no code paths or public API behavior affected.
> 
> **Overview**
> **Documentation-only:** the `getCellMeta` JSDoc in `core.ts` now points readers to **`getCellMetaTransient`** for read-only bulk scans over many cells, noting it returns the same effective meta without caching a meta object per cell.
> 
> The new paragraph uses the same `{@link Core#...}` style as the existing `getSettings` / `getColumnMeta` references in that block. **No runtime or API behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 475bf2a8cebce3297ba431aa5d384e5a093a7cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->