### PR TITLE
DEV-2665: Address undo/redo of a data change by physical row

### DIFF
--- a/.changelogs/13396-changed.json
+++ b/.changelogs/13396-changed.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Undoing a cell edit on a row that a filter or row trimming has since hidden now writes the source data, so it fires `afterSetSourceDataAtCell` and `modifySourceData` instead of `beforeChange`, `afterChange`, and `modifyData`.",
+  "type": "changed",
+  "issueOrPR": 13396,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13396.json
+++ b/.changelogs/13396.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed an undo of a cell edit writing to the wrong row, or adding a row, when a filter or row trimming hid the edited row after the edit.",
+  "title": "Fixed an undo of a cell edit writing to the wrong row, adding a row, or stopping the undo history from recording, when a filter or row trimming hid the edited row after the edit.",
   "type": "fixed",
   "issueOrPR": 13396,
   "breaking": false,

--- a/.changelogs/13396.json
+++ b/.changelogs/13396.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an undo of a cell edit writing to the wrong row, or adding a row, when a filter or row trimming hid the edited row after the edit.",
+  "type": "fixed",
+  "issueOrPR": 13396,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
+++ b/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
@@ -112,7 +112,11 @@ For data edits, UndoRedo records only effective changes:
 
 When you undo a data-change action, Handsontable can also remove rows or columns that were created as a side effect of that edit, and then restore the previous selection.
 
-An undo puts each value back on the row you edited, even when that row moved or is no longer visible. If a [filter](@/guides/columns/column-filter/column-filter.md) or [row trimming](@/guides/rows/row-trimming/row-trimming.md) hides the row after your edit, Handsontable writes the value straight to the source data. Two things follow from that. The [`beforeChange`](@/api/hooks.md#beforechange) and [`afterChange`](@/api/hooks.md#afterchange) hooks do not run for those values - [`afterSetSourceDataAtCell`](@/api/hooks.md#aftersetsourcedataatcell) fires instead, so a listener that vetoes or rewrites edited values has to cover that hook as well. And the write does not re-run the filter, so the row stays hidden until you filter again. If the row was removed from the data altogether, the value is dropped.
+An undo puts each value back on the row you edited, even when that row moved or is no longer visible. If a [filter](@/guides/columns/column-filter/column-filter.md) or [row trimming](@/guides/rows/row-trimming/row-trimming.md) hides the row after your edit, Handsontable writes the value straight to the source data. Three things follow from that:
+
+- The [`beforeChange`](@/api/hooks.md#beforechange), [`afterChange`](@/api/hooks.md#afterchange), and [`modifyData`](@/api/hooks.md#modifydata) hooks do not run for those values. [`afterSetSourceDataAtCell`](@/api/hooks.md#aftersetsourcedataatcell) and [`modifySourceData`](@/api/hooks.md#modifysourcedata) run instead, so a listener that vetoes, rewrites, or normalizes edited values has to cover the source hooks as well.
+- The write does not re-run the filter, so the row stays hidden until you filter again.
+- Handsontable identifies the row by its position in the source data, not by a stable ID. If you remove rows without going through the undo stack, an undo recorded before that removal can land on a neighboring row.
 
 ## Hooks and stack lifecycle
 

--- a/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
+++ b/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
@@ -112,6 +112,8 @@ For data edits, UndoRedo records only effective changes:
 
 When you undo a data-change action, Handsontable can also remove rows or columns that were created as a side effect of that edit, and then restore the previous selection.
 
+An undo puts each value back on the row you edited, even when that row moved or is no longer visible. If a [filter](@/guides/columns/column-filter/column-filter.md) or [row trimming](@/guides/rows/row-trimming/row-trimming.md) hides the row after your edit, Handsontable writes the value straight to the source data. Two things follow from that. The [`beforeChange`](@/api/hooks.md#beforechange) and [`afterChange`](@/api/hooks.md#afterchange) hooks do not run for those values - [`afterSetSourceDataAtCell`](@/api/hooks.md#aftersetsourcedataatcell) fires instead, so a listener that vetoes or rewrites edited values has to cover that hook as well. And the write does not re-run the filter, so the row stays hidden until you filter again. If the row was removed from the data altogether, the value is dropped.
+
 ## Hooks and stack lifecycle
 
 UndoRedo exposes hooks for both stack updates and action execution:

--- a/handsontable/src/plugins/filters/__tests__/plugins/undoRedo.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/plugins/undoRedo.spec.js
@@ -200,4 +200,63 @@ describe('Filters UI cooperation with UndoRedo', () => {
 
     expect(getDataAtCol(2)).toEqual(['Jenkinsville', null, 'Saranap', 'Cascades', 'Soham']);
   });
+
+  it('should undo and redo a change to a row the filter no longer matches (#dev-2665)', async() => {
+    handsontable({
+      data: getDataForFilters().splice(0, 5),
+      columns: getColumnsForFilters().splice(0, 3),
+      dropdownMenu: true,
+      filters: true,
+      width: 500,
+      height: 300
+    });
+    const undoPlugin = getPlugin('undoRedo');
+    const filtersPlugin = getPlugin('filters');
+
+    // The narrow seed the test above deliberately widens: only the value the row starts with is
+    // selected, so the edit below makes the row stop matching. That is the case the widened seed
+    // stopped covering, and pinning it needs the undo to address the row physically - once the
+    // condition is restored, the edited row is trimmed away and has no visual index at all.
+    filtersPlugin.addCondition(2, 'by_value', [['Gardiner']]);
+    filtersPlugin.filter();
+
+    expect(getDataAtCol(2)).toEqual(['Gardiner']);
+
+    await setDataAtCell(0, 2, null);
+
+    filtersPlugin.removeConditions(2);
+    filtersPlugin.filter();
+
+    expect(getDataAtCol(2)).toEqual(['Jenkinsville', null, 'Saranap', 'Cascades', 'Soham']);
+
+    undoPlugin.undo();
+
+    // The condition is back and nothing matches it any more, so the grid shows no rows.
+    expect(countRows()).toBe(0);
+
+    undoPlugin.undo();
+
+    // Restoring a trimmed row writes to the source data, which does not re-run the filter - so the
+    // grid still shows no rows. What matters is that the value went back to its own record, and
+    // that no row was invented to hold it.
+    expect(countRows()).toBe(0);
+    expect(countSourceRows()).toBe(5);
+
+    undoPlugin.undo();
+
+    expect(getDataAtCol(2)).toEqual(['Jenkinsville', 'Gardiner', 'Saranap', 'Cascades', 'Soham']);
+
+    undoPlugin.redo();
+
+    expect(getDataAtCol(2)).toEqual(['Gardiner']);
+
+    undoPlugin.redo();
+
+    expect(getDataAtCol(2)).toEqual([null]);
+    expect(countSourceRows()).toBe(5);
+
+    undoPlugin.redo();
+
+    expect(getDataAtCol(2)).toEqual(['Jenkinsville', null, 'Saranap', 'Cascades', 'Soham']);
+  });
 });

--- a/handsontable/src/plugins/undoRedo/AGENTS.md
+++ b/handsontable/src/plugins/undoRedo/AGENTS.md
@@ -71,6 +71,43 @@ It is registered to run **after** other `beforeChange` hooks (including the user
 entries and records **only effective changes** — a listener setting `changes[i] = null` must not leave a
 phantom entry on the stack.
 
+## `DataChangeAction` addresses rows PHYSICALLY, and that shaped three things (DEV-2665)
+
+The action records a `physicalRows` array alongside `changes`, and the replay routes each change by it.
+A visible row is written through `setDataAtCell` at its **current** visual index; a trimmed one has no
+visual index at all and is written with `setSourceDataAtCell`. Do not "simplify" this back to replaying
+the recorded visual row — that row index only describes the grid state the edit happened in, and a filter
+applied since puts another record there (it grew a phantom row, or silently did nothing).
+
+Three traps come with it, and each one has a measured defect behind it.
+
+1. **`beforeChange` runs before the rows exist.** A write past the last row is recorded while
+   `applyChanges()` has not created its rows yet, so `toPhysicalRow()` returns `null` for it. `null` is
+   therefore *meaningful*: it is what makes the replay address the grid visually, which is what re-creates
+   the row. Do not coerce it to a number, and do not treat it as "no row".
+2. **The settle callback rides on `afterChange`, which a source-only replay never fires.** So `#replay()`
+   settles itself when the grid-write list comes out empty, and the source writes go **first** so the
+   `afterChange` settle still runs after the whole replay landed. An armed hook left behind is not a
+   cosmetic leak: `ignoreNewActions` stays on until it fires, so **every action the user performs in
+   between is silently dropped from the stack**, and the action then settles on an unrelated change. Keep
+   the two write lists in one `setDataAtCell` call for the same reason — two calls settle on the first.
+3. **The row-count guard measures `countSourceRows`, not `countRows`.** Its job is to remove the rows the
+   change grew the dataset by: the rows a past-the-end write created, *and* the ones `minSpareRows` topped
+   up when the edit filled the last spare row (that second one is why gating the guard on "some change was
+   past the end" is not enough — `UndoRedo.spec.js` pins it). `countRows()` counts only what a filter or a
+   trim leaves visible, so comparing it read a trim *lifted* since the edit as rows to delete, and took
+   that many rows of the user's data off the end. `countRows` is still recorded, because it is part of the
+   payload `beforeUndo`/`afterUndo` hand to listeners.
+
+Formulas needs no change for the source path: it already ignores `UndoRedo.*` sources on
+`afterSetSourceDataAtCell` and resolves a trimmed row's engine index physically — see `../formulas/AGENTS.md`.
+
+One gap stays open, deliberately. `physicalRows` holds a **position in the source array, not a record
+identity**, so a row removal that is not on the undo stack shifts every entry below it and the replay
+lands one row off. That is the same class of gap the visual index had, one step further out: LIFO puts a
+recorded removal's own undo first, so it only bites a removal performed with a blocked source. Do not read
+the field as an ID.
+
 ## `CellAlignmentAction` restores an ABSENT value as absent
 
 Falling back to a horizontal alignment when nothing was recorded used to leave the cell aligned left after

--- a/handsontable/src/plugins/undoRedo/AGENTS.md
+++ b/handsontable/src/plugins/undoRedo/AGENTS.md
@@ -89,24 +89,48 @@ Three traps come with it, and each one has a measured defect behind it.
    settles itself when the grid-write list comes out empty, and the source writes go **first** so the
    `afterChange` settle still runs after the whole replay landed. An armed hook left behind is not a
    cosmetic leak: `ignoreNewActions` stays on until it fires, so **every action the user performs in
-   between is silently dropped from the stack**, and the action then settles on an unrelated change. Keep
-   the two write lists in one `setDataAtCell` call for the same reason — two calls settle on the first.
-3. **The row-count guard measures `countSourceRows`, not `countRows`.** Its job is to remove the rows the
-   change grew the dataset by: the rows a past-the-end write created, *and* the ones `minSpareRows` topped
-   up when the edit filled the last spare row (that second one is why gating the guard on "some change was
-   past the end" is not enough — `UndoRedo.spec.js` pins it). `countRows()` counts only what a filter or a
-   trim leaves visible, so comparing it read a trim *lifted* since the edit as rows to delete, and took
-   that many rows of the user's data off the end. `countRows` is still recorded, because it is part of the
-   payload `beforeUndo`/`afterUndo` hand to listeners.
+   between is silently dropped from the stack**, and the action then settles on an unrelated change. The
+   grid list therefore has to stay **one** `setDataAtCell` call — split it in two and the settle runs on
+   the first one's `afterChange`, while the second is still to come.
+3. **The rows the change created are named INDIVIDUALLY, and measured in source rows.** Two separate
+   mistakes are already burned in here. Measuring against `countRows()` is wrong because it counts only
+   what a filter or a trim leaves visible, so a trim *lifted* since the edit reads as rows to delete —
+   and gating the guard on "some change was past the end" instead does not work either, because
+   `minSpareRows` tops the spares up when an edit fills the last spare row and grows the dataset with no
+   change addressing a new row at all (`UndoRedo.spec.js`'s minSpareRows case pins that). And passing an
+   **amount** to `alter('remove_row', undefined, n)` is wrong even with the right number, because
+   `alter()` counts an amount back from the last **visible** row: with anything trimmed that is a
+   different record, so it deleted a row the change never touched, and with everything trimmed it handed
+   listeners a `beforeRemoveRow(NaN, 0, [])` round. Hence `#collectCreatedRows()` — one
+   `[visualRow, 1]` group per trailing source row, trimmed ones skipped because they have no visual
+   index. `countRows` is still recorded, because it is part of the payload `beforeUndo`/`afterUndo` hand
+   to listeners.
 
 Formulas needs no change for the source path: it already ignores `UndoRedo.*` sources on
 `afterSetSourceDataAtCell` and resolves a trimmed row's engine index physically — see `../formulas/AGENTS.md`.
 
-One gap stays open, deliberately. `physicalRows` holds a **position in the source array, not a record
-identity**, so a row removal that is not on the undo stack shifts every entry below it and the replay
-lands one row off. That is the same class of gap the visual index had, one step further out: LIFO puts a
-recorded removal's own undo first, so it only bites a removal performed with a blocked source. Do not read
-the field as an ID.
+Four gaps stay open, deliberately. Each one is a known defect, not an oversight — say so rather than
+rediscovering them.
+
+- **`physicalRows` is a position, not an identity.** A row removal that is not on the undo stack shifts
+  every entry below it, and the replay then lands one row off. Same class of gap the visual index had,
+  one step further out: LIFO puts a recorded removal's own undo first, so it bites only a removal
+  performed with a blocked source. Do not read the field as an ID, and do not write "a removed row's
+  value is discarded" anywhere — that only holds for a removal at the very **end** of the dataset.
+- **The data is restored physically, the selection still visually.** After a reorder this action did not
+  record, the values land on the right records while `selectCells(this.selected)` highlights whatever now
+  sits at the recorded visual coordinates. `remergeCellsGeometryOnly` carries the same issue, narrower
+  (paste source only). Fixing it needs a physical form for a *range*, which `CellRange` cannot describe.
+- **`allowInvalid: false` can still strand the stack.** When a validator rejects every grid change,
+  `validateChanges` splices them all out, `applyChanges` fires no `afterChange`, and the settle never
+  runs — so `ignoreNewActions` stays on for the rest of the session. Pre-existing, and the `try/catch` in
+  `#replay()` does **not** cover it (nothing throws). What this rewrite added is that the source writes
+  have already landed by then, so such an action is now stranded *and* half-applied. A real fix needs a
+  completion signal from Core that survives an all-rejected validation round.
+- **The column half of the guard still counts visible columns.** `countCols()` is
+  `min(maxCols, notTrimmedColumns)`, so a `maxCols` raised since the edit reads as columns this change
+  added. It is the same defect the row half above fixed, left alone because the column axis is outside
+  DEV-2665 and `countSourceCols()` reads the first row's keys, which is not a reliable count.
 
 ## `CellAlignmentAction` restores an ABSENT value as absent
 

--- a/handsontable/src/plugins/undoRedo/AGENTS.md
+++ b/handsontable/src/plugins/undoRedo/AGENTS.md
@@ -117,16 +117,26 @@ rediscovering them.
   one step further out: LIFO puts a recorded removal's own undo first, so it bites only a removal
   performed with a blocked source. Do not read the field as an ID, and do not write "a removed row's
   value is discarded" anywhere — that only holds for a removal at the very **end** of the dataset.
-- **The data is restored physically, the selection still visually.** After a reorder this action did not
-  record, the values land on the right records while `selectCells(this.selected)` highlights whatever now
-  sits at the recorded visual coordinates. `remergeCellsGeometryOnly` carries the same issue, narrower
-  (paste source only). Fixing it needs a physical form for a *range*, which `CellRange` cannot describe.
+- **The data is restored physically, the selection and the merge geometry still visually.** After a
+  reorder this action did not record, the values land on the right records while
+  `selectCells(this.selected)` highlights whatever now sits at the recorded visual coordinates.
+  `remergeCellsGeometryOnly` carries the same issue and one of its own: it runs *after*
+  `#collectCreatedRows()` has removed rows, so a paste that destroyed a merge, appended rows and was
+  followed by a reorder can re-merge at shifted coordinates. Both need a physical form for a *range*,
+  which `CellRange` cannot describe.
 - **`allowInvalid: false` can still strand the stack.** When a validator rejects every grid change,
   `validateChanges` splices them all out, `applyChanges` fires no `afterChange`, and the settle never
   runs — so `ignoreNewActions` stays on for the rest of the session. Pre-existing, and the `try/catch` in
-  `#replay()` does **not** cover it (nothing throws). What this rewrite added is that the source writes
-  have already landed by then, so such an action is now stranded *and* half-applied. A real fix needs a
-  completion signal from Core that survives an all-rejected validation round.
+  `#replay()` does **not** cover it (nothing throws). The action is at least no longer *half*-applied:
+  the source writes are held inside the settle path, behind that same `afterChange`, so a rejected grid
+  write leaves nothing written. Do not hoist them back ahead of `setDataAtCell()`. A real fix for the
+  stranding needs a completion signal from Core that survives an all-rejected validation round.
+- **A row that never existed is replayed at its recorded visual index, and that index can drift.**
+  There is nothing to re-derive — the row had no physical index when `beforeChange` recorded it. The
+  index is trusted only while it still names a row this change appended, or no row at all; a trim
+  lifted since then can slide it onto a record that existed all along, and `#collectWrites()` drops the
+  change rather than blanking that record. Dropping it means a past-the-end edit is not reverted in
+  that case, which is the lesser of the two.
 - **The column half of the guard still counts visible columns.** `countCols()` is
   `min(maxCols, notTrimmedColumns)`, so a `maxCols` raised since the edit reads as columns this change
   added. It is the same defect the row half above fixed, left alone because the column axis is outside

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.spec.js
@@ -29,9 +29,15 @@ describe('UndoRedo -> DataChange action', () => {
     expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'change',
       changes: [[1, 2, 'C2', 'test']],
+      // The physical row of each entry in `changes`. This is what the replay addresses, so that a
+      // filter or a trim applied between the edit and the undo cannot send it to another row.
+      physicalRows: [1],
       selected: [[1, 2]],
       countCols: 5,
       countRows: 5,
+      // The undo measures how far the change grew the dataset against this, not against
+      // `countRows` - that one counts only the rows a filter or a trim leaves visible.
+      countSourceRows: 5,
       // Merge areas the change destroyed. Empty here: the MergeCells plugin is not enabled, and an
       // ordinary edit destroys no merge even when it is.
       mergedCells: [],

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.unit.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.unit.js
@@ -1,11 +1,13 @@
 import Handsontable from 'handsontable/base';
 import {
   registerPlugin,
+  TrimRows,
   UndoRedo,
 } from 'handsontable/plugins';
 import { registerAllCellTypes } from 'handsontable/registry';
 
 registerAllCellTypes();
+registerPlugin(TrimRows);
 registerPlugin(UndoRedo);
 
 /**
@@ -153,5 +155,114 @@ describe('UndoRedo -> DataChange action', () => {
 
     expect(hasHeaderCoordinates).toBe(false);
     expect(action.changes.length).toBe(9);
+  });
+
+  describe('rows trimmed since the change was recorded (DEV-2665)', () => {
+    /**
+     * Builds a five-row, one-column grid with `trimRows` and undo on.
+     *
+     * @returns {Handsontable} The instance.
+     */
+    function buildTrimmableGrid() {
+      return new Handsontable(container, {
+        licenseKey: 'non-commercial-and-evaluation',
+        data: [['A1'], ['A2'], ['A3'], ['A4'], ['A5']],
+        trimRows: true,
+        undo: true,
+      });
+    }
+
+    it('should restore the record the edit was made on, not the row now at that visual index', () => {
+      hot = buildTrimmableGrid();
+
+      hot.setDataAtCell(1, 0, 'changed');
+      hot.getPlugin('trimRows').trimRows([1]);
+
+      expect(hot.countRows()).toBe(4);
+
+      hot.getPlugin('undoRedo').undo();
+
+      expect(hot.getSourceDataAtCell(1, 0)).toBe('A2');
+      // The record that took over visual row 1 when the edited one was trimmed away must not have
+      // been written to - that is where a visually addressed undo lands.
+      expect(hot.getSourceDataAtCell(2, 0)).toBe('A3');
+      // And no row was invented to hold the restored value.
+      expect(hot.countSourceRows()).toBe(5);
+    });
+
+    it('should restore and settle when every changed row is trimmed away', () => {
+      hot = buildTrimmableGrid();
+
+      const undoRedo = hot.getPlugin('undoRedo');
+
+      hot.setDataAtCell(0, 0, 'changed');
+      hot.getPlugin('trimRows').trimRows([0, 1, 2, 3, 4]);
+
+      expect(hot.countRows()).toBe(0);
+
+      undoRedo.undo();
+
+      expect(hot.getSourceDataAtCell(0, 0)).toBe('A1');
+      expect(hot.countSourceRows()).toBe(5);
+      // With no visible row to write through there is no `afterChange` to settle on, so the action
+      // has to settle itself - otherwise it is neither redoable nor out of the way.
+      expect(undoRedo.isRedoAvailable()).toBe(true);
+      expect(undoRedo.ignoreNewActions).toBe(false);
+
+      undoRedo.redo();
+
+      expect(hot.getSourceDataAtCell(0, 0)).toBe('changed');
+    });
+
+    it('should leave no settle hook armed when every changed row is trimmed away', () => {
+      hot = buildTrimmableGrid();
+
+      const undoRedo = hot.getPlugin('undoRedo');
+
+      hot.setDataAtCell(0, 0, 'changed');
+      hot.getPlugin('trimRows').trimRows([0, 1, 2, 3, 4]);
+      undoRedo.undo();
+      hot.getPlugin('trimRows').untrimAll();
+
+      hot.setDataAtCell(3, 0, 'later');
+
+      // An `afterChange` listener still armed from the undo settles that action on this edit
+      // instead, and `ignoreNewActions` is still on while the edit is recorded - so the edit is
+      // dropped from the stack.
+      expect(undoRedo.doneActions.length).toBe(1);
+      expect(hot.getSourceDataAtCol(0)).toEqual(['A1', 'A2', 'A3', 'later', 'A5']);
+    });
+
+    it('should not delete rows off the end when rows were untrimmed after the change', () => {
+      hot = buildTrimmableGrid();
+
+      hot.getPlugin('trimRows').trimRows([2, 3, 4]);
+      hot.setDataAtCell(1, 0, 'changed');
+      hot.getPlugin('trimRows').untrimAll();
+
+      hot.getPlugin('undoRedo').undo();
+
+      // The row count grew because the trim was lifted, not because this change added rows. Reading
+      // it as rows to remove takes three rows of the user's data with it.
+      expect(hot.countSourceRows()).toBe(5);
+      expect(hot.getSourceDataAtCol(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5']);
+    });
+
+    it('should still remove the rows that a write past the last row created', () => {
+      hot = new Handsontable(container, {
+        licenseKey: 'non-commercial-and-evaluation',
+        data: [['A1'], ['A2'], ['A3']],
+        undo: true,
+      });
+
+      hot.setDataAtCell([[3, 0, 'x'], [4, 0, 'y']]);
+
+      expect(hot.countSourceRows()).toBe(5);
+
+      hot.getPlugin('undoRedo').undo();
+
+      expect(hot.countSourceRows()).toBe(3);
+      expect(hot.getSourceDataAtCol(0)).toEqual(['A1', 'A2', 'A3']);
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.unit.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.unit.js
@@ -248,6 +248,30 @@ describe('UndoRedo -> DataChange action', () => {
       expect(hot.getSourceDataAtCol(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5']);
     });
 
+    it('should keep the rows a lifted trim revealed when it removes the created ones', () => {
+      hot = new Handsontable(container, {
+        licenseKey: 'non-commercial-and-evaluation',
+        data: [['A1'], ['A2'], ['A3'], ['A4'], ['A5']],
+        trimRows: true,
+        undo: true,
+      });
+
+      hot.getPlugin('trimRows').trimRows([0, 1]);
+
+      // Three rows are visible, so this lands past the last one and appends a sixth source row.
+      hot.setDataAtCell(3, 0, 'x');
+
+      expect(hot.countSourceRows()).toBe(6);
+
+      hot.getPlugin('trimRows').untrimAll();
+
+      hot.getPlugin('undoRedo').undo();
+
+      // The visible row count went 3 -> 6 because the trim was lifted, so a guard measured in
+      // visible rows wants three rows removed and takes A4 and A5 with the created one.
+      expect(hot.getSourceDataAtCol(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5']);
+    });
+
     it('should not remove a populated row in place of a created row that is trimmed', () => {
       hot = new Handsontable(container, {
         licenseKey: 'non-commercial-and-evaluation',
@@ -268,6 +292,33 @@ describe('UndoRedo -> DataChange action', () => {
       // visible row" instead takes A3, which this change never touched.
       expect(hot.getSourceDataAtCell(2, 0)).toBe('A3');
       expect(hot.countSourceRows()).toBe(4);
+    });
+
+    it('should not blank a pre-existing record the stale visual index slid onto', () => {
+      hot = new Handsontable(container, {
+        licenseKey: 'non-commercial-and-evaluation',
+        data: [['A1'], ['A2'], ['A3'], ['A4'], ['A5']],
+        trimRows: true,
+        undo: true,
+      });
+
+      hot.getPlugin('trimRows').trimRows([0, 1, 2, 3]);
+
+      // One row is visible, so this lands past it and appends a sixth source row. The row did not
+      // exist when the change was recorded, so it carries no physical index - only visual row 1.
+      hot.setDataAtCell(1, 0, 'x');
+
+      expect(hot.countSourceRows()).toBe(6);
+
+      // Lifting the trim pushes four rows back into the visual space, so visual row 1 now names
+      // A2 - a record that existed all along.
+      hot.getPlugin('trimRows').untrimAll();
+
+      expect(hot.toPhysicalRow(1)).toBe(1);
+
+      hot.getPlugin('undoRedo').undo();
+
+      expect(hot.getSourceDataAtCell(1, 0)).toBe('A2');
     });
 
     it('should not run a row removal when no created row is reachable', () => {
@@ -318,21 +369,24 @@ describe('UndoRedo -> DataChange action', () => {
       expect(hot.getSourceDataAtCell(3, 0)).toBe(null);
     });
 
-    it('should still remove the rows that a write past the last row created', () => {
-      hot = new Handsontable(container, {
-        licenseKey: 'non-commercial-and-evaluation',
-        data: [['A1'], ['A2'], ['A3']],
-        undo: true,
-      });
+  });
 
-      hot.setDataAtCell([[3, 0, 'x'], [4, 0, 'y']]);
-
-      expect(hot.countSourceRows()).toBe(5);
-
-      hot.getPlugin('undoRedo').undo();
-
-      expect(hot.countSourceRows()).toBe(3);
-      expect(hot.getSourceDataAtCol(0)).toEqual(['A1', 'A2', 'A3']);
+  // Nothing is trimmed here, so this passes with or without the physical-row addressing. It guards
+  // the plain case of the row removal the undo performs, which the DEV-2665 cases above rewrote.
+  it('should remove the rows that a write past the last row created', () => {
+    hot = new Handsontable(container, {
+      licenseKey: 'non-commercial-and-evaluation',
+      data: [['A1'], ['A2'], ['A3']],
+      undo: true,
     });
+
+    hot.setDataAtCell([[3, 0, 'x'], [4, 0, 'y']]);
+
+    expect(hot.countSourceRows()).toBe(5);
+
+    hot.getPlugin('undoRedo').undo();
+
+    expect(hot.countSourceRows()).toBe(3);
+    expect(hot.getSourceDataAtCol(0)).toEqual(['A1', 'A2', 'A3']);
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.unit.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.unit.js
@@ -248,6 +248,76 @@ describe('UndoRedo -> DataChange action', () => {
       expect(hot.getSourceDataAtCol(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5']);
     });
 
+    it('should not remove a populated row in place of a created row that is trimmed', () => {
+      hot = new Handsontable(container, {
+        licenseKey: 'non-commercial-and-evaluation',
+        data: [['A1'], ['A2'], ['A3']],
+        trimRows: true,
+        undo: true,
+      });
+
+      hot.setDataAtCell(3, 0, 'x');
+
+      expect(hot.countSourceRows()).toBe(4);
+
+      hot.getPlugin('trimRows').trimRows([3]);
+
+      hot.getPlugin('undoRedo').undo();
+
+      // The created row has no visual index left, so it cannot be removed. Removing "the last
+      // visible row" instead takes A3, which this change never touched.
+      expect(hot.getSourceDataAtCell(2, 0)).toBe('A3');
+      expect(hot.countSourceRows()).toBe(4);
+    });
+
+    it('should not run a row removal when no created row is reachable', () => {
+      hot = new Handsontable(container, {
+        licenseKey: 'non-commercial-and-evaluation',
+        data: [['A1'], ['A2'], ['A3']],
+        trimRows: true,
+        undo: true,
+      });
+
+      hot.setDataAtCell(3, 0, 'x');
+      hot.getPlugin('trimRows').trimRows([0, 1, 2, 3]);
+
+      expect(hot.countRows()).toBe(0);
+
+      const beforeRemoveRow = jest.fn();
+
+      hot.addHook('beforeRemoveRow', beforeRemoveRow);
+
+      hot.getPlugin('undoRedo').undo();
+
+      // With no visible row to address, `alter('remove_row')` resolves an empty index list and a
+      // `NaN` row index. Listeners must not be handed that round at all.
+      expect(beforeRemoveRow).not.toHaveBeenCalled();
+      expect(hot.countSourceRows()).toBe(4);
+    });
+
+    it('should remove the created rows measured in source rows, not visible ones', () => {
+      hot = new Handsontable(container, {
+        licenseKey: 'non-commercial-and-evaluation',
+        data: [['A1'], ['A2'], ['A3']],
+        minSpareRows: 1,
+        trimRows: true,
+        undo: true,
+      });
+
+      // The grid carries one spare row, so this fills it and `minSpareRows` tops it up again.
+      hot.setDataAtCell(3, 0, 'typed');
+
+      expect(hot.countSourceRows()).toBe(5);
+
+      // What a filter excluding empty values does to the two trailing rows.
+      hot.getPlugin('trimRows').trimRows([3, 4]);
+
+      hot.getPlugin('undoRedo').undo();
+
+      expect(hot.getSourceDataAtCell(2, 0)).toBe('A3');
+      expect(hot.getSourceDataAtCell(3, 0)).toBe(null);
+    });
+
     it('should still remove the rows that a write past the last row created', () => {
       hot = new Handsontable(container, {
         licenseKey: 'non-commercial-and-evaluation',

--- a/handsontable/src/plugins/undoRedo/actions/dataChange.ts
+++ b/handsontable/src/plugins/undoRedo/actions/dataChange.ts
@@ -43,9 +43,10 @@ export class DataChangeAction extends BaseAction {
   /**
    * @param {number} countSourceRows The number of source rows before data change. This is what the
    *   undo measures the dataset against, because `countRows` counts only the rows a filter or a
-   *   trim leaves visible - see `undo()`.
+   *   trim leaves visible - see `undo()`. Absent on an action built without it, and the undo then
+   *   removes no rows at all rather than measuring against a count of something else.
    */
-  declare countSourceRows: number;
+  declare countSourceRows: number | undefined;
   /**
    * @param {Array} mergedCells Merge areas this change destroyed, as `{ row, col, rowspan, colspan }`
    *   objects captured before the change landed. Empty for every change that destroys no merge.
@@ -63,7 +64,7 @@ export class DataChangeAction extends BaseAction {
    * Initializes the data change action with the recorded cell changes, selection state, and grid dimensions at the time of the change.
    */
   constructor({
-    changes, selected, countCols, countRows, countSourceRows = countRows, mergedCells = [], physicalRows = []
+    changes, selected, countCols, countRows, countSourceRows, mergedCells = [], physicalRows = []
   }: {
     changes: unknown[][], selected: unknown[], countCols: number, countRows: number,
     countSourceRows?: number, mergedCells?: MergeAreaGeometry[], physicalRows?: (number | null)[]
@@ -160,12 +161,17 @@ export class DataChangeAction extends BaseAction {
    *   the normal path, and it keeps everything a grid write brings with it: the validators, the
    *   `afterChange` hook the settle callback rides on, and the editor refresh;
    * - the row exists but is trimmed away (a filter, `trimRows`), so it has no visual index at all
-   *   and the grid cannot address it. It is written straight to the source data instead. A row
-   *   removed since the change takes the same branch, and `dataSource.setAtCell()` drops a write
-   *   past the last source row - so the value goes nowhere instead of onto a surviving row;
+   *   and the grid cannot address it. It is written straight to the source data instead;
    * - the row had no physical index when the change was recorded, which means it did not exist yet.
    *   The recorded visual index is all there is, and writing there is what re-creates the row, so
    *   this case keeps addressing the grid visually.
+   *
+   * A physical row is a **position** in the source array, not a record identity, so a row removal the
+   * undo stack never recorded shifts it. Removing a row below the recorded one leaves this correct;
+   * removing one above it slides the index onto a neighbouring record, and the write then lands there.
+   * LIFO covers the ordinary case, because a recorded removal is undone before this action is reached.
+   * The same shift is why `dataSource.setAtCell()` dropping a write past the last source row cannot be
+   * read as "a removed row's value is discarded" - that only holds for a removal at the very end.
    *
    * @param {Core} hot The Handsontable instance.
    * @param {number} valueIndex Index of the value to replay within a change entry - `2` for the old
@@ -204,6 +210,41 @@ export class DataChangeAction extends BaseAction {
     });
 
     return { gridChanges, sourceChanges };
+  }
+
+  /**
+   * Names the rows this change appended to the source data, as `alter()`'s `[visualRow, amount]`
+   * groups, so each one is removed by its own index instead of by an amount counted from the last
+   * visible row.
+   *
+   * A trailing row that is trimmed away is skipped: it has no visual index, and `alter()` addresses
+   * rows visually. Skipping it leaves an empty row behind, which is what happened before the guard
+   * could see the source data at all - and far better than the alternative, which is removing
+   * whichever record happens to sit at the end of the visible range instead.
+   *
+   * @param {Core} hot The Handsontable instance.
+   * @returns {Array} The `[visualRow, amount]` groups to remove, possibly empty.
+   */
+  #collectCreatedRows(hot: HotInstance) {
+    const recordedSourceRows = this.countSourceRows;
+    const createdRows: number[][] = [];
+
+    // An action built by an external `done()` caller carries no source-row baseline. The removal is
+    // then skipped rather than measured against `countRows`, which counts a different thing - mixing
+    // the two deletes rows purely because a filter is active.
+    if (!Number.isInteger(recordedSourceRows)) {
+      return createdRows;
+    }
+
+    for (let physicalRow = recordedSourceRows!; physicalRow < hot.countSourceRows(); physicalRow++) {
+      const visualRow = hot.toVisualRow(physicalRow) as number | null;
+
+      if (visualRow !== null) {
+        createdRows.push([visualRow, 1]);
+      }
+    }
+
+    return createdRows;
   }
 
   /**
@@ -256,14 +297,20 @@ export class DataChangeAction extends BaseAction {
 
     this.#replay(hot, gridChanges, sourceChanges, 'UndoRedo.undo', () => {
       // Rows the change grew the dataset by - a write past the last row creates the rows it needs,
-      // and filling the last spare row makes `minSpareRows` top them up again. Measured in *source*
-      // rows, not the `countRows` this action also records: that one counts only what a filter or a
-      // trim leaves visible, so it reads a filter applied or dropped since the change as rows this
-      // action added, and then deletes that many rows of the user's data off the end (DEV-2665).
-      const rowsToRemove = hot.countSourceRows() - this.countSourceRows;
+      // and filling the last spare row makes `minSpareRows` top them up again. They are the trailing
+      // *source* rows, not a count of visible ones: `countRows()` counts only what a filter or a trim
+      // leaves visible, so measuring against it reads a filter applied or dropped since the change as
+      // rows this action added, and then deletes that many rows of the user's data (DEV-2665).
+      //
+      // Each one is named by its own visual index rather than by an amount, because `alter()` counts
+      // an amount from the last VISIBLE row - a different row as soon as anything is trimmed, so an
+      // amount measured in source rows would delete a record this change never touched. A trailing
+      // row that is trimmed has no visual index at all and cannot be addressed; it is left in place,
+      // which is what happened before this guard could see it.
+      const createdRows = this.#collectCreatedRows(hot);
 
-      if (rowsToRemove > 0) {
-        hot.alter('remove_row', undefined, rowsToRemove, 'UndoRedo.undo');
+      if (createdRows.length > 0) {
+        hot.alter('remove_row', createdRows, undefined, 'UndoRedo.undo');
       }
 
       const columnsToRemove = hot.countCols() - this.countCols;

--- a/handsontable/src/plugins/undoRedo/actions/dataChange.ts
+++ b/handsontable/src/plugins/undoRedo/actions/dataChange.ts
@@ -41,24 +41,41 @@ export class DataChangeAction extends BaseAction {
    */
   declare countRows: number;
   /**
+   * @param {number} countSourceRows The number of source rows before data change. This is what the
+   *   undo measures the dataset against, because `countRows` counts only the rows a filter or a
+   *   trim leaves visible - see `undo()`.
+   */
+  declare countSourceRows: number;
+  /**
    * @param {Array} mergedCells Merge areas this change destroyed, as `{ row, col, rowspan, colspan }`
    *   objects captured before the change landed. Empty for every change that destroys no merge.
    */
   declare mergedCells: MergeAreaGeometry[];
+  /**
+   * @param {Array} physicalRows The physical row of every entry in `changes`, in the same order,
+   *   read when the change was recorded. `null` marks a change whose row did not exist yet - this
+   *   is recorded from `beforeChange`, which runs before `applyChanges()` creates the rows a write
+   *   past the last row needs.
+   */
+  declare physicalRows: (number | null)[];
 
   /**
    * Initializes the data change action with the recorded cell changes, selection state, and grid dimensions at the time of the change.
    */
-  constructor({ changes, selected, countCols, countRows, mergedCells = [] }: {
+  constructor({
+    changes, selected, countCols, countRows, countSourceRows = countRows, mergedCells = [], physicalRows = []
+  }: {
     changes: unknown[][], selected: unknown[], countCols: number, countRows: number,
-    mergedCells?: MergeAreaGeometry[]
+    countSourceRows?: number, mergedCells?: MergeAreaGeometry[], physicalRows?: (number | null)[]
   }) {
     super('change');
     this.changes = changes;
     this.selected = selected;
     this.countCols = countCols;
     this.countRows = countRows;
+    this.countSourceRows = countSourceRows;
     this.mergedCells = mergedCells;
+    this.physicalRows = physicalRows;
   }
 
   /**
@@ -96,6 +113,14 @@ export class DataChangeAction extends BaseAction {
         const clonedChanges = effectiveChanges.map(
           (change: unknown[]) => [...change]
         );
+        // Read now, alongside the visual row, because the visual row only describes the grid state
+        // this edit happened in - a filter or a trim applied afterwards puts another row at that
+        // index, or no row at all (DEV-2665). A row that does not exist yet has no physical index:
+        // this hook runs before `applyChanges()` creates the rows a write past the last row needs,
+        // and `null` is what tells the replay to address such a change visually.
+        const physicalRows = clonedChanges.map(
+          (change: unknown[]) => hot.toPhysicalRow(change[0] as number) as number | null
+        );
 
         clonedChanges.forEach((change: unknown[]) => {
           change[1] = hot.propToCol(change[1] as string | number);
@@ -107,9 +132,11 @@ export class DataChangeAction extends BaseAction {
 
         return new DataChangeAction({
           changes: clonedChanges,
+          physicalRows,
           selected,
           countCols: hot.countCols(),
           countRows: hot.countRows(),
+          countSourceRows: hot.countSourceRows(),
           // Merge areas this change is about to destroy. Carried inside this action so a single
           // undo step puts back both the data and the geometry - see the MergeCells plugin, which
           // records them from its own `beforeChange` listener at an earlier priority than this one.
@@ -124,18 +151,116 @@ export class DataChangeAction extends BaseAction {
   }
 
   /**
+   * Routes every recorded change to the write path that can still reach the row it was recorded on.
+   *
+   * The row is addressed physically, so a change lands back on its own record rather than on
+   * whatever row now sits at the recorded visual index. Three cases come out of that:
+   *
+   * - the row is visible, so it is written through the grid at its **current** visual index. This is
+   *   the normal path, and it keeps everything a grid write brings with it: the validators, the
+   *   `afterChange` hook the settle callback rides on, and the editor refresh;
+   * - the row exists but is trimmed away (a filter, `trimRows`), so it has no visual index at all
+   *   and the grid cannot address it. It is written straight to the source data instead. A row
+   *   removed since the change takes the same branch, and `dataSource.setAtCell()` drops a write
+   *   past the last source row - so the value goes nowhere instead of onto a surviving row;
+   * - the row had no physical index when the change was recorded, which means it did not exist yet.
+   *   The recorded visual index is all there is, and writing there is what re-creates the row, so
+   *   this case keeps addressing the grid visually.
+   *
+   * @param {Core} hot The Handsontable instance.
+   * @param {number} valueIndex Index of the value to replay within a change entry - `2` for the old
+   *   value (undo), `3` for the new one (redo).
+   * @returns {{gridChanges: Array, sourceChanges: Array}}
+   */
+  #collectWrites(hot: HotInstance, valueIndex: number) {
+    // Cloned for the reason the whole change set used to be: a replayed object value has to be a
+    // copy, so that mutating the cell afterwards cannot reach back into the stack.
+    const data = deepClone(this.changes) as unknown[][];
+    const gridChanges: unknown[][] = [];
+    const sourceChanges: unknown[][] = [];
+
+    data.forEach((change: unknown[], index: number) => {
+      const visualColumn = change[1] as number;
+      const value = change[valueIndex];
+      // An action recorded before this field existed, or one built by hand, carries no entry here.
+      // Every change then falls back to its recorded visual row, which is what used to happen.
+      const physicalRow = this.physicalRows?.[index] ?? null;
+
+      if (physicalRow === null) {
+        gridChanges.push([change[0], visualColumn, value]);
+
+        return;
+      }
+
+      const visualRow = hot.toVisualRow(physicalRow) as number | null;
+
+      if (visualRow === null) {
+        sourceChanges.push([physicalRow, hot.colToProp(visualColumn), value]);
+
+        return;
+      }
+
+      gridChanges.push([visualRow, visualColumn, value]);
+    });
+
+    return { gridChanges, sourceChanges };
+  }
+
+  /**
+   * Replays both write lists and settles the action exactly once.
+   *
+   * The source-data writes run first, so the settle callback - which rides on the grid write's
+   * `afterChange` - runs once the whole replay has landed. With no grid write to make, that hook
+   * would never fire and the action has to settle from here instead. Leaving it armed would settle
+   * this action on the next unrelated change, and until then `ignoreNewActions` stays on, dropping
+   * every action the user performs in between.
+   *
+   * @param {Core} hot The Handsontable instance.
+   * @param {Array} gridChanges Changes to write through the grid, as `[visualRow, visualColumn, value]`.
+   * @param {Array} sourceChanges Changes to write to the source data, as `[physicalRow, prop, value]`.
+   * @param {string} source The source string the writes carry.
+   * @param {function(): void} settle Runs once the replay has landed.
+   */
+  #replay(
+    hot: HotInstance, gridChanges: unknown[][], sourceChanges: unknown[][], source: string, settle: () => void
+  ) {
+    if (sourceChanges.length > 0) {
+      hot.setSourceDataAtCell(sourceChanges, undefined, undefined, source);
+    }
+
+    if (gridChanges.length === 0) {
+      settle();
+
+      return;
+    }
+
+    hot.addHookOnce('afterChange', settle);
+
+    try {
+      hot.setDataAtCell(gridChanges, null, null, source);
+    } catch (error) {
+      // The write threw, so `afterChange` never fires. An armed hook would settle this half-applied
+      // action on the next change to reach the grid - see `RemoveRowAction#undo`.
+      hot.removeHook('afterChange', settle);
+
+      throw error;
+    }
+  }
+
+  /**
    * @param {Core} hot The Handsontable instance.
    * @param {function(): void} undoneCallback The callback to be called after the action is undone.
    */
   undo(hot: HotInstance, undoneCallback: HookCallback) {
-    const data = deepClone(this.changes) as unknown[][];
+    const { gridChanges, sourceChanges } = this.#collectWrites(hot, 2);
 
-    for (let i = 0, len = data.length; i < len; i++) {
-      data[i].splice(3, 1);
-    }
-
-    hot.addHookOnce('afterChange', () => {
-      const rowsToRemove = hot.countRows() - this.countRows;
+    this.#replay(hot, gridChanges, sourceChanges, 'UndoRedo.undo', () => {
+      // Rows the change grew the dataset by - a write past the last row creates the rows it needs,
+      // and filling the last spare row makes `minSpareRows` top them up again. Measured in *source*
+      // rows, not the `countRows` this action also records: that one counts only what a filter or a
+      // trim leaves visible, so it reads a filter applied or dropped since the change as rows this
+      // action added, and then deletes that many rows of the user's data off the end (DEV-2665).
+      const rowsToRemove = hot.countSourceRows() - this.countSourceRows;
 
       if (rowsToRemove > 0) {
         hot.alter('remove_row', undefined, rowsToRemove, 'UndoRedo.undo');
@@ -156,7 +281,6 @@ export class DataChangeAction extends BaseAction {
 
       undoneCallback();
     });
-    hot.setDataAtCell(data, null, null, 'UndoRedo.undo');
   }
 
   /**
@@ -164,13 +288,9 @@ export class DataChangeAction extends BaseAction {
    * @param {function(): void} redoneCallback The callback to be called after the action is redone.
    */
   redo(hot: HotInstance, redoneCallback: HookCallback) {
-    const data = deepClone(this.changes) as unknown[][];
+    const { gridChanges, sourceChanges } = this.#collectWrites(hot, 3);
 
-    for (let i = 0, len = data.length; i < len; i++) {
-      data[i].splice(2, 1);
-    }
-
-    hot.addHookOnce('afterChange', () => {
+    this.#replay(hot, gridChanges, sourceChanges, 'UndoRedo.redo', () => {
       // The redo write carries the `UndoRedo.redo` source, so the MergeCells plugin's own paste
       // path does not run - the merges it dropped have to be dropped again from here.
       unmergeCellsGeometryOnly(hot, this.mergedCells);
@@ -179,6 +299,5 @@ export class DataChangeAction extends BaseAction {
 
       redoneCallback();
     });
-    hot.setDataAtCell(data, null, null, 'UndoRedo.redo');
   }
 }

--- a/handsontable/src/plugins/undoRedo/actions/dataChange.ts
+++ b/handsontable/src/plugins/undoRedo/actions/dataChange.ts
@@ -193,7 +193,18 @@ export class DataChangeAction extends BaseAction {
       const physicalRow = this.physicalRows?.[index] ?? null;
 
       if (physicalRow === null) {
-        gridChanges.push([change[0], visualColumn, value]);
+        // Nothing to re-derive here - the row had no physical index to record. The stale visual
+        // index is all there is, and writing at it is what re-creates the row. It is only trusted
+        // while it still names a row this change appended (or no row at all, which is the state a
+        // redo starts from): anything that pushed rows into the visual space since - a trim lifted,
+        // an unrecorded insert - can slide it onto a record that existed all along, and blanking
+        // that record is worse than not replaying the change at all.
+        const targetRow = hot.toPhysicalRow(change[0] as number) as number | null;
+
+        if (targetRow === null || !Number.isInteger(this.countSourceRows) ||
+            targetRow >= this.countSourceRows!) {
+          gridChanges.push([change[0], visualColumn, value]);
+        }
 
         return;
       }
@@ -250,11 +261,16 @@ export class DataChangeAction extends BaseAction {
   /**
    * Replays both write lists and settles the action exactly once.
    *
-   * The source-data writes run first, so the settle callback - which rides on the grid write's
-   * `afterChange` - runs once the whole replay has landed. With no grid write to make, that hook
-   * would never fire and the action has to settle from here instead. Leaving it armed would settle
-   * this action on the next unrelated change, and until then `ignoreNewActions` stays on, dropping
-   * every action the user performs in between.
+   * The grid write goes first and the source writes are held back until it has actually landed. Two
+   * things ride on that order. A validator that rejects every grid change under `allowInvalid: false`
+   * fires no `afterChange`, so nothing after it runs and the action stays entirely un-applied rather
+   * than half-applied. And the settle callback, which rides on that same `afterChange`, runs once the
+   * whole replay is in place rather than in the middle of it.
+   *
+   * With no grid write to make there is no `afterChange` to wait for, so the source writes and the
+   * settle both run from here. Leaving the hook armed instead would settle this action on the next
+   * unrelated change, and until then `ignoreNewActions` stays on, dropping every action the user
+   * performs in between.
    *
    * @param {Core} hot The Handsontable instance.
    * @param {Array} gridChanges Changes to write through the grid, as `[visualRow, visualColumn, value]`.
@@ -265,24 +281,30 @@ export class DataChangeAction extends BaseAction {
   #replay(
     hot: HotInstance, gridChanges: unknown[][], sourceChanges: unknown[][], source: string, settle: () => void
   ) {
-    if (sourceChanges.length > 0) {
-      hot.setSourceDataAtCell(sourceChanges, undefined, undefined, source);
-    }
+    const finish = () => {
+      // Before `settle()`, never after: the undo's tail removes the rows this change appended, and
+      // these writes address rows by a physical index taken before that removal.
+      if (sourceChanges.length > 0) {
+        hot.setSourceDataAtCell(sourceChanges, undefined, undefined, source);
+      }
+
+      settle();
+    };
 
     if (gridChanges.length === 0) {
-      settle();
+      finish();
 
       return;
     }
 
-    hot.addHookOnce('afterChange', settle);
+    hot.addHookOnce('afterChange', finish);
 
     try {
       hot.setDataAtCell(gridChanges, null, null, source);
     } catch (error) {
-      // The write threw, so `afterChange` never fires. An armed hook would settle this half-applied
-      // action on the next change to reach the grid - see `RemoveRowAction#undo`.
-      hot.removeHook('afterChange', settle);
+      // The write threw, so `afterChange` never fires. An armed hook would settle this action on the
+      // next change to reach the grid - see `RemoveRowAction#undo`.
+      hot.removeHook('afterChange', finish);
 
       throw error;
     }


### PR DESCRIPTION
### Context

The PR fixes an undo of a cell edit writing to the wrong row, or growing the dataset, when the edited row is no longer visible.

`DataChangeAction.undo/redo` replayed every recorded edit through `hot.setDataAtCell(...)` using the **visual** row captured at edit time. That index only describes the grid state the edit happened in, so a filter or `trimRows` applied afterwards makes it address a different record — or no record at all. Three measured failures came out of that:

1. A filter applied after the edit puts another row at that visual index, so the undo **overwrote the wrong row**.
2. With every row trimmed away, `countRows()` is `0`, so the recorded index sits past the last row. `applyChanges()`'s `allowInsertRow` branch then **created a phantom row** and put the restored value there — the shape reported on the `#dev-2079` flow, where the source data grew a sixth row.
3. The action's own guard compared **visible** row counts (`countRows() - this.countRows`), so it could not see the source data growing. In the other direction it was worse: a trim *lifted* between the edit and the undo made the guard read the reappeared rows as rows this change had added, and it then **deleted that many rows of the user's data off the end**.

A fourth failure surfaced while fixing the first three. With nothing to write, `setDataAtCell` fires no `afterChange`, so the `addHookOnce('afterChange')` the settle callback rides on stayed armed. `ignoreNewActions` then stayed on, and **every action the user performed afterwards was silently dropped from the undo stack** until some unrelated change fired the stale hook and settled this action at the wrong time.

This was split out of DEV-2656 / #13267, where it was found and deliberately left unfixed because the completion callback depends on `setDataAtCell` firing `afterChange`.

#### What changed

`handsontable/src/plugins/undoRedo/actions/dataChange.ts`:

- The action records a `physicalRows` array alongside `changes`, read from the same `beforeChange` listener and parallel to it by index.
- `#collectWrites()` routes each change to the write path that can still reach its row:
  - **row visible** → `setDataAtCell` at its *current* visual index. The normal path, and it keeps everything a grid write brings with it: validators, the `afterChange` hook, the editor refresh.
  - **row exists but is trimmed** → `setSourceDataAtCell(physicalRow, prop, value)`.
  - **row had no physical index when recorded** → it did not exist yet, because `beforeChange` runs before `applyChanges()` creates the rows a past-the-end write needs. That case keeps addressing the grid visually, which is what re-creates the row.
- `#replay()` makes the grid write first and holds the source writes inside the settle path, behind the same `afterChange`. A validator that rejects every grid change under `allowInvalid: false` fires no `afterChange`, so such an action stays entirely un-applied instead of half-applied. With no grid write to make, the source writes and the settle both run directly.
- The `physicalRow === null` branch — a row that did not exist when the change was recorded, so there is no physical index to re-derive — trusts its recorded visual index only while that index still names a row this change appended, or no row at all. Anything that pushed rows into the visual space since (a lifted trim, an unrecorded insert) can slide it onto a record that existed all along, and the change is then dropped rather than blanking that record.
- The rows the change appended are now named **individually** by `#collectCreatedRows()`, as one `alter()` `[visualRow, 1]` group per trailing source row. Two things were wrong before: measuring against `countRows()` (which counts only visible rows, so a trim lifted since the edit read as rows to delete), and passing an *amount* at all — `alter('remove_row', undefined, n)` counts back from the last **visible** row, so with anything trimmed it removes a record the change never touched. A trailing row that is itself trimmed has no visual index and is skipped. `countRows` is still recorded, because it is part of the payload `beforeUndo`/`afterUndo` hand to listeners.
- `countSourceRows` is optional on the action. An action built by an external `undoRedo.done()` caller carries no source-row baseline, and the removal is then skipped rather than measured against a count of something else.

The `#dev-2079` spec in `handsontable/src/plugins/filters/__tests__/plugins/undoRedo.spec.js` had to widen its seed condition in #13267, which left the "an edit makes a row stop matching, then undo" path uncovered. This PR restores that coverage with a second spec on the narrow seed, as the task asks.

#### Behavior note for the reviewer

A trimmed-row undo now bypasses `beforeChange` and `afterChange` and fires `afterSetSourceDataAtCell` instead. This is a bug fix rather than a breaking change — the previous behavior wrote to the wrong row or grew the dataset — but the hook change is visible to a listener, so the undo/redo guide now states it.

#### One trap worth naming

Gating the row-count guard on "some change was recorded past the last row" looks right and passes every trimming test, but it is **not** enough: `minSpareRows` tops the spares up when an edit fills the last spare row, so the dataset grows even though every change addressed a row that already existed. `UndoRedo.spec.js`'s "should undo creation of multiple rows with minSpareRows" is what catches it. Measuring source rows is what actually works. That, and the other traps, are recorded in `handsontable/src/plugins/undoRedo/AGENTS.md`.

Two things were checked and needed no change: the Formulas plugin already ignores `UndoRedo.*` sources on `afterSetSourceDataAtCell` and resolves a trimmed row's engine index physically, so the HyperFormula stack stays in step; and the Filters plugin re-filters only on `filter()`, never on `afterChange`, so the source write correctly leaves the row trimmed.

#### Known gaps, left open deliberately

All four are recorded in `handsontable/src/plugins/undoRedo/AGENTS.md` so they are not rediscovered as new bugs:

1. `physicalRows` is a **position** in the source array, not a record identity. A row removal that never reached the undo stack shifts it, and the replay then lands on a neighboring record. Same class of gap the visual index had, one step further out; LIFO covers the ordinary case.
2. The data is restored physically but the **selection** is still restored visually, so after a reorder this action did not record, the values land on the right records while the highlight does not. A physical form for a *range* is not something `CellRange` can express.
3. `allowInvalid: false` can still strand the stack: when a validator rejects every grid change, `applyChanges` fires no `afterChange` and the settle never runs. Pre-existing, and the `try/catch` does not cover it because nothing throws. The action is at least not *half*-applied — the source writes sit behind that same `afterChange` — but a real fix for the stranding needs a completion signal from Core.
4. The **column** half of the guard still compares `countCols()`, which is the same defect the row half fixes. Left alone because the column axis is outside DEV-2665, and `countSourceCols()` reads the first row's keys, which is not a reliable count.

### How has this been tested?

Nine new unit cases in `handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.unit.js`, on a `trimRows` grid: the edited record is restored and its visual-index neighbour is not touched; the all-trimmed restore settles and is redoable; no settle hook is left armed; no rows are deleted when rows were untrimmed after the change; the rows a lifted trim revealed survive the removal of the created ones; a populated row is not removed in place of a created row that is trimmed; a pre-existing record the stale visual index slid onto is not blanked; no row removal runs at all when no created row is reachable (no `beforeRemoveRow(NaN, 0, [])` round); and the created rows are measured in source rows with `minSpareRows` in play. One new E2E case restores the `#dev-2665` filters coverage. The action-shape assertion in `dataChange.spec.js` gains the two new fields.

Reverting `dataChange.ts` to its `develop` state turns **7 of those 9** red, and turns the new filters spec red with exactly the reported shape (`countSourceRows` becomes 6, and `'Gardiner'` lands on a phantom row 5). The two that stay green on `develop` — `should not remove a populated row in place of a created row that is trimmed` and `should not run a row removal when no created row is reachable` — guard an intermediate version of this PR rather than `develop`: the old `countRows()` arithmetic evaluates to 0 in their setups, so no removal is attempted there at all. They are kept because the mistake they pin is easy to make again. A tenth case, `should remove the rows that a write past the last row created`, sits outside the DEV-2665 block: it enables no trimming and passes either way, guarding the plain removal path.

```bash
npm run eslint --prefix handsontable
npm run stylelint --prefix handsontable
npm run test:types --prefix handsontable

npm run test:unit --prefix handsontable -- --testPathPattern='undoRedo'
npm run test:e2e --prefix handsontable -- --testPathPattern='undoRedo|filters|trimRows|nestedRows|mergeCells|formulas|columnSorting|copyPaste'

# full suites, because this touches a core write path
npm run test:unit --prefix handsontable
npm run test:e2e --prefix handsontable
npm run test --prefix wrappers/react-wrapper
```

Results: eslint 0 errors, stylelint clean, `test:types` clean, `bin/changelog consume --dry-run` clean. Full core unit suite **4435 passed / 345 suites**. Full core E2E suite **9895 specs, 0 failures**, 8 pending. React wrapper **102 passed / 16 suites** (it is the only wrapper suite that touches undo).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2665
2. Split out of DEV-2656 / #13267

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2665
