### PR TITLE
DEV-2525: Stop an auto-height grid growing scrollbars below 100% zoom

### DIFF
--- a/.changelogs/13392.json
+++ b/.changelogs/13392.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a grid with `height: 'auto'` showing a vertical scrollbar, and a horizontal one behind it, when it was rendered below 100% browser zoom or system display scaling.",
+  "type": "fixed",
+  "issueOrPR": 13392,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -124,6 +124,49 @@ Three more things that pass every functional test and only show up in a profile 
 
 When you add a new content-driven measurement, ask which tables actually render the content — measuring the master alone is the trap both of these exist to work around.
 
+## The hider height is fractional below 100% zoom, and two coordinate spaces meet there
+
+`SpreaderSize#adjustElementsSize` writes the master hider's height, and below 100% browser zoom or
+display scaling it writes a **fractional** value (`"1210.45px"`). That element is what decides
+whether the grid shows a scrollbar: with `height: 'auto'` the holder keeps `style.height = 'auto'`
+and simply resolves to the hider, so a hider a fraction shorter than the table inside it is a
+vertical scrollbar on a grid that must never scroll — and, because `stretchH` already sized the
+columns against the full width, a horizontal one behind it (DEV-2525).
+
+Four rules come out of that, and each of them was a defect first.
+
+- **Never `parseInt` a value read back off `hider.style.height`.** It truncates the fraction and
+  hands back the shortfall. `expandHiderVerticallyBy` does `parseFloat`. (`topOverlay.ts`'s
+  `parseInt(holderParent.style.height, 10)` reads the *clone's* holder parent, a different element,
+  and is not this.)
+- **The sum's fixed terms must carry their fraction too.** `getHiderHeightCompensation`
+  (`axisSizing/hiderCompensation.ts`) reads the cells' *rendered* `border-bottom-width` — a browser
+  cannot paint a border thinner than one device pixel, so a declared `1px` resolves to 1.11111px at
+  90% and 1.49254px at 67% — and `Viewport#getColumnHeaderHeightFraction()` supplies what
+  `getColumnHeaderHeight()`'s integer `offsetHeight` rounded away. Both are 0 at 100%.
+- **`getBoundingClientRect()` and `offsetHeight` are NOT in the same coordinate space.** A rect is
+  scaled by an ancestor's CSS `zoom`; `offsetHeight`, `clientHeight` and the computed style are not.
+  Subtracting one from the other to get a fraction looks right under
+  `--force-device-scale-factor` (where they agree) and yields a large **negative** number under CSS
+  `zoom`, shrinking the hider instead of growing it. Take the fractional height from
+  `getComputedStyle(el).height`, which matches `offsetHeight`'s space at any zoom. The same trap
+  ruins measurements in tests — never compare a rect against a `clientHeight`.
+- **`gatherLayoutInput` re-derives the same total independently**, so both sites fold in the same two
+  terms and the same device-pixel rounding. A prediction built on whole pixels while the DOM carries
+  fractional ones disagrees exactly at the knife edge, which is a scrollbar the solver said would not
+  be there.
+
+`snapUpToDevicePixel()` rounds the finished total up to the next device pixel, because summing the
+rows reproduces the browser's own sub-pixel snapping only to about 0.02px and that is enough to
+summon a full-size bar on a small grid at 67%. It is a no-op at 100%, where the totals are whole
+pixels already.
+
+**`stylesHandler` is a user-supplied setting that defaults to `null`, and a standalone Walkontable
+host may implement only part of it** — the engine's own Puppeteer harness (`test/helpers/common.js`)
+does. `getStyleForTD` is therefore declared optional on the `StylesHandler` interface in `types.ts`,
+and calling it unguarded threw inside the draw and took out 695 of 816 specs. Guard every method you
+add a dependency on, and teach the harness stub the same method.
+
 ## Column-axis border ownership: the row header owns its gridline
 
 The two axes are NOT symmetric, and the column axis is the settled one. On the column axis a row

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -140,10 +140,20 @@ Four rules come out of that, and each of them was a defect first.
   `parseInt(holderParent.style.height, 10)` reads the *clone's* holder parent, a different element,
   and is not this.)
 - **The sum's fixed terms must carry their fraction too.** `getHiderHeightCompensation`
-  (`axisSizing/hiderCompensation.ts`) reads the cells' *rendered* `border-bottom-width` — a browser
-  cannot paint a border thinner than one device pixel, so a declared `1px` resolves to 1.11111px at
-  90% and 1.49254px at 67% — and `Viewport#getColumnHeaderHeightFraction()` supplies what
+  (`axisSizing/hiderCompensation.ts`) adds the amount by which the browser *inflated* the cells'
+  bottom border past the whole pixel the row heights were summed with — a browser cannot paint a
+  border thinner than one device pixel, so a declared `1px` resolves to 1.11111px at 90% and
+  1.49254px at 67% — and `Viewport#getColumnHeaderHeightFraction()` supplies what
   `getColumnHeaderHeight()`'s integer `offsetHeight` rounded away. Both are 0 at 100%.
+- **Add the inflation to the historical `1`; never return the border itself.** The menu grids and
+  the Filters by-value list drop all four borders on `td:first-child`
+  (`.handsontable.htDropdownMenu table tbody tr td:first-child` and its two siblings), and
+  `StylesHandler`'s probe cell IS a `td:first-child` inside them, so the border reads `0px` there —
+  at 100% zoom, on every platform. Returning it would have resized those grids by a whole pixel at
+  the default zoom. The same trap runs the other way at 50% (`2px`) and above 100% (`0.8px`), where
+  the row sum already accounts for the whole pixel. The `> Math.round(…)` gate is deliberately the
+  one `StylesHandler#calculateRowHeight` uses, because the two have to agree about which borders the
+  rows already carry.
 - **`getBoundingClientRect()` and `offsetHeight` are NOT in the same coordinate space.** A rect is
   scaled by an ancestor's CSS `zoom`; `offsetHeight`, `clientHeight` and the computed style are not.
   Subtracting one from the other to get a fraction looks right under
@@ -156,10 +166,25 @@ Four rules come out of that, and each of them was a defect first.
   fractional ones disagrees exactly at the knife edge, which is a scrollbar the solver said would not
   be there.
 
-`snapUpToDevicePixel()` rounds the finished total up to the next device pixel, because summing the
-rows reproduces the browser's own sub-pixel snapping only to about 0.02px and that is enough to
-summon a full-size bar on a small grid at 67%. It is a no-op at 100%, where the totals are whole
-pixels already.
+`addContentHeightSlack()` adds a fixed 0.05px to a *fractional* total, because summing the rows
+reproduces the browser's own sub-pixel snapping only to about 0.024px and that is enough to summon a
+full-size bar on a small grid at 67%. Two things about it are load-bearing and were both learned the
+hard way.
+
+**Do not round up to the device-pixel grid instead.** It reads as the principled choice — one device
+pixel is the smallest distance a screen can show, so the added height is invisible — but this total
+is also what the browser weighs against a fixed `height` setting. A 264px box holding 264.22px of
+rows at 80% zoom shows no scrollbar, because the browser rounds that deficit away; inflating the
+content by most of a device pixel pushes it over and produces a full 15px bar. That trades one
+unwanted scrollbar for another. Deciding the rounding from the holder's own height does not rescue
+it either: with `height: 'auto'` the holder resolves FROM the hider being written, so the test would
+read the previous draw's height.
+
+**A whole-pixel total is returned untouched**, which is every total at 100% zoom. Besides being
+unnecessary there, the total has a second consumer: `resolveLayout`'s window-mode prediction adds it
+to `documentScrollHeight` after subtracting the hider's INTEGER `offsetHeight`, so an unconditional
+slack leaves the prediction 0.05px over on a page whose document does not scroll — enough for a `>`
+test to invent a window scrollbar at the default zoom.
 
 **`stylesHandler` is a user-supplied setting that defaults to `null`, and a standalone Walkontable
 host may implement only part of it** — the engine's own Puppeteer harness (`test/helpers/common.js`)

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -180,11 +180,18 @@ unwanted scrollbar for another. Deciding the rounding from the holder's own heig
 it either: with `height: 'auto'` the holder resolves FROM the hider being written, so the test would
 read the previous draw's height.
 
-**A whole-pixel total is returned untouched**, which is every total at 100% zoom. Besides being
-unnecessary there, the total has a second consumer: `resolveLayout`'s window-mode prediction adds it
-to `documentScrollHeight` after subtracting the hider's INTEGER `offsetHeight`, so an unconditional
-slack leaves the prediction 0.05px over on a page whose document does not scroll — enough for a `>`
-test to invent a window scrollbar at the default zoom.
+**A whole-pixel total is returned untouched**, which is every total at 100% zoom — there is no
+sub-pixel residue to cover when nothing was measured in fractions.
+
+**Only the hider write gets the slack; `gatherLayoutInput` deliberately does not.** The two ask
+different questions. The slack stops the hider ELEMENT falling a hair short of the table inside it,
+a comparison the browser makes and rounds to device pixels. The solver asks whether the content
+overflows the workspace, and both of its tests are an exact `>` — element mode against
+`workspaceHeight`, window mode against `documentClientHeight` after subtracting the hider's INTEGER
+`offsetHeight`. A deliberate 0.05px overshoot fed into an exact comparison models nothing the browser
+can see and can only flip the verdict the wrong way: the solver reserves a vertical bar, `stretchH`
+shrinks the columns to make room, and no bar is ever painted. The two shared sub-pixel terms (the
+border inflation and the header fraction) still go into both, because those describe real height.
 
 **`stylesHandler` is a user-supplied setting that defaults to `null`, and a standalone Walkontable
 host may implement only part of it** — the engine's own Puppeteer harness (`test/helpers/common.js`)

--- a/handsontable/src/3rdparty/walkontable/src/axisSizing/hiderCompensation.ts
+++ b/handsontable/src/3rdparty/walkontable/src/axisSizing/hiderCompensation.ts
@@ -1,0 +1,73 @@
+import type { default as Settings } from '../settings';
+
+/**
+ * The width the theme declares for a cell's bottom border, in CSS pixels.
+ */
+const DECLARED_BOTTOM_BORDER_WIDTH = 1;
+
+/**
+ * The compensation added to the summed row heights to get the height the table actually renders at.
+ *
+ * The internal row-height calculator carries a known miscalculation worth one cell bottom border,
+ * which both the hider write (`SpreaderSize#adjustElementsSize`) and the single-pass layout
+ * prediction (`gatherLayoutInput`) have to fold in. It is not needed when AutoRowSize supplies exact
+ * heights — the `externalRowCalculator` case.
+ *
+ * The compensation is the border's *rendered* width, not the declared `1`. Below 100% zoom or
+ * display scaling the browser cannot paint a border thinner than one device pixel, so a declared
+ * `1px` resolves to 1.11111px at 90% and 1.49254px at 67%. Using the literal left the hider that
+ * fraction short of the table it holds, which is enough for the browser to show a vertical scrollbar
+ * on a grid that needs none (DEV-2525). At 100% the computed value is exactly `1px`, so this returns
+ * the same number it always did.
+ *
+ * The value comes from the `StylesHandler` snapshot, so it costs no DOM read.
+ *
+ * @param {Settings} wtSettings The Walkontable settings accessor.
+ * @returns {number} The compensation in CSS pixels.
+ */
+export function getHiderHeightCompensation(wtSettings: Settings): number {
+  if (wtSettings.getSetting<boolean>('externalRowCalculator')) {
+    return 0;
+  }
+
+  const stylesHandler = wtSettings.getSetting('stylesHandler');
+  // A standalone Walkontable host may supply no styles handler at all, or one implementing only
+  // part of the class Handsontable passes in — the engine's own test harness does exactly that.
+  const readStyle = stylesHandler?.getStyleForTD;
+  const renderedBorderWidth = Number.parseFloat(
+    typeof readStyle === 'function' ? `${readStyle.call(stylesHandler, 'border-bottom-width')}` : ''
+  );
+
+  // A theme that removes the border reports `0px`, which is a legitimate answer and must survive.
+  // Only an unreadable snapshot (no theme applied yet) falls back to the declared width.
+  return Number.isFinite(renderedBorderWidth) ? renderedBorderWidth : DECLARED_BOTTOM_BORDER_WIDTH;
+}
+
+/**
+ * Absorbs the floating-point slack left in a content height so it cannot land a hair under the
+ * content it has to hold.
+ *
+ * Summing the rows reproduces the browser's own sub-pixel snapping only to about 0.02px, and that is
+ * enough: a hider 0.02px under its table is still a scrollbar on a small grid at 67% zoom. Rounding
+ * the total up to the next device pixel removes the question — the hider's bottom edge then lands on
+ * the same physical pixel row as the table's, or one past it. One device pixel is the smallest
+ * distance the screen can show, so the extra height is never visible.
+ *
+ * A total already on the grid is returned unchanged, which is every total at 100% zoom, where the
+ * row heights are whole pixels. The epsilon keeps binary floating-point error from pushing such a
+ * total onto the next pixel.
+ *
+ * @param {number} value The content height in CSS pixels.
+ * @param {number} devicePixelRatio The device pixel ratio to snap against.
+ * @returns {number} The height rounded up to the next device pixel.
+ */
+export function snapUpToDevicePixel(value: number, devicePixelRatio: number): number {
+  if (!Number.isFinite(value) || !(devicePixelRatio > 0)) {
+    return value;
+  }
+
+  const snapped = Math.ceil((value * devicePixelRatio) - 1e-6) / devicePixelRatio;
+
+  // `Math.ceil` answers -0 for a zero total, which would reach the DOM as the string "-0px".
+  return snapped === 0 ? 0 : snapped;
+}

--- a/handsontable/src/3rdparty/walkontable/src/axisSizing/hiderCompensation.ts
+++ b/handsontable/src/3rdparty/walkontable/src/axisSizing/hiderCompensation.ts
@@ -1,4 +1,5 @@
 import type { default as Settings } from '../settings';
+import type { StylesHandler } from '../types';
 
 /**
  * The width the theme declares for a cell's bottom border, in CSS pixels.
@@ -13,14 +14,28 @@ const DECLARED_BOTTOM_BORDER_WIDTH = 1;
  * prediction (`gatherLayoutInput`) have to fold in. It is not needed when AutoRowSize supplies exact
  * heights — the `externalRowCalculator` case.
  *
- * The compensation is the border's *rendered* width, not the declared `1`. Below 100% zoom or
- * display scaling the browser cannot paint a border thinner than one device pixel, so a declared
- * `1px` resolves to 1.11111px at 90% and 1.49254px at 67%. Using the literal left the hider that
- * fraction short of the table it holds, which is enough for the browser to show a vertical scrollbar
- * on a grid that needs none (DEV-2525). At 100% the computed value is exactly `1px`, so this returns
- * the same number it always did.
+ * The compensation is the declared `1` **plus** the sub-pixel amount by which the browser inflated
+ * the cells' bottom border beyond the whole-pixel value the row heights were summed with. Below 100%
+ * zoom or display scaling a browser cannot paint a border thinner than one device pixel, so a
+ * declared `1px` resolves to 1.11111px at 90% and 1.49254px at 67%, and every row renders that
+ * fraction taller than the sum accounted for. Left out, it put the hider short of the table it
+ * holds, which is enough for the browser to show a vertical scrollbar on a grid that needs none
+ * (DEV-2525).
  *
- * The value comes from the `StylesHandler` snapshot, so it costs no DOM read.
+ * Adding the inflation to the constant rather than *replacing* it is what keeps this exact at 100%
+ * and above, and on a surface that removes the border altogether:
+ *
+ *   - 1px (100% zoom) — nothing was inflated, so the compensation is the historical `1`;
+ *   - 0px (a borderless surface, such as the Filters by-value list or the menu grids, whose
+ *     `td:first-child` drops all four borders) — likewise `1`. Returning the border itself here
+ *     would have changed the hider by a pixel at 100% zoom, on every platform;
+ *   - 2px (50% zoom) or 0.8px (125%) — a whole number of device pixels, or a border narrower than
+ *     the pixel it is declared in. Neither is an inflation the row sum missed, so both keep `1`.
+ *
+ * The `> rounded` test is deliberately the same gate `StylesHandler#calculateRowHeight` uses before
+ * it replaces a declared row height with a measured one, because the two have to agree about which
+ * borders the row heights already account for. They are read from the same snapshot, so this costs
+ * no DOM read.
  *
  * @param {Settings} wtSettings The Walkontable settings accessor.
  * @returns {number} The compensation in CSS pixels.
@@ -30,7 +45,7 @@ export function getHiderHeightCompensation(wtSettings: Settings): number {
     return 0;
   }
 
-  const stylesHandler = wtSettings.getSetting('stylesHandler');
+  const stylesHandler = wtSettings.getSetting<StylesHandler | null>('stylesHandler');
   // A standalone Walkontable host may supply no styles handler at all, or one implementing only
   // part of the class Handsontable passes in — the engine's own test harness does exactly that.
   const readStyle = stylesHandler?.getStyleForTD;
@@ -38,36 +53,76 @@ export function getHiderHeightCompensation(wtSettings: Settings): number {
     typeof readStyle === 'function' ? `${readStyle.call(stylesHandler, 'border-bottom-width')}` : ''
   );
 
-  // A theme that removes the border reports `0px`, which is a legitimate answer and must survive.
-  // Only an unreadable snapshot (no theme applied yet) falls back to the declared width.
-  return Number.isFinite(renderedBorderWidth) ? renderedBorderWidth : DECLARED_BOTTOM_BORDER_WIDTH;
+  if (!Number.isFinite(renderedBorderWidth)) {
+    return DECLARED_BOTTOM_BORDER_WIDTH;
+  }
+
+  const wholePixelWidth = Math.round(renderedBorderWidth);
+  const inflation = renderedBorderWidth > wholePixelWidth
+    ? renderedBorderWidth - wholePixelWidth : 0;
+
+  return DECLARED_BOTTOM_BORDER_WIDTH + inflation;
 }
 
 /**
- * Absorbs the floating-point slack left in a content height so it cannot land a hair under the
- * content it has to hold.
+ * The slack added to a summed content height so it cannot land a hair under the content it has to
+ * hold, in CSS pixels.
  *
- * Summing the rows reproduces the browser's own sub-pixel snapping only to about 0.02px, and that is
- * enough: a hider 0.02px under its table is still a scrollbar on a small grid at 67% zoom. Rounding
- * the total up to the next device pixel removes the question — the hider's bottom edge then lands on
- * the same physical pixel row as the table's, or one past it. One device pixel is the smallest
- * distance the screen can show, so the extra height is never visible.
+ * Summing the rows reproduces the browser's own sub-pixel snapping of each row only to about
+ * 0.024px — measured across 5-row and 40-row grids at five zoom levels, and constant rather than
+ * accumulating, because the rows all snap alike. That much is still enough to summon a full-size
+ * scrollbar: at 67% zoom a hider 0.023px under its table gets one.
  *
- * A total already on the grid is returned unchanged, which is every total at 100% zoom, where the
- * row heights are whole pixels. The epsilon keeps binary floating-point error from pushing such a
- * total onto the next pixel.
+ * The value is double the largest residue measured, and still one to two orders of magnitude below
+ * one device pixel at every supported zoom (1.49px at 67%, 1px at 100%), which is what keeps it from
+ * ever deciding a scrollbar on its own.
+ */
+const CONTENT_HEIGHT_SLACK = 0.05;
+
+/**
+ * How far a summed height may sit from a whole pixel and still count as one, in CSS pixels.
+ *
+ * Absorbs the binary floating-point error of repeated addition only — orders of magnitude below the
+ * smallest real sub-pixel measurement, so it can never mistake a fractional total for a whole one.
+ */
+const WHOLE_PIXEL_TOLERANCE = 1e-6;
+
+/**
+ * Adds the slack above to a summed content height.
+ *
+ * Rounding up to the next whole *device* pixel was tried first and is wrong here. It is the
+ * principled-looking choice — one device pixel is the smallest distance a screen can show, so the
+ * extra height is invisible — but the height this produces is also what the browser compares against
+ * a fixed `height` setting. On a grid whose box is a fraction of a pixel shorter than its content
+ * (a 264px box holding 264.22px of rows at 80% zoom), the browser rounds that deficit away and shows
+ * no scrollbar; inflating the content by most of a device pixel pushes it over the threshold and
+ * produces a full 15px bar. Trading one unwanted scrollbar for another is no fix. Deciding the snap
+ * from the holder's own height cannot work either: with `height: 'auto'` the holder resolves FROM
+ * the hider being written here, so the test would read the previous draw's height.
+ *
+ * A fixed sub-pixel slack has neither problem: it covers the arithmetic residue it is sized for and
+ * is far too small to change any scrollbar decision the browser was not already making.
+ *
+ * **A whole-pixel total is returned untouched**, which is every total at 100% zoom with no display
+ * scaling. There is no sub-pixel residue to cover when nothing was measured in fractions, and the
+ * total has a second consumer that must not be perturbed: `resolveLayout`'s window-mode prediction
+ * adds it to `documentScrollHeight` after subtracting the hider's INTEGER `offsetHeight`, so an
+ * unconditional slack would leave the prediction 0.05px over on a page whose document does not
+ * scroll — enough for a `>` test to invent a window scrollbar at the default zoom.
  *
  * @param {number} value The content height in CSS pixels.
- * @param {number} devicePixelRatio The device pixel ratio to snap against.
- * @returns {number} The height rounded up to the next device pixel.
+ * @returns {number} The height with the slack added, or the value unchanged if it needs none.
  */
-export function snapUpToDevicePixel(value: number, devicePixelRatio: number): number {
-  if (!Number.isFinite(value) || !(devicePixelRatio > 0)) {
+export function addContentHeightSlack(value: number): number {
+  if (!Number.isFinite(value)) {
     return value;
   }
 
-  const snapped = Math.ceil((value * devicePixelRatio) - 1e-6) / devicePixelRatio;
+  // Not `Number.isInteger`: the sum is built by repeated addition, so a whole-pixel total can
+  // arrive as 1189.9999999999998 and would then be treated as fractional.
+  if (Math.abs(value - Math.round(value)) < WHOLE_PIXEL_TOLERANCE) {
+    return value;
+  }
 
-  // `Math.ceil` answers -0 for a zero total, which would reach the DOM as the string "-0px".
-  return snapped === 0 ? 0 : snapped;
+  return value + CONTENT_HEIGHT_SLACK;
 }

--- a/handsontable/src/3rdparty/walkontable/src/overlay/spreaderSize.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/spreaderSize.ts
@@ -1,3 +1,4 @@
+import { getHiderHeightCompensation, snapUpToDevicePixel } from '../axisSizing/hiderCompensation';
 import type { EngineContext } from '../wire';
 import type { default as Overlays } from './overlays';
 
@@ -104,8 +105,18 @@ export class SpreaderSize {
     // as the flaw is embedded across multiple core modules and corresponding test cases.
     // This limitation does not affect when the external calculator is used (AutoRowSize), which
     // computes heights accurately, so no adjustment is required when using it.
-    const hiderHeightComp = wtSettings.getSetting('externalRowCalculator') ? 0 : 1;
-    const proposedHiderHeight = headerColumnSize + topOverlay.sumCellSizes(0, totalRows) + hiderHeightComp;
+    //
+    // Both terms carry their sub-pixel part: `getColumnHeaderHeight()` is an integer the calculators
+    // depend on, and the compensation is a real border the browser widens below 100% zoom. Dropping
+    // either left the hider short of the table it holds and the browser drew a scrollbar on a grid
+    // that needs none (DEV-2525). Both are 0 at 100% zoom. `gatherLayoutInput` folds in exactly the
+    // same two terms, so the predicted scroll boundary keeps matching what is written here.
+    const hiderHeightComp = getHiderHeightCompensation(wtSettings);
+    const proposedHiderHeight = snapUpToDevicePixel(
+      headerColumnSize + wtViewport.getColumnHeaderHeightFraction() +
+        topOverlay.sumCellSizes(0, totalRows) + hiderHeightComp,
+      rootWindow.devicePixelRatio
+    );
     const proposedHiderWidth = headerRowSize + inlineStartOverlay.sumCellSizes(0, totalColumns);
     const hiderElement = wtTable.hider;
     const hiderStyle = hiderElement.style;
@@ -140,6 +151,9 @@ export class SpreaderSize {
   expandHiderVerticallyBy(heightDelta: number) {
     const { hider } = this.#deps.wtTable;
 
-    hider.style.height = `${parseInt(hider.style.height, 10) + heightDelta}px`;
+    // `parseFloat`, not `parseInt`: below 100% zoom the height written above is fractional
+    // (e.g. "1209.1px"), and truncating it here would hand back the sub-pixel shortfall that
+    // `adjustElementsSize` just corrected.
+    hider.style.height = `${parseFloat(hider.style.height) + heightDelta}px`;
   }
 }

--- a/handsontable/src/3rdparty/walkontable/src/overlay/spreaderSize.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/spreaderSize.ts
@@ -1,4 +1,4 @@
-import { getHiderHeightCompensation, snapUpToDevicePixel } from '../axisSizing/hiderCompensation';
+import { getHiderHeightCompensation, addContentHeightSlack } from '../axisSizing/hiderCompensation';
 import type { EngineContext } from '../wire';
 import type { default as Overlays } from './overlays';
 
@@ -112,11 +112,8 @@ export class SpreaderSize {
     // that needs none (DEV-2525). Both are 0 at 100% zoom. `gatherLayoutInput` folds in exactly the
     // same two terms, so the predicted scroll boundary keeps matching what is written here.
     const hiderHeightComp = getHiderHeightCompensation(wtSettings);
-    const proposedHiderHeight = snapUpToDevicePixel(
-      headerColumnSize + wtViewport.getColumnHeaderHeightFraction() +
-        topOverlay.sumCellSizes(0, totalRows) + hiderHeightComp,
-      rootWindow.devicePixelRatio
-    );
+    const summedHiderHeight = headerColumnSize + wtViewport.getColumnHeaderHeightFraction() +
+      topOverlay.sumCellSizes(0, totalRows) + hiderHeightComp;
     const proposedHiderWidth = headerRowSize + inlineStartOverlay.sumCellSizes(0, totalColumns);
     const hiderElement = wtTable.hider;
     const hiderStyle = hiderElement.style;
@@ -126,9 +123,15 @@ export class SpreaderSize {
       }
 
       return scrollableElement.scrollTop >
-        Math.max(0, proposedHiderHeight - geometryReader.clientHeight(wtTable.holder));
+        Math.max(0, summedHiderHeight - geometryReader.clientHeight(wtTable.holder));
     };
     const columnHeaderBorderCompensation = isScrolledBeyondHiderHeight() ? 1 : 0;
+    // The slack goes on last, over the scroll compensation too, so the height that actually reaches
+    // the DOM is the one that carries it. The scroll test above reads the plain sum on purpose: it
+    // asks how far this element can scroll, which is the content total, not the written height.
+    const proposedHiderHeight = addContentHeightSlack(
+      summedHiderHeight + columnHeaderBorderCompensation
+    );
 
     // If the elements are being adjusted after scrolling the table from the very beginning to the very end,
     // we need to adjust the hider height by the column header border size.
@@ -136,7 +139,7 @@ export class SpreaderSize {
     // The width needs no such compensation: the row header carries its inline-end border at every
     // scroll position, so the horizontal total never changes by scrolling (#6673).
     hiderStyle.width = `${proposedHiderWidth}px`;
-    hiderStyle.height = `${proposedHiderHeight + columnHeaderBorderCompensation}px`;
+    hiderStyle.height = `${proposedHiderHeight}px`;
 
     topOverlay.adjustElementsSize();
     inlineStartOverlay.adjustElementsSize();

--- a/handsontable/src/3rdparty/walkontable/src/types.ts
+++ b/handsontable/src/3rdparty/walkontable/src/types.ts
@@ -72,6 +72,10 @@ export type OverlayType = 'inline_start' | 'top' | 'top_inline_start_corner' | '
 export interface StylesHandler {
   getCSSVariableValue(variableName: string): string | number;
   getDefaultRowHeight(visualRowIndex?: number): number;
+  // Optional: `stylesHandler` is a user-supplied setting (it defaults to `null`), and a standalone
+  // Walkontable host — the engine's own test harness included — may implement only part of the
+  // class Handsontable passes in. Every caller must handle its absence.
+  getStyleForTD?(cssProperty: string): number | string | undefined;
   areCellsBorderBox(): boolean;
   [key: string]: unknown;
 }

--- a/handsontable/src/3rdparty/walkontable/src/viewport/boxLayout/gatherLayoutInput.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/boxLayout/gatherLayoutInput.ts
@@ -15,6 +15,7 @@
 import type { EngineContext } from '../../wire';
 import type { LayoutInput, OverflowMode } from './layoutSnapshot';
 import { measureWorkspaceWidth, measureWorkspaceHeight } from '../workspaceSize';
+import { getHiderHeightCompensation, snapUpToDevicePixel } from '../../axisSizing/hiderCompensation';
 
 /**
  * Narrows the engine context to the dependencies the layout slice reads.
@@ -83,14 +84,22 @@ export function gatherLayoutInput(deps: LayoutDeps): LayoutInput {
   const rowHeaderWidth = viewport.getRowHeaderWidth();
   const columnHeaderHeight = viewport.getColumnHeaderHeight();
   // Match the hider extent the engine actually renders into: the internal row-height calculator
-  // carries a known 1px miscalculation that `Overlays#adjustElementsSize` compensates for by adding
-  // 1px to the hider height (and does not when AutoRowSize supplies exact heights — the
-  // `externalRowCalculator` case). Fold the same compensation into the total so the predicted
-  // vertical-scroll boundary matches today's post-render measurement exactly.
-  const hiderHeightCompensation = wtSettings.getSetting<boolean>('externalRowCalculator') ? 0 : 1;
+  // carries a known miscalculation worth one cell bottom border that `Overlays#adjustElementsSize`
+  // compensates for when writing the hider height (and does not when AutoRowSize supplies exact
+  // heights — the `externalRowCalculator` case). Fold the same compensation into the total so the
+  // predicted vertical-scroll boundary matches the post-render measurement exactly.
+  //
+  // Both this and the column-header fraction are sub-pixel terms that are 0 at 100% zoom. They must
+  // stay identical to the ones `SpreaderSize#adjustElementsSize` writes — a prediction built on the
+  // whole-pixel values while the DOM carries the fractional ones disagrees at the knife edge, which
+  // is a scrollbar appearing where the solver said there would be none.
+  const hiderHeightCompensation = getHiderHeightCompensation(wtSettings);
   const totalContentWidth = rowHeaderWidth + viewport.columnWidthCache.getTotalSize();
-  const totalContentHeight = columnHeaderHeight + viewport.rowHeightCache.getTotalSize() +
-    hiderHeightCompensation;
+  const totalContentHeight = snapUpToDevicePixel(
+    columnHeaderHeight + viewport.getColumnHeaderHeightFraction() +
+      viewport.rowHeightCache.getTotalSize() + hiderHeightCompensation,
+    rootWindow.devicePixelRatio
+  );
 
   // The element whose overflow decides the scrollbars is the one that actually scrolls: the document
   // in window mode, the table `holder` in element mode. This is NOT the trimming container — a

--- a/handsontable/src/3rdparty/walkontable/src/viewport/boxLayout/gatherLayoutInput.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/boxLayout/gatherLayoutInput.ts
@@ -15,7 +15,7 @@
 import type { EngineContext } from '../../wire';
 import type { LayoutInput, OverflowMode } from './layoutSnapshot';
 import { measureWorkspaceWidth, measureWorkspaceHeight } from '../workspaceSize';
-import { getHiderHeightCompensation, addContentHeightSlack } from '../../axisSizing/hiderCompensation';
+import { getHiderHeightCompensation } from '../../axisSizing/hiderCompensation';
 
 /**
  * Narrows the engine context to the dependencies the layout slice reads.
@@ -93,12 +93,20 @@ export function gatherLayoutInput(deps: LayoutDeps): LayoutInput {
   // stay identical to the ones `SpreaderSize#adjustElementsSize` writes — a prediction built on the
   // whole-pixel values while the DOM carries the fractional ones disagrees at the knife edge, which
   // is a scrollbar appearing where the solver said there would be none.
+  //
+  // What this total deliberately does NOT carry is `addContentHeightSlack`, which the hider write
+  // applies on top. The two are answering different questions. The slack exists to stop the hider
+  // ELEMENT falling a hair short of the table inside it, a comparison the browser makes and rounds
+  // to device pixels. The solver instead asks whether the content overflows the workspace, and both
+  // of its tests are an exact `>` — element mode against `workspaceHeight`, window mode against
+  // `documentClientHeight` after subtracting the hider's INTEGER `offsetHeight`. Feeding a
+  // deliberate 0.05px overshoot into an exact comparison models nothing the browser can see and can
+  // only flip the verdict the wrong way: the solver reserves a vertical bar, `stretchH` shrinks the
+  // columns to make room, and no bar is ever painted.
   const hiderHeightCompensation = getHiderHeightCompensation(wtSettings);
   const totalContentWidth = rowHeaderWidth + viewport.columnWidthCache.getTotalSize();
-  const totalContentHeight = addContentHeightSlack(
-    columnHeaderHeight + viewport.getColumnHeaderHeightFraction() +
-      viewport.rowHeightCache.getTotalSize() + hiderHeightCompensation
-  );
+  const totalContentHeight = columnHeaderHeight + viewport.getColumnHeaderHeightFraction() +
+    viewport.rowHeightCache.getTotalSize() + hiderHeightCompensation;
 
   // The element whose overflow decides the scrollbars is the one that actually scrolls: the document
   // in window mode, the table `holder` in element mode. This is NOT the trimming container — a

--- a/handsontable/src/3rdparty/walkontable/src/viewport/boxLayout/gatherLayoutInput.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/boxLayout/gatherLayoutInput.ts
@@ -15,7 +15,7 @@
 import type { EngineContext } from '../../wire';
 import type { LayoutInput, OverflowMode } from './layoutSnapshot';
 import { measureWorkspaceWidth, measureWorkspaceHeight } from '../workspaceSize';
-import { getHiderHeightCompensation, snapUpToDevicePixel } from '../../axisSizing/hiderCompensation';
+import { getHiderHeightCompensation, addContentHeightSlack } from '../../axisSizing/hiderCompensation';
 
 /**
  * Narrows the engine context to the dependencies the layout slice reads.
@@ -95,10 +95,9 @@ export function gatherLayoutInput(deps: LayoutDeps): LayoutInput {
   // is a scrollbar appearing where the solver said there would be none.
   const hiderHeightCompensation = getHiderHeightCompensation(wtSettings);
   const totalContentWidth = rowHeaderWidth + viewport.columnWidthCache.getTotalSize();
-  const totalContentHeight = snapUpToDevicePixel(
+  const totalContentHeight = addContentHeightSlack(
     columnHeaderHeight + viewport.getColumnHeaderHeightFraction() +
-      viewport.rowHeightCache.getTotalSize() + hiderHeightCompensation,
-    rootWindow.devicePixelRatio
+      viewport.rowHeightCache.getTotalSize() + hiderHeightCompensation
   );
 
   // The element whose overflow decides the scrollbars is the one that actually scrolls: the document

--- a/handsontable/src/3rdparty/walkontable/src/viewport/calculatorFactory.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/calculatorFactory.ts
@@ -283,6 +283,7 @@ export const calculatorFactory: CalculatorFactory = {
     let pos = Math.abs(inlineStartOverlay.getScrollPosition()) - inlineStartOverlay.getTableParentOffset();
 
     this.columnHeaderHeight = NaN;
+    this.columnHeaderHeightFraction = NaN;
 
     const fixedColumnsStart = wtSettings.getSetting<number>('fixedColumnsStart');
 

--- a/handsontable/src/3rdparty/walkontable/src/viewport/viewport.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/viewport.ts
@@ -141,6 +141,12 @@ class Viewport {
    */
   declare columnHeaderHeight: number;
   /**
+   * The sub-pixel part `columnHeaderHeight` rounds away. Always 0 at 100% zoom.
+   *
+   * @type {number}
+   */
+  declare columnHeaderHeightFraction: number;
+  /**
    * @type {number}
    */
   declare rowHeaderWidth: number;

--- a/handsontable/src/3rdparty/walkontable/src/viewport/workspaceSize.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/workspaceSize.ts
@@ -14,6 +14,23 @@
 import type { default as Viewport } from './viewport';
 
 /**
+ * The sub-pixel remainder between a used height read from the computed style and the whole-pixel
+ * value `offsetHeight` reported for the same element.
+ *
+ * Returns 0 for an unreadable style (`auto`, or an element with no layout), so a caller adding this
+ * to a total can never turn it into `NaN`.
+ *
+ * @param {string} usedHeight The computed `height`, e.g. `'29.0972px'`.
+ * @param {number} roundedHeight The whole-pixel height the same element reports.
+ * @returns {number} The remainder in CSS pixels.
+ */
+function measuredHeightFraction(usedHeight: string, roundedHeight: number): number {
+  const used = Number.parseFloat(usedHeight);
+
+  return Number.isFinite(used) ? used - roundedHeight : 0;
+}
+
+/**
  * Reduces a row-header width answer to the single number the viewport needs.
  *
  * The `modifyRowHeaderWidth` hook may answer per row header level - `AutoRowHeaderSize` does, so
@@ -186,6 +203,7 @@ export interface WorkspaceSize {
   sumColumnWidths(from: number, length: number): number;
   getWorkspaceOffset(): { left: number, top: number };
   getColumnHeaderHeight(): number;
+  getColumnHeaderHeightFraction(): number;
   getRowHeaderWidth(): number;
 }
 
@@ -364,12 +382,42 @@ export const workspaceSize: WorkspaceSize = {
 
     if (!columnHeaders.length) {
       this.columnHeaderHeight = 0;
+      this.columnHeaderHeightFraction = 0;
     } else if (isNaN(this.columnHeaderHeight)) {
-      this.columnHeaderHeight = this.wtTable.THEAD
-        ? this.deps.geometryReader.outerHeight(this.wtTable.THEAD) : 0;
+      const { THEAD } = this.wtTable;
+
+      this.columnHeaderHeight = THEAD ? this.deps.geometryReader.outerHeight(THEAD) : 0;
+      // `outerHeight` is `offsetHeight`, an integer, so below 100% zoom it drops up to a pixel of
+      // the header's real height. Record what it dropped, measured in the same pass so this costs
+      // one extra read per cache fill and none per draw. Only the hider/content total consumes it —
+      // the calculators keep the integer they have always been given.
+      //
+      // The used height comes from the computed style, NOT from `getBoundingClientRect()`. Both
+      // report the fraction, but a rect is scaled by an ancestor's CSS `zoom` while `offsetHeight`
+      // is not, so subtracting one from the other under CSS zoom yields a large negative number and
+      // shrinks the hider instead of growing it. The computed style is in the same space as
+      // `offsetHeight` at any zoom.
+      this.columnHeaderHeightFraction = THEAD
+        ? measuredHeightFraction(this.deps.geometryReader.getComputedStyle(THEAD).height,
+          this.columnHeaderHeight) : 0;
     }
 
     return this.columnHeaderHeight;
+  },
+
+  /**
+   * The sub-pixel part of the column header height that `getColumnHeaderHeight()` rounds away.
+   *
+   * Always `0` at 100% zoom, where the header lands on a whole pixel.
+   *
+   * @this Viewport
+   * @returns {number}
+   */
+  getColumnHeaderHeightFraction(this: Viewport): number {
+    // Fill the cache through the integer getter, which owns both values.
+    this.getColumnHeaderHeight();
+
+    return this.columnHeaderHeightFraction || 0;
   },
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/viewport/workspaceSize.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/workspaceSize.ts
@@ -20,14 +20,30 @@ import type { default as Viewport } from './viewport';
  * Returns 0 for an unreadable style (`auto`, or an element with no layout), so a caller adding this
  * to a total can never turn it into `NaN`.
  *
+ * **Clamped to one pixel either way, and that is load-bearing.** The computed `height` is the
+ * CONTENT box while `offsetHeight` is the BORDER box, so the subtraction is a rounding remainder
+ * only while the element carries no vertical border or padding. That holds for the grid's own THEAD
+ * — those borders live on the `th` — but a host page's CSS reset or table framework can put a
+ * border on `thead`, and the difference would then be several whole pixels of real box, not a
+ * fraction. Subtracted from a content total it would leave the scroll box shorter than the table
+ * and clip the last row: the very defect this fraction exists to prevent, and one no rounding
+ * afterwards could recover. A true remainder is always inside (-1, 1), so anything outside it is
+ * not a remainder and is discarded.
+ *
  * @param {string} usedHeight The computed `height`, e.g. `'29.0972px'`.
  * @param {number} roundedHeight The whole-pixel height the same element reports.
- * @returns {number} The remainder in CSS pixels.
+ * @returns {number} The remainder in CSS pixels, or 0 if it is not one.
  */
 function measuredHeightFraction(usedHeight: string, roundedHeight: number): number {
   const used = Number.parseFloat(usedHeight);
 
-  return Number.isFinite(used) ? used - roundedHeight : 0;
+  if (!Number.isFinite(used)) {
+    return 0;
+  }
+
+  const remainder = used - roundedHeight;
+
+  return Math.abs(remainder) < 1 ? remainder : 0;
 }
 
 /**
@@ -388,9 +404,17 @@ export const workspaceSize: WorkspaceSize = {
 
       this.columnHeaderHeight = THEAD ? this.deps.geometryReader.outerHeight(THEAD) : 0;
       // `outerHeight` is `offsetHeight`, an integer, so below 100% zoom it drops up to a pixel of
-      // the header's real height. Record what it dropped, measured in the same pass so this costs
-      // one extra read per cache fill and none per draw. Only the hider/content total consumes it —
+      // the header's real height. Record what it dropped. Only the hider/content total consumes it —
       // the calculators keep the integer they have always been given.
+      //
+      // Cost: this branch is NOT once per grid. `createColumnsCalculator` resets the height to `NaN`,
+      // and the draw cycle creates calculators two to four times per master draw, so the branch runs
+      // on every draw. What it adds over the `outerHeight` above is one resolved style declaration,
+      // not a second reflow — `outerHeight` has already flushed layout and nothing invalidates it in
+      // between, so the read lands on clean layout. Keying it on a cache that survives the reset was
+      // considered and rejected: the fraction can move while the integer does not (29.0972px and
+      // 29.4776px both report 29), so the key would have to carry `devicePixelRatio` too, and a stale
+      // fraction reintroduces the scrollbar this exists to prevent.
       //
       // The used height comes from the computed style, NOT from `getBoundingClientRect()`. Both
       // report the fraction, but a rect is scaled by an ancestor's CSS `zoom` while `offsetHeight`
@@ -417,6 +441,12 @@ export const workspaceSize: WorkspaceSize = {
     // Fill the cache through the integer getter, which owns both values.
     this.getColumnHeaderHeight();
 
+    // The two are written together at every site that writes either — the zero-header branch and
+    // the measure branch above, and the reset in `CalculatorFactory#createColumnsCalculator` — and
+    // only the integer gates the refill, so a site that ever assigns the height alone would strand
+    // this one. The coalesce keeps a stranded or not-yet-filled value out of a content total, where
+    // `NaN` would propagate into the hider height and size the grid to nothing; it is a floor, not
+    // a substitute for keeping the pair in lockstep.
     return this.columnHeaderHeightFraction || 0;
   },
 

--- a/handsontable/src/3rdparty/walkontable/test/helpers/common.js
+++ b/handsontable/src/3rdparty/walkontable/test/helpers/common.js
@@ -368,6 +368,11 @@ export function createStylesHandler() {
     areCellsBorderBox() {
       return false;
     },
+    getStyleForTD(cssProperty) {
+      // The hider height compensation reads the cells' rendered bottom border here. Puppeteer runs
+      // this suite at 100% with no display scaling, so the declared 1px is what a browser paints.
+      return ({ 'border-bottom-width': '1px', 'box-sizing': 'content-box' })[cssProperty];
+    },
     getCSSVariableValue(variableName) {
       const cssVariables = {
         'cell-autofill-size': 6,

--- a/handsontable/src/3rdparty/walkontable/test/unit/axisSizing/hiderCompensation.unit.ts
+++ b/handsontable/src/3rdparty/walkontable/test/unit/axisSizing/hiderCompensation.unit.ts
@@ -1,4 +1,4 @@
-import { getHiderHeightCompensation, snapUpToDevicePixel } from '../../../src/axisSizing/hiderCompensation';
+import { getHiderHeightCompensation, addContentHeightSlack } from '../../../src/axisSizing/hiderCompensation';
 
 /**
  * Builds a settings double exposing only the two keys the compensation reads.
@@ -31,16 +31,36 @@ describe('getHiderHeightCompensation', () => {
   });
 
   // The whole defect: below 100% the browser cannot paint a border thinner than one device pixel,
-  // so it widens the declared 1px and the row is that much taller than the theme asked for. The
-  // compensation has to follow, or the hider ends up short of the table and grows a scrollbar.
+  // so it widens the declared 1px and every row renders that much taller than the sum accounted
+  // for. The compensation carries the excess, or the hider ends up short of the table and the
+  // browser draws a scrollbar.
   it.each([
     ['90%', '1.11111px', 1.11111],
     ['80%', '1.25px', 1.25],
     ['75%', '1.33333px', 1.33333],
     ['67%', '1.49254px', 1.49254],
-    ['50%', '2px', 2],
-  ])('should carry the rendered border width at %s zoom', (_zoom, computed, expected) => {
+  ])('should add the border inflation at %s zoom', (_zoom, computed, expected) => {
     expect(getHiderHeightCompensation(settingsMock({ borderBottomWidth: computed }))).toBeCloseTo(expected, 5);
+  });
+
+  // Nothing was inflated in these three, so the compensation must stay the historical `1`.
+  // Returning the border itself instead changed the hider by a whole pixel at 100% zoom — on a
+  // borderless surface by -1, at 50% zoom by +1 — which is what the row sum already accounts for.
+  it.each([
+    ['a border on a whole number of device pixels (50% zoom)', '2px'],
+    ['a border narrower than its declared pixel (125% zoom)', '0.8px'],
+    ['a surface that removes the border entirely', '0px'],
+  ])('should keep the declared 1px for %s', (_label, computed) => {
+    expect(getHiderHeightCompensation(settingsMock({ borderBottomWidth: computed }))).toBe(1);
+  });
+
+  // The menu grids and the Filters by-value list drop all four borders on `td:first-child`, and
+  // `StylesHandler`'s probe cell IS a `td:first-child` inside them, so it reads `0px` there at
+  // 100% zoom on every platform. Compensating with the border itself would have resized those
+  // grids by a pixel — a change at the default zoom, which this fix must not make.
+  it('should not change a borderless surface at 100% zoom', () => {
+    expect(getHiderHeightCompensation(settingsMock({ borderBottomWidth: '0px' })))
+      .toBe(getHiderHeightCompensation(settingsMock({ borderBottomWidth: '1px' })));
   });
 
   it('should not compensate when AutoRowSize supplies exact heights', () => {
@@ -48,12 +68,6 @@ describe('getHiderHeightCompensation', () => {
       externalRowCalculator: true,
       borderBottomWidth: '1.25px',
     }))).toBe(0);
-  });
-
-  // A surface that removes the border (the Filters by-value list) reports `0px`, and that is the
-  // right answer — not a missing reading to fall back from.
-  it('should keep a genuine zero border', () => {
-    expect(getHiderHeightCompensation(settingsMock({ borderBottomWidth: '0px' }))).toBe(0);
   });
 
   it.each([
@@ -82,53 +96,56 @@ describe('getHiderHeightCompensation', () => {
   });
 });
 
-describe('snapUpToDevicePixel', () => {
-  // The no-op that matters most: at 100% zoom the totals are whole pixels already, so the grid
-  // must be sized exactly as it was before this rounding existed.
-  it.each([0, 1, 175, 1190, 1204])('should leave the whole pixel %p unchanged at ratio 1', (value) => {
-    expect(snapUpToDevicePixel(value, 1)).toBe(value);
-  });
+describe('addContentHeightSlack', () => {
+  // The residue it exists for: summing the rows reproduces the browser's own snapping only to about
+  // 0.024px, and a hider that far under its table still gets a full-size scrollbar at 67% zoom.
+  it('should cover the largest arithmetic residue measured', () => {
+    const largestResidueMeasured = 0.024;
 
-  it('should leave a total that already lands on a device pixel unchanged', () => {
-    // 1198.75 * 0.8 = 959 exactly.
-    expect(snapUpToDevicePixel(1198.75, 0.8)).toBeCloseTo(1198.75, 6);
-  });
-
-  it.each([
-    [0.9, 1194.097, 1194.4444],
-    [0.8, 1199.219, 1200],
-    [0.67, 1210.075, 1210.4478],
-  ])('should round up to the next device pixel at ratio %p', (ratio, value, expected) => {
-    expect(snapUpToDevicePixel(value, ratio)).toBeCloseTo(expected, 3);
+    expect(addContentHeightSlack(1210.075) - 1210.075).toBeGreaterThan(largestResidueMeasured);
   });
 
   it('should never return less than the value it was given', () => {
-    for (const ratio of [0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.25, 2]) {
-      for (const value of [0.5, 29.0972, 175.694, 1194.097, 1210.075]) {
-        expect(snapUpToDevicePixel(value, ratio)).toBeGreaterThanOrEqual(value);
-      }
+    for (const value of [0, 0.5, 29.0972, 175.694, 1194.097, 1210.075]) {
+      expect(addContentHeightSlack(value)).toBeGreaterThanOrEqual(value);
     }
   });
 
-  // The slack has to stay under one device pixel, or the grid gains a visible strip of dead space
-  // below its last row.
-  it('should add less than one device pixel of slack', () => {
-    for (const ratio of [0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.25, 2]) {
-      for (const value of [29.0972, 175.694, 1194.097, 1210.075]) {
-        expect(snapUpToDevicePixel(value, ratio) - value).toBeLessThan(1 / ratio);
-      }
+  // The whole point of a sub-pixel slack rather than a device-pixel rounding: it must be far too
+  // small to decide a scrollbar the browser was not already going to draw. One device pixel is
+  // 1.49px at 67% zoom and 1px at 100%, the two extremes the grid is supported at.
+  it('should stay an order of magnitude below one device pixel at every supported zoom', () => {
+    const smallestDevicePixel = 1;
+
+    for (const value of [29.0972, 175.694, 1194.097, 1210.075]) {
+      expect(addContentHeightSlack(value) - value).toBeLessThan(smallestDevicePixel / 10);
     }
   });
 
-  it.each([
-    ['a zero ratio', 100, 0],
-    ['a negative ratio', 100, -1],
-    ['an unreadable ratio', 100, NaN],
-  ])('should pass the value through for %s', (_label, value, ratio) => {
-    expect(snapUpToDevicePixel(value, ratio)).toBe(value);
+  it('should add the same amount whatever the magnitude of the total', () => {
+    const added = v => addContentHeightSlack(v) - v;
+
+    expect(added(1)).toBeCloseTo(added(100000), 9);
+  });
+
+  // The no-op that matters most. At 100% zoom with no display scaling every total is whole pixels,
+  // so the grid must be sized exactly as it was before this correction existed — and the layout
+  // solver's window-mode prediction, which subtracts the hider's integer `offsetHeight` before
+  // adding this total back, must not be left a fraction over either.
+  it.each([0, 1, 175, 262, 1190, 1204])('should leave the whole pixel %p untouched', (value) => {
+    expect(addContentHeightSlack(value)).toBe(value);
+  });
+
+  it('should treat a whole pixel reached by repeated addition as whole', () => {
+    // What summing forty row heights actually produces.
+    expect(addContentHeightSlack(1189.9999999999998)).toBe(1189.9999999999998);
+  });
+
+  it.each([1194.097, 1199.219, 1210.075, 175.694])('should add the slack to the fraction %p', (value) => {
+    expect(addContentHeightSlack(value)).toBeGreaterThan(value);
   });
 
   it('should pass a non-finite value through', () => {
-    expect(snapUpToDevicePixel(NaN, 0.8)).toBeNaN();
+    expect(addContentHeightSlack(NaN)).toBeNaN();
   });
 });

--- a/handsontable/src/3rdparty/walkontable/test/unit/axisSizing/hiderCompensation.unit.ts
+++ b/handsontable/src/3rdparty/walkontable/test/unit/axisSizing/hiderCompensation.unit.ts
@@ -1,0 +1,134 @@
+import { getHiderHeightCompensation, snapUpToDevicePixel } from '../../../src/axisSizing/hiderCompensation';
+
+/**
+ * Builds a settings double exposing only the two keys the compensation reads.
+ *
+ * @param {object} options The values to report.
+ * @param {boolean} options.externalRowCalculator Whether AutoRowSize supplies exact heights.
+ * @param {string|undefined} options.borderBottomWidth The computed `border-bottom-width` of a `td`.
+ * @param {boolean} options.noStylesHandler Report no styles handler at all.
+ * @returns {object} The settings double.
+ */
+function settingsMock({ externalRowCalculator = false, borderBottomWidth = '1px', noStylesHandler = false } = {}) {
+  return {
+    getSetting(key: string) {
+      if (key === 'externalRowCalculator') {
+        return externalRowCalculator;
+      }
+
+      if (key === 'stylesHandler') {
+        return noStylesHandler ? null : { getStyleForTD: () => borderBottomWidth };
+      }
+
+      return undefined;
+    },
+  } as never;
+}
+
+describe('getHiderHeightCompensation', () => {
+  it('should compensate the declared 1px border at 100% zoom', () => {
+    expect(getHiderHeightCompensation(settingsMock({ borderBottomWidth: '1px' }))).toBe(1);
+  });
+
+  // The whole defect: below 100% the browser cannot paint a border thinner than one device pixel,
+  // so it widens the declared 1px and the row is that much taller than the theme asked for. The
+  // compensation has to follow, or the hider ends up short of the table and grows a scrollbar.
+  it.each([
+    ['90%', '1.11111px', 1.11111],
+    ['80%', '1.25px', 1.25],
+    ['75%', '1.33333px', 1.33333],
+    ['67%', '1.49254px', 1.49254],
+    ['50%', '2px', 2],
+  ])('should carry the rendered border width at %s zoom', (_zoom, computed, expected) => {
+    expect(getHiderHeightCompensation(settingsMock({ borderBottomWidth: computed }))).toBeCloseTo(expected, 5);
+  });
+
+  it('should not compensate when AutoRowSize supplies exact heights', () => {
+    expect(getHiderHeightCompensation(settingsMock({
+      externalRowCalculator: true,
+      borderBottomWidth: '1.25px',
+    }))).toBe(0);
+  });
+
+  // A surface that removes the border (the Filters by-value list) reports `0px`, and that is the
+  // right answer — not a missing reading to fall back from.
+  it('should keep a genuine zero border', () => {
+    expect(getHiderHeightCompensation(settingsMock({ borderBottomWidth: '0px' }))).toBe(0);
+  });
+
+  it.each([
+    ['an unreadable value', 'auto'],
+    ['an empty value', ''],
+    ['an absent value', undefined],
+  ])('should fall back to the declared 1px for %s', (_label, computed) => {
+    expect(getHiderHeightCompensation(settingsMock({ borderBottomWidth: computed as string }))).toBe(1);
+  });
+
+  it('should fall back to the declared 1px when no styles handler is available yet', () => {
+    expect(getHiderHeightCompensation(settingsMock({ noStylesHandler: true }))).toBe(1);
+  });
+
+  // Walkontable is a standalone engine and `stylesHandler` is a user-supplied setting, so a host can
+  // legitimately implement only part of the class Handsontable passes in. The engine's own Puppeteer
+  // harness did exactly that, and an unguarded call threw inside the draw — 695 of 816 specs.
+  it('should fall back to the declared 1px for a styles handler without getStyleForTD', () => {
+    const partialHandler = {
+      getSetting(key: string) {
+        return key === 'stylesHandler' ? { getDefaultRowHeight: () => 23 } : undefined;
+      },
+    } as never;
+
+    expect(getHiderHeightCompensation(partialHandler)).toBe(1);
+  });
+});
+
+describe('snapUpToDevicePixel', () => {
+  // The no-op that matters most: at 100% zoom the totals are whole pixels already, so the grid
+  // must be sized exactly as it was before this rounding existed.
+  it.each([0, 1, 175, 1190, 1204])('should leave the whole pixel %p unchanged at ratio 1', (value) => {
+    expect(snapUpToDevicePixel(value, 1)).toBe(value);
+  });
+
+  it('should leave a total that already lands on a device pixel unchanged', () => {
+    // 1198.75 * 0.8 = 959 exactly.
+    expect(snapUpToDevicePixel(1198.75, 0.8)).toBeCloseTo(1198.75, 6);
+  });
+
+  it.each([
+    [0.9, 1194.097, 1194.4444],
+    [0.8, 1199.219, 1200],
+    [0.67, 1210.075, 1210.4478],
+  ])('should round up to the next device pixel at ratio %p', (ratio, value, expected) => {
+    expect(snapUpToDevicePixel(value, ratio)).toBeCloseTo(expected, 3);
+  });
+
+  it('should never return less than the value it was given', () => {
+    for (const ratio of [0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.25, 2]) {
+      for (const value of [0.5, 29.0972, 175.694, 1194.097, 1210.075]) {
+        expect(snapUpToDevicePixel(value, ratio)).toBeGreaterThanOrEqual(value);
+      }
+    }
+  });
+
+  // The slack has to stay under one device pixel, or the grid gains a visible strip of dead space
+  // below its last row.
+  it('should add less than one device pixel of slack', () => {
+    for (const ratio of [0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.25, 2]) {
+      for (const value of [29.0972, 175.694, 1194.097, 1210.075]) {
+        expect(snapUpToDevicePixel(value, ratio) - value).toBeLessThan(1 / ratio);
+      }
+    }
+  });
+
+  it.each([
+    ['a zero ratio', 100, 0],
+    ['a negative ratio', 100, -1],
+    ['an unreadable ratio', 100, NaN],
+  ])('should pass the value through for %s', (_label, value, ratio) => {
+    expect(snapUpToDevicePixel(value, ratio)).toBe(value);
+  });
+
+  it('should pass a non-finite value through', () => {
+    expect(snapUpToDevicePixel(NaN, 0.8)).toBeNaN();
+  });
+});

--- a/tests/e2e/auto-height-scrollbar-zoom.spec.ts
+++ b/tests/e2e/auto-height-scrollbar-zoom.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from '../fixtures/test';
+import { AutoHeightScrollbarZoomPage } from '../fixtures/pages/AutoHeightScrollbarZoomPage';
+
+/**
+ * DEV-2525: a `height: 'auto'` grid grew scrollbars it should never have whenever the browser
+ * rendered below 100% — a zoom level under 100%, or Windows display scaling under 100%.
+ *
+ * The grid's scroll box is sized from a sum, and the sum dropped two sub-pixel terms: the cells'
+ * bottom border, which a browser cannot paint thinner than one device pixel (1.111px at 90%,
+ * 1.25px at 80%), and the column header height, read through the whole-pixel `offsetHeight`. The
+ * box came out a fraction shorter than the table inside it and the browser answered with a
+ * vertical scrollbar — then that bar took ~15px of width from columns already stretched to the
+ * full width, and a horizontal scrollbar followed it in.
+ *
+ * The shortfall is a CONSTANT, not a per-row drift (that part is #6280, fixed separately and
+ * covered by `row-height-device-scale.spec.ts`), so the 5-row case matters as much as the 40-row
+ * one and both are run here.
+ *
+ * WHICH ASSERTION DISCRIMINATES, and why the file carries both kinds. `the scroll box holds the
+ * whole table` is the one that fails on the unfixed code here — all eight of its cases do. The two
+ * scrollbar assertions do NOT: this fixture drives the zoom through CSS `zoom`, which leaves
+ * `devicePixelRatio` at 1, and at that ratio Chrome rounds a sub-pixel overflow away instead of
+ * painting a bar. They still earn their place — they pin the user-visible contract, and they are
+ * what a return of the pre-#13269 per-row accumulation (whole pixels, not a fraction) would trip —
+ * but they are a backstop here, not the proof.
+ *
+ * Under a real `--force-device-scale-factor` the bar IS painted from the same fraction, and that is
+ * where the defect was measured: 12 device scales from 0.5 to 1.25, in the standalone harness at
+ * `PLAN-DEV-2525-zoom-repro/`. That harness cannot run inside these projects, because the launch
+ * flag needs `viewport: null` and every project's `devices['Desktop Chrome']` pins
+ * `deviceScaleFactor` instead — the same constraint `row-height-device-scale.spec.ts` documents.
+ */
+
+const ZOOMS = [0.9, 0.8, 0.75, 0.67];
+
+test.describe('auto-height grid below 100% zoom', () => {
+  let grid: AutoHeightScrollbarZoomPage;
+
+  test.beforeEach(async({ page, theme, bundle }) => {
+    grid = new AutoHeightScrollbarZoomPage(page, theme, bundle);
+  });
+
+  test('the leg really runs the theme it claims', async({ theme }) => {
+    // Guards the matrix itself. The fixture links the theme stylesheet, but the rules only apply
+    // through the container's `ht-theme-*` class — miss it and all six legs render the default
+    // theme while reporting as three.
+    await grid.goto(0.9);
+    expect(await grid.activeTheme()).toBe(`ht-theme-${theme}`);
+  });
+
+  test('the zoom really inflated the cell border', async() => {
+    // Guards every assertion below: no inflated border means no defect to catch, and the rest of
+    // this file would pass on code that still has it. 1px is the declared width.
+    await grid.goto(0.9);
+    expect(await grid.cellBorderBottomWidth()).toBeGreaterThan(1);
+  });
+
+  test('a grid at 100% has no scrollbars — the control', async() => {
+    await grid.goto(1);
+
+    const { vertical, horizontal } = await grid.scrollbarSizes();
+
+    expect(vertical).toBe(0);
+    expect(horizontal).toBe(0);
+  });
+
+  for (const zoom of ZOOMS) {
+    for (const rows of [5, 40]) {
+      test(`no vertical scrollbar at ${zoom * 100}% with ${rows} rows`, async() => {
+        await grid.goto(zoom, rows);
+
+        expect((await grid.scrollbarSizes()).vertical).toBe(0);
+      });
+
+      test(`no horizontal scrollbar at ${zoom * 100}% with ${rows} rows`, async() => {
+        // The second half of the symptom, and the one the reporters saw first: the columns are
+        // stretched to the width left over after a vertical scrollbar, so an unwanted vertical
+        // bar drags a horizontal one in behind it.
+        await grid.goto(zoom, rows);
+
+        expect((await grid.scrollbarSizes()).horizontal).toBe(0);
+      });
+
+      test(`the scroll box holds the whole table at ${zoom * 100}% with ${rows} rows`, async() => {
+        // The mechanism itself, measured directly. Any positive number here is a box shorter than
+        // its own content, which is what the browser turns into a scrollbar.
+        await grid.goto(zoom, rows);
+
+        expect(await grid.tableOverflowBelowScrollBox()).toBeLessThanOrEqual(0);
+      });
+
+      test(`the correction leaves no visible gap at ${zoom * 100}% with ${rows} rows`, async() => {
+        // The other edge. The box is rounded up to the next device pixel, so the slack it adds is
+        // bounded by one physical pixel — the smallest distance a screen can show. A tolerance of
+        // 2 CSS px keeps this honest at 67%, where one device pixel is ~1.5 CSS px, while still
+        // failing a correction that overshot by a whole row.
+        await grid.goto(zoom, rows);
+
+        expect(await grid.deadSpaceBelowTable()).toBeLessThanOrEqual(2);
+      });
+    }
+  }
+});

--- a/tests/e2e/auto-height-scrollbar-zoom.spec.ts
+++ b/tests/e2e/auto-height-scrollbar-zoom.spec.ts
@@ -66,37 +66,29 @@ test.describe('auto-height grid below 100% zoom', () => {
 
   for (const zoom of ZOOMS) {
     for (const rows of [5, 40]) {
-      test(`no vertical scrollbar at ${zoom * 100}% with ${rows} rows`, async() => {
+      // One navigation per case, four measurements on it. None of them mutates the page, and each
+      // `goto` is a document load plus a bundle parse plus a grid construction — split across four
+      // tests that was 32 grid builds per project, and six projects run this file.
+      test(`${zoom * 100}% zoom with ${rows} rows scrolls in neither direction`, async() => {
         await grid.goto(zoom, rows);
 
-        expect((await grid.scrollbarSizes()).vertical).toBe(0);
-      });
+        const { vertical, horizontal } = await grid.scrollbarSizes();
 
-      test(`no horizontal scrollbar at ${zoom * 100}% with ${rows} rows`, async() => {
+        expect(vertical, 'vertical scrollbar width').toBe(0);
         // The second half of the symptom, and the one the reporters saw first: the columns are
-        // stretched to the width left over after a vertical scrollbar, so an unwanted vertical
-        // bar drags a horizontal one in behind it.
-        await grid.goto(zoom, rows);
+        // stretched to the width left over after a vertical scrollbar, so an unwanted vertical bar
+        // drags a horizontal one in behind it.
+        expect(horizontal, 'horizontal scrollbar height').toBe(0);
 
-        expect((await grid.scrollbarSizes()).horizontal).toBe(0);
-      });
+        // The mechanism itself, measured directly, and the assertion that actually discriminates
+        // this fix. Any positive number is a box shorter than its own content.
+        expect(await grid.tableOverflowBelowScrollBox(), 'table height beyond the scroll box')
+          .toBeLessThanOrEqual(0);
 
-      test(`the scroll box holds the whole table at ${zoom * 100}% with ${rows} rows`, async() => {
-        // The mechanism itself, measured directly. Any positive number here is a box shorter than
-        // its own content, which is what the browser turns into a scrollbar.
-        await grid.goto(zoom, rows);
-
-        expect(await grid.tableOverflowBelowScrollBox()).toBeLessThanOrEqual(0);
-      });
-
-      test(`the correction leaves no visible gap at ${zoom * 100}% with ${rows} rows`, async() => {
-        // The other edge. The box is rounded up to the next device pixel, so the slack it adds is
-        // bounded by one physical pixel — the smallest distance a screen can show. A tolerance of
-        // 2 CSS px keeps this honest at 67%, where one device pixel is ~1.5 CSS px, while still
-        // failing a correction that overshot by a whole row.
-        await grid.goto(zoom, rows);
-
-        expect(await grid.deadSpaceBelowTable()).toBeLessThanOrEqual(2);
+        // The other edge. The correction adds a fixed sub-pixel slack, so a whole pixel of dead
+        // space below the last row would mean it overshot.
+        expect(await grid.deadSpaceBelowTable(), 'dead space below the last row')
+          .toBeLessThanOrEqual(1);
       });
     }
   }

--- a/tests/fixtures/demo/auto-height-scrollbar-zoom.html
+++ b/tests/fixtures/demo/auto-height-scrollbar-zoom.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable e2e fixture — spurious scrollbars on an auto-height grid below 100% zoom</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the Playwright
+    // projects, mapped through fixed allowlists to LITERALS so a crafted param can never be
+    // reflected into the document. An ABSENT param keeps the default (main / plain UMD) so the
+    // fixture stays browsable by hand; an unknown value THROWS rather than falling back — a typo
+    // in the project config must be one red leg, never a silently mislabeled green one.
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+
+    // Sub-100% rendering through CSS zoom on the root element, the same mechanism
+    // `row-height-device-scale.html` uses and for the same reasons: Chrome routes CSS zoom
+    // through the effective-zoom machinery that inflates the cells' 1px border, a
+    // `--force-device-scale-factor` launch flag needs `viewport: null` (which every project's
+    // `devices['Desktop Chrome']` forbids), and Playwright's context `deviceScaleFactor` reports
+    // the ratio without ever inflating the border, so a test built on it passes on unfixed code.
+    const htZoom = Number(htParams.get('zoom') ?? '1');
+
+    if (!Number.isFinite(htZoom) || htZoom <= 0 || htZoom > 4) {
+      throw new Error('Unknown ?zoom= value: ' + JSON.stringify(htParams.get('zoom')));
+    }
+
+    window.htZoom = htZoom;
+
+    // Row count is a parameter here: the defect's vertical part is a CONSTANT, so it has to be
+    // shown on a small grid as well as a large one. A per-row error would scale with this.
+    const htRows = Number(htParams.get('rows') ?? '40');
+
+    if (!Number.isInteger(htRows) || htRows < 1 || htRows > 1000) {
+      throw new Error('Unknown ?rows= value: ' + JSON.stringify(htParams.get('rows')));
+    }
+
+    window.htRowCount = htRows;
+  </script>
+  <style>
+    body { font-family: sans-serif; margin: 0; padding: 1rem; }
+    /* A relative width plus `stretchH` is the reported setup: the columns are sized from the
+       area left over once a vertical scrollbar has taken its share, so an unwanted vertical
+       scrollbar drags a horizontal one in behind it. */
+    #wrap { width: 100%; }
+  </style>
+</head>
+<body>
+  <!--
+    DEV-2525. With `height: 'auto'` the grid must never scroll itself — it grows to its rows and
+    the page scrolls instead. Below 100% zoom it did: the hider was written from a sum that
+    dropped two sub-pixel terms (the cells' bottom border, which the browser cannot paint thinner
+    than one device pixel, and the column header height, read through the whole-pixel
+    `offsetHeight`), leaving the scroll box a fraction shorter than the table inside it. The
+    browser answered with a vertical scrollbar, that scrollbar took ~15px of width away from the
+    already-stretched columns, and a horizontal scrollbar followed.
+
+    Both are visible to a user and neither is a fraction: the bars are full size however small the
+    shortfall that summoned them, which is what makes this assertable without a pixel tolerance.
+  -->
+  <script>
+    // Before the bundle loads, so the first render already measures the zoomed cell.
+    document.documentElement.style.zoom = String(window.htZoom);
+  </script>
+
+  <div id="wrap">
+    <!-- The theme class is set beside the grid's construction below. Linking the stylesheet is not
+         enough on its own: every theme rule is scoped to this class. -->
+    <div id="grid" data-testid="grid"></div>
+  </div>
+
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The closing tag is split
+    // so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const data = [];
+
+    for (let row = 0; row < window.htRowCount; row++) {
+      data.push([`R${row}C0`, `R${row}C1`, `R${row}C2`, `R${row}C3`, `R${row}C4`]);
+    }
+
+    const testIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    };
+
+    const container = document.getElementById('grid');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    window.hot = new Handsontable(container, {
+      data,
+      height: 'auto',
+      width: '100%',
+      stretchH: 'all',
+      colHeaders: true,
+      rowHeaders: true,
+      renderer: testIdRenderer,
+      // Defeat row virtualization so the whole table is in the DOM and its real height can be
+      // compared against the scroll box in one shot.
+      viewportRowRenderingOffset: window.htRowCount + 10,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/auto-height-scrollbar-zoom.html
+++ b/tests/fixtures/demo/auto-height-scrollbar-zoom.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Handsontable e2e fixture — spurious scrollbars on an auto-height grid below 100% zoom</title>
+  <title>Handsontable e2e fixture — unwanted scrollbars on an auto-height grid below 100% zoom</title>
   <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
   <script>
     // Theme and bundle come from the ?theme=/?bundle= query params set by the Playwright
@@ -12,16 +12,26 @@
     // in the project config must be one red leg, never a silently mislabeled green one.
     const htParams = new URLSearchParams(location.search);
 
-    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
-    if (!window.htTheme) {
-      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
-    }
+    // `Object.hasOwn`, not a bare lookup: a plain object inherits `constructor`, `toString` and
+    // `__proto__`, so `?theme=constructor` would resolve to a truthy inherited value, sail past the
+    // guard below and be written into the document - the silently mislabeled leg this is meant to
+    // prevent. Only the map's own keys are allowed.
+    const htPick = (map, value, fallback, label) => {
+      const key = value ?? fallback;
+
+      if (!Object.hasOwn(map, key)) {
+        throw new Error('Unknown ?' + label + '= value: ' + JSON.stringify(value));
+      }
+
+      return map[key];
+    };
+
+    window.htTheme = htPick(
+      { main: 'main', horizon: 'horizon', classic: 'classic' }, htParams.get('theme'), 'main', 'theme');
     document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
 
-    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
-    if (!window.htBundle) {
-      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
-    }
+    window.htBundle = htPick(
+      { umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' }, htParams.get('bundle'), 'umd', 'bundle');
 
     // Sub-100% rendering through CSS zoom on the root element, the same mechanism
     // `row-height-device-scale.html` uses and for the same reasons: Chrome routes CSS zoom

--- a/tests/fixtures/pages/AutoHeightScrollbarZoomPage.ts
+++ b/tests/fixtures/pages/AutoHeightScrollbarZoomPage.ts
@@ -1,0 +1,123 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the auto-height-scrollbar-zoom fixture (DEV-2525): a `height: 'auto'` grid with
+ * relative width and `stretchH`, rendered below 100% through CSS zoom.
+ *
+ * A grid told to size itself to its rows must never scroll itself, on either axis. The queries
+ * below read the master scroll box, which is the element the browser decides that on.
+ */
+export class AutoHeightScrollbarZoomPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+  }
+
+  /**
+   * Navigate at a given zoom and row count, and wait for a real DOM condition rather than a sleep.
+   *
+   * @param zoom The CSS zoom to render the page at. Below 1 reproduces the defect.
+   * @param rows How many rows the grid holds.
+   */
+  async goto(zoom = 1, rows = 40): Promise<void> {
+    await this.page.goto(
+      `/tests/fixtures/demo/auto-height-scrollbar-zoom.html` +
+      `?theme=${this.theme}&bundle=${this.bundle}&zoom=${zoom}&rows=${rows}`
+    );
+    await expect(this.cell(0, 0)).toBeVisible();
+    await expect(this.lastRow()).toBeAttached();
+  }
+
+  /**
+   * A data cell in the grid's master table.
+   */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId('grid').locator('.ht_master').getByTestId(`cell-${row}-${col}`);
+  }
+
+  /**
+   * The last row of the master table. Virtualization is off in the fixture, so this is the last
+   * row of the data.
+   */
+  lastRow(): Locator {
+    return this.page.getByTestId('grid').locator('.ht_master table.htCore tbody tr').last();
+  }
+
+  /**
+   * The theme the grid actually resolved, read from the instance rather than from the DOM.
+   *
+   * Linking a theme's stylesheet does not apply it — every rule is scoped to an `ht-theme-*` class
+   * on the container. Without that class all three theme legs render the built-in default and
+   * quietly test one configuration six times over.
+   */
+  async activeTheme(): Promise<string> {
+    return this.page.evaluate(() => (window as unknown as {
+      hot: { getCurrentThemeName(): string },
+    }).hot.getCurrentThemeName());
+  }
+
+  /**
+   * The width the browser actually paints a cell's bottom border at.
+   *
+   * Asserted before anything else: no inflated border means the zoom did not take, and every
+   * assertion below would pass on code that still has the defect.
+   */
+  async cellBorderBottomWidth(): Promise<number> {
+    return this.page.evaluate(() => {
+      const td = document.querySelector('[data-testid="grid"] .ht_master table.htCore tbody td');
+
+      return Number.parseFloat(getComputedStyle(td as Element).borderBottomWidth);
+    });
+  }
+
+  /**
+   * The width a scrollbar is taking out of the master scroll box, in pixels.
+   *
+   * This is the honest signal rather than `scrollHeight - clientHeight`: those are integers, so a
+   * sub-pixel overflow reads as zero while the browser is already painting a full-size bar.
+   */
+  async scrollbarSizes(): Promise<{ vertical: number, horizontal: number }> {
+    return this.page.evaluate(() => {
+      const holder = document.querySelector(
+        '[data-testid="grid"] .ht_master .wtHolder'
+      ) as HTMLElement;
+
+      return {
+        vertical: holder.offsetWidth - holder.clientWidth,
+        horizontal: holder.offsetHeight - holder.clientHeight,
+      };
+    });
+  }
+
+  /**
+   * How far the rendered table overflows the scroll box that holds it, in CSS pixels.
+   *
+   * Both sides are `getBoundingClientRect()` reads so the fraction survives and the two are in the
+   * same coordinate space — a rect is scaled by CSS zoom and `clientHeight` is not, so mixing them
+   * produces confident nonsense. Positive means the box is too short; zero or below is correct.
+   */
+  async tableOverflowBelowScrollBox(): Promise<number> {
+    return this.page.evaluate(() => {
+      const grid = document.querySelector('[data-testid="grid"]') as HTMLElement;
+      const hider = grid.querySelector('.ht_master .wtHider') as HTMLElement;
+      const table = grid.querySelector('.ht_master table.htCore') as HTMLElement;
+
+      return table.getBoundingClientRect().height - hider.getBoundingClientRect().height;
+    });
+  }
+
+  /**
+   * How much taller the scroll box is than the table it holds, in CSS pixels.
+   *
+   * The other side of the same edge: the correction must not overshoot into a visible strip of
+   * dead space below the last row.
+   */
+  async deadSpaceBelowTable(): Promise<number> {
+    return -(await this.tableOverflowBelowScrollBox());
+  }
+}

--- a/tests/fixtures/pages/AutoHeightScrollbarZoomPage.ts
+++ b/tests/fixtures/pages/AutoHeightScrollbarZoomPage.ts
@@ -29,6 +29,12 @@ export class AutoHeightScrollbarZoomPage {
       `/tests/fixtures/demo/auto-height-scrollbar-zoom.html` +
       `?theme=${this.theme}&bundle=${this.bundle}&zoom=${zoom}&rows=${rows}`
     );
+    // Wait for the bundle itself before anything else. The `document.write`-injected script and the
+    // block that constructs the grid are separate, so a page can look ready while `Handsontable` is
+    // still undefined, and the failure then surfaces inside a later `page.evaluate` far from its
+    // cause. `waitForFunction`, not `expect`: the plain UMD bundle is ~6 MB and every worker pulls
+    // its own copy, which outlasts the 10s `expect` timeout on a cold server.
+    await this.page.waitForFunction(() => 'Handsontable' in window);
     await expect(this.cell(0, 0)).toBeVisible();
     await expect(this.lastRow()).toBeAttached();
   }


### PR DESCRIPTION
### Context

The PR fixes a grid configured with `height: 'auto'` growing scrollbars it should never have, whenever the browser renders below 100% — a zoom level under 100%, or Windows display scaling under 100%.

A grid told to size itself to its rows must not scroll itself; it grows and the page scrolls instead. Below 100% it did. The hider (the grid's scroll box) came out a fraction shorter than the table inside it, the browser answered with a vertical scrollbar, that bar took ~15px of width away from columns already stretched to the full width by `stretchH`, and a horizontal scrollbar followed it in. Both bars are full size however small the fraction that summoned them.

**This is a regression in the 18.x line, not long-standing behavior.** Measured across five versions and twelve zoom levels:

| zoom | 16.2.0 | 17.1.0 | 18.0.0 | 18.1.0 | develop (before) | this PR |
|---|---|---|---|---|---|---|
| 100% | clean | clean | clean | clean | clean | clean |
| 90% | clean | clean | both bars | both bars | both bars | clean |
| 85% | clean | clean | both bars | both bars | clean | clean |
| 80% | clean | clean | both bars | both bars | clean | clean |
| 75% | clean | clean | both bars | both bars | both bars | clean |
| 70% | clean | clean | both bars | both bars | clean | clean |
| 67% | clean | clean | both bars | both bars | both bars | clean |
| 60 / 55 / 50 / 110 / 125% | clean | clean | clean | clean | clean | clean |

The levels that pass on the broken builds are the ones where the rounding happens to come out right, which is why users report the problem as intermittent.

DEV-2657 / #13269 already took the bulk of this off on `develop` (it removed a per-row accumulation worth up to 18px), but it landed after the 18.1.0 RC branch was cut, so it is not in any released version. What it left behind is a **constant** sub-pixel shortfall — identical for a 5-row grid and a 40-row one — and that is what this PR removes.

#### Root cause

With `height: 'auto'` the holder keeps `style.height = 'auto'` and simply resolves to its child, so the `.wtHider` height decides everything. It is a sum, written in `SpreaderSize#adjustElementsSize`, and two of its terms dropped their sub-pixel part:

- **the cells' bottom border**, entered as the integer literal `1`. A browser cannot paint a border thinner than one device pixel, so a declared `1px` resolves to `1.11111px` at 90% and `1.49254px` at 67%, and every row renders that fraction taller than the sum accounted for;
- **the column header height**, read through the whole-pixel `offsetHeight`.

Added together those account for essentially the whole gap:

| zoom | border inflation lost | header fraction lost | sum | measured gap |
|---|---|---|---|---|
| 90% | 0.1111 | 0.0972 | 0.2083 | 0.2254 |
| 80% | 0.2500 | 0.2188 | 0.4688 | 0.4690 |
| 75% | 0.3333 | 0.3333 | 0.6667 | 0.6875 |
| 67% | 0.4925 | 0.4776 | 0.9701 | 0.9799 |

#### The change

| File | Change |
|---|---|
| `axisSizing/hiderCompensation.ts` (new) | `getHiderHeightCompensation()` adds the amount by which the browser **inflated** the cells' bottom border past the whole pixel the row heights were summed with, read from the cached style snapshot (no DOM read). `addContentHeightSlack()` adds a fixed 0.05px to a fractional total. |
| `viewport/workspaceSize.ts` | A cached `getColumnHeaderHeightFraction()` twin supplies the sub-pixel part `getColumnHeaderHeight()` rounds away. The integer getter is untouched — the calculators depend on it. |
| `overlay/spreaderSize.ts` | Folds in both terms. `expandHiderVerticallyBy` reads the height back with `parseFloat`, not `parseInt`, which would truncate the correction straight off again. |
| `viewport/boxLayout/gatherLayoutInput.ts` | The single-pass solver re-derives the same total independently, so it folds in the identical terms and its prediction keeps matching what is written to the DOM. |
| `types.ts`, `test/helpers/common.js` | `getStyleForTD` declared optional on the engine's minimal `StylesHandler` interface, and implemented in the Puppeteer harness stub. |

**Nothing changes at 100% zoom with no display scaling.** Every term is 0 there and the slack is skipped for a whole-pixel total, which is what the green suites below assert.

The horizontal scrollbar needed no separate fix for the reported case — it was only ever a consequence of the unwanted vertical one, and the measured horizontal overflow is 0 at every level once the vertical bar is gone.

#### Three decisions a reviewer should check

1. **Add the inflation to the historical `1`; never return the border itself.** The menu grids and the Filters by-value list drop all four borders on `td:first-child`, and `StylesHandler`'s probe cell *is* a `td:first-child` inside them, so the border reads `0px` there — at 100% zoom, on every platform. Returning it would have resized those grids by a whole pixel at the default zoom. The same trap runs the other way at 50% (`2px`) and above 100% (`0.8px`), where the row sum already carries the whole pixel. The `> Math.round(…)` gate is deliberately the one `StylesHandler#calculateRowHeight` uses, so the two agree about which borders the rows already account for.
2. **A fixed sub-pixel slack, not a rounding up to the device-pixel grid.** The device-pixel version reads as the principled choice, but this total is also what the browser weighs against a fixed `height`: a 264px box holding 264.22px of rows at 80% zoom shows no bar because the browser rounds the deficit away, and inflating the content by most of a device pixel pushes it over into a full 15px bar. Measured, then replaced. Deciding it from the holder's own height cannot work either — with `height: 'auto'` the holder resolves *from* the hider being written, so the test would read the previous draw.
3. **`getBoundingClientRect()` and `offsetHeight` are in different coordinate spaces.** A rect is scaled by an ancestor's CSS `zoom`; `offsetHeight` and the computed style are not. The header fraction therefore comes from `getComputedStyle().height`, and is clamped to ±1px — the computed height is the content box while `offsetHeight` is the border box, so a host stylesheet putting a border on `thead` would otherwise turn the "fraction" into several whole pixels of real box, subtracted straight out of the hider.

Two smaller notes: `stylesHandler` is a user-supplied setting that defaults to `null`, so `getStyleForTD` is optional and guarded — calling it unguarded threw inside the draw and took out 695 of 816 walkontable specs. And `getColumnHeaderHeight()`'s cache is reset per draw by `createColumnsCalculator`, so the extra computed-style read runs every draw; it adds a resolved style, not a second reflow, because the `outerHeight` above it has already flushed layout.

All of the above is recorded in `handsontable/src/3rdparty/walkontable/AGENTS.md`.

#### Known limitation, deliberately out of scope

A zoom applied **after** the grid is built is still not followed. `StylesHandler` reads the cells' border once from a snapshot taken at init, so a grid built at 100% and then zoomed out keeps its original row heights — the limitation DEV-2657 documented in its own comment. Measured on a 40-row grid, vertical overflow with the zoom applied post-load:

| zoom | 18.1.0 | this PR |
|---|---|---|
| 90% | 4px | 3px |
| 80% | 9px | 8px |
| 67% | 18px | 17px |

Better at every level, never worse, but not fixed — the dominant term there is the frozen row-height cache. Chrome remembers zoom per origin, so a returning user loads at their zoom level and gets the fixed path; the gap is the first live Ctrl− press. It needs the row-height cache and the style snapshot invalidated on a zoom change, and wants its own ticket.

### How has this been tested?

New tests, both verified failing-first. With the fix reverted, all eight `the scroll box holds the whole table` assertions fail.

- `handsontable/src/3rdparty/walkontable/test/unit/axisSizing/hiderCompensation.unit.ts` — 31 cases over the two pure helpers: the borderless / 50% / 125% cases that must stay at the historical `1`, the partial-`stylesHandler` case that caused the 695 failures, and the whole-pixel totals the slack must leave untouched.
- `tests/e2e/auto-height-scrollbar-zoom.spec.ts` plus its fixture and page object — eight cases across four zoom levels and two row counts, one navigation each. The file documents which assertion discriminates: the scroll-box-vs-table one, since this fixture drives the zoom through CSS `zoom` (which leaves `devicePixelRatio` at 1, where Chrome rounds a sub-pixel overflow away instead of painting a bar). The scrollbar assertions are the user-visible backstop.

The twelve-device-scale evidence above comes from a standalone harness that cannot run inside these Playwright projects: `--force-device-scale-factor` needs `viewport: null`, and every project's `devices['Desktop Chrome']` pins `deviceScaleFactor` instead — the constraint `tests/AGENTS.md` documents. Playwright's context `deviceScaleFactor` and CDP `Emulation.setDeviceMetricsOverride` both report the ratio faithfully but never inflate the border, so a test built on either passes on the unfixed code.

Full suites, all green:

```bash
npm run test:walkontable --prefix handsontable   # 816 specs, 0 failures
npm run test:unit --prefix handsontable          # 4456 tests, 0 failures
npm run test:e2e --prefix handsontable           # 9894 specs, 0 failures, 8 pending
npm run test:types --prefix handsontable         # pass
npm run eslint --prefix handsontable             # 0 errors
npm run stylelint --prefix handsontable          # 0 errors
npm run build --prefix handsontable              # pass, incl. the strict postbuild gate

cd tests && npx playwright test --project=e2e-main   # 910 passed, 1 skipped, 0 failed
```

Chrome only, per the project's browser-testing rule. Edge shares the Blink layout engine, so the pixel-snapping behavior carries.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2525
2. Builds on DEV-2657 / #13269, which is on `develop` but missed the 18.1.0 release cut.

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2525

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the master hider height calculation and layout input path in Walkontable; behavior is unchanged at 100% zoom but affects scroll/overflow at sub-100% scaling, with broad unit and e2e coverage mitigating regression risk.
> 
> **Overview**
> Fixes **DEV-2525 / #13392**: grids with `height: 'auto'` no longer grow vertical (and follow-on horizontal) scrollbars when the browser renders below 100% zoom or display scaling.
> 
> Walkontable now sizes the master **hider** with sub-pixel-aware totals instead of a whole-pixel sum. A new **`hiderCompensation`** module supplies border inflation compensation (historical `1px` plus device-pixel inflation read via optional `stylesHandler.getStyleForTD`) and a **0.05px slack** on fractional totals for the DOM write only. **`SpreaderSize#adjustElementsSize`** folds in **`getColumnHeaderHeightFraction()`** and uses **`parseFloat`** when expanding the hider so fractional heights are not truncated. **`gatherLayoutInput`** applies the same compensation and header fraction so layout prediction stays aligned, but deliberately omits the slack.
> 
> Supporting changes: optional **`getStyleForTD`** on the engine `StylesHandler` type with harness stubbing, expanded **AGENTS.md** guidance, unit tests for the helpers, and Playwright e2e coverage across zoom levels and row counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 207e2c26f6c2af68dea8ec5da63f1da0cafb71cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->