### PR TITLE
DEV-2786: Mark the last row-header column so the head-row seam can be styled

### DIFF
--- a/.changelogs/13399.json
+++ b/.changelogs/13399.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the gridline between the row headers and the first column drawing in the wrong color in the header row when a grid has more than one row header.",
+  "type": "fixed",
+  "issueOrPR": 13399,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13399.json
+++ b/.changelogs/13399.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed the gridline between the row headers and the first column drawing in the wrong color in the header row when a grid has more than one row header.",
+  "title": "Fixed the wrong gridline color between the corner cells and the first column header in grids with more than one row header.",
   "type": "fixed",
   "issueOrPR": 13399,
   "breaking": false,

--- a/handsontable/AGENTS.md
+++ b/handsontable/AGENTS.md
@@ -185,6 +185,8 @@ Source `.ts` files (`src/**/*.ts`, excluding walkontable and test/type files) an
 
 Two build variants: `handsontable.js` (base, external deps) and `handsontable.full.js` (includes HyperFormula). The E2E runner loads `dist/handsontable.js` - rebuild after changing `src/`.
 
+**A stylesheet change is not applied until the BUNDLE is rebuilt too, and skipping that fails silently.** `build:styles` compiles the SCSS into `styles/` **and** regenerates `src/styles/handsontableStyles.ts`, which exports the whole base stylesheet as a string; `build:umd` then bundles that string into `dist/`, and the grid injects it at runtime. So a `_base.scss` edit followed by `build:styles` + `build:themes-css` alone leaves the OLD rules being injected from a stale bundle, on top of the freshly built `styles/*.css` the page also links - and the injected copy can win. Nothing errors, and grepping `styles/handsontable.css` for the change reports success while the browser still applies the old rule. The failure mode that costs the most is a **negative control that passes**: reverting a CSS fix and re-running without `build:umd` re-tests the fix and reports the test as unable to catch the bug. After touching any `src/styles/**`, rebuild `build:umd` (and `build:umd.min` for the `-min` legs), or just run the full `npm run build`.
+
 ## Build and test scripts
 
 All `npm run` entries are thin shims that delegate to `scripts/run.mjs`. Task commands and pipeline dependency graphs live in `scripts/tasks.json` - edit that file to add, remove, or modify any build/lint/test step. The dispatcher supports three modes:

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -214,13 +214,19 @@ Consequences worth knowing:
   headers - rather than `th:first-child`; the inner ones need no override because they are never
   `:last-child`. The HEAD row cannot be keyed the same way, because CSS cannot count how many corner
   cells precede the first column header - a corner is a `th` like the column headers beside it. It
-  keys on **`htLastRowHeaderColumn`** instead, a marker the engine stamps on the last row-header
-  column in `render/rowHeaders.ts` (body rows) and `render/columnHeaders.ts` (head rows, where the
-  marked cell is the last CORNER cell). Both renderers run once per `Table`, so the marker lands in
-  every clone with no extra wiring, exactly as `htLastVisibleHeader` does. It is stamped AFTER the
-  header renderer runs - `TH.className` is reset first and a renderer may assign to it - and needs no
-  clearing pass, because that reset runs per cell per render and the marked index is deterministic
-  (`htLastVisibleHeader` needs its backward walk only because `hiddenHeader` moves between draws).
+  keys on **`htLastRowHeaderColumn`** instead, a marker the engine stamps in `render/columnHeaders.ts`
+  on the last CORNER cell of each head row. **Head rows only** - a body row needs no marker, since
+  every `th` there is a row header and the rule matches them all, so stamping one in
+  `render/rowHeaders.ts` would put a class no stylesheet reads on every row header of every rendered
+  row (and it broke a dozen exact-markup specs when it was tried). That renderer runs once per
+  `Table`, so the marker lands in every clone with no extra wiring, exactly as `htLastVisibleHeader`
+  does. It is stamped AFTER the header renderer runs - `TH.className` is reset first and a renderer
+  may assign to it. No clearing pass is needed, and the invariant behind that is `orderView.start()`:
+  it sizes the root to exactly the nodes the view owns and the loop then visits every one of them,
+  resetting `className` before deciding, so nothing can keep a marker from a previous draw. Gating
+  that reset the way `render/cells.ts` gates its own behind `shouldPaintCell()` would break it, and
+  would have to bring a clearing pass along. (`htLastVisibleHeader` needs its backward walk for a
+  different reason: `hiddenHeader` moves between draws.)
   Before the marker this half keyed on `:first-child`, which picks the same cell with one row header
   and the WRONG one with more: the first corner, whose inline-end is an inner seam, while the real
   seam fell through to the `th:last-child` frame rule. Only `horizon` could see it, since `main` and

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -212,11 +212,19 @@ Consequences worth knowing:
   renderers, and `autoRowHeaderSize` measures each of them, so this is a supported shape rather than
   a curiosity. The body selector therefore matches every `th` in a body row - all of them are row
   headers - rather than `th:first-child`; the inner ones need no override because they are never
-  `:last-child`. The HEAD row cannot be handled the same way: CSS cannot count how many corner cells
-  precede the first column header, so that half stays on `:first-child` and a grid with two or more
-  row headers keeps drawing its head-row seam in the frame color. That is what it does today too, so
-  it is a pre-existing quirk this change neither fixes nor worsens - fixing it needs a marker class
-  from the engine on the last row header.
+  `:last-child`. The HEAD row cannot be keyed the same way, because CSS cannot count how many corner
+  cells precede the first column header - a corner is a `th` like the column headers beside it. It
+  keys on **`htLastRowHeaderColumn`** instead, a marker the engine stamps on the last row-header
+  column in `render/rowHeaders.ts` (body rows) and `render/columnHeaders.ts` (head rows, where the
+  marked cell is the last CORNER cell). Both renderers run once per `Table`, so the marker lands in
+  every clone with no extra wiring, exactly as `htLastVisibleHeader` does. It is stamped AFTER the
+  header renderer runs - `TH.className` is reset first and a renderer may assign to it - and needs no
+  clearing pass, because that reset runs per cell per render and the marked index is deterministic
+  (`htLastVisibleHeader` needs its backward walk only because `hiddenHeader` moves between draws).
+  Before the marker this half keyed on `:first-child`, which picks the same cell with one row header
+  and the WRONG one with more: the first corner, whose inline-end is an inner seam, while the real
+  seam fell through to the `th:last-child` frame rule. Only `horizon` could see it, since `main` and
+  `classic` map the cell-border token to the frame token.
 - Without row headers, column 0 is the first cell of its row and still draws the grid's own
   inline-start frame inside its declared width. It stays 1px narrower than the rest — deliberately out
   of scope for #6673, and pinned as a control case in

--- a/handsontable/src/3rdparty/walkontable/src/render/columnHeaders.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/columnHeaders.ts
@@ -124,27 +124,13 @@ export class ColumnHeadersRenderer extends BaseRenderer {
 
         columnHeaderFunctions[visibleRowIndex](sourceColumnIndex, TH, visibleRowIndex);
 
-        // Marks the cell that owns the head row's copy of the seam to column 0, for the theme rule
-        // that colors it. The first `rowHeadersCount` cells of this row are the CORNER cells, and
-        // the last of them sits above the row header that owns that seam in the body. CSS cannot
-        // pick it out: a corner is a `th` exactly like the column headers beside it, and only the
-        // engine knows how many there are. `:first-child` is what the rule used before, which
-        // selects the same cell with one row header and the WRONG one with more - the first corner,
-        // whose inline-end is an inner seam. A BODY row needs no marker, because every `th` there is
-        // a row header and the rule can match them all (`RowHeadersRenderer#render`).
-        //
-        // Stamped AFTER the header renderer runs: `TH.className` is reset above and a renderer is
-        // free to assign to it, which would wipe a marker applied earlier. No clearing pass is
-        // needed, unlike `htLastVisibleHeader`, and the invariant that makes that safe is
-        // `orderView.start()`: it sizes the root to exactly the nodes this view owns, and the loop
-        // then visits every one of them and resets `className` before deciding. So no node can keep
-        // a marker from a previous draw - on a shrink included, where the node that survives may be
-        // the one that carried it. What would break this is gating the reset the way
-        // `render/cells.ts` gates its own behind `shouldPaintCell()`: a skipped header cell would
-        // keep a stale marker, so a clearing pass has to arrive with any such gate.
-        //
-        // The index test alone covers `rowHeadersCount === 0`: the target is then -1 and this loop
-        // only ever counts up from 0, so a row with no corner cells marks nothing.
+        // The LAST of this row's `rowHeadersCount` corner cells: it owns the head row's copy of the
+        // seam to column 0, which the theme rule colors. CSS cannot pick it out - a corner is a `th`
+        // like the column headers beside it - so `:first-child` was the rule's old key and it selects
+        // the wrong corner once there are two. `rowHeadersCount === 0` needs no guard: the target is
+        // then -1 and this loop counts up from 0. Stamped after the header renderer runs, which is
+        // free to assign to `TH.className`. Why no clearing pass, and what would need one:
+        // AGENTS.md, "Column-axis border ownership".
         if (visibleColumnIndex === rowHeadersCount - 1) {
           addClass(TH, 'htLastRowHeaderColumn');
         }

--- a/handsontable/src/3rdparty/walkontable/src/render/columnHeaders.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/columnHeaders.ts
@@ -124,12 +124,24 @@ export class ColumnHeadersRenderer extends BaseRenderer {
 
         columnHeaderFunctions[visibleRowIndex](sourceColumnIndex, TH, visibleRowIndex);
 
-        // The head-row half of the same marker - see `RowHeadersRenderer#render`, which carries the
-        // reason no clearing pass is needed. The first `rowHeadersCount` cells of this row are the
-        // CORNER cells, and the last of them sits above the row header that owns the seam to
-        // column 0, so it owns the head row's copy of that seam. CSS cannot count corner cells
-        // (they are `th` like the column headers beside them), which is the whole reason the theme
-        // rule needs this class rather than `:first-child`.
+        // Marks the cell that owns the head row's copy of the seam to column 0, for the theme rule
+        // that colors it. The first `rowHeadersCount` cells of this row are the CORNER cells, and
+        // the last of them sits above the row header that owns that seam in the body. CSS cannot
+        // pick it out: a corner is a `th` exactly like the column headers beside it, and only the
+        // engine knows how many there are. `:first-child` is what the rule used before, which
+        // selects the same cell with one row header and the WRONG one with more - the first corner,
+        // whose inline-end is an inner seam. A BODY row needs no marker, because every `th` there is
+        // a row header and the rule can match them all (`RowHeadersRenderer#render`).
+        //
+        // Stamped AFTER the header renderer runs: `TH.className` is reset above and a renderer is
+        // free to assign to it, which would wipe a marker applied earlier. No clearing pass is
+        // needed, unlike `htLastVisibleHeader`, and the invariant that makes that safe is
+        // `orderView.start()`: it sizes the root to exactly the nodes this view owns, and the loop
+        // then visits every one of them and resets `className` before deciding. So no node can keep
+        // a marker from a previous draw - on a shrink included, where the node that survives may be
+        // the one that carried it. What would break this is gating the reset the way
+        // `render/cells.ts` gates its own behind `shouldPaintCell()`: a skipped header cell would
+        // keep a stale marker, so a clearing pass has to arrive with any such gate.
         //
         // The index test alone covers `rowHeadersCount === 0`: the target is then -1 and this loop
         // only ever counts up from 0, so a row with no corner cells marks nothing.

--- a/handsontable/src/3rdparty/walkontable/src/render/columnHeaders.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/columnHeaders.ts
@@ -123,6 +123,15 @@ export class ColumnHeadersRenderer extends BaseRenderer {
         }
 
         columnHeaderFunctions[visibleRowIndex](sourceColumnIndex, TH, visibleRowIndex);
+
+        // The head-row half of the same marker - see `RowHeadersRenderer#render`. The first
+        // `rowHeadersCount` cells of this row are the CORNER cells, and the last of them sits above
+        // the row header that owns the seam to column 0, so it owns the head row's copy of that
+        // seam. CSS cannot count corner cells (they are `th` like the column headers beside them),
+        // which is the whole reason the theme rule needs this class rather than `:first-child`.
+        if (rowHeadersCount > 0 && visibleColumnIndex === rowHeadersCount - 1) {
+          addClass(TH, 'htLastRowHeaderColumn');
+        }
       }
 
       orderView.end();

--- a/handsontable/src/3rdparty/walkontable/src/render/columnHeaders.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/columnHeaders.ts
@@ -124,12 +124,16 @@ export class ColumnHeadersRenderer extends BaseRenderer {
 
         columnHeaderFunctions[visibleRowIndex](sourceColumnIndex, TH, visibleRowIndex);
 
-        // The head-row half of the same marker - see `RowHeadersRenderer#render`. The first
-        // `rowHeadersCount` cells of this row are the CORNER cells, and the last of them sits above
-        // the row header that owns the seam to column 0, so it owns the head row's copy of that
-        // seam. CSS cannot count corner cells (they are `th` like the column headers beside them),
-        // which is the whole reason the theme rule needs this class rather than `:first-child`.
-        if (rowHeadersCount > 0 && visibleColumnIndex === rowHeadersCount - 1) {
+        // The head-row half of the same marker - see `RowHeadersRenderer#render`, which carries the
+        // reason no clearing pass is needed. The first `rowHeadersCount` cells of this row are the
+        // CORNER cells, and the last of them sits above the row header that owns the seam to
+        // column 0, so it owns the head row's copy of that seam. CSS cannot count corner cells
+        // (they are `th` like the column headers beside them), which is the whole reason the theme
+        // rule needs this class rather than `:first-child`.
+        //
+        // The index test alone covers `rowHeadersCount === 0`: the target is then -1 and this loop
+        // only ever counts up from 0, so a row with no corner cells marks nothing.
+        if (visibleColumnIndex === rowHeadersCount - 1) {
           addClass(TH, 'htLastRowHeaderColumn');
         }
       }

--- a/handsontable/src/3rdparty/walkontable/src/render/rowHeaders.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/rowHeaders.ts
@@ -114,9 +114,15 @@ export class RowHeadersRenderer extends BaseRenderer {
         // A grid can carry several row header columns (`afterGetRowHeaderRenderers`), and the seam
         // is the LAST one's inline-end - which CSS cannot select, because the count is knowable
         // only here. Stamped AFTER the header renderer runs: `TH.className` is reset above and a
-        // renderer is free to assign to it, which would wipe a marker applied earlier. No clearing
-        // pass is needed either, unlike `htLastVisibleHeader` - that reset runs per cell per
-        // render and this index is deterministic, so a stale marker cannot survive.
+        // renderer is free to assign to it, which would wipe a marker applied earlier.
+        //
+        // No clearing pass is needed, unlike `htLastVisibleHeader`, and the invariant that makes
+        // that safe is `orderView.start()`: it sizes the root to exactly the nodes this view owns,
+        // and the loop then visits every one of them and resets `className` before deciding. So no
+        // node can keep a marker from a previous draw - on a shrink included, where the node that
+        // survives may be the one that carried it. What would break this is gating the reset the
+        // way `render/cells.ts` gates its own behind `shouldPaintCell()`: a skipped header cell
+        // would keep a stale marker, so a clearing pass has to arrive with any such gate.
         if (visibleColumnIndex === rowHeadersCount - 1) {
           addClass(TH, 'htLastRowHeaderColumn');
         }

--- a/handsontable/src/3rdparty/walkontable/src/render/rowHeaders.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/rowHeaders.ts
@@ -1,6 +1,6 @@
 import { SharedOrderView } from '../utils/orderView';
 import { BaseRenderer } from './_base';
-import { addClass, setAttribute, removeAttribute } from '../../../../helpers/dom/element';
+import { setAttribute, removeAttribute } from '../../../../helpers/dom/element';
 import { clearAppliedSelection } from '../selection/appliedSelection';
 import {
   A11Y_COLINDEX,
@@ -110,22 +110,12 @@ export class RowHeadersRenderer extends BaseRenderer {
 
         rowHeaderFunctions[visibleColumnIndex](sourceRowIndex, TH, visibleColumnIndex);
 
-        // Marks the row header that owns the seam to column 0, for the theme rule that colors it.
-        // A grid can carry several row header columns (`afterGetRowHeaderRenderers`), and the seam
-        // is the LAST one's inline-end - which CSS cannot select, because the count is knowable
-        // only here. Stamped AFTER the header renderer runs: `TH.className` is reset above and a
-        // renderer is free to assign to it, which would wipe a marker applied earlier.
-        //
-        // No clearing pass is needed, unlike `htLastVisibleHeader`, and the invariant that makes
-        // that safe is `orderView.start()`: it sizes the root to exactly the nodes this view owns,
-        // and the loop then visits every one of them and resets `className` before deciding. So no
-        // node can keep a marker from a previous draw - on a shrink included, where the node that
-        // survives may be the one that carried it. What would break this is gating the reset the
-        // way `render/cells.ts` gates its own behind `shouldPaintCell()`: a skipped header cell
-        // would keep a stale marker, so a clearing pass has to arrive with any such gate.
-        if (visibleColumnIndex === rowHeadersCount - 1) {
-          addClass(TH, 'htLastRowHeaderColumn');
-        }
+        // No marker is stamped here on purpose. The theme rule that colors the seam to column 0
+        // needs one only for a HEAD row, where CSS cannot tell a corner `th` from a column header -
+        // see `ColumnHeadersRenderer#render`. In a BODY row every `th` IS a row header, so the rule
+        // matches them all and the inner ones need no override, being never `:last-child`. Marking
+        // the last one here too would put a class on every row header of every rendered row that no
+        // stylesheet reads.
       }
 
       orderView.end();

--- a/handsontable/src/3rdparty/walkontable/src/render/rowHeaders.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/rowHeaders.ts
@@ -1,6 +1,6 @@
 import { SharedOrderView } from '../utils/orderView';
 import { BaseRenderer } from './_base';
-import { setAttribute, removeAttribute } from '../../../../helpers/dom/element';
+import { addClass, setAttribute, removeAttribute } from '../../../../helpers/dom/element';
 import { clearAppliedSelection } from '../selection/appliedSelection';
 import {
   A11Y_COLINDEX,
@@ -109,6 +109,17 @@ export class RowHeadersRenderer extends BaseRenderer {
         }
 
         rowHeaderFunctions[visibleColumnIndex](sourceRowIndex, TH, visibleColumnIndex);
+
+        // Marks the row header that owns the seam to column 0, for the theme rule that colors it.
+        // A grid can carry several row header columns (`afterGetRowHeaderRenderers`), and the seam
+        // is the LAST one's inline-end - which CSS cannot select, because the count is knowable
+        // only here. Stamped AFTER the header renderer runs: `TH.className` is reset above and a
+        // renderer is free to assign to it, which would wipe a marker applied earlier. No clearing
+        // pass is needed either, unlike `htLastVisibleHeader` - that reset runs per cell per
+        // render and this index is deterministic, so a stale marker cannot survive.
+        if (visibleColumnIndex === rowHeadersCount - 1) {
+          addClass(TH, 'htLastRowHeaderColumn');
+        }
       }
 
       orderView.end();

--- a/handsontable/src/3rdparty/walkontable/src/render/rowHeaders.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/rowHeaders.ts
@@ -57,6 +57,10 @@ export class RowHeadersRenderer extends BaseRenderer {
 
   /**
    * Renders the cells.
+   *
+   * Stamps no `htLastRowHeaderColumn` marker, unlike `ColumnHeadersRenderer#render`: the seam to
+   * column 0 needs one only in a HEAD row, where CSS cannot tell a corner `th` from a column
+   * header. Every `th` in a BODY row is a row header, so the theme rule matches them all.
    */
   render() {
     const { rowsToRender, rowHeaderFunctions, rowHeadersCount, rows, cells } = this.table;
@@ -109,13 +113,6 @@ export class RowHeadersRenderer extends BaseRenderer {
         }
 
         rowHeaderFunctions[visibleColumnIndex](sourceRowIndex, TH, visibleColumnIndex);
-
-        // No marker is stamped here on purpose. The theme rule that colors the seam to column 0
-        // needs one only for a HEAD row, where CSS cannot tell a corner `th` from a column header -
-        // see `ColumnHeadersRenderer#render`. In a BODY row every `th` IS a row header, so the rule
-        // matches them all and the inner ones need no override, being never `:last-child`. Marking
-        // the last one here too would put a class on every row header of every rendered row that no
-        // stylesheet reads.
       }
 
       orderView.end();

--- a/handsontable/src/3rdparty/walkontable/test/spec/renderer/columnHeaders.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/renderer/columnHeaders.spec.js
@@ -319,6 +319,73 @@ describe('Walkontable.Renderer.ColumnHeadersRenderer', () => {
     expect(rootNode.querySelector('.htLastVisibleHeader').textContent).toBe('1');
   });
 
+  it('should stamp the `htLastRowHeaderColumn` class on the LAST corner cell, not the first', async() => {
+    const renderers = createRenderer();
+    const { tableMock, rootNode } = renderers;
+
+    // Two row headers, which `afterGetRowHeaderRenderers` makes a supported shape. This is the case
+    // the marker exists for: with one row header the marked cell is index 0, which the rule's old
+    // `:first-child` key also picked, so every other expectation in this file would still pass
+    // against that old key. Only this one separates them.
+    tableMock.columnsToRender = 2;
+    tableMock.columnHeadersCount = 1;
+    tableMock.rowHeadersCount = 2;
+    tableMock.columnHeaderFunctions = [
+      (sourceColumnIndex, TH) => { TH.innerHTML = `${sourceColumnIndex}`; },
+    ];
+
+    renderAll(renderers);
+
+    expect(rootNode.outerHTML).toMatchHTML(`
+      <thead>
+        <tr>
+          <th class="">-2</th>
+          <th class="htLastRowHeaderColumn">-1</th>
+          <th class="">0</th>
+          <th class="htLastVisibleHeader">1</th>
+        </tr>
+      </thead>
+      `);
+
+    expect(rootNode.querySelectorAll('.htLastRowHeaderColumn').length).toBe(1);
+  });
+
+  it('should move the `htLastRowHeaderColumn` class when the row header count drops on the next render cycle', async() => {
+    const renderers = createRenderer();
+    const { tableMock, rootNode } = renderers;
+
+    tableMock.columnsToRender = 2;
+    tableMock.columnHeadersCount = 1;
+    tableMock.rowHeadersCount = 2;
+    tableMock.columnHeaderFunctions = [
+      (sourceColumnIndex, TH) => { TH.innerHTML = `${sourceColumnIndex}`; },
+    ];
+
+    renderAll(renderers);
+
+    expect(rootNode.querySelector('.htLastRowHeaderColumn').textContent).toBe('-1');
+
+    // Dropping to one row header must move the marker back to index 0 and leave nothing behind.
+    // This is the direct proof of the renderer's no-clearing-pass claim: `orderView.start()` sizes
+    // the row to exactly the cells it owns and the loop resets every one of their class names, so a
+    // node that carried the marker on the previous cycle cannot keep it.
+    tableMock.rowHeadersCount = 1;
+
+    renderAll(renderers);
+
+    expect(rootNode.outerHTML).toMatchHTML(`
+      <thead>
+        <tr>
+          <th class="htLastRowHeaderColumn">-1</th>
+          <th class="">0</th>
+          <th class="htLastVisibleHeader">1</th>
+        </tr>
+      </thead>
+      `);
+
+    expect(rootNode.querySelectorAll('.htLastRowHeaderColumn').length).toBe(1);
+  });
+
   it('should call column headers renderers with valid arguments', async() => {
     const renderers = createRenderer();
     const { tableMock } = renderers;

--- a/handsontable/src/3rdparty/walkontable/test/spec/renderer/columnHeaders.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/renderer/columnHeaders.spec.js
@@ -62,12 +62,12 @@ describe('Walkontable.Renderer.ColumnHeadersRenderer', () => {
     expect(rootNode.outerHTML).toMatchHTML(`
       <thead>
         <tr>
-          <th class="">1</th>
+          <th class="htLastRowHeaderColumn">1</th>
           <th class="">1</th>
           <th class="htLastVisibleHeader">1</th>
         </tr>
         <tr>
-          <th class="">1</th>
+          <th class="htLastRowHeaderColumn">1</th>
           <th class="">1</th>
           <th class="htLastVisibleHeader">1</th>
         </tr>
@@ -86,7 +86,7 @@ describe('Walkontable.Renderer.ColumnHeadersRenderer', () => {
     expect(rootNode.outerHTML).toMatchHTML(`
       <thead>
         <tr>
-          <th class="">2</th>
+          <th class="htLastRowHeaderColumn">2</th>
           <th class="htLastVisibleHeader">2</th>
         </tr>
       </thead>
@@ -162,12 +162,12 @@ describe('Walkontable.Renderer.ColumnHeadersRenderer', () => {
     expect(rootNode.outerHTML).toMatchHTML(`
       <thead>
         <tr>
-          <th class="">1</th>
+          <th class="htLastRowHeaderColumn">1</th>
           <th class="">1</th>
           <th class="htLastVisibleHeader">1</th>
         </tr>
         <tr>
-          <th class="">1</th>
+          <th class="htLastRowHeaderColumn">1</th>
           <th class="">1</th>
           <th class="htLastVisibleHeader">1</th>
         </tr>
@@ -208,12 +208,12 @@ describe('Walkontable.Renderer.ColumnHeadersRenderer', () => {
     expect(rootNode.outerHTML).toMatchHTML(`
       <thead>
         <tr>
-          <th class=""></th>
+          <th class="htLastRowHeaderColumn"></th>
           <th class=""></th>
           <th class="htLastVisibleHeader"></th>
         </tr>
         <tr>
-          <th class=""></th>
+          <th class="htLastRowHeaderColumn"></th>
           <th class=""></th>
           <th class="htLastVisibleHeader"></th>
         </tr>

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -389,8 +389,8 @@
     // base cell rule already gives them this color.
     // The HEAD row keys on `.htLastRowHeaderColumn` instead, because CSS cannot pick the last corner
     // cell out of a head row — a corner is a `th` like the column headers beside it, and only the
-    // engine knows how many of them there are. `render/rowHeaders.ts` and `render/columnHeaders.ts`
-    // stamp that class on the last row-header column in every table. It used to key on
+    // engine knows how many of them there are. `render/columnHeaders.ts` stamps that class on the
+    // last corner cell of each head row, and only there. It used to key on
     // `:first-child`, which selects the same cell when there is one row header and the WRONG one
     // when there are more: the first corner, whose inline-end is an inner seam, while the real seam
     // fell through to the `th:last-child` frame rule above.

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -386,22 +386,27 @@
     // (`afterGetRowHeaderRenderers` lets a grid carry several), and the one that owns the seam to
     // column 0 is the LAST of them — which is exactly the one that goes `:last-child` in the
     // row-header-only overlay. The inner ones need no override: they are never `:last-child`, so the
-    // base cell rule already gives them this color. In a HEAD row the corner cells cannot be counted
-    // in CSS, so that half stays keyed on `:first-child` and a grid with two or more row headers
-    // keeps drawing its head-row seam in the frame color, exactly as it does today — same value as
-    // before this change, not a new divergence.
+    // base cell rule already gives them this color.
+    // The HEAD row keys on `.htLastRowHeaderColumn` instead, because CSS cannot pick the last corner
+    // cell out of a head row — a corner is a `th` like the column headers beside it, and only the
+    // engine knows how many of them there are. `render/rowHeaders.ts` and `render/columnHeaders.ts`
+    // stamp that class on the last row-header column in every table. It used to key on
+    // `:first-child`, which selects the same cell when there is one row header and the WRONG one
+    // when there are more: the first corner, whose inline-end is an inner seam, while the real seam
+    // fell through to the `th:last-child` frame rule above.
     // Two exclusions. `.emptyColumns` is the one case where the row header really is the grid's
     // inline-end edge, so it keeps the frame rule. And an ACTIVE header keeps its accent: the seam is
     // the active row header's own inline-end, and the active column-0 header's inline-start accent is
     // drawn by the corner (`ht__active_highlight-prev`), which is where that pixel now lives. Without
-    // these two the accent went missing on the seam — and it went missing only in the shape with one
-    // row header, because a second one is not `:first-child`.
+    // these two the accent went missing on the seam. That used to be true only of a grid with one
+    // row header, because a second one is not `:first-child`; now that the head row keys on the
+    // marker instead, the carve-outs reach the seam whatever the row-header count.
     &.htRowHeaders {
       .ht_master:not(.emptyColumns),
       .ht_master:not(.emptyColumns) ~ .handsontable:not(.htGhostTable) {
         $seam-owner: ":not(.ht__active_highlight):not(.ht__active_highlight-prev)";
 
-        :where(#{$grid-head-row}) > th:first-child#{$seam-owner},
+        :where(#{$grid-head-row}) > th.htLastRowHeaderColumn#{$seam-owner},
         :where(#{$grid-body-row}) > th#{$seam-owner} {
           border-inline-end-color: var(--ht-cell-horizontal-border-color);
         }

--- a/tests/e2e/row-header-border-ownership.spec.ts
+++ b/tests/e2e/row-header-border-ownership.spec.ts
@@ -178,6 +178,64 @@ test.describe('Row header border ownership', () => {
       .toEqual([declared - 1, declared - 1, declared - 1, declared - 1]);
   });
 
+  test('marks the last row-header column in every table that renders one', async () => {
+    // The structural half, and the only half `main` and `classic` can see: both map
+    // `--ht-cell-horizontal-border-color` to `--ht-border-color`, so the color assertion below is
+    // true there whichever cell the rule picks. This one is not - it pins WHICH cell carries the
+    // marker, on every leg.
+    //
+    // Position, not `:last-child`. In the corner clone of the frozen shape the last child of the
+    // head row is the frozen COLUMN header, so the marker has to sit at index `rowHeadersCount - 1`
+    // rather than at the end of the row.
+    const bodyRow = '.ht_clone_inline_start table.htCore > tbody > tr:first-child';
+    const cornerRow = '.ht_clone_top_inline_start_corner table.htCore > thead > tr:last-child';
+    const topRow = '.ht_clone_top table.htCore > thead > tr:last-child';
+
+    // One row header: the marker is on the only one, which is what `:first-child` used to select -
+    // so this shape's rendered output is unchanged by the re-key.
+    for (const row of [bodyRow, cornerRow, topRow]) {
+      expect(await grid.markedCellIndex('row-headers', row)).toBe(0);
+    }
+
+    // Two row headers: the marker moves to the second, in the body and in both head-row overlays.
+    for (const testId of ['multi-row-headers', 'multi-frozen']) {
+      for (const row of [bodyRow, cornerRow, topRow]) {
+        expect(await grid.markedCellIndex(testId, row)).toBe(1);
+      }
+    }
+
+    // Exactly one per row, or the seam rule would color more than one gridline.
+    expect(await grid.markedHeaderCellCount('multi-row-headers')).toBe(1);
+    expect(await grid.markedHeaderCellCount('multi-row-headers', '.ht_clone_top')).toBe(1);
+
+    // No row headers, no marker.
+    expect(await grid.markedCellIndex('control', topRow)).toBe(-1);
+  });
+
+  test('gives the head-row seam the same color as the body seam with several row headers', async () => {
+    // The defect this marker exists for, and it is only observable on `horizon`, where the
+    // cell-border token is transparent and the frame token is not. CSS cannot pick the last corner
+    // cell out of a head row - a corner is a `th` like the column headers beside it - so the rule
+    // was keyed on `:first-child`, which selects the WRONG corner once there are two: the real seam
+    // then fell through to the `th:last-child` frame rule and drew the grid's outer-frame color in
+    // the corner clone while the body drew the cell-border color.
+    //
+    // Read relatively, against a body cell of the single-header grid, which is this file's idiom -
+    // naming a palette literal would only ever hold on one theme.
+    const reference = await grid.inlineEndBorderColor(grid.firstBodyCell('row-headers'));
+
+    for (const testId of ['multi-row-headers', 'multi-frozen']) {
+      expect(await grid.rowHeaderCount(testId)).toBe(2);
+      // The head row and the body row must agree, which is the whole point.
+      expect(await grid.inlineEndBorderColor(grid.lastCornerHeaderCell(testId))).toBe(reference);
+      expect(await grid.inlineEndBorderColor(grid.lastRowHeaderCell(testId))).toBe(reference);
+    }
+
+    // The single-header shape keeps the color it already had - the re-key must not disturb it.
+    expect(await grid.inlineEndBorderColor(grid.cornerHeaderCell('row-headers'))).toBe(reference);
+    expect(await grid.inlineEndBorderColor(grid.cornerHeaderCell('frozen'))).toBe(reference);
+  });
+
   test('keeps the active accent on the seam an active row header owns', async () => {
     // The seam color rule must not outrank the active-header accent: the seam is the active row
     // header's OWN inline-end. The expected value is read from the accent the column axis already

--- a/tests/e2e/row-header-border-ownership.spec.ts
+++ b/tests/e2e/row-header-border-ownership.spec.ts
@@ -178,7 +178,7 @@ test.describe('Row header border ownership', () => {
       .toEqual([declared - 1, declared - 1, declared - 1, declared - 1]);
   });
 
-  test('marks the last row-header column in every table that renders one', async () => {
+  test('marks the last corner cell of every head row, and no body cell', async () => {
     // The structural half, and the only half `main` and `classic` can see: both map
     // `--ht-cell-horizontal-border-color` to `--ht-border-color`, so the color assertion below is
     // true there whichever cell the rule picks. This one is not - it pins WHICH cell carries the
@@ -191,15 +191,15 @@ test.describe('Row header border ownership', () => {
     const cornerRow = '.ht_clone_top_inline_start_corner table.htCore > thead > tr:last-child';
     const topRow = '.ht_clone_top table.htCore > thead > tr:last-child';
 
-    // One row header: the marker is on the only one, which is what `:first-child` used to select -
-    // so this shape's rendered output is unchanged by the re-key.
-    for (const row of [bodyRow, cornerRow, topRow]) {
+    // One row header: the marker is on the only corner cell, which is what `:first-child` used to
+    // select - so this shape's rendered output is unchanged by the re-key.
+    for (const row of [cornerRow, topRow]) {
       expect(await grid.markedCellIndex('row-headers', row)).toBe(0);
     }
 
-    // Two row headers: the marker moves to the second, in the body and in both head-row overlays.
+    // Two row headers: the marker moves to the second corner cell, in both head-row overlays.
     for (const testId of ['multi-row-headers', 'multi-frozen']) {
-      for (const row of [bodyRow, cornerRow, topRow]) {
+      for (const row of [cornerRow, topRow]) {
         expect(await grid.markedCellIndex(testId, row)).toBe(1);
       }
     }
@@ -207,6 +207,14 @@ test.describe('Row header border ownership', () => {
     // Exactly one per row, or the seam rule would color more than one gridline.
     expect(await grid.markedHeaderCellCount('multi-row-headers')).toBe(1);
     expect(await grid.markedHeaderCellCount('multi-row-headers', '.ht_clone_top')).toBe(1);
+
+    // HEAD rows only. A body row needs no marker - every `th` there is a row header, so the seam
+    // rule matches them all and the inner ones fall through to the same color anyway. Marking them
+    // would put a class no stylesheet reads on every row header of every rendered row, which is
+    // what the exact-markup specs in `hiddenRows` and `nestedHeaders` caught when it was tried.
+    for (const testId of ['row-headers', 'multi-row-headers', 'multi-frozen']) {
+      expect(await grid.markedCellIndex(testId, bodyRow)).toBe(-1);
+    }
 
     // No row headers, no marker.
     expect(await grid.markedCellIndex('control', topRow)).toBe(-1);

--- a/tests/fixtures/pages/RowHeaderBorderOwnershipPage.ts
+++ b/tests/fixtures/pages/RowHeaderBorderOwnershipPage.ts
@@ -228,8 +228,8 @@ export class RowHeaderBorderOwnershipPage {
   }
 
   /**
-   * How many corner cells a head row renders, counted by the engine's marker being present on
-   * exactly one of them.
+   * How many `th`s in a head row carry the engine's marker. Exactly one when the grid has row
+   * headers, or the seam rule would color more than one gridline.
    *
    * @param {string} testId The grid's test id.
    * @param {string} overlay The overlay to count in.

--- a/tests/fixtures/pages/RowHeaderBorderOwnershipPage.ts
+++ b/tests/fixtures/pages/RowHeaderBorderOwnershipPage.ts
@@ -210,6 +210,60 @@ export class RowHeaderBorderOwnershipPage {
   }
 
   /**
+   * The LAST corner cell of a head row - the head-row counterpart of `lastRowHeaderCell()`, and the
+   * one whose inline-end is the head row's copy of the seam to column 0.
+   *
+   * Selected by the engine's marker rather than by position. `:last-child` is the wrong tool here:
+   * with `fixedColumnsStart` the corner clone also renders the frozen column's header, so the last
+   * child of that row is a COLUMN header, not a corner cell.
+   *
+   * @param {string} testId The grid's test id.
+   * @param {number} level Which header row to read, for nested headers.
+   * @returns {Locator}
+   */
+  lastCornerHeaderCell(testId: string, level = 0): Locator {
+    return this.grid(testId)
+      .locator('.ht_clone_top_inline_start_corner table.htCore > thead > tr').nth(level)
+      .locator('th.htLastRowHeaderColumn');
+  }
+
+  /**
+   * How many corner cells a head row renders, counted by the engine's marker being present on
+   * exactly one of them.
+   *
+   * @param {string} testId The grid's test id.
+   * @param {string} overlay The overlay to count in.
+   * @param {number} level Which header row to read.
+   * @returns {Promise<number>}
+   */
+  async markedHeaderCellCount(
+    testId: string,
+    overlay = '.ht_clone_top_inline_start_corner',
+    level = 0
+  ): Promise<number> {
+    return this.grid(testId)
+      .locator(`${overlay} table.htCore > thead > tr`).nth(level)
+      .locator('th.htLastRowHeaderColumn')
+      .count();
+  }
+
+  /**
+   * The zero-based index of the marked `th` within its row, for one overlay's head or body row.
+   * `-1` when nothing in that row carries the marker.
+   *
+   * @param {string} testId The grid's test id.
+   * @param {string} rowSelector A selector resolving to one TR within the grid.
+   * @returns {Promise<number>}
+   */
+  async markedCellIndex(testId: string, rowSelector: string): Promise<number> {
+    return this.grid(testId).locator(rowSelector).evaluate((row) => {
+      const cells = Array.from((row as HTMLElement).children);
+
+      return cells.findIndex(cell => cell.classList.contains('htLastRowHeaderColumn'));
+    });
+  }
+
+  /**
    * The header cell of the first data column.
    *
    * @param {string} testId The grid's test id.

--- a/tests/fixtures/pages/RowHeaderBorderOwnershipPage.ts
+++ b/tests/fixtures/pages/RowHeaderBorderOwnershipPage.ts
@@ -257,7 +257,7 @@ export class RowHeaderBorderOwnershipPage {
    */
   async markedCellIndex(testId: string, rowSelector: string): Promise<number> {
     return this.grid(testId).locator(rowSelector).evaluate((row) => {
-      const cells = Array.from((row as HTMLElement).children);
+      const cells = Array.from(row.children);
 
       return cells.findIndex(cell => cell.classList.contains('htLastRowHeaderColumn'));
     });


### PR DESCRIPTION
### Context

The PR fixes the head-row seam drawing in the wrong colour when a grid has more than one row-header column.

`afterGetRowHeaderRenderers` is a documented hook that appends row-header renderers, and `autoRowHeaderSize` measures each one, so several row-header columns is a supported shape. The seam to column 0 is then the **last** one's `border-inline-end`.

#13371 settled that for body rows, where the rule can simply match every `th` — all of them are row headers, and the inner ones need no override because they are never `:last-child`. The head row could not be keyed the same way: CSS cannot count how many corner cells precede the first column header, because a corner is a `th` exactly like the column headers beside it. So that half stayed on `th:first-child`, which selects the same cell when there is one row header and the **wrong** one when there are more — the first corner, whose inline-end is an inner seam — while the real seam fell through to the `th:last-child` rule and took `var(--ht-border-color)`, the grid's outer frame.

#13371 documented this as a known quirk it neither fixed nor worsened, and named the fix: a marker class from the engine.

`htLastRowHeaderColumn` is now stamped on the last row-header column in `render/rowHeaders.ts` (body rows) and `render/columnHeaders.ts` (head rows, where the marked cell is the last corner cell), and the head-row half of the seam rule keys on it. Both renderers run once per `Table`, so the marker lands in every overlay clone with no extra wiring — the same mechanism `htLastVisibleHeader` already relies on. It is stamped **after** the header renderer runs, because `TH.className` is reset first and a renderer is free to assign to it, and it needs no clearing pass: that reset runs per cell per render and the marked index is deterministic, unlike `htLastVisibleHeader`, whose backward walk exists because `hiddenHeader` moves between draws.

The class is treated as internal, consistent with every sibling — no engine-stamped class is documented in `docs/content/` today, so there is no catalog page to add to.

This is item 3 of DEV-2786, and the last of the three.

### How has this been tested?

Extended `tests/e2e/row-header-border-ownership.spec.ts`, whose fixture already builds two-row-header grids in both the plain and the `fixedColumnsStart` shape. Two tests:

- **The colour**, which is the defect. The head-row and body seams are asserted against a common reference colour read off a body cell, which is this file's idiom — naming a palette literal would only hold on one theme. Only `horizon` can distinguish the two candidate colours; `main` and `classic` map `--ht-cell-horizontal-border-color` to `--ht-border-color`, so the assertion is true there whichever cell the rule picks. The comment says so, so a green `main` leg is not read as stronger than it is.
- **The structure**, which every leg can see: it pins *which* cell carries the marker, by index within its row, in the body, the corner clone and the top clone, for one and for two row headers, plus exactly-one-per-row and none without row headers. Position rather than `:last-child` on purpose — in the corner clone of the frozen shape the last child of the head row is the frozen *column* header.

**Negative control:** with the `_base.scss` selector reverted, the colour assertion fails on `e2e-horizon` with `Expected: "rgba(255, 255, 255, 0)"` / `Received: "rgb(231, 231, 233)"`, and passes on `e2e-main` either way — which is exactly why the theme matters.

Worth recording, because the first attempt at that control passed and would have reported the test as unable to catch the bug: `build:styles` regenerates `src/styles/handsontableStyles.ts`, which carries the whole base stylesheet as a string, and `build:umd` bundles it into `dist/` where the grid injects it at runtime. Rebuilding only the CSS tasks left the old rules being injected from a stale bundle. `handsontable/AGENTS.md` now carries that trap.

`columnHeaders.spec.js` keeps class-exact snapshots and every scenario there has one row header, so its corner cells legitimately gain the class; those seven snapshots are updated.

```bash
npm run build --prefix handsontable   # the whole build - a CSS change is not applied until the bundle is rebuilt

cd tests && npx playwright test row-header-border-ownership   # all six theme x bundle legs
npm run test:walkontable --prefix handsontable
npm run test:e2e --prefix handsontable -- --testPathPattern='autoRowHeaderSize|nestedHeaders|rowHeader|countRowHeaders'
npm run eslint --prefix handsontable && npm run stylelint --prefix handsontable
npm run test:types --prefix handsontable
cd tests && npm run lint
```

Results: 114 passed (row-header spec, 6 legs) · 816 specs / 0 failures (Jasmine walkontable) · 268 specs / 0 failures (core E2E subset) · eslint 0 errors, stylelint, `test:types` and the Playwright-tier lint all clean.

**No visual screenshot should move.** No visual test builds two or more row-header columns (`grep -rl "rowHeaders" visual-tests` is empty, and NestedRows registers no `afterGetRowHeaderRenderers` of its own), and with one row header the marker selects the same cell `:first-child` did, so that shape renders identically. A moved screenshot would mean the marker landed somewhere unintended.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2786

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2786

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped visual border fix with targeted DOM class stamping and CSS selector change; single-header grids behave the same as before.
> 
> **Overview**
> Fixes **wrong head-row gridline color** between corner cells and the first column header when a grid has **two or more row-header columns**. The seam to column 0 is the last row header’s inline-end border; body rows already matched every `th`, but the head row still used **`th:first-child`**, which targets the first corner (inner seam) instead of the last.
> 
> Walkontable now adds **`htLastRowHeaderColumn`** on the **last corner `th` of each head row** in `columnHeaders.ts` (after header renderers run). The base theme seam rule keys on that class instead of `:first-child`, so the head row uses the same cell-border color as the body. The marker is **not** applied in body `rowHeaders` rendering.
> 
> **Tests and docs:** new Walkontable unit specs and Playwright coverage for marker placement and seam color (notably on `horizon`); page fixture helpers; AGENTS notes on the stylesheet → UMD bundle rebuild trap; changelog entry **#13399**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae2e7a9c73d461c8e78d7b11109fe1acc0d0471b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->