### PR TITLE
Add console render-performance measurement to Performance guide

### DIFF
--- a/docs/content/guides/optimization/performance/performance.md
+++ b/docs/content/guides/optimization/performance/performance.md
@@ -29,18 +29,53 @@ The optimizations on this page come from measuring Handsontable's execution time
 
 ## Measure render performance in the console
 
-To check how many times the grid renders and how long each render takes, log it from the [`afterRender`](@/api/hooks.md#afterrender) hook instead of reading a generic browser profiler. This logs one line per render cycle directly in your browser console, scoped to Handsontable:
+To check how many times the grid renders and how long each render takes, log it from the [`beforeRender`](@/api/hooks.md#beforerender) and [`afterRender`](@/api/hooks.md#afterrender) hooks instead of reading a generic browser profiler. This logs one line per render cycle directly in your browser console, scoped to Handsontable. Note that these hooks don't fire on scroll, since scrolling doesn't trigger a full render.
+
+::: only-for react
+::: tip
+
+To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
+
+For more information, see the [Instance methods](@/guides/getting-started/react-methods/react-methods.md) page.
+
+:::
+:::
+
+::: only-for angular
+::: tip
+
+To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
+
+For more information, see the [Instance access](@/guides/getting-started/angular-hot-instance/angular-hot-instance.md) page.
+
+:::
+:::
+
+::: only-for vue
+::: tip
+
+To use the Handsontable API, you'll need access to the Handsontable instance. Use a template ref on the `HotTable` component and read its `hotInstance` property.
+
+For more information, see the [Referencing the Handsontable instance in Vue 3](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md) page.
+
+:::
+:::
 
 ```js
 let renderCount = 0;
+let renderStart = 0;
+
+hot.addHook('beforeRender', () => {
+  renderStart = performance.now();
+});
 
 hot.addHook('afterRender', () => {
   renderCount += 1;
-  console.log(`Render #${renderCount} at`, performance.now(), 'ms since page load');
+  console.log(`Render #${renderCount} took ${(performance.now() - renderStart).toFixed(2)} ms`);
 });
 ```
 
-For per-cell timing, use the [`afterRenderer`](@/api/hooks.md#afterrenderer) hook instead - it runs once for every rendered cell.
+For per-cell timing, pair the [`beforeRenderer`](@/api/hooks.md#beforerenderer) and [`afterRenderer`](@/api/hooks.md#afterrenderer) hooks instead - they run once for every rendered cell.
 
 ## Set constant row and column sizes
 

--- a/docs/content/guides/optimization/performance/performance.md
+++ b/docs/content/guides/optimization/performance/performance.md
@@ -26,6 +26,21 @@ Handsontable performs multiple calculations to display the grid properly. The mo
 
 The optimizations on this page come from measuring Handsontable's execution times in various configurations. Each one applies only in certain cases. Check which ones fit your application. To see how those measurements work, browse the [performance test suite](https://github.com/handsontable/handsontable/tree/develop/performance-tests) in the Handsontable repository. It runs scripted interactions in a real browser and records the timings.
 
+## Measure render performance in the console
+
+To check how many times the grid renders and how long each render takes, log it from the [`afterRender`](@/api/hooks.md#afterrender) hook instead of reading a generic browser profiler. This logs one line per render cycle directly in your browser console, scoped to Handsontable:
+
+```js
+let renderCount = 0;
+
+hot.addHook('afterRender', () => {
+  renderCount += 1;
+  console.log(`Render #${renderCount} at`, performance.now(), 'ms since page load');
+});
+```
+
+For per-cell timing, use the [`afterRenderer`](@/api/hooks.md#afterrenderer) hook instead - it runs once for every rendered cell.
+
 ## Set constant row and column sizes
 
 Configure your [column widths](@/guides/columns/column-width/column-width.md) and [row heights](@/guides/rows/row-height/row-height.md) in advance. This way, Handsontable doesn't have to calculate them.

--- a/docs/content/guides/optimization/performance/performance.md
+++ b/docs/content/guides/optimization/performance/performance.md
@@ -15,6 +15,7 @@ vue:
   metaTitle: Performance - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization
+menuTag: updated
 ---
 Boost your grid's performance by setting a constant column size, suspending rendering, deciding how many rows and columns are pre-rendered, and more.
 


### PR DESCRIPTION
### Context
The docs-assistant repeatedly answered "how do I see FPS/render time/memory in the console for Handsontable" with only a generic Chrome DevTools walkthrough, even after being asked specifically for console output rather than optimization advice. The Performance guide had no Handsontable-specific way to answer this, even though the `afterRender`/`afterRenderer` hooks already make it possible to log render count and timing straight to the console. This adds a short section covering that.

### Test evidence (required for source changes)
- Unit tests added/modified (`*.unit.js`): none — docs only
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none — docs only
- Type tests (`*.types.ts`) updated if public API changed: none — no API change
- For a bug fix — the spec that fails without this fix: n/a
- Demo page / recorded trace (for UI changes): n/a — prose + snippet addition only

### Commands run
none — docs-only text addition, no build/lint run

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://app.clickup.com/t/123kvxe9wqc

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> The **Performance** guide now documents how to log render count and duration in the browser console using Handsontable’s `beforeRender` / `afterRender` hooks (with a copy-paste snippet), and clarifies that those hooks don’t run on scroll. It also points readers to `beforeRenderer` / `afterRenderer` for per-cell timing.
> 
> React, Angular, and Vue variants get the same `hotInstance` access tips used elsewhere in the guide. Front matter adds `menuTag: updated` so the page is marked as refreshed in the docs nav.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3458ea7921625bd64dd62f7bc0a10227fb377124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->