### PR TITLE
DEV-2782: Reset the fill handle drag state when the plugin is disabled

### DIFF
--- a/.changelogs/13391.json
+++ b/.changelogs/13391.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the fill handle staying in a drag state when the `fillHandle` option was disabled through `updateSettings()` in the middle of a drag, which made the fill border follow the pointer after the mouse button was released.",
+  "type": "fixed",
+  "issueOrPR": 13391,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/autofill/AGENTS.md
+++ b/handsontable/src/plugins/autofill/AGENTS.md
@@ -58,6 +58,18 @@ on the counter skipped it and left `mouseDownOnCellCorner` stuck, so `#onMouseMo
 fill border under a released pointer. Gate any teardown on the flag, never on the counter.
 `tests/e2e/fill-handle-double-click.spec.ts` pins it with a real-pointer double-click.
 
+**The teardown rule covers the lifecycle path, not just `mouseup` (DEV-2782).** `disablePlugin()` is the
+second way a gesture ends: `updateSettings({ fillHandle: false })` routes through
+`BasePlugin.onUpdateSettings`, which calls `disablePlugin()` **alone** – no `enablePlugin()` follows, the
+way it does inside `updatePlugin()`. The base class then clears the event manager, so the
+`documentElement` `mouseup` listener that owns the teardown is gone before the button is released and
+`#onMouseUp` never runs. Both teardown paths therefore share `#resetDragState()`, and any new field that
+belongs to a live corner gesture belongs in it. One field deliberately stays out: `addingStarted` mirrors
+a pending `addRow()` timeout registered through `_registerTimeout`, that timeout still fires after the
+plugin is disabled and clears the flag itself, so resetting it early lets a re-enabled drag schedule a
+second `addRow()` and insert two rows. Cancel the timer if that ever has to change.
+`tests/e2e/fill-handle-disable-mid-drag.spec.ts` pins the lifecycle path.
+
 ## Auto-inserting rows
 
 With `autoInsertRow: true`, dragging past the last row inserts rows (`insert_row_below`) on a 200 ms

--- a/handsontable/src/plugins/autofill/AGENTS.md
+++ b/handsontable/src/plugins/autofill/AGENTS.md
@@ -79,8 +79,17 @@ therefore cancelled a live drag on an ordinary re-render. `#isReconfiguring` is 
 `updatePlugin()` raises it around its disable/enable pair, and the reset is skipped while it is set,
 because the `mouseup` listener is re-registered in the same tick and the gesture is genuinely still
 live. Any future teardown added to `disablePlugin()` has to respect that flag, or it re-creates the
-regression. `tests/e2e/fill-handle-disable-mid-drag.spec.ts` pins both halves: the disable ends the
-gesture, the same-value re-send does not.
+regression.
+
+The carve-out is scoped to a reconfiguration that **changes nothing**, and that is not the same as
+"any `updatePlugin()` pass". A pass that genuinely narrows what a fill may do has to end the gesture
+as well, or `#onMouseUp` commits it under the rules it was drawn with: drag down with both axes
+allowed, send `fillHandle: 'horizontal'`, release without moving, and the abandoned vertical drag
+fills anyway. So `updatePlugin()` compares the **resolved** configuration (`directions`,
+`autoInsertRow`) across its disable/enable pair and resets when it moved. Resolved, not raw, because
+`'vertical'` and `{ direction: 'vertical' }` are the same configuration and neither should end a
+drag. `tests/e2e/fill-handle-disable-mid-drag.spec.ts` pins all three outcomes: the disable ends the
+gesture, the same-value re-send does not, the direction change does.
 
 ## Auto-inserting rows
 

--- a/handsontable/src/plugins/autofill/AGENTS.md
+++ b/handsontable/src/plugins/autofill/AGENTS.md
@@ -68,7 +68,19 @@ belongs to a live corner gesture belongs in it. One field deliberately stays out
 a pending `addRow()` timeout registered through `_registerTimeout`, that timeout still fires after the
 plugin is disabled and clears the flag itself, so resetting it early lets a re-enabled drag schedule a
 second `addRow()` and insert two rows. Cancel the timer if that ever has to change.
-`tests/e2e/fill-handle-disable-mid-drag.spec.ts` pins the lifecycle path.
+
+**A reconfiguration is not a disable, and the difference is load-bearing.** `updatePlugin()` calls
+`disablePlugin()` too, and `BasePlugin#isRelevantToSettings()` tests whether a `SETTING_KEYS` entry is
+**present** in the payload, not whether its value changed – so `updateSettings({ fillHandle: true })`
+reaches `updatePlugin()` with the value unchanged. That is not a rare shape: the React wrapper forwards
+every declared prop on every re-render (`fillHandle` is not in its `DEEP_COMPARABLE_SETTINGS`), so any
+sibling state change re-sends it, mid-drag included. Resetting unconditionally in `disablePlugin()`
+therefore cancelled a live drag on an ordinary re-render. `#isReconfiguring` is the carve-out:
+`updatePlugin()` raises it around its disable/enable pair, and the reset is skipped while it is set,
+because the `mouseup` listener is re-registered in the same tick and the gesture is genuinely still
+live. Any future teardown added to `disablePlugin()` has to respect that flag, or it re-creates the
+regression. `tests/e2e/fill-handle-disable-mid-drag.spec.ts` pins both halves: the disable ends the
+gesture, the same-value re-send does not.
 
 ## Auto-inserting rows
 

--- a/handsontable/src/plugins/autofill/autofill.ts
+++ b/handsontable/src/plugins/autofill/autofill.ts
@@ -136,6 +136,12 @@ export class Autofill extends BasePlugin {
    */
   #currentDragDirection: string | null = null;
   /**
+   * Whether the plugin is being torn down and rebuilt by `updatePlugin()` rather than genuinely
+   * disabled. `updateSettings()` reaches `updatePlugin()` whenever `fillHandle` is merely *present*
+   * in the payload, unchanged value included, so this must not end a live gesture.
+   */
+  #isReconfiguring = false;
+  /**
    * Last mouse client position. Stays `null` until the first `mousemove` of a drag, so a scroll
    * that happens after pressing the fill handle but before any drag move is not replayed with a
    * stale or default position.
@@ -203,8 +209,15 @@ export class Autofill extends BasePlugin {
    *  - [`fillHandle`](@/api/options.md#fillhandle)
    */
   updatePlugin(): void {
-    this.disablePlugin();
-    this.enablePlugin();
+    this.#isReconfiguring = true;
+
+    try {
+      this.disablePlugin();
+      this.enablePlugin();
+    } finally {
+      this.#isReconfiguring = false;
+    }
+
     super.updatePlugin();
   }
 
@@ -215,7 +228,12 @@ export class Autofill extends BasePlugin {
     // The base class drops the `documentElement` `mouseup` listener that owns the drag teardown,
     // so a gesture that is in progress when the plugin is disabled would otherwise stay armed
     // until the next `enablePlugin()` picks it up (DEV-2782, the lifecycle twin of GitHub #13370).
-    this.#resetDragState();
+    // A reconfiguration re-registers that listener in the same tick, so the gesture it belongs to
+    // is still live and must survive - see `updatePlugin()`.
+    if (!this.#isReconfiguring) {
+      this.#resetDragState();
+    }
+
     super.disablePlugin();
   }
 

--- a/handsontable/src/plugins/autofill/autofill.ts
+++ b/handsontable/src/plugins/autofill/autofill.ts
@@ -212,6 +212,10 @@ export class Autofill extends BasePlugin {
    * Disables the plugin functionality for this Handsontable instance.
    */
   disablePlugin(): void {
+    // The base class drops the `documentElement` `mouseup` listener that owns the drag teardown,
+    // so a gesture that is in progress when the plugin is disabled would otherwise stay armed
+    // until the next `enablePlugin()` picks it up (DEV-2782, the lifecycle twin of GitHub #13370).
+    this.#resetDragState();
     super.disablePlugin();
   }
 
@@ -880,10 +884,20 @@ export class Autofill extends BasePlugin {
         this.fillIn();
       }
 
-      this.handleDraggedCells = 0;
-      this.mouseDownOnCellCorner = false;
-      this.#currentDragDirection = null;
+      this.#resetDragState();
     }
+  }
+
+  /**
+   * Ends the corner gesture: clears the drag flag, the step counter, the drag direction, and the
+   * fill preview border. Shared by the `mouseup` teardown and `disablePlugin()`.
+   */
+  #resetDragState() {
+    this.resetSelectionOfDraggedArea();
+    this.mouseDownOnCellCorner = false;
+    this.mouseDragOutside = false;
+    this.#currentDragDirection = null;
+    this.#lastMouseClientPosition = null;
   }
 
   /**

--- a/handsontable/src/plugins/autofill/autofill.ts
+++ b/handsontable/src/plugins/autofill/autofill.ts
@@ -4,7 +4,7 @@ import type { CellProperties } from '../../settings';
 import { BasePlugin } from '../base';
 import { Hooks } from '../../core/hooks';
 import { offset, outerHeight, outerWidth } from '../../helpers/dom/element';
-import { isObject } from '../../helpers/object';
+import { isObject, isObjectEqual } from '../../helpers/object';
 import { arrayEach, arrayMap } from '../../helpers/array';
 import { isEmpty } from '../../helpers/mixed';
 import { getCellCoordsFromMousePosition } from '../../helpers/dom/cellCoords';
@@ -139,6 +139,8 @@ export class Autofill extends BasePlugin {
    * Whether the plugin is being torn down and rebuilt by `updatePlugin()` rather than genuinely
    * disabled. `updateSettings()` reaches `updatePlugin()` whenever `fillHandle` is merely *present*
    * in the payload, unchanged value included, so this must not end a live gesture.
+   *
+   * @type {boolean}
    */
   #isReconfiguring = false;
   /**
@@ -209,6 +211,9 @@ export class Autofill extends BasePlugin {
    *  - [`fillHandle`](@/api/options.md#fillhandle)
    */
   updatePlugin(): void {
+    const previousDirections = this.directions;
+    const previousAutoInsertRow = this.autoInsertRow;
+
     this.#isReconfiguring = true;
 
     try {
@@ -216,6 +221,18 @@ export class Autofill extends BasePlugin {
       this.enablePlugin();
     } finally {
       this.#isReconfiguring = false;
+    }
+
+    // A reconfiguration that changes what a fill is allowed to do must still end the gesture it
+    // interrupted, or `#onMouseUp` commits it under the rules it was drawn with - a drag started
+    // while both axes were allowed would fill vertically after the update narrowed it to
+    // `horizontal`. The comparison is on the resolved configuration, so re-sending the same value
+    // in another shape (`'vertical'` against `{ direction: 'vertical' }`) still counts as no change.
+    if (
+      this.autoInsertRow !== previousAutoInsertRow ||
+      !isObjectEqual(previousDirections, this.directions)
+    ) {
+      this.#resetDragState();
     }
 
     super.updatePlugin();

--- a/tests/e2e/fill-handle-disable-mid-drag.spec.ts
+++ b/tests/e2e/fill-handle-disable-mid-drag.spec.ts
@@ -23,8 +23,15 @@ test.describe('fill handle disabled mid-drag', () => {
     await grid.selectCells(0, 0, 0, 0);
     await grid.pressFillHandle();
 
+    // Drag one cell first, so the fill border is actually painted when the plugin is disabled. That
+    // is the damaging half of the bug: the old code left the dashed border on screen as well as the
+    // gesture armed, and a disable that never drew one cannot tell the two teardowns apart.
+    await grid.dragPointerToCell(2, 0);
+    await expect(grid.visibleFillBorders()).not.toHaveCount(0);
+
     await grid.setFillHandleEnabled(false);
     await expect(grid.fillHandle()).toHaveCount(0);
+    await expect(grid.visibleFillBorders()).toHaveCount(0);
 
     await grid.releasePointer();
     await grid.setFillHandleEnabled(true);
@@ -66,7 +73,7 @@ test.describe('fill handle disabled mid-drag', () => {
     await grid.pressFillHandle();
     await grid.dragPointerToCell(2, 0);
 
-    await grid.setFillHandleEnabled(true);
+    await grid.resendFillHandleSetting();
 
     await grid.dragPointerToCell(3, 0);
     await grid.releasePointer();
@@ -74,6 +81,24 @@ test.describe('fill handle disabled mid-drag', () => {
     // The drag was never interrupted, so the fill commits over the whole dragged extent.
     await expect(grid.cell(2, 0)).toHaveText('A1');
     await expect(grid.cell(3, 0)).toHaveText('A1');
+    await expect(grid.visibleFillBorders()).toHaveCount(0);
+    expect(await grid.isFillHandlePressed()).toBe(false);
+  });
+
+  // The limit of the carve-out above. A reconfiguration that genuinely changes what a fill may do
+  // still has to end the gesture, or the drag commits under the rules it was drawn with.
+  test('ends the drag when updateSettings narrows the allowed direction mid-drag', async () => {
+    await grid.selectCells(0, 0, 0, 0);
+    await grid.pressFillHandle();
+    await grid.dragPointerToCell(2, 0);
+
+    await grid.setFillHandleDirection('horizontal');
+
+    await grid.releasePointer();
+
+    // The vertical drag is abandoned rather than committed against the now horizontal-only setting.
+    await expect(grid.cell(1, 0)).toHaveText('A2');
+    await expect(grid.cell(2, 0)).toHaveText('A3');
     await expect(grid.visibleFillBorders()).toHaveCount(0);
     expect(await grid.isFillHandlePressed()).toBe(false);
   });

--- a/tests/e2e/fill-handle-disable-mid-drag.spec.ts
+++ b/tests/e2e/fill-handle-disable-mid-drag.spec.ts
@@ -38,6 +38,9 @@ test.describe('fill handle disabled mid-drag', () => {
     expect(await grid.isFillHandlePressed()).toBe(false);
   });
 
+  // Not a regression test for DEV-2782 (every corner mousedown re-arms the drag state, so it passes
+  // on the unfixed code too). It guards the teardown against over-resetting: a fix that tore down
+  // more than the gesture owns would break the very next drag-fill.
   test('keeps the fill handle usable for a drag after it was disabled mid-gesture and re-enabled', async () => {
     await grid.selectCells(0, 0, 0, 0);
     await grid.pressFillHandle();
@@ -50,6 +53,27 @@ test.describe('fill handle disabled mid-drag', () => {
 
     await expect(grid.cell(1, 1)).toHaveText('A2');
     await expect(grid.cell(1, 2)).toHaveText('A2');
+    await expect(grid.visibleFillBorders()).toHaveCount(0);
+    expect(await grid.isFillHandlePressed()).toBe(false);
+  });
+
+  // The other half of the teardown rule. `updateSettings` reaches the plugin whenever `fillHandle` is
+  // merely present in the payload, unchanged value included, and the React wrapper re-sends every
+  // declared prop on every re-render. That routes through `updatePlugin()`, which disables and
+  // re-enables the plugin in the same tick, so the gesture it belongs to has to survive.
+  test('keeps a drag alive when updateSettings re-sends the same fillHandle value mid-drag', async () => {
+    await grid.selectCells(0, 0, 0, 0);
+    await grid.pressFillHandle();
+    await grid.dragPointerToCell(2, 0);
+
+    await grid.setFillHandleEnabled(true);
+
+    await grid.dragPointerToCell(3, 0);
+    await grid.releasePointer();
+
+    // The drag was never interrupted, so the fill commits over the whole dragged extent.
+    await expect(grid.cell(2, 0)).toHaveText('A1');
+    await expect(grid.cell(3, 0)).toHaveText('A1');
     await expect(grid.visibleFillBorders()).toHaveCount(0);
     expect(await grid.isFillHandlePressed()).toBe(false);
   });

--- a/tests/e2e/fill-handle-disable-mid-drag.spec.ts
+++ b/tests/e2e/fill-handle-disable-mid-drag.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '../fixtures/test';
+import { SelectionFeaturesPage } from '../fixtures/pages/SelectionFeaturesPage';
+
+/**
+ * Disabling the fill handle while it is being held. `updateSettings({ fillHandle: false })` routes
+ * the Autofill plugin through `disablePlugin()`, which drops the `mouseup` listener that would
+ * normally end the gesture. The drag state has to be torn down on that lifecycle path as well, or
+ * the next time the handle is enabled the plugin still believes the pointer is pressed
+ * (DEV-2782, the lifecycle twin of GitHub #13370).
+ */
+test.describe('fill handle disabled mid-drag', () => {
+  let grid: SelectionFeaturesPage;
+
+  const DATA = Array.from({ length: 8 }, (_, row) => [`A${row + 1}`, null, null, null]);
+
+  test.beforeEach(async ({ page, theme }) => {
+    grid = new SelectionFeaturesPage(page, theme);
+    await grid.goto();
+    await grid.initGrid({ data: DATA });
+  });
+
+  test('ends the drag state when the fill handle is disabled between mousedown and mouseup', async () => {
+    await grid.selectCells(0, 0, 0, 0);
+    await grid.pressFillHandle();
+
+    await grid.setFillHandleEnabled(false);
+    await expect(grid.fillHandle()).toHaveCount(0);
+
+    await grid.releasePointer();
+    await grid.setFillHandleEnabled(true);
+    await expect(grid.fillHandle()).toBeVisible();
+
+    // Move around with no button held. A stuck drag state redraws the fill border under the pointer.
+    await grid.hoverCell(3, 2);
+    await grid.hoverCell(6, 1);
+
+    await expect(grid.visibleFillBorders()).toHaveCount(0);
+    expect(await grid.isFillHandlePressed()).toBe(false);
+  });
+
+  test('keeps the fill handle usable for a drag after it was disabled mid-gesture and re-enabled', async () => {
+    await grid.selectCells(0, 0, 0, 0);
+    await grid.pressFillHandle();
+    await grid.setFillHandleEnabled(false);
+    await grid.releasePointer();
+    await grid.setFillHandleEnabled(true);
+
+    await grid.selectCells(1, 0, 1, 0);
+    await grid.dragFillHandleTo(1, 2);
+
+    await expect(grid.cell(1, 1)).toHaveText('A2');
+    await expect(grid.cell(1, 2)).toHaveText('A2');
+    await expect(grid.visibleFillBorders()).toHaveCount(0);
+    expect(await grid.isFillHandlePressed()).toBe(false);
+  });
+});

--- a/tests/fixtures/pages/SelectionFeaturesPage.ts
+++ b/tests/fixtures/pages/SelectionFeaturesPage.ts
@@ -837,6 +837,24 @@ export class SelectionFeaturesPage {
   }
 
   /**
+   * Press the fill handle with the real pointer and keep the button held. The caller owns the
+   * release (`releasePointer()`), which is what lets a test slip a settings update inside the
+   * gesture.
+   */
+  async pressFillHandle(): Promise<void> {
+    await this.#pressElementCenter(this.fillHandle());
+  }
+
+  /**
+   * Turn the fill handle on or off through `updateSettings`, the way an application toggles it at
+   * runtime. Goes through the settings path on purpose: that is what routes the plugin through
+   * `disablePlugin()` alone, without the `enablePlugin()` that `updatePlugin()` pairs it with.
+   */
+  async setFillHandleEnabled(enabled: boolean): Promise<void> {
+    await this.page.evaluate(isEnabled => window.hot.updateSettings({ fillHandle: isEnabled }), enabled);
+  }
+
+  /**
    * The fill handle drawn by the frozen-columns overlay — a selection ending inside that pane is
    * rendered by the clone, not by the master.
    */

--- a/tests/fixtures/pages/SelectionFeaturesPage.ts
+++ b/tests/fixtures/pages/SelectionFeaturesPage.ts
@@ -863,6 +863,25 @@ export class SelectionFeaturesPage {
   }
 
   /**
+   * Re-send the grid's current `fillHandle` value through `updateSettings`, changing nothing. This
+   * is the shape a framework wrapper produces on an unrelated re-render, when it forwards every
+   * declared prop back into the grid.
+   */
+  async resendFillHandleSetting(): Promise<void> {
+    await this.page.evaluate(() => {
+      window.hot.updateSettings({ fillHandle: window.hot.getSettings().fillHandle });
+    });
+  }
+
+  /**
+   * Narrow the fill handle to one axis through `updateSettings` — a reconfiguration that changes
+   * what a fill is allowed to do, as opposed to a re-send of the same value.
+   */
+  async setFillHandleDirection(direction: 'vertical' | 'horizontal'): Promise<void> {
+    await this.page.evaluate(value => window.hot.updateSettings({ fillHandle: value }), direction);
+  }
+
+  /**
    * The fill handle drawn by the frozen-columns overlay — a selection ending inside that pane is
    * rendered by the clone, not by the master.
    */

--- a/tests/fixtures/pages/SelectionFeaturesPage.ts
+++ b/tests/fixtures/pages/SelectionFeaturesPage.ts
@@ -846,6 +846,14 @@ export class SelectionFeaturesPage {
   }
 
   /**
+   * Move the held pointer onto a cell without releasing it, continuing whatever drag is in
+   * progress.
+   */
+  async dragPointerToCell(row: number, col: number): Promise<void> {
+    await this.#movePointerToCell(row, col);
+  }
+
+  /**
    * Turn the fill handle on or off through `updateSettings`, the way an application toggles it at
    * runtime. Goes through the settings path on purpose: that is what routes the plugin through
    * `disablePlugin()` alone, without the `enablePlugin()` that `updatePlugin()` pairs it with.


### PR DESCRIPTION
### Context

The PR fixes the fill handle staying armed when the Autofill plugin is disabled in the middle of a pointer gesture.

`Autofill.disablePlugin()` only delegated to the base class. The base class clears the event manager, which removes the `documentElement` `mouseup` listener that owns the drag teardown. So when `updateSettings({ fillHandle: false })` lands between the corner `mousedown` and the `mouseup`, `#onMouseUp()` never runs and `mouseDownOnCellCorner` stays `true`. Re-enabling the fill handle re-adds the `mousemove` listener, `#onMouseMove` sees the stale flag, and the fill border follows a released pointer.

`updatePlugin()` was never affected: it calls `disablePlugin()` and `enablePlugin()` synchronously, so the listeners are back before the `mouseup` arrives. The setting path is different, because `BasePlugin.onUpdateSettings` calls `disablePlugin()` alone when the option turns falsy.

The fix extracts the teardown into a private `#resetDragState()` shared by `#onMouseUp` and `disablePlugin()`. It clears `handleDraggedCells` and the fill preview border (through `resetSelectionOfDraggedArea()`, so a disable does not leave the dashed border painted), `mouseDownOnCellCorner`, `mouseDragOutside`, `#currentDragDirection` and the last pointer position.

Two notes for review:

1. `addingStarted` is deliberately left out of the reset. It mirrors a pending `addRow()` timeout registered through `_registerTimeout`; that timeout still fires after the plugin is disabled and clears the flag itself. Resetting it early would let a re-enabled drag schedule a second `addRow()` and insert two rows. The reasoning is recorded in the plugin's `AGENTS.md`.
2. `updatePlugin()` also calls `disablePlugin()`, so the reset had to be kept away from it. `BasePlugin#isRelevantToSettings()` tests whether a `SETTING_KEYS` entry is *present* in the payload, not whether its value changed, so `updateSettings({ fillHandle: true })` reaches `updatePlugin()` with the value unchanged — and the React wrapper re-sends every declared prop on every re-render (`fillHandle` is not in its `DEEP_COMPARABLE_SETTINGS`). An unconditional reset therefore cancelled a live drag on any ordinary re-render, which would have been a worse regression than the bug being fixed. `#isReconfiguring` marks the disable/enable pair inside `updatePlugin()` and the reset is skipped while it is set: the `mouseup` listener is re-registered in the same tick, so the gesture is genuinely still live. The third E2E case pins that, and it fails against a build with the unconditional reset.

### How has this been tested?

New Playwright spec `tests/e2e/fill-handle-disable-mid-drag.spec.ts`, three cases driven with a real pointer:

- press the fill handle, disable it through `updateSettings`, release, re-enable, then hover with no button held. Asserts no visible `.wtBorder.fill` and `getPlugin('autofill').mouseDownOnCellCorner === false`. Red before the fix (4 fill borders), green after.
- a follow-up drag-fill still works after the disable/re-enable round trip, so a teardown that over-resets would be caught. Not regression coverage on its own (a corner `mousedown` re-arms the state either way), and the spec says so in a comment.
- a drag survives `updateSettings({ fillHandle: true })` re-sending the unchanged value mid-gesture, and the fill commits over the whole dragged extent. Verified red against a build carrying the unconditional reset (the fill never committed, `A3` instead of `A1`).

```bash
# new spec plus the neighbouring fill-handle specs
cd tests && npx playwright test --project=e2e-main \
  e2e/fill-handle-disable-mid-drag.spec.ts \
  e2e/fill-handle-double-click.spec.ts \
  e2e/fill-handle-frozen-panes.spec.ts \
  e2e/fill-handle-formulas.spec.ts
# 12 passed

# the legacy Jasmine autofill suite
npm run build:umd --prefix handsontable
npm run test:e2e.dump --prefix handsontable -- --testPathPattern=plugins/autofill
npm run test:e2e.puppeteer --prefix handsontable -- --testPathPattern=plugins/autofill
# 158 specs, 0 failures, 1 pending

npm run eslint --prefix handsontable
npm run build:types --prefix handsontable
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2782

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2782

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Autofill gesture lifecycle and `disablePlugin`/`updatePlugin` interaction; incorrect reset timing could break mid-drag fills on React re-renders or leave stuck drag state.
> 
> **Overview**
> Fixes the fill handle staying armed (and the dashed preview border following the pointer) when **`fillHandle` is turned off via `updateSettings()`** while the corner is still held. Disabling the Autofill plugin removes the document `mouseup` listener before release, so teardown now goes through a shared **`#resetDragState()`** used by **`#onMouseUp`** and **`disablePlugin()`**.
> 
> **`updatePlugin()`** also calls `disablePlugin()`, but framework re-renders often re-send unchanged `fillHandle`, so a **`#isReconfiguring`** flag skips reset during the synchronous disable/enable pair. If the **resolved** fill rules actually change (`directions` or `autoInsertRow`), the gesture is still cleared so release cannot commit under stale constraints.
> 
> Adds Playwright coverage (`fill-handle-disable-mid-drag.spec.ts`) and page helpers for mid-drag settings updates; **`AGENTS.md`** documents the lifecycle rules (including leaving **`addingStarted`** out of reset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a8b93616eb4a2294ec3c005f54af807bcdac456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->