### PR TITLE
DEV-2786: Drop the dead position-change report on the inline-start axis

### DIFF
--- a/.changelogs/13393.json
+++ b/.changelogs/13393.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved scrolling performance by removing a redundant re-render that ran whenever the grid was scrolled across its horizontal start.",
+  "type": "changed",
+  "issueOrPR": 13393,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/.ai/RENDERING-LIFECYCLE.md
+++ b/handsontable/src/3rdparty/walkontable/.ai/RENDERING-LIFECYCLE.md
@@ -276,9 +276,12 @@ All line numbers are in `table.ts` unless noted. "Master only" = guarded by `thi
 - Call `resetFixedPosition()` on top (`624`), bottom-if-cloned (`626–628`), inline-start (`630`), and
   corner overlays (`632–638`). Each positions its clone and, for top/bottom/inline-start, decides the
   `innerBorderTop` / `innerBorderInlineStart` / `innerBorderBottom` class via `adjustHeaderBordersPosition`.
-  Those calls OR-together into `positionChanged`. Only the two ROW-axis classes still shift the layout;
-  `innerBorderInlineStart` is stamped for backward compatibility and drives no geometry since #6673
-  (see AGENTS.md, "Column-axis border ownership").
+  Only the TOP and BOTTOM results OR-together into `positionChanged`, because only the two ROW-axis
+  classes still shift the layout. `innerBorderInlineStart` is stamped for backward compatibility and
+  drives no geometry since #6673, so the inline-start overlay reports `false` unconditionally and its
+  result is not read at all; the corner overlays never contributed and return a constant `true` that
+  must never be ORed in (see AGENTS.md, "Column-axis border ownership", and the comment in
+  `placeFixedOverlays`).
 - **S16a seam:** the border decision is now a pure `#computeHeaderBordersState(...)` separated from its
   DOM write in `overlay/regions/topOverlay.ts` / `inlineStartOverlay.ts` / `bottomOverlay.ts` — so S16b
   can move the decision pre-render. Behavior today is unchanged (compute + apply still called in

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -149,6 +149,31 @@ Consequences worth knowing:
   reads them any more. `innerBorderInlineStart` also only toggles when the grid has row headers and NO
   frozen columns, so it is not a usable "has scrolled" signal in a test — poll the holder's
   `scrollLeft` instead.
+- **`InlineStartOverlay#resetFixedPosition` reports `false` unconditionally**, and `placeFixedOverlays`
+  no longer ORs it into `ctx.positionChanged` — only the top and bottom overlays feed that flag now.
+  The class shifts no layout, so the flag's one job (reconciling a 1px shift) had nothing to do, yet
+  every scroll crossing horizontal offset 0 ran `refreshAll()`: a nested `wot.draw(true)` over the
+  master and every clone. Grids on the single-pass path did not pay it, because `prepareHeaderBorders`
+  applies the class before the cells render and the post-render toggle then finds it already in place.
+  Those two gates line up exactly, which is worth knowing before you assume a window-scrolled grid slips
+  between them: `usesLayoutSnapshotForCalculators()` requires `!isHorizontallyScrollableByWindow()`,
+  that predicate IS `inlineStartOverlay.trimmingContainer === rootWindow`, and `prepareHeaderBorders`
+  bails on the same test against the same overlay — so anything passing the single-pass gate is
+  element-scrolled and never bails. `preventOverflow` does not enter into it; it changes how
+  `resetFixedPosition` uses the trimming container, not what the container is. The cost therefore landed
+  on the grids that drop off that path, which `colWidths` as an array or an active `manualColumnResize`
+  is enough to do.
+- **Counting `refreshAll` cannot measure a reconciliation draw on its own.** `ScrollSync` calls
+  `refreshAll` once per scroll event as the normal response to a scroll (`overlay/scroll/scrollSync.ts`),
+  so a per-crossing count is at least 1 whether or not anything reconciled, and that baseline hides the
+  difference. The reconciliation is the **re-entrant** call: the scroll-driven one runs `wot.draw(true)`,
+  and a draw that sees `positionChanged` calls `refreshAll` again from inside it. Count by nesting depth
+  **on `refreshAll` itself**, which is reachable: `ScrollSync` holds it as a late-bound closure
+  (`refreshAll: () => overlays.refreshAll()`), so replacing the method is observed through that call too.
+  Do **not** try to get the depth by patching `draw` on the instance `hot.view._wt` hands you:
+  `wtOverlays.wot !== hot.view._wt`, so a patched `_wt.draw` counts **zero** calls even for a
+  `refreshAll()` invoked directly, which definitely runs `this.wot.draw(true)`.
+  `tests/e2e/walkontable/inline-start-border-refresh.spec.ts` measures it this way.
 - **The row axis is unchanged.** `innerBorderTop` / `innerBorderBottom` still shift the layout by 1px,
   which is what `positionChanged` and the reconciliation draw in `table/drawCycle.ts` exist for, and
   `columnHeaderBorderCompensation` in `topOverlay`/`spreaderSize` is the vertical twin that stayed.

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -160,9 +160,13 @@ Consequences worth knowing:
   that predicate IS `inlineStartOverlay.trimmingContainer === rootWindow`, and `prepareHeaderBorders`
   bails on the same test against the same overlay — so anything passing the single-pass gate is
   element-scrolled and never bails. `preventOverflow` does not enter into it; it changes how
-  `resetFixedPosition` uses the trimming container, not what the container is. The cost therefore landed
-  on the grids that drop off that path, which `colWidths` as an array or an active `manualColumnResize`
-  is enough to do.
+  `resetFixedPosition` uses the trimming container, not what the container is. The cost therefore
+  landed on the grids that drop off that path, and there are TWO ways to do that, both of which paid:
+  breaking the uniform-size requirement (`colWidths` as an array, or an active `manualColumnResize`),
+  and breaking the element-mode requirement (a window-scrolled grid, i.e. no `width`/`height`). The
+  window shape is the harsher one, since `prepareHeaderBorders` bails on it outright and so could
+  never have pre-applied the class whatever the other settings said. Both have a leg in
+  `tests/e2e/walkontable/inline-start-border-refresh.spec.ts`.
 - **Counting `refreshAll` cannot measure a reconciliation draw on its own.** `ScrollSync` calls
   `refreshAll` once per scroll event as the normal response to a scroll (`overlay/scroll/scrollSync.ts`),
   so a per-crossing count is at least 1 whether or not anything reconciled, and that baseline hides the

--- a/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
@@ -405,6 +405,11 @@ class Overlays {
    * the cell render, so the post-render `resetFixedPosition` toggle is a no-op and the nested
    * `wot.draw(true)` re-render is skipped. Called from the master draw on the single-pass gated path,
    * before `beginDrawLayout`. Mirrors the overlay set used by the post-render position pass.
+   *
+   * The skipped re-render is `innerBorderTop`'s alone. The inline-start class shifts no layout since
+   * #6673, so that overlay reports no position change whether or not this pass applied its class;
+   * pre-applying it only keeps a `beforeViewRender` listener from seeing a stale value. See
+   * `InlineStartOverlay#prepareHeaderBorders`.
    */
   prepareHeaderBorders() {
     this.topOverlay.prepareHeaderBorders();

--- a/handsontable/src/3rdparty/walkontable/src/overlay/regions/inlineStartOverlay.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/regions/inlineStartOverlay.ts
@@ -2,7 +2,6 @@ import type { TableDeps } from '../../table/baseTable';
 import {
   addClass,
   getScrollLeft,
-  hasClass,
   removeClass,
   setOverlayPosition,
   resetCssTransform,
@@ -60,7 +59,8 @@ export class InlineStartOverlay extends Overlay {
   /**
    * Updates the left overlay position.
    *
-   * @returns {boolean}
+   * @returns {boolean} Always `false` - this overlay's header-border classes shift no layout, so it
+   * never reports a position change. See `InlineStartOverlay#adjustHeaderBordersPosition`.
    */
   resetFixedPosition() {
     const wtTable = this.deps.getWtTable();
@@ -88,11 +88,11 @@ export class InlineStartOverlay extends Overlay {
       resetCssTransform(overlayRoot);
     }
 
-    const positionChanged = this.adjustHeaderBordersPosition(overlayPosition);
+    this.adjustHeaderBordersPosition(overlayPosition);
 
     this.adjustElementsSize();
 
-    return positionChanged;
+    return false;
   }
 
   /**
@@ -410,9 +410,10 @@ export class InlineStartOverlay extends Overlay {
   }
 
   /**
-   * Pre-applies the `innerBorderInlineStart` class before the cell render (single-pass gated
-   * path), so the post-render `resetFixedPosition` toggle is a no-op and the nested re-draw is
-   * skipped. Element mode only — see `TopOverlay#prepareHeaderBorders`.
+   * Pre-applies the `innerBorderInlineStart` class before the cell render (single-pass gated path),
+   * so a `beforeViewRender` listener sees the class in the state this draw ends in. Unlike the top
+   * overlay's copy, this one saves no re-draw: the class shifts no layout, so the post-render toggle
+   * reports nothing either way. Element mode only — see `TopOverlay#prepareHeaderBorders`.
    */
   prepareHeaderBorders() {
     if (!this.needFullRender || !this.shouldBeRendered() ||
@@ -425,10 +426,17 @@ export class InlineStartOverlay extends Overlay {
   }
 
   /**
-   * Adds css classes to hide the header border's header (cell-selection border hiding issue).
+   * Stamps the `innerBorderInlineStart` / `innerBorderLeft` / `emptyRows` classes on the master.
+   *
+   * Always reports `false`: the row header carries its inline-end border at every scroll position
+   * and no cell behind it carries an inline-start border (#6673), so none of these classes moves the
+   * layout by a pixel and no stylesheet reads them. They are stamped for backward compatibility
+   * only. Reporting a position change made every scroll crossing horizontal offset 0 run
+   * `refreshAll()` - a nested `wot.draw(true)` over the master and every clone - to reconcile a
+   * 1px shift that cannot happen.
    *
    * @param {number} position Header X position if trimming container is window or scroll top if not.
-   * @returns {boolean}
+   * @returns {boolean} Always `false`.
    */
   adjustHeaderBordersPosition(position: number) {
     const masterParent = this.deps.getWtTable().holder.parentNode as HTMLElement;
@@ -447,45 +455,38 @@ export class InlineStartOverlay extends Overlay {
       removeClass(masterParent, 'innerBorderLeft innerBorderInlineStart');
     }
 
-    return state.positionChanged;
+    return false;
   }
 
   /**
    * Computes the inline-start overlay's header-border state without mutating the DOM. Pure: reads
-   * settings and the current class state only. Splitting the decision from the write lets the
-   * single-pass draw resolve the `innerBorderInlineStart` toggle before rendering, instead of after.
+   * the settings only. Splitting the decision from the write lets the single-pass draw resolve the
+   * `innerBorderInlineStart` toggle before rendering, instead of after.
+   *
+   * Reports no position change, which is why it does not read the current class state either: the
+   * class shifts nothing. See `InlineStartOverlay#adjustHeaderBordersPosition`.
    *
    * @param {number} position The overlay offset that decides whether the inline-start border is shown.
-   * @returns {{ hasEmptyRows: boolean, innerBorder: string, positionChanged: boolean }}
+   * @returns {{ hasEmptyRows: boolean, innerBorder: string }}
    */
   #computeHeaderBordersState(position: number) {
     const { wtSettings } = this;
-    const masterParent = this.deps.getWtTable().holder.parentNode as HTMLElement;
     const rowHeaders = wtSettings.getSetting('rowHeaders') as ((...args: unknown[]) => unknown)[];
     const fixedColumnsStart = wtSettings.getSetting<number>('fixedColumnsStart');
     const totalRows = wtSettings.getSetting<number>('totalRows');
     const preventVerticalOverflow = wtSettings.getSetting('preventOverflow') === 'vertical';
     const hasEmptyRows = !totalRows;
     let innerBorder = 'keep';
-    let positionChanged = false;
 
     if (!preventVerticalOverflow) {
       if (fixedColumnsStart && !rowHeaders.length) {
         innerBorder = 'add';
 
       } else if (!fixedColumnsStart && rowHeaders.length) {
-        const previousState = hasClass(masterParent, 'innerBorderInlineStart');
-
-        if (position) {
-          innerBorder = 'add';
-          positionChanged = !previousState;
-        } else {
-          innerBorder = 'remove';
-          positionChanged = previousState;
-        }
+        innerBorder = position ? 'add' : 'remove';
       }
     }
 
-    return { hasEmptyRows, innerBorder, positionChanged };
+    return { hasEmptyRows, innerBorder };
   }
 }

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -523,9 +523,9 @@ function renderActiveSelections(table: Table, runFastDraw: boolean): void {
  *
  * Only the TOP and BOTTOM overlays contribute to the flag. The corners never did, and the
  * inline-start overlay no longer does: its `innerBorderInlineStart` class shifts no layout since
- * #6673, so it always reported `false` while still forcing the OR - and on the draws where the class
- * did toggle, a nested reconciliation draw over the master and every clone for a 1px shift that
- * cannot happen. It is still repositioned here, its result is just not read.
+ * #6673, so its report meant nothing — `false` on most draws, and `true` on the draws where the
+ * class toggled, which cost a nested reconciliation draw over the master and every clone for a 1px
+ * shift that cannot happen. It is still repositioned here, its result is just not read.
  *
  * @param {Table} table The master table.
  * @param {DrawContext} ctx The per-draw scratch (receives `positionChanged`).

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -123,9 +123,10 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
   // (`innerBorderTop` / `innerBorderInlineStart`) BEFORE resolving the snapshot and rendering the
   // cells, from the pre-render scroll position + settings. Cells then render in their final
   // position, so the post-render `resetFixedPosition` toggle is a no-op (`positionChanged` stays
-  // `false`) and the nested `wot.draw(true)` re-render never fires. Element mode only (guaranteed
-  // by the gate); the border box is thus present when `beginDrawLayout` measures the workspace,
-  // matching a steady-state scrolled draw.
+  // `false`) and the nested `wot.draw(true)` re-render never fires. That saving is `innerBorderTop`'s
+  // alone — the inline-start class shifts no layout and reports nothing whenever it is applied
+  // (#6673). Element mode only (guaranteed by the gate); the border box is thus present when
+  // `beginDrawLayout` measures the workspace, matching a steady-state scrolled draw.
   if (wtViewport.usesLayoutSnapshotForCalculators()) {
     wtOverlays.prepareHeaderBorders();
   }
@@ -518,8 +519,13 @@ function renderActiveSelections(table: Table, runFastDraw: boolean): void {
 
 /**
  * Master-only fixed-position pass: repositions the top / bottom / inline-start / corner overlays and
- * records in `ctx.positionChanged` whether an `innerBorder*` toggle shifted the layout by 1px (the
- * corners do not contribute to the flag, matching the original).
+ * records in `ctx.positionChanged` whether an `innerBorder*` toggle shifted the layout by 1px.
+ *
+ * Only the TOP and BOTTOM overlays contribute to the flag. The corners never did, and the
+ * inline-start overlay no longer does: its `innerBorderInlineStart` class shifts no layout since
+ * #6673, so it always reported `false` while still forcing the OR - and on the draws where the class
+ * did toggle, a nested reconciliation draw over the master and every clone for a 1px shift that
+ * cannot happen. It is still repositioned here, its result is just not read.
  *
  * @param {Table} table The master table.
  * @param {DrawContext} ctx The per-draw scratch (receives `positionChanged`).
@@ -533,7 +539,7 @@ function placeFixedOverlays(table: Table, ctx: DrawContext): void {
     ctx.positionChanged = wtOverlays.bottomOverlay.resetFixedPosition() || ctx.positionChanged;
   }
 
-  ctx.positionChanged = wtOverlays.inlineStartOverlay.resetFixedPosition() || ctx.positionChanged;
+  wtOverlays.inlineStartOverlay.resetFixedPosition();
 
   if (wtOverlays.topInlineStartCornerOverlay) {
     wtOverlays.topInlineStartCornerOverlay.resetFixedPosition();

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -541,6 +541,13 @@ function placeFixedOverlays(table: Table, ctx: DrawContext): void {
 
   wtOverlays.inlineStartOverlay.resetFixedPosition();
 
+  // The two corner overlays' results are CONSTANTS - both `return true` unconditionally
+  // (`topInlineStartCornerOverlay`, `bottomInlineStartCornerOverlay`), because they satisfy the
+  // `boolean` the base class declares without having a border class to decide. Never OR either of
+  // them in to make this pass look symmetrical: `positionChanged` would then be `true` on every draw
+  // of any grid with row headers and frozen columns, and every draw would pay a nested `refreshAll()`
+  // over the master and every clone. Only an overlay that actually toggles a layout-shifting
+  // `innerBorder*` class may feed the flag, which today means the top and bottom overlays alone.
   if (wtOverlays.topInlineStartCornerOverlay) {
     wtOverlays.topInlineStartCornerOverlay.resetFixedPosition();
   }

--- a/tests/e2e/walkontable/inline-start-border-refresh.spec.ts
+++ b/tests/e2e/walkontable/inline-start-border-refresh.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '../../fixtures/test';
+import { InlineStartBorderRefreshPage } from '../../fixtures/pages/walkontable/InlineStartBorderRefreshPage';
+
+/**
+ * DEV-2786 item 2 - the dead `positionChanged` report on the inline-start axis.
+ *
+ * `InlineStartOverlay#resetFixedPosition` reported a position change whenever it toggled
+ * `innerBorderInlineStart`, and the draw cycle ORed that into `positionChanged`, whose only job is
+ * to reconcile a 1px layout shift. Since #6673 the class shifts nothing: the row header carries its
+ * inline-end border at every scroll position and no cell behind it carries an inline-start border.
+ * So every scroll crossing horizontal offset 0 ran `refreshAll()` - a nested `wot.draw(true)` over
+ * the master and every clone - for a shift that cannot happen.
+ *
+ * Nothing about this is visible: `refreshAll` re-renders the cells the draw already rendered, so the
+ * grid looks identical either way. The draw count is the observable contract, which is why these
+ * assertions count rather than measure. The geometry assertions are the other half - dropping the
+ * report must not drop a refresh some overlay actually needed.
+ */
+test.describe('walkontable inline-start header border refresh', { tag: '@walkontable' }, () => {
+  let wt: InlineStartBorderRefreshPage;
+
+  test.describe('with one declared column width (the single-pass layout path)', () => {
+    test.beforeEach(async ({ page, theme, bundle }) => {
+      wt = new InlineStartBorderRefreshPage(page, theme, bundle);
+      await wt.goto({ colWidths: 'uniform' });
+    });
+
+    test('takes the single-pass calculator path', async () => {
+      // The premise that separates this block from the varied one. Without it both would measure the
+      // same path and the varied block would prove nothing.
+      expect(await wt.usesSinglePassPath()).toBe(true);
+    });
+
+    test('costs no reconciliation draw when the grid crosses horizontal offset 0', async () => {
+      // A CONTROL, not the regression: this configuration already cost nothing, because
+      // `prepareHeaderBorders` applies the class before the cells render, so the post-render toggle
+      // found it already in place and reported no change. It is here to pin that, and to show the
+      // scroll-driven refresh is still counted on a path where the reconciliation never ran - so a
+      // zero in the varied block below cannot be read as the counter being broken.
+      const draws = await wt.countDrawsAcrossOffsetZero();
+
+      expect(draws.leavingOffsetZero.reconciliation).toBe(0);
+      expect(draws.returningToOffsetZero.reconciliation).toBe(0);
+      expect(draws.leavingOffsetZero.scrollDriven).toBeGreaterThanOrEqual(1);
+      expect(draws.returningToOffsetZero.scrollDriven).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  test.describe('with a colWidths array (off the single-pass layout path)', () => {
+    test.beforeEach(async ({ page, theme, bundle }) => {
+      wt = new InlineStartBorderRefreshPage(page, theme, bundle);
+      await wt.goto({ colWidths: 'varied' });
+    });
+
+    test('drops off the single-pass calculator path', async () => {
+      // `usesLayoutSnapshotForCalculators` needs uniform column widths, so an array takes the grid
+      // off the pre-render border path - which is the shape that paid twice per crossing.
+      expect(await wt.usesSinglePassPath()).toBe(false);
+    });
+
+    test('costs no reconciliation draw when the grid crosses horizontal offset 0', async () => {
+      // THE regression assertion. Off the single-pass path the class is toggled after the cells
+      // render, so the overlay reported a position change and the draw ran the 1px reconciliation:
+      // one re-entrant `refreshAll` on each crossing, a full nested draw over the master and every
+      // clone, for a shift that cannot happen since #6673. This is the assertion that fails without
+      // the source change.
+      const draws = await wt.countDrawsAcrossOffsetZero();
+
+      expect(draws.leavingOffsetZero.reconciliation).toBe(0);
+      expect(draws.returningToOffsetZero.reconciliation).toBe(0);
+
+      // The scroll itself must still refresh the overlays - the cost that was removed is the nested
+      // one, not this one.
+      expect(draws.leavingOffsetZero.scrollDriven).toBeGreaterThanOrEqual(1);
+      expect(draws.returningToOffsetZero.scrollDriven).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  test.describe('regardless of the layout path', () => {
+    for (const colWidths of ['uniform', 'varied'] as const) {
+      test.describe(`with ${colWidths} column widths`, () => {
+        test.beforeEach(async ({ page, theme, bundle }) => {
+          wt = new InlineStartBorderRefreshPage(page, theme, bundle);
+          await wt.goto({ colWidths });
+        });
+
+        test('keeps stamping the backward-compatibility classes on the master', async () => {
+          // No stylesheet reads these any more, but they are public DOM surface that has been there
+          // for years. Dropping the position REPORT must not drop the stamping with it.
+          expect(await wt.masterBorderClasses())
+            .toEqual({ innerBorderInlineStart: false, innerBorderLeft: false });
+
+          await wt.scrollAwayFromOffsetZero();
+
+          expect(await wt.masterBorderClasses())
+            .toEqual({ innerBorderInlineStart: true, innerBorderLeft: true });
+
+          await wt.scrollToOffsetZero();
+
+          expect(await wt.masterBorderClasses())
+            .toEqual({ innerBorderInlineStart: false, innerBorderLeft: false });
+        });
+
+        test('leaves every overlay correctly sized and aligned after a round trip', async () => {
+          // The other half of the change: no overlay may stop refreshing. A clone left stale by the
+          // missing reconciliation draw shows up as a size that does not come back, or as the
+          // inline-start clone's rows sitting at a different offset than the master's.
+          const before = await wt.overlayMetrics();
+
+          await wt.scrollAwayFromOffsetZero();
+
+          const scrolled = await wt.overlayMetrics();
+
+          // The row header's width is scroll independent since #6673, and so is the scroll range it
+          // feeds. Both used to change by scrolling.
+          expect(scrolled.rowHeaderWidth).toBe(before.rowHeaderWidth);
+          expect(scrolled.hiderWidth).toBe(before.hiderWidth);
+
+          // The reconciliation branch that no longer runs also carried the master's
+          // `adjustElementsSize()`, the only place the hider is sized on that path. A horizontal
+          // crossing must leave the vertical extent alone - the row-axis compensation reads
+          // `scrollTop`, which a horizontal scroll does not move - and the scroll range in both axes
+          // has to survive, or the grid keeps a scrollbar it cannot ride to the end.
+          expect(scrolled.hiderHeight).toBe(before.hiderHeight);
+          expect(scrolled.masterScrollHeight).toBe(before.masterScrollHeight);
+          expect(scrolled.masterScrollWidth).toBe(before.masterScrollWidth);
+
+          expect(scrolled.inlineStartCloneWidth).toBe(before.inlineStartCloneWidth);
+          expect(scrolled.topCloneWidth).toBe(before.topCloneWidth);
+          expect(scrolled.cornerCloneWidth).toBe(before.cornerCloneWidth);
+          expect(scrolled.inlineStartFirstRowTop).toBe(scrolled.masterFirstRowTop);
+
+          await wt.scrollToOffsetZero();
+
+          expect(await wt.overlayMetrics()).toEqual(before);
+        });
+      });
+    }
+  });
+});

--- a/tests/e2e/walkontable/inline-start-border-refresh.spec.ts
+++ b/tests/e2e/walkontable/inline-start-border-refresh.spec.ts
@@ -46,6 +46,47 @@ test.describe('walkontable inline-start header border refresh', { tag: '@walkont
     });
   });
 
+  // There are two ways off the single-pass path, and both used to pay the reconciliation, so both
+  // get a leg. A `colWidths` array breaks the uniform-size requirement. Window scrolling breaks the
+  // element-mode requirement, and it is the harsher of the two: `prepareHeaderBorders` bails
+  // outright on `trimmingContainer === rootWindow`, so that shape could never have had its class
+  // pre-applied whatever the other settings said.
+  test.describe('with the window as the scroll container (off the single-pass layout path)', () => {
+    test.beforeEach(async ({ page, theme, bundle }) => {
+      wt = new InlineStartBorderRefreshPage(page, theme, bundle);
+      await wt.goto({ colWidths: 'uniform', scroll: 'window' });
+    });
+
+    test('drops off the single-pass calculator path', async () => {
+      // Uniform widths here, so the gate can only be failing on the window-mode term.
+      expect(await wt.usesSinglePassPath()).toBe(false);
+    });
+
+    test('costs no reconciliation draw when the grid crosses horizontal offset 0', async () => {
+      const draws = await wt.countDrawsAcrossOffsetZero();
+
+      expect(draws.leavingOffsetZero.reconciliation).toBe(0);
+      expect(draws.returningToOffsetZero.reconciliation).toBe(0);
+      expect(draws.leavingOffsetZero.scrollDriven).toBeGreaterThanOrEqual(1);
+      expect(draws.returningToOffsetZero.scrollDriven).toBeGreaterThanOrEqual(1);
+    });
+
+    test('keeps stamping the backward-compatibility classes on the master', async () => {
+      expect(await wt.masterBorderClasses())
+        .toEqual({ innerBorderInlineStart: false, innerBorderLeft: false });
+
+      await wt.scrollAwayFromOffsetZero();
+
+      expect(await wt.masterBorderClasses())
+        .toEqual({ innerBorderInlineStart: true, innerBorderLeft: true });
+
+      await wt.scrollToOffsetZero();
+
+      expect(await wt.masterBorderClasses())
+        .toEqual({ innerBorderInlineStart: false, innerBorderLeft: false });
+    });
+  });
+
   test.describe('with a colWidths array (off the single-pass layout path)', () => {
     test.beforeEach(async ({ page, theme, bundle }) => {
       wt = new InlineStartBorderRefreshPage(page, theme, bundle);
@@ -59,11 +100,11 @@ test.describe('walkontable inline-start header border refresh', { tag: '@walkont
     });
 
     test('costs no reconciliation draw when the grid crosses horizontal offset 0', async () => {
-      // THE regression assertion. Off the single-pass path the class is toggled after the cells
-      // render, so the overlay reported a position change and the draw ran the 1px reconciliation:
-      // one re-entrant `refreshAll` on each crossing, a full nested draw over the master and every
-      // clone, for a shift that cannot happen since #6673. This is the assertion that fails without
-      // the source change.
+      // THE regression assertion, together with its twin in the window-mode block. Off the
+      // single-pass path the class is toggled after the cells render, so the overlay reported a
+      // position change and the draw ran the 1px reconciliation: one re-entrant `refreshAll` on each
+      // crossing, a full nested draw over the master and every clone, for a shift that cannot happen
+      // since #6673. This is the assertion that fails without the source change.
       const draws = await wt.countDrawsAcrossOffsetZero();
 
       expect(draws.leavingOffsetZero.reconciliation).toBe(0);

--- a/tests/e2e/walkontable/inline-start-border-refresh.spec.ts
+++ b/tests/e2e/walkontable/inline-start-border-refresh.spec.ts
@@ -115,6 +115,41 @@ test.describe('walkontable inline-start header border refresh', { tag: '@walkont
       expect(draws.leavingOffsetZero.scrollDriven).toBeGreaterThanOrEqual(1);
       expect(draws.returningToOffsetZero.scrollDriven).toBeGreaterThanOrEqual(1);
     });
+
+    test('still pays exactly one reconciliation draw on a VERTICAL crossing', async () => {
+      // The positive assertion, and the reason this file cannot pass vacuously. Every other
+      // reconciliation expectation here is `toBe(0)`, so a later change that deleted
+      // `ctx.positionChanged` and its whole branch would keep all of them green. The row axis still
+      // shifts the layout by 1px and still feeds the flag, so a vertical crossing off the
+      // single-pass path must cost exactly one re-entrant `refreshAll` - no more, and crucially no
+      // fewer. This is the assertion that fails if the flag is removed rather than narrowed.
+      //
+      // It also marks the boundary of this change: bringing the row axis into line is separate work,
+      // and when that lands this expectation becomes 0 like the others.
+      const draws = await wt.countDrawsAcrossOffsetZero('vertical');
+
+      expect(draws.leavingOffsetZero.reconciliation).toBe(1);
+      expect(draws.returningToOffsetZero.reconciliation).toBe(1);
+    });
+
+    test('leaves the master sizes alone when the crossing draw skips its render', async () => {
+      // The one shape the metrics above cannot reach: they come only from draws that rendered. A
+      // skipped draw used to get the master `adjustElementsSize()` from the `positionChanged` branch
+      // and now takes the plain `else`, so this is where that would show up.
+      const { skipped, before, after } = await wt.crossOffsetZeroWithRenderSkipped();
+
+      // Precondition. Without it the rest passes on a draw that rendered normally.
+      expect(skipped).toBeGreaterThanOrEqual(1);
+
+      // Only the size fields: a skipped render rolls the rendered band back, so row offsets within
+      // the table legitimately differ. A horizontal crossing changes no master size since #6673,
+      // which is exactly why dropping the extra `adjustElementsSize()` is safe here.
+      expect(after.hiderWidth).toBe(before.hiderWidth);
+      expect(after.hiderHeight).toBe(before.hiderHeight);
+      expect(after.masterScrollWidth).toBe(before.masterScrollWidth);
+      expect(after.masterScrollHeight).toBe(before.masterScrollHeight);
+      expect(after.rowHeaderWidth).toBe(before.rowHeaderWidth);
+    });
   });
 
   test.describe('regardless of the layout path', () => {

--- a/tests/fixtures/demo/walkontable/inline-start-border-refresh.html
+++ b/tests/fixtures/demo/walkontable/inline-start-border-refresh.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Walkontable (inline-start border refresh) e2e fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back — a
+    // typo in the project config must be one red leg, never a silently
+    // mislabeled green one (nothing else asserts which file actually loaded).
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    // Written into <head> so the themed stylesheet is present before first render.
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    // 1:1 with the Puppeteer legs (umd = handsontable.js, full-min =
+    // handsontable.full.min.js, the exact file `test:production` loads).
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+    // `uniform` keeps one declared column width, which is what the single-pass
+    // layout snapshot needs; `varied` passes a colWidths ARRAY, which drops the
+    // grid off that path. Both must cost zero reconciliation draws, and the
+    // varied one is where the cost used to double. Unknown values THROW.
+    window.htColWidthsMode = ({ uniform: 'uniform', varied: 'varied' })[htParams.get('colWidths') ?? 'uniform'];
+    if (!window.htColWidthsMode) {
+      throw new Error('Unknown ?colWidths= value: ' + JSON.stringify(htParams.get('colWidths')));
+    }
+  </script>
+  <style> body { font-family: sans-serif; margin: 1rem; } </style>
+</head>
+<body>
+  <!--
+    DEV-2786 item 2. `InlineStartOverlay#resetFixedPosition` used to report a position change
+    whenever it toggled `innerBorderInlineStart`, and that result was ORed into the draw cycle's
+    `positionChanged`. Since #6673 the class shifts nothing - the row header carries its inline-end
+    border at every scroll position and no cell behind it carries an inline-start border - so every
+    scroll crossing horizontal offset 0 ran `refreshAll()`, a nested `wot.draw(true)` over the
+    master and every clone, to reconcile a 1px shift that cannot happen.
+
+    The grid shape is the one that toggles the class at all: row headers on, `fixedColumnsStart` 0,
+    and content far wider than the container so there is somewhere to scroll.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The
+    // closing tag is split so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const TOTAL_COLUMNS = 30;
+    // The column to scroll to when leaving offset 0. Far enough in that the rendered band no longer
+    // contains column 0, so the draw is a real band change rather than a reposition.
+    const FAR_COLUMN = 12;
+
+    const hot = new Handsontable(container, {
+      data: Handsontable.helper.createSpreadsheetData(20, TOTAL_COLUMNS),
+      width: 500,
+      height: 300,
+      // The shape under test: a row header, and NO frozen columns. The overlay only toggles
+      // `innerBorderInlineStart` in exactly this combination.
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsStart: 0,
+      colWidths: window.htColWidthsMode === 'varied'
+        ? Array.from({ length: TOTAL_COLUMNS }, (_, c) => (c % 2 ? 80 : 75))
+        : 75,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    window.hot = hot;
+
+    const holder = () => container.querySelector('.ht_master .wtHolder');
+    const masterParent = () => container.querySelector('.ht_master');
+
+    /**
+     * Resolves once `predicate` holds, then after two more frames so the rAF-batched draw has
+     * landed. Throws rather than hanging if the state never arrives - a silent timeout here would
+     * read as "zero reconciliation draws" and pass the very assertion under test.
+     */
+    const waitFor = async (predicate, what) => {
+      for (let frame = 0; frame < 240; frame++) {
+        if (predicate()) {
+          await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+          return;
+        }
+        await new Promise(resolve => requestAnimationFrame(resolve));
+      }
+
+      throw new Error(`Timed out waiting for ${what}`);
+    };
+
+    /**
+     * Scrolls so `column` sits at the inline start and waits for the draw.
+     *
+     * The wait is on the master holder's own `scrollLeft` rather than on the class: whether
+     * `innerBorderInlineStart` appears is the thing under test, so waiting on it would make the
+     * test depend on its own conclusion.
+     */
+    const scrollToColumn = async (column) => {
+      hot.scrollViewportTo({ col: column, horizontalSnap: 'start' });
+
+      await waitFor(
+        () => (column === 0 ? holder().scrollLeft === 0 : holder().scrollLeft !== 0),
+        `the master to scroll to column ${column}`
+      );
+    };
+
+    window.scrollToColumn = scrollToColumn;
+    window.scrollToFarColumn = () => scrollToColumn(FAR_COLUMN);
+
+    /** Whether this grid takes the single-pass calculator path. A premise, asserted by the spec. */
+    window.usesSinglePassPath = () => hot.view._wt.wtViewport.usesLayoutSnapshotForCalculators();
+
+    /** The backward-compatibility classes the overlay still stamps on `.ht_master`. */
+    window.masterBorderClasses = () => ({
+      innerBorderInlineStart: masterParent().classList.contains('innerBorderInlineStart'),
+      innerBorderLeft: masterParent().classList.contains('innerBorderLeft'),
+    });
+
+    /**
+     * Counts the draws that one round trip across horizontal offset 0 costs, split into the two
+     * kinds, per direction (the class toggles on one and off on the other).
+     *
+     * `scrollDriven` is the legitimate response to a scroll event: `ScrollSync` calls
+     * `Overlays#refreshAll` once per scroll, and it must keep happening or the overlays go stale.
+     *
+     * `reconciliation` is the 1px-shift reconciliation, and it is measured as a RE-ENTRANT
+     * `refreshAll`: the scroll-driven call runs `wot.draw(true)`, and a draw that sees
+     * `positionChanged` calls `refreshAll` again from inside it. Nesting is what separates the two -
+     * counting `refreshAll` outright cannot, because the scroll-driven call is always there and
+     * would mask the difference entirely.
+     *
+     * A counter is the only way to see any of this: the reconciliation re-renders the cells the
+     * draw already rendered, so the grid looks identical whether it runs or not.
+     */
+    window.countDrawsAcrossOffsetZero = async () => {
+      const { wtOverlays } = hot.view._wt;
+      const original = wtOverlays.refreshAll.bind(wtOverlays);
+      let depth = 0;
+      let scrollDriven = 0;
+      let reconciliation = 0;
+
+      // Start the measurement at offset 0, so leaving it is a real crossing.
+      await scrollToColumn(0);
+
+      wtOverlays.refreshAll = () => {
+        if (depth === 0) {
+          scrollDriven += 1;
+        } else {
+          reconciliation += 1;
+        }
+
+        depth += 1;
+
+        try {
+          return original();
+        } finally {
+          depth -= 1;
+        }
+      };
+
+      try {
+        await window.scrollToFarColumn();
+
+        const leaving = { scrollDriven, reconciliation };
+
+        await scrollToColumn(0);
+
+        return {
+          leavingOffsetZero: leaving,
+          returningToOffsetZero: {
+            scrollDriven: scrollDriven - leaving.scrollDriven,
+            reconciliation: reconciliation - leaving.reconciliation,
+          },
+        };
+
+      } finally {
+        wtOverlays.refreshAll = original;
+      }
+    };
+
+    /**
+     * The overlay geometry that a dropped refresh would leave stale: each clone's rendered size, the
+     * row header width, the hider width that drives the scroll range, and the vertical alignment
+     * between the master's first rendered row and the inline-start clone's copy of it.
+     */
+    window.overlayMetrics = () => {
+      const round = value => Math.round(value * 100) / 100;
+      // Every selector below must resolve in this fixture's single grid. Returning `null` on a miss
+      // would make the spec's comparisons pass on `null === null` - a selector that silently stopped
+      // matching (a renamed clone class, a theme leg that renders a clone differently) would read as
+      // "geometry unchanged" instead of failing. Throw instead, so a miss surfaces as a red leg.
+      const need = (selector) => {
+        const element = container.querySelector(selector);
+
+        if (!element) {
+          throw new Error(`overlayMetrics: nothing matched ${selector}`);
+        }
+
+        return element;
+      };
+      const rect = selector => round(need(selector).getBoundingClientRect().width);
+      const firstRowTop = (overlay) => {
+        const table = need(`${overlay} table.htCore`);
+        const row = need(`${overlay} table.htCore > tbody > tr`);
+
+        return round(row.getBoundingClientRect().top - table.getBoundingClientRect().top);
+      };
+
+      return {
+        rowHeaderWidth: rect('.ht_master table.htCore > tbody > tr > th'),
+        hiderWidth: need('.ht_master .wtHider').style.width,
+        // The disconnected branch also carried the master's `wtOverlays.adjustElementsSize()`, which
+        // is the only place the hider is sized on the 1px-shift path. The hider drives the scroll
+        // range, so a size left stale by the dropped reconciliation shows up here and nowhere else.
+        // Height as well as width: the vertical compensation is still live on the row axis, and the
+        // point is that a HORIZONTAL crossing may not disturb it.
+        hiderHeight: need('.ht_master .wtHider').style.height,
+        masterScrollHeight: need('.ht_master .wtHolder').scrollHeight,
+        masterScrollWidth: need('.ht_master .wtHolder').scrollWidth,
+        inlineStartCloneWidth: rect('.ht_clone_inline_start'),
+        topCloneWidth: rect('.ht_clone_top'),
+        cornerCloneWidth: rect('.ht_clone_top_inline_start_corner'),
+        masterFirstRowTop: firstRowTop('.ht_master'),
+        inlineStartFirstRowTop: firstRowTop('.ht_clone_inline_start'),
+      };
+    };
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/walkontable/inline-start-border-refresh.html
+++ b/tests/fixtures/demo/walkontable/inline-start-border-refresh.html
@@ -34,6 +34,15 @@
     if (!window.htColWidthsMode) {
       throw new Error('Unknown ?colWidths= value: ' + JSON.stringify(htParams.get('colWidths')));
     }
+    // `element` gives the grid a width/height so it scrolls inside its own
+    // holder; `window` omits both, which makes the window the trimming
+    // container. That is the SECOND way off the single-pass path, and the one
+    // `prepareHeaderBorders` bails on outright, so it toggled the class after
+    // the render on every crossing. Unknown values THROW.
+    window.htScrollMode = ({ element: 'element', window: 'window' })[htParams.get('scroll') ?? 'element'];
+    if (!window.htScrollMode) {
+      throw new Error('Unknown ?scroll= value: ' + JSON.stringify(htParams.get('scroll')));
+    }
   </script>
   <style> body { font-family: sans-serif; margin: 1rem; } </style>
 </head>
@@ -65,11 +74,18 @@
     // The column to scroll to when leaving offset 0. Far enough in that the rendered band no longer
     // contains column 0, so the draw is a real band change rather than a reposition.
     const FAR_COLUMN = 12;
+    // The page offset window mode scrolls to instead, chosen to land well past column 0's band for
+    // the same reason. 30 columns at ~75px leaves plenty of document to the right of it.
+    const WINDOW_FAR_OFFSET = 900;
+
+    // Element mode sizes the grid so it scrolls inside its own holder. Window mode declares neither
+    // width nor height, which is what makes the window the trimming container - the columns then
+    // overflow the viewport and the PAGE scrolls.
+    const scrollBox = window.htScrollMode === 'window' ? {} : { width: 500, height: 300 };
 
     const hot = new Handsontable(container, {
       data: Handsontable.helper.createSpreadsheetData(20, TOTAL_COLUMNS),
-      width: 500,
-      height: 300,
+      ...scrollBox,
       // The shape under test: a row header, and NO frozen columns. The overlay only toggles
       // `innerBorderInlineStart` in exactly this combination.
       rowHeaders: true,
@@ -105,18 +121,37 @@
     };
 
     /**
+     * The grid's horizontal scroll offset, read from whichever element actually scrolls. In window
+     * mode the PAGE scrolls and the holder's own `scrollLeft` stays 0 forever, so keying the wait on
+     * the holder there would return immediately and the draw would not have happened yet.
+     */
+    const horizontalOffset = () => (
+      window.htScrollMode === 'window' ? window.scrollX : holder().scrollLeft
+    );
+
+    /**
      * Scrolls so `column` sits at the inline start and waits for the draw.
      *
-     * The wait is on the master holder's own `scrollLeft` rather than on the class: whether
+     * The wait is on the real scroll offset rather than on the class: whether
      * `innerBorderInlineStart` appears is the thing under test, so waiting on it would make the
      * test depend on its own conclusion.
+     *
+     * Window mode drives the PAGE scroll directly instead of going through `scrollViewportTo`.
+     * Asking that API for column 0 there targets the grid's own document origin, which is NOT
+     * `scrollX === 0` - the body margin and the heading above the grid put the table a little way
+     * into the page - so the offset the border state is derived from never returns to zero and the
+     * crossing never happens. A page scroll to 0 is both unambiguous and what a user does.
      */
     const scrollToColumn = async (column) => {
-      hot.scrollViewportTo({ col: column, horizontalSnap: 'start' });
+      if (window.htScrollMode === 'window') {
+        window.scrollTo(column === 0 ? 0 : WINDOW_FAR_OFFSET, window.scrollY);
+      } else {
+        hot.scrollViewportTo({ col: column, horizontalSnap: 'start' });
+      }
 
       await waitFor(
-        () => (column === 0 ? holder().scrollLeft === 0 : holder().scrollLeft !== 0),
-        `the master to scroll to column ${column}`
+        () => (column === 0 ? horizontalOffset() === 0 : horizontalOffset() !== 0),
+        `the grid to scroll to column ${column}`
       );
     };
 

--- a/tests/fixtures/demo/walkontable/inline-start-border-refresh.html
+++ b/tests/fixtures/demo/walkontable/inline-start-border-refresh.html
@@ -14,35 +14,53 @@
     // mislabeled green one (nothing else asserts which file actually loaded).
     const htParams = new URLSearchParams(location.search);
 
-    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
-    if (!window.htTheme) {
-      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
-    }
+    // Read through `Object.hasOwn`, never by plain lookup. These maps are object literals, so a
+    // PROTOTYPE key reaches them: `?theme=constructor` resolves to the `Object` constructor, which is
+    // truthy, so a truthiness guard never fires and a stringified function lands in the href. The one
+    // that actually bites is `?colWidths=valueOf`, which passes such a guard and then matches neither
+    // branch below, so a leg labelled `varied` would quietly measure the uniform grid - the silently
+    // mislabeled green this whole block exists to prevent.
+    const pick = (map, raw, name) => {
+      if (!Object.hasOwn(map, raw)) {
+        throw new Error(`Unknown ?${name}= value: ${JSON.stringify(raw)}`);
+      }
+
+      return map[raw];
+    };
+
+    window.htTheme = pick(
+      { main: 'main', horizon: 'horizon', classic: 'classic' },
+      htParams.get('theme') ?? 'main',
+      'theme'
+    );
     // Written into <head> so the themed stylesheet is present before first render.
     document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
     // 1:1 with the Puppeteer legs (umd = handsontable.js, full-min =
     // handsontable.full.min.js, the exact file `test:production` loads).
-    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
-    if (!window.htBundle) {
-      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
-    }
+    window.htBundle = pick(
+      { umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' },
+      htParams.get('bundle') ?? 'umd',
+      'bundle'
+    );
     // `uniform` keeps one declared column width, which is what the single-pass
     // layout snapshot needs; `varied` passes a colWidths ARRAY, which drops the
     // grid off that path. Both must cost zero reconciliation draws, and the
     // varied one is where the cost used to double. Unknown values THROW.
-    window.htColWidthsMode = ({ uniform: 'uniform', varied: 'varied' })[htParams.get('colWidths') ?? 'uniform'];
-    if (!window.htColWidthsMode) {
-      throw new Error('Unknown ?colWidths= value: ' + JSON.stringify(htParams.get('colWidths')));
-    }
+    window.htColWidthsMode = pick(
+      { uniform: 'uniform', varied: 'varied' },
+      htParams.get('colWidths') ?? 'uniform',
+      'colWidths'
+    );
     // `element` gives the grid a width/height so it scrolls inside its own
     // holder; `window` omits both, which makes the window the trimming
     // container. That is the SECOND way off the single-pass path, and the one
     // `prepareHeaderBorders` bails on outright, so it toggled the class after
     // the render on every crossing. Unknown values THROW.
-    window.htScrollMode = ({ element: 'element', window: 'window' })[htParams.get('scroll') ?? 'element'];
-    if (!window.htScrollMode) {
-      throw new Error('Unknown ?scroll= value: ' + JSON.stringify(htParams.get('scroll')));
-    }
+    window.htScrollMode = pick(
+      { element: 'element', window: 'window' },
+      htParams.get('scroll') ?? 'element',
+      'scroll'
+    );
   </script>
   <style> body { font-family: sans-serif; margin: 1rem; } </style>
 </head>
@@ -77,6 +95,8 @@
     // The page offset window mode scrolls to instead, chosen to land well past column 0's band for
     // the same reason. 30 columns at ~75px leaves plenty of document to the right of it.
     const WINDOW_FAR_OFFSET = 900;
+    // The row axis twin of FAR_COLUMN, far enough down to leave the first rendered band.
+    const FAR_ROW = 12;
 
     // Element mode sizes the grid so it scrolls inside its own holder. Window mode declares neither
     // width nor height, which is what makes the window the trimming container - the columns then
@@ -98,6 +118,18 @@
     });
 
     window.hot = hot;
+
+    // A real draw signal. The scroll offset alone cannot serve as one: `setScrollPosition` writes
+    // `scrollEl.scrollLeft` synchronously, so an offset-only predicate is already true on its first
+    // evaluation and the wait then returns two frames after the scroll was ISSUED, while the draw
+    // arrives later from the async scroll event through `ScrollSync`. On a loaded runner that gap can
+    // outlast the two frames, and the crossing's draws would then be counted against the next
+    // direction - a wrong count rather than a visible timing miss.
+    let viewRenders = 0;
+
+    hot.addHook('afterViewRender', () => {
+      viewRenders += 1;
+    });
 
     const holder = () => container.querySelector('.ht_master .wtHolder');
     const masterParent = () => container.querySelector('.ht_master');
@@ -143,20 +175,66 @@
      * crossing never happens. A page scroll to 0 is both unambiguous and what a user does.
      */
     const scrollToColumn = async (column) => {
+      const atTarget = () => (column === 0 ? horizontalOffset() === 0 : horizontalOffset() !== 0);
+      // Already there (the opening scroll to column 0 on a fresh page): nothing will scroll, so no
+      // draw is coming and requiring one would hang. Settle and return.
+      if (atTarget()) {
+        await waitFor(() => true, 'the current position to settle');
+
+        return;
+      }
+
+      const rendersBefore = viewRenders;
+
       if (window.htScrollMode === 'window') {
         window.scrollTo(column === 0 ? 0 : WINDOW_FAR_OFFSET, window.scrollY);
       } else {
         hot.scrollViewportTo({ col: column, horizontalSnap: 'start' });
       }
 
+      // Both conditions: the offset has moved AND a draw has actually run for it.
       await waitFor(
-        () => (column === 0 ? horizontalOffset() === 0 : horizontalOffset() !== 0),
-        `the grid to scroll to column ${column}`
+        () => atTarget() && viewRenders > rendersBefore,
+        `the grid to scroll to column ${column} and redraw`
       );
     };
 
     window.scrollToColumn = scrollToColumn;
     window.scrollToFarColumn = () => scrollToColumn(FAR_COLUMN);
+
+    /** The vertical twin of `horizontalOffset`. */
+    const verticalOffset = () => (
+      window.htScrollMode === 'window' ? window.scrollY : holder().scrollTop
+    );
+
+    /**
+     * The vertical twin of `scrollToColumn`, for the ROW axis - which still shifts the layout by 1px
+     * and still feeds `positionChanged`. Used by the positive assertion: a vertical crossing off the
+     * single-pass path must cost exactly one re-entrant `refreshAll`, so a change that deleted the
+     * flag and its branch outright cannot pass this file.
+     */
+    const scrollToRow = async (row) => {
+      const atTarget = () => (row === 0 ? verticalOffset() === 0 : verticalOffset() !== 0);
+
+      if (atTarget()) {
+        await waitFor(() => true, 'the current position to settle');
+
+        return;
+      }
+
+      const rendersBefore = viewRenders;
+
+      if (window.htScrollMode === 'window') {
+        window.scrollTo(window.scrollX, row === 0 ? 0 : WINDOW_FAR_OFFSET);
+      } else {
+        hot.scrollViewportTo({ row, verticalSnap: 'top' });
+      }
+
+      await waitFor(
+        () => atTarget() && viewRenders > rendersBefore,
+        `the grid to scroll to row ${row} and redraw`
+      );
+    };
 
     /** Whether this grid takes the single-pass calculator path. A premise, asserted by the spec. */
     window.usesSinglePassPath = () => hot.view._wt.wtViewport.usesLayoutSnapshotForCalculators();
@@ -183,15 +261,17 @@
      * A counter is the only way to see any of this: the reconciliation re-renders the cells the
      * draw already rendered, so the grid looks identical whether it runs or not.
      */
-    window.countDrawsAcrossOffsetZero = async () => {
+    window.countDrawsAcrossOffsetZero = async (axis = 'horizontal') => {
       const { wtOverlays } = hot.view._wt;
       const original = wtOverlays.refreshAll.bind(wtOverlays);
+      const goTo = axis === 'vertical' ? scrollToRow : scrollToColumn;
+      const goFar = () => goTo(axis === 'vertical' ? FAR_ROW : FAR_COLUMN);
       let depth = 0;
       let scrollDriven = 0;
       let reconciliation = 0;
 
       // Start the measurement at offset 0, so leaving it is a real crossing.
-      await scrollToColumn(0);
+      await goTo(0);
 
       wtOverlays.refreshAll = () => {
         if (depth === 0) {
@@ -210,11 +290,11 @@
       };
 
       try {
-        await window.scrollToFarColumn();
+        await goFar();
 
         const leaving = { scrollDriven, reconciliation };
 
-        await scrollToColumn(0);
+        await goTo(0);
 
         return {
           leavingOffsetZero: leaving,
@@ -225,7 +305,53 @@
         };
 
       } finally {
-        wtOverlays.refreshAll = original;
+        // `delete`, not `= original`. `original` is pre-bound, so assigning it back would leave an
+        // OWN property shadowing `Overlays.prototype.refreshAll` rather than falling through to it -
+        // anything later spying on the prototype, or calling with another receiver, would miss the
+        // real one. Deleting the own property is what actually restores the instance.
+        delete wtOverlays.refreshAll;
+      }
+    };
+
+    /**
+     * Crosses horizontal offset 0 on a draw whose cell render is CANCELLED, and reports the master's
+     * sizes either side of it.
+     *
+     * This is the one shape the other metrics cannot reach, because they only ever come from draws
+     * that rendered. A skipped draw used to take the `positionChanged` branch and with it the master
+     * `wtOverlays.adjustElementsSize()`, and now takes the plain `else`, so the stale-scrollbar note
+     * on that line is what narrows. It is reachable outside tests: `NestedRows` turns its own
+     * `#skipRender` on and clears it inside a `_registerTimeout`, so a horizontal scroll landing in
+     * that window is exactly this.
+     *
+     * The wait is on the offset alone, deliberately: no draw renders here, so `afterViewRender` never
+     * fires and requiring it would hang.
+     */
+    window.crossOffsetZeroWithRenderSkipped = async () => {
+      await scrollToColumn(0);
+
+      const before = window.overlayMetrics();
+      let armed = true;
+      let skipped = 0;
+      const skipNextRender = (isForced, skipObject) => {
+        if (armed && skipObject) {
+          skipObject.skipRender = true;
+          armed = false;
+          skipped += 1;
+        }
+      };
+
+      hot.addHook('beforeViewRender', skipNextRender);
+
+      try {
+        hot.scrollViewportTo({ col: FAR_COLUMN, horizontalSnap: 'start' });
+
+        await waitFor(() => horizontalOffset() !== 0, 'the grid to scroll off offset 0');
+
+        return { skipped, before, after: window.overlayMetrics() };
+
+      } finally {
+        hot.removeHook('beforeViewRender', skipNextRender);
       }
     };
 

--- a/tests/fixtures/pages/walkontable/InlineStartBorderRefreshPage.ts
+++ b/tests/fixtures/pages/walkontable/InlineStartBorderRefreshPage.ts
@@ -1,0 +1,125 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/** The two kinds of draw one crossing of horizontal offset 0 costs. */
+export interface DrawCounts {
+  /** `refreshAll` calls from the scroll event. Must stay >= 1 or the overlays go stale. */
+  scrollDriven: number;
+  /** Re-entrant `refreshAll` calls, i.e. the 1px-shift reconciliation. Must be 0. */
+  reconciliation: number;
+}
+
+/** The draws one round trip across horizontal offset 0 costs, per direction. */
+export interface DrawsAcrossOffsetZero {
+  leavingOffsetZero: DrawCounts;
+  returningToOffsetZero: DrawCounts;
+}
+
+/**
+ * The overlay geometry a dropped refresh would leave stale. No field is nullable: the fixture throws
+ * on a selector that does not match, rather than reporting `null` and letting two misses compare
+ * equal.
+ */
+export interface OverlayMetrics {
+  rowHeaderWidth: number;
+  hiderWidth: string;
+  hiderHeight: string;
+  masterScrollHeight: number;
+  masterScrollWidth: number;
+  inlineStartCloneWidth: number;
+  topCloneWidth: number;
+  cornerCloneWidth: number;
+  masterFirstRowTop: number;
+  inlineStartFirstRowTop: number;
+}
+
+/** The classes the inline-start overlay still stamps for backward compatibility. */
+export interface MasterBorderClasses {
+  innerBorderInlineStart: boolean;
+  innerBorderLeft: boolean;
+}
+
+/**
+ * Page Object for the inline-start border refresh fixture (DEV-2786 item 2).
+ *
+ * Everything here is a thin call into a fixture-side helper. The counting and the frame waits live
+ * in the fixture on purpose: they have to run inside one browser task sequence, and a spec-side
+ * `page.evaluate` per step would let a draw land between the steps.
+ */
+export class InlineStartBorderRefreshPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly grid: Locator;
+  readonly master: Locator;
+  readonly inlineStartOverlay: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.grid = page.getByTestId('grid');
+    this.master = this.grid.locator('.ht_master');
+    this.inlineStartOverlay = this.grid.locator('.ht_clone_inline_start');
+  }
+
+  /**
+   * Navigate and wait for the grid to render (a real DOM condition, no sleep).
+   *
+   * @param {object} [options] Fixture options. `colWidths` picks one declared width (`uniform`,
+   *   the single-pass layout path) or a per-column array (`varied`, off that path).
+   */
+  async goto(options: { colWidths?: 'uniform' | 'varied' } = {}): Promise<void> {
+    const params = new URLSearchParams({ theme: this.theme, bundle: this.bundle });
+
+    Object.entries(options).forEach(([key, value]) => params.set(key, String(value)));
+
+    await this.page.goto(`/tests/fixtures/demo/walkontable/inline-start-border-refresh.html?${params}`);
+    // The bundle is injected with `document.write`, separately from the block that installs these
+    // helpers, so a visible grid is not proof either has run.
+    await this.page.waitForFunction(() => 'Handsontable' in window);
+    await expect(this.master).toBeVisible();
+    await expect(this.inlineStartOverlay).toBeVisible();
+  }
+
+  /** Whether this grid takes the single-pass calculator path. */
+  async usesSinglePassPath(): Promise<boolean> {
+    return this.page.evaluate(() => (window as unknown as {
+      usesSinglePassPath: () => boolean
+    }).usesSinglePassPath());
+  }
+
+  /** Scroll a column well past the first to the inline start, and wait for the draw. */
+  async scrollAwayFromOffsetZero(): Promise<void> {
+    await this.page.evaluate(() => (window as unknown as {
+      scrollToFarColumn: () => Promise<void>
+    }).scrollToFarColumn());
+  }
+
+  /** Scroll back to horizontal offset 0, and wait for the draw. */
+  async scrollToOffsetZero(): Promise<void> {
+    await this.page.evaluate(() => (window as unknown as {
+      scrollToColumn: (column: number) => Promise<void>
+    }).scrollToColumn(0));
+  }
+
+  /** The scroll-driven and reconciliation draws one round trip across offset 0 costs. */
+  async countDrawsAcrossOffsetZero(): Promise<DrawsAcrossOffsetZero> {
+    return this.page.evaluate(() => (window as unknown as {
+      countDrawsAcrossOffsetZero: () => Promise<DrawsAcrossOffsetZero>
+    }).countDrawsAcrossOffsetZero());
+  }
+
+  /** The backward-compatibility classes on `.ht_master`. */
+  async masterBorderClasses(): Promise<MasterBorderClasses> {
+    return this.page.evaluate(() => (window as unknown as {
+      masterBorderClasses: () => MasterBorderClasses
+    }).masterBorderClasses());
+  }
+
+  /** The overlay sizes and the master/inline-start row alignment. */
+  async overlayMetrics(): Promise<OverlayMetrics> {
+    return this.page.evaluate(() => (window as unknown as {
+      overlayMetrics: () => OverlayMetrics
+    }).overlayMetrics());
+  }
+}

--- a/tests/fixtures/pages/walkontable/InlineStartBorderRefreshPage.ts
+++ b/tests/fixtures/pages/walkontable/InlineStartBorderRefreshPage.ts
@@ -107,11 +107,33 @@ export class InlineStartBorderRefreshPage {
     }).scrollToColumn(0));
   }
 
-  /** The scroll-driven and reconciliation draws one round trip across offset 0 costs. */
-  async countDrawsAcrossOffsetZero(): Promise<DrawsAcrossOffsetZero> {
+  /**
+   * The scroll-driven and reconciliation draws one round trip across offset 0 costs.
+   *
+   * @param {string} [axis] `horizontal` (the axis this change touches) or `vertical` (the row axis,
+   *   which still shifts the layout and still feeds the flag).
+   */
+  async countDrawsAcrossOffsetZero(axis: 'horizontal' | 'vertical' = 'horizontal'):
+  Promise<DrawsAcrossOffsetZero> {
+    return this.page.evaluate(which => (window as unknown as {
+      countDrawsAcrossOffsetZero: (axis: string) => Promise<DrawsAcrossOffsetZero>
+    }).countDrawsAcrossOffsetZero(which), axis);
+  }
+
+  /**
+   * Crosses horizontal offset 0 on a draw whose cell render is cancelled, with the master's sizes
+   * either side of it.
+   */
+  async crossOffsetZeroWithRenderSkipped(): Promise<{
+    skipped: number,
+    before: OverlayMetrics,
+    after: OverlayMetrics,
+  }> {
     return this.page.evaluate(() => (window as unknown as {
-      countDrawsAcrossOffsetZero: () => Promise<DrawsAcrossOffsetZero>
-    }).countDrawsAcrossOffsetZero());
+      crossOffsetZeroWithRenderSkipped: () => Promise<{
+        skipped: number, before: OverlayMetrics, after: OverlayMetrics,
+      }>
+    }).crossOffsetZeroWithRenderSkipped());
   }
 
   /** The backward-compatibility classes on `.ht_master`. */

--- a/tests/fixtures/pages/walkontable/InlineStartBorderRefreshPage.ts
+++ b/tests/fixtures/pages/walkontable/InlineStartBorderRefreshPage.ts
@@ -66,9 +66,14 @@ export class InlineStartBorderRefreshPage {
    * Navigate and wait for the grid to render (a real DOM condition, no sleep).
    *
    * @param {object} [options] Fixture options. `colWidths` picks one declared width (`uniform`,
-   *   the single-pass layout path) or a per-column array (`varied`, off that path).
+   *   the single-pass layout path) or a per-column array (`varied`, off that path). `scroll` picks
+   *   whether the grid scrolls inside its own holder (`element`) or the page scrolls (`window`),
+   *   which is the other way off that path and the one `prepareHeaderBorders` bails on.
    */
-  async goto(options: { colWidths?: 'uniform' | 'varied' } = {}): Promise<void> {
+  async goto(options: {
+    colWidths?: 'uniform' | 'varied',
+    scroll?: 'element' | 'window',
+  } = {}): Promise<void> {
     const params = new URLSearchParams({ theme: this.theme, bundle: this.bundle });
 
     Object.entries(options).forEach(([key, value]) => params.set(key, String(value)));


### PR DESCRIPTION
### Context

The PR removes a nested reconciliation draw that a horizontal scroll paid for nothing.

`ctx.positionChanged` in `walkontable/src/table/drawCycle.ts` exists for one purpose: an `innerBorder*` class toggle shifts the layout by 1px, so the draw has to reconcile the overlays against the shifted layout by calling `refreshAll()` — a nested `wot.draw(true)` over the master and every clone.

Since #6673 (PR #13371) the inline-start axis no longer shifts by that pixel. The row header carries its `border-inline-end` at every scroll position and no cell behind it carries a `border-inline-start`, so `innerBorderInlineStart` (and `innerBorderLeft`, `emptyColumns`) drive no geometry and no stylesheet reads them; they are stamped for backward compatibility only. `InlineStartOverlay#resetFixedPosition` nevertheless kept reporting a position change whenever it toggled that class, and `placeFixedOverlays` ORed the result into the flag. Every scroll crossing horizontal offset 0 therefore ran the full reconciliation to fix a shift that cannot happen.

The overlay now reports `false` unconditionally and `placeFixedOverlays` no longer reads its result; only the top and bottom overlays feed the flag. The class stamping is untouched, so the public DOM surface is unchanged.

Grids on the single-pass layout path did not pay this, because `prepareHeaderBorders` applies the class before the cells render and the post-render toggle then found it already in place. The cost landed on the grids that drop off that path, and there are **two** ways to do that, both of which paid: breaking the uniform-size requirement (a `colWidths` array, or an active `manualColumnResize`), and breaking the element-mode requirement (a window-scrolled grid). The window shape is the harsher one, since `prepareHeaderBorders` bails on `trimmingContainer === rootWindow` outright and so could never have pre-applied the class whatever the other settings said. Both have a leg in the spec.

This is item 2 of DEV-2786. The row axis keeps its 1px shift and its compensations, and is the scope of a separate PR; the `AGENTS.md` bullet describing it is deliberately left in place.

### Why this is user-facing

An earlier revision of this description claimed `[skip changelog]` on the grounds that no released version paid the cost. That was wrong, and the review caught it. The released `18.1.0` tag still carries `ctx.positionChanged = wtOverlays.inlineStartOverlay.resetFixedPosition() || ctx.positionChanged` at `drawCycle.ts:554`, so released grids do run this nested draw on every crossing. What #13371 changed is that the draw stopped fixing anything — my `git tag --contains` check proved the *waste* is unreleased, not the *draw*.

Since #13371 and this change ship together, the net effect against 18.1.0 is a genuine scroll improvement, so this carries a `changed` changelog entry rather than a skip.

### How has this been tested?

New Playwright coverage in `tests/e2e/walkontable/inline-start-border-refresh.spec.ts`, with a fixture and page object. It measures the draw cost of one round trip across horizontal offset 0, on the single-pass path and off it, and separately asserts that the overlays stay correctly sized and aligned and that the compatibility classes are still stamped.

Counting `refreshAll` outright cannot see this: `ScrollSync` calls it once per scroll event as the normal scroll response, so the count is at least 1 per crossing either way and that baseline hides the difference. The reconciliation draw is the **re-entrant** call — the scroll-driven one runs `wot.draw(true)`, and a draw that sees `positionChanged` calls `refreshAll` again from inside it — so the fixture counts by nesting depth and reports the two kinds separately. The depth is counted on `refreshAll` itself rather than on `draw`: measured, `wtOverlays.wot !== hot.view._wt`, and a `draw` patched on the instance `hot.view._wt` hands you counts zero calls even for a `refreshAll()` invoked directly. `ScrollSync` holds `refreshAll` as a late-bound closure, so replacing the method is observed through its call too.

The negative control is the two off-path reconciliation assertions — the `colWidths` array and the window-scrolled shape — both of which fail `Expected: 0, Received: 1` against `origin/develop`'s source with the bundle rebuilt. The uniform-width case is labelled in the spec as a control rather than a regression, because that path already cost nothing. The overlay-geometry assertions pass with and without the fix; they guard the `wtOverlays.adjustElementsSize()` call that shared the disconnected branch, and are not themselves proof of the fix.

The file also carries one **positive** assertion, so it cannot pass vacuously: a vertical crossing off the single-pass path must cost exactly **one** re-entrant `refreshAll`. Without it, every reconciliation expectation here is `toBe(0)` and a later change that deleted `ctx.positionChanged` and its whole branch would keep the whole file green. That expectation also marks this change's boundary — when the row axis is brought into line it becomes 0 like the others.

Two shapes the metrics could not otherwise reach are covered explicitly: a crossing whose cell render is cancelled via `skipRender` (reachable outside tests through `NestedRows`, and the case that used to get the master `adjustElementsSize()` from the removed branch), and the backward-compatibility classes still being stamped in both scroll modes.

```bash
# the new spec, all six theme x bundle legs
cd tests && npx playwright test walkontable/inline-start-border-refresh

# every walkontable Playwright spec, all six legs
cd tests && npx playwright test walkontable

# the Jasmine walkontable suite
npm run test:walkontable --prefix handsontable

# core E2E around scrolling, overflow and column resizing
npm run test:e2e --prefix handsontable -- --testPathPattern='scroll|preventOverflow|manualColumnResize'

npm run eslint --prefix handsontable
npm run stylelint --prefix handsontable
npm run test:types --prefix handsontable
cd tests && npm run lint
```

Results: 48 passed (new spec, 6 legs) · 192 passed (all walkontable Playwright, 6 legs) · 816 specs / 0 failures (Jasmine walkontable) · 386 specs / 0 failures (core E2E subset) · eslint, stylelint, `test:types` and the Playwright-tier lint all clean.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2786

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2786

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the master draw cycle’s `positionChanged` → `refreshAll` reconciliation path; incorrect narrowing could skip needed overlay refreshes, though e2e tests assert geometry and that vertical (row-axis) reconciliation still runs once.
> 
> **Overview**
> Walkontable no longer treats toggling **`innerBorderInlineStart`** on the inline-start overlay as a 1px layout change. **`InlineStartOverlay#resetFixedPosition`** and **`adjustHeaderBordersPosition`** always return **`false`**, and **`placeFixedOverlays`** in **`drawCycle.ts`** stops OR-ing that overlay into **`ctx.positionChanged`**. Only top/bottom overlays still drive the nested **`refreshAll()`** reconciliation path.
> 
> **Backward-compatibility class stamping on `.ht_master` is unchanged**; the fix only removes an extra nested **`wot.draw(true)`** that ran when horizontal scroll crossed offset 0 (especially on layouts off the single-pass path, e.g. varied **`colWidths`** or window scrolling).
> 
> Adds Playwright coverage (**`inline-start-border-refresh.spec.ts`**) that counts re-entrant vs scroll-driven **`refreshAll`** calls and checks overlay geometry, plus changelog and Walkontable lifecycle docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfc99696ef62bd587e7b6d82dac3f8dadde7b60c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->