### PR TITLE
DEV-2626: Shift cell meta when a nested row is detached from its parent

### DIFF
--- a/.changelogs/13402.json
+++ b/.changelogs/13402.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed a bug where detaching a row from its parent left cell metadata, such as comments and custom class names, on the wrong rows.",
+  "title": "Fixed a bug where detaching a row from its parent left cell metadata, such as comments and custom class names, on the wrong rows. The detached row's own metadata is now cleared instead of being left behind on another row.",
   "type": "fixed",
   "issueOrPR": 13402,
   "breaking": false,

--- a/.changelogs/13402.json
+++ b/.changelogs/13402.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a bug where detaching a row from its parent left cell metadata, such as comments and custom class names, on the wrong rows.",
+  "type": "fixed",
+  "issueOrPR": 13402,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -4581,9 +4581,11 @@ describe('Formulas general', () => {
       ]);
       expect(formulasPlugin.engine.getSheetValues(formulasPlugin.sheetId)[1]).toEqual([123456]);
 
-      // Detaching the child moves it below its former parent's block, so it becomes physical row 3
-      // – the preserved text cell. The `cell` markings stay with their physical coordinates, they do
-      // not follow the moved row.
+      // Detaching the child shifts every row below it up by one, and since DEV-2626 the cell meta
+      // moves with them: the marking follows `parent2` from physical row 3 to row 2, so its value
+      // stays escaped. The detached child is appended last and lands on physical row 3, but it was
+      // never marked and now gets fresh meta there, so it is NOT escaped – before DEV-2626 it
+      // inherited the marking left behind on the index it happened to land on.
       getPlugin('nestedRows').dataManager.detachFromParent(
         getPlugin('nestedRows').dataManager.getDataObject(1)
       );
@@ -4592,7 +4594,7 @@ describe('Formulas general', () => {
         ['parent1'],
         ['child2'],
         ['\'parent2'],
-        ['\'0123456'],
+        ['0123456'],
       ]);
     });
 

--- a/handsontable/src/plugins/nestedRows/AGENTS.md
+++ b/handsontable/src/plugins/nestedRows/AGENTS.md
@@ -108,6 +108,24 @@ They are written in different places and can drift. Keep this in mind:
   `TypeError: Cannot read properties of undefined`, which is what forced one customer to retry inside
   `requestAnimationFrame`. Never re-introduce the non-null assertion, and never feed the result
   straight into the trimming map — filter `null` out first.
+- **The hand-built tree operations have to shift the cell meta themselves.** `MetaManager` is kept in
+  step only by `DataMap#createRow`/`removeRow`, and `addChild`, `addChildAtIndex` and
+  `detachFromParent` reach neither — they splice `__children` and fire the row hooks by hand. So
+  stored meta (comments, `className`, everything) stays on the old physical rows and lands on the
+  wrong cells: #7727 for the insert side, DEV-2626 for the detach side, same context menu. Use
+  `dataManager.shiftCellsMeta()` for an insert and `moveCellsMeta()` for a move. Both take
+  **physical** indexes, which is what `getRowIndex()` already returns, so never pass the result
+  through `toPhysicalRow()` and never use `hot.spliceCellsMeta()`, which takes a **visual** index and
+  would translate a second time. Three traps ride along, one per fix. Read the destination with
+  `getRowIndex(element)` **after** the last `rewriteCache()` — never derive it arithmetically from the
+  parent position, because a sibling that owns descendants breaks any `parentIndex + n` formula.
+  Keep the raw `getRowIndex()` result out of the `?? 0` fallback the hook arguments use: as a meta
+  index that `0` splices from the top of the grid whenever the cache does not know the row object.
+  And skip the move when the block lands back on its own index — detaching the last child of a last
+  child re-parents it without moving any row, and a remove plus re-insert there would blank meta that
+  is still on the right cell. `moveCellsMeta()` resets the moved block's own meta rather than carrying
+  it across, because `LazyFactoryMap` has no move primitive; the alternative, `getCellMetas()`, takes
+  visual indexes, materializes meta for every column and fires `afterSetCellMeta` per cell.
 - **`collapseRow()` and `expandRow()` are dead code.** They delegate with `doTrimming` defaulting to
   `false`, so they neither trim nor render. Do not expose them and do not copy their names.
 - **`updatePlugin()` rebuilds everything.** It unregisters the trimming map and constructs a new

--- a/handsontable/src/plugins/nestedRows/AGENTS.md
+++ b/handsontable/src/plugins/nestedRows/AGENTS.md
@@ -109,14 +109,22 @@ They are written in different places and can drift. Keep this in mind:
   `requestAnimationFrame`. Never re-introduce the non-null assertion, and never feed the result
   straight into the trimming map — filter `null` out first.
 - **The hand-built tree operations have to shift the cell meta themselves.** `MetaManager` is kept in
-  step only by `DataMap#createRow`/`removeRow`, and `addChild`, `addChildAtIndex` and
-  `detachFromParent` reach neither — they splice `__children` and fire the row hooks by hand. So
+  step only by `DataMap#createRow`/`removeRow`, and `addChild`, `addChildAtIndex`,
+  `detachFromParent` and the row-move path reach neither — they splice `__children` and fire the row
+  hooks by hand. So
   stored meta (comments, `className`, everything) stays on the old physical rows and lands on the
   wrong cells: #7727 for the insert side, DEV-2626 for the detach side, same context menu. Use
-  `dataManager.shiftCellsMeta()` for an insert and `moveCellsMeta()` for a move. Both take
-  **physical** indexes, which is what `getRowIndex()` already returns, so never pass the result
+  `dataManager.shiftCellsMeta()` for an insert and `dataManager.moveCellsMeta()` for a move. Both
+  take **physical** indexes, which is what `getRowIndex()` already returns, so never pass the result
   through `toPhysicalRow()` and never use `hot.spliceCellsMeta()`, which takes a **visual** index and
-  would translate a second time. Three traps ride along, one per fix. Read the destination with
+  would translate a second time. Qualify the class when you name the mover: `RowMoveController` has
+  its own, unrelated `moveCellsMeta()` for the row-move path, and the two are not interchangeable —
+  it *preserves* the moved rows' meta (snapshot through `getCellMetaAtRow()`, re-insert through
+  `spliceCellsMeta()`) where the `DataManager` one blanks it. That one is also the standing example
+  of the double translation this rule forbids: it reads physical (`getCellMetaAtRow()`) and writes
+  visual (`spliceCellsMeta()`) with the same indexes, so its meta lands on the wrong rows as soon as
+  a collapsed or trimmed row makes visual and physical diverge. Do not copy it, and do not "fix" the
+  `DataManager` side to match it. Three traps ride along, one per fix. Read the destination with
   `getRowIndex(element)` **after** the last `rewriteCache()` — never derive it arithmetically from the
   parent position, because a sibling that owns descendants breaks any `parentIndex + n` formula.
   Keep the raw `getRowIndex()` result out of the `?? 0` fallback the hook arguments use: as a meta

--- a/handsontable/src/plugins/nestedRows/__tests__/alter.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/alter.spec.js
@@ -443,7 +443,11 @@ describe('NestedRows', () => {
       expect(getDataAtCell(3, 0)).toBe(belowValue);
       expect(getCellMeta(3, 0).className).toBe('below-cell');
       expect(getCellMeta(3, 0).comment).toEqual({ value: 'below-comment' });
-      expect(getCellMeta(4, 0).className).toBeUndefined();
+
+      // Row 6 is where the meta sat before the fix, and it now holds `a2-a0` - a row from a
+      // different parent. Asserting row 4 instead would prove nothing: it holds `a1`, which never
+      // carried meta either way.
+      expect(getCellMeta(6, 0).className).toBeUndefined();
     });
 
     // Guards the fix against over-reaching rather than the original bug: this one passed before the

--- a/handsontable/src/plugins/nestedRows/__tests__/alter.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/alter.spec.js
@@ -328,4 +328,150 @@ describe('NestedRows', () => {
       expect(getCellMeta(3, 2).className).toBeUndefined();
     });
   });
+
+  describe('cell meta shifting when a row is detached from its parent (DEV-2626)', () => {
+    /**
+     * Detaches a row through the context menu, the way a user does it.
+     *
+     * @param {number} row Visual row index to open the context menu on.
+     */
+    async function detachViaContextMenu(row) {
+      await selectCell(row, 0);
+      await contextMenu();
+      await selectContextMenuOption('Detach from parent');
+    }
+
+    /**
+     * Marks one cell above the detached row and one below it, so an assertion can tell a correct
+     * shift from a shift at the wrong index. Detaching moves the rows in between UP - the opposite
+     * direction to an insert - so the row above must stay exactly where it is.
+     *
+     * @param {number} aboveRow Visual row above the detached row.
+     * @param {number} belowRow Visual row below the detached row.
+     * @param {number} column Visual column to mark.
+     * @returns {object} The values held by both marked cells before the detach.
+     */
+    async function markCells(aboveRow, belowRow, column) {
+      await setCellMeta(aboveRow, column, 'className', 'above-cell');
+      await setCellMeta(belowRow, column, 'className', 'below-cell');
+      await setCellMeta(belowRow, column, 'comment', { value: 'below-comment' });
+
+      return {
+        aboveValue: getDataAtCell(aboveRow, column),
+        belowValue: getDataAtCell(belowRow, column),
+      };
+    }
+
+    it('nestedRows ON, context menu "Detach from parent"', async() => {
+      handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        comments: true,
+        contextMenu: true,
+        rowHeaders: true,
+      });
+
+      // Rows 1-5 are the children of the first parent. Detaching row 2 re-parents it to the root
+      // level, where it is appended last, so rows 3-5 move up by one.
+      const { aboveValue, belowValue } = await markCells(1, 3, 2);
+
+      await detachViaContextMenu(2);
+
+      // The row above the detached one does not move, and neither does its meta.
+      expect(getDataAtCell(1, 2)).toBe(aboveValue);
+      expect(getCellMeta(1, 2).className).toBe('above-cell');
+
+      // The row below moved up by one, so its meta must follow.
+      expect(getDataAtCell(2, 2)).toBe(belowValue);
+      expect(getCellMeta(2, 2).className).toBe('below-cell');
+      expect(getCellMeta(2, 2).comment).toEqual({ value: 'below-comment' });
+      expect(getCellMeta(3, 2).className).toBeUndefined();
+      expect(getCellMeta(3, 2).comment).toBeUndefined();
+
+      // The detached row's own meta is reset, not carried across: `LazyFactoryMap` has no move
+      // primitive, so the block is removed and re-inserted blank. Before the fix the meta stayed
+      // on the old physical row, which by then held a different record.
+      expect(getCellMeta(countRows() - 1, 2).className).toBeUndefined();
+    });
+
+    it('nestedRows ON, a deep subtree sits below the detached row', async() => {
+      handsontable({
+        data: getMoreComplexNestedData(),
+        nestedRows: true,
+        comments: true,
+        contextMenu: true,
+        rowHeaders: true,
+      });
+
+      // Flattened: 0 a0, 1 a0-a0, 2 a0-a1, 3 a0-a2, 4 a0-a2-a0, 5 a0-a2-a0-a0, 6 a0-a3, 7 a1, 8 a2.
+      // Detaching `a0-a1` moves it to the root level, so rows 3-6 - the whole `a0-a2` subtree
+      // included - move up by one.
+      const { aboveValue, belowValue } = await markCells(1, 5, 0);
+
+      await detachViaContextMenu(2);
+
+      expect(getDataAtCell(1, 0)).toBe(aboveValue);
+      expect(getCellMeta(1, 0).className).toBe('above-cell');
+
+      expect(getDataAtCell(4, 0)).toBe('a0-a2-a0-a0');
+      expect(getDataAtCell(4, 0)).toBe(belowValue);
+      expect(getCellMeta(4, 0).className).toBe('below-cell');
+      expect(getCellMeta(4, 0).comment).toEqual({ value: 'below-comment' });
+      expect(getCellMeta(5, 0).className).toBeUndefined();
+    });
+
+    it('nestedRows ON, the detached row carries its own descendants', async() => {
+      handsontable({
+        data: getMoreComplexNestedData(),
+        nestedRows: true,
+        comments: true,
+        contextMenu: true,
+        rowHeaders: true,
+      });
+
+      // `a0-a2` owns rows 3-5, so detaching it moves a three-row block and `a0-a3` at row 6 moves
+      // up to row 3. Passing an amount of 1 instead of the whole block would leave its meta two
+      // rows too low.
+      const { aboveValue, belowValue } = await markCells(2, 6, 0);
+
+      await detachViaContextMenu(3);
+
+      expect(getDataAtCell(2, 0)).toBe(aboveValue);
+      expect(getCellMeta(2, 0).className).toBe('above-cell');
+
+      expect(getDataAtCell(3, 0)).toBe('a0-a3');
+      expect(getDataAtCell(3, 0)).toBe(belowValue);
+      expect(getCellMeta(3, 0).className).toBe('below-cell');
+      expect(getCellMeta(3, 0).comment).toEqual({ value: 'below-comment' });
+      expect(getCellMeta(4, 0).className).toBeUndefined();
+    });
+
+    // Guards the fix against over-reaching rather than the original bug: this one passed before the
+    // fix too, because nothing shifted.
+    it('nestedRows ON, the detached row keeps its own meta when its index does not change', async() => {
+      handsontable({
+        data: getMoreComplexNestedData(),
+        nestedRows: true,
+        comments: true,
+        contextMenu: true,
+        rowHeaders: true,
+      });
+
+      // `a2-a1-a1` is the last child of `a2-a1`, which is the last child of `a2`. Detaching it
+      // re-parents it to `a2`, where it lands back on row 12, so no row shifts at all. Removing and
+      // re-inserting the block here would blank meta that is still on the right cell.
+      await setCellMeta(12, 0, 'className', 'detached-cell');
+      await setCellMeta(12, 0, 'comment', { value: 'detached-comment' });
+      await setCellMeta(11, 0, 'className', 'sibling-cell');
+
+      await detachViaContextMenu(12);
+
+      expect(getDataAtCell(12, 0)).toBe('a2-a1-a1');
+      expect(getCellMeta(12, 0).className).toBe('detached-cell');
+      expect(getCellMeta(12, 0).comment).toEqual({ value: 'detached-comment' });
+
+      expect(getDataAtCell(11, 0)).toBe('a2-a1-a0');
+      expect(getCellMeta(11, 0).className).toBe('sibling-cell');
+    });
+  });
 });

--- a/handsontable/src/plugins/nestedRows/__tests__/alter.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/alter.spec.js
@@ -343,8 +343,8 @@ describe('NestedRows', () => {
 
     /**
      * Marks one cell above the detached row and one below it, so an assertion can tell a correct
-     * shift from a shift at the wrong index. Detaching moves the rows in between UP - the opposite
-     * direction to an insert - so the row above must stay exactly where it is.
+     * shift from a shift at the wrong index. Detaching moves the rows in between UP – the opposite
+     * direction to an insert – so the row above must stay exactly where it is.
      *
      * @param {number} aboveRow Visual row above the detached row.
      * @param {number} belowRow Visual row below the detached row.
@@ -375,6 +375,11 @@ describe('NestedRows', () => {
       // level, where it is appended last, so rows 3-5 move up by one.
       const { aboveValue, belowValue } = await markCells(1, 3, 2);
 
+      // The detached row is marked too, or the reset assertion at the end of this test is vacuous.
+      await setCellMeta(2, 2, 'className', 'detached-cell');
+
+      const detachedValue = getDataAtCell(2, 2);
+
       await detachViaContextMenu(2);
 
       // The row above the detached one does not move, and neither does its meta.
@@ -389,9 +394,14 @@ describe('NestedRows', () => {
       expect(getCellMeta(3, 2).comment).toBeUndefined();
 
       // The detached row's own meta is reset, not carried across: `LazyFactoryMap` has no move
-      // primitive, so the block is removed and re-inserted blank. Before the fix the meta stayed
-      // on the old physical row, which by then held a different record.
+      // primitive, so the block is removed and re-inserted blank. This pins that choice – an
+      // implementation that preserved the meta would land `detached-cell` on the row below.
+      expect(getDataAtCell(countRows() - 1, 2)).toBe(detachedValue);
       expect(getCellMeta(countRows() - 1, 2).className).toBeUndefined();
+
+      // And it must not stay behind on the index the detached row used to occupy. Before the fix
+      // that is exactly where it sat, so row 2 wore `detached-cell` instead of `below-cell`.
+      expect(getCellMeta(2, 2).className).not.toBe('detached-cell');
     });
 
     it('nestedRows ON, a deep subtree sits below the detached row', async() => {
@@ -404,8 +414,8 @@ describe('NestedRows', () => {
       });
 
       // Flattened: 0 a0, 1 a0-a0, 2 a0-a1, 3 a0-a2, 4 a0-a2-a0, 5 a0-a2-a0-a0, 6 a0-a3, 7 a1, 8 a2.
-      // Detaching `a0-a1` moves it to the root level, so rows 3-6 - the whole `a0-a2` subtree
-      // included - move up by one.
+      // Detaching `a0-a1` moves it to the root level, so rows 3-6 – the whole `a0-a2` subtree
+      // included – move up by one.
       const { aboveValue, belowValue } = await markCells(1, 5, 0);
 
       await detachViaContextMenu(2);
@@ -444,10 +454,44 @@ describe('NestedRows', () => {
       expect(getCellMeta(3, 0).className).toBe('below-cell');
       expect(getCellMeta(3, 0).comment).toEqual({ value: 'below-comment' });
 
-      // Row 6 is where the meta sat before the fix, and it now holds `a2-a0` - a row from a
+      // Row 6 is where the meta sat before the fix, and it now holds `a2-a0` – a row from a
       // different parent. Asserting row 4 instead would prove nothing: it holds `a1`, which never
       // carried meta either way.
       expect(getCellMeta(6, 0).className).toBeUndefined();
+    });
+
+    it('nestedRows ON, the row re-parents to a grandparent instead of the root', async() => {
+      handsontable({
+        data: getMoreComplexNestedData(),
+        nestedRows: true,
+        comments: true,
+        contextMenu: true,
+        rowHeaders: true,
+      });
+
+      // The other moving tests all detach a child of a ROOT parent, so the element is appended to
+      // the end of the grid. This one has a grandparent (`a0-a2-a0`'s parent `a0-a2` is itself a
+      // child of `a0`), so the block is re-inserted mid-grid instead: `a0-a2-a0` owns rows 4-5 and
+      // re-parents to `a0`, landing at rows 5-6, which moves `a0-a3` from row 6 up to row 4.
+      const { aboveValue, belowValue } = await markCells(3, 6, 0);
+
+      await detachViaContextMenu(4);
+
+      // `a0-a2` is the detached row's own parent and sits above it, so it must not move.
+      expect(getDataAtCell(3, 0)).toBe('a0-a2');
+      expect(getDataAtCell(3, 0)).toBe(aboveValue);
+      expect(getCellMeta(3, 0).className).toBe('above-cell');
+
+      expect(getDataAtCell(4, 0)).toBe('a0-a3');
+      expect(getDataAtCell(4, 0)).toBe(belowValue);
+      expect(getCellMeta(4, 0).className).toBe('below-cell');
+      expect(getCellMeta(4, 0).comment).toEqual({ value: 'below-comment' });
+
+      // Rows 5-6 are the two-row block that moved, and row 7 is `a1`, which never held meta.
+      expect(getDataAtCell(5, 0)).toBe('a0-a2-a0');
+      expect(getDataAtCell(6, 0)).toBe('a0-a2-a0-a0');
+      expect(getCellMeta(6, 0).className).toBeUndefined();
+      expect(getDataAtCell(7, 0)).toBe('a1');
     });
 
     // Guards the fix against over-reaching rather than the original bug: this one passed before the

--- a/handsontable/src/plugins/nestedRows/data/dataManager.ts
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.ts
@@ -605,6 +605,38 @@ class DataManager {
   }
 
   /**
+   * Moves the cell meta of a relocated block of rows, so meta stored between the block's old and
+   * new position moves with its data.
+   *
+   * `detachFromParent` restructures the tree by hand, so it needs both halves of the move, not just
+   * the insert side `shiftCellsMeta` covers: the block is removed at its old physical index and
+   * re-inserted at its new one. `MetaManager` takes physical indexes, which is what `getRowIndex()`
+   * returns, and neither call renders.
+   *
+   * The moved block's own meta is reset rather than carried across. `LazyFactoryMap` has no move
+   * primitive, and the alternative - snapshotting through `getCellMetas()` - takes visual indexes,
+   * materializes meta for every column, and fires `afterSetCellMeta` per cell. Leaving the meta
+   * behind is worse than resetting it: it would land on whatever row took the old index.
+   *
+   * @param {number|null} fromPhysicalRow Physical index the block sat at before the move.
+   * @param {number|null} toPhysicalRow Physical index the block sits at after the move. A `null` on
+   * either side skips the move, so an unknown row object cannot splice meta from index 0. An
+   * unchanged index also skips it - nothing shifted, so resetting the block's meta would drop meta
+   * that is still on the right cells.
+   * @param {number} amount Number of rows in the moved block.
+   */
+  moveCellsMeta(fromPhysicalRow: number | null, toPhysicalRow: number | null, amount: number) {
+    if (fromPhysicalRow === null || toPhysicalRow === null || fromPhysicalRow === toPhysicalRow) {
+      return;
+    }
+
+    const metaManager = this.hot._getMetaManager();
+
+    metaManager.removeRow(fromPhysicalRow, amount);
+    metaManager.createRow(toPhysicalRow, amount);
+  }
+
+  /**
    * Add a child node to the provided parent at a specified index.
    *
    * @param {object} parent Parent node.
@@ -723,7 +755,10 @@ class DataManager {
       return;
     }
 
-    const childRowIndex = this.getRowIndex(element) ?? 0;
+    // Kept separate from `childRowIndex`: the `?? 0` fallback below is safe for the hook arguments,
+    // but as a meta index it would splice the meta from the top of the grid on an unknown row.
+    const childPhysicalIndex = this.getRowIndex(element);
+    const childRowIndex = childPhysicalIndex ?? 0;
     const childCount = this.countChildren(element);
     const indexWithinParent = this.getRowIndexWithinParent(element);
     const parent = this.getRowParent(element);
@@ -777,6 +812,13 @@ class DataManager {
     }
 
     this.rewriteCache();
+
+    if (indexWithinParent !== null && indexWithinParent !== undefined) {
+      // Read the destination instead of reusing `movedElementRowIndex`: that one is derived
+      // arithmetically from the grandparent position, and a sibling with descendants breaks the
+      // formula. This is the same index the `afterDetachChild` hook below reports.
+      this.moveCellsMeta(childPhysicalIndex, this.getRowIndex(element), childCount + 1);
+    }
 
     this.hot.runHooks('afterCreateRow', movedElementRowIndex! - 2, childCount + 1, this.plugin.pluginName);
 

--- a/handsontable/src/plugins/nestedRows/data/dataManager.ts
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.ts
@@ -614,14 +614,14 @@ class DataManager {
    * returns, and neither call renders.
    *
    * The moved block's own meta is reset rather than carried across. `LazyFactoryMap` has no move
-   * primitive, and the alternative - snapshotting through `getCellMetas()` - takes visual indexes,
+   * primitive, and the alternative – snapshotting through `getCellMetas()` – takes visual indexes,
    * materializes meta for every column, and fires `afterSetCellMeta` per cell. Leaving the meta
    * behind is worse than resetting it: it would land on whatever row took the old index.
    *
    * @param {number|null} fromPhysicalRow Physical index the block sat at before the move.
    * @param {number|null} toPhysicalRow Physical index the block sits at after the move. A `null` on
    * either side skips the move, so an unknown row object cannot splice meta from index 0. An
-   * unchanged index also skips it - nothing shifted, so resetting the block's meta would drop meta
+   * unchanged index also skips it – nothing shifted, so resetting the block's meta would drop meta
    * that is still on the right cells.
    * @param {number} amount Number of rows in the moved block.
    */
@@ -766,6 +766,10 @@ class DataManager {
     const grandparent = this.getRowParent(parent!);
     const grandparentRowIndex = this.getRowIndex(grandparent) ?? 0;
     let movedElementRowIndex: number | null = null;
+    // Set inside the branch that actually restructures the tree, so the cell meta move below can
+    // never run on its own. Re-testing `indexWithinParent` there would be a second copy of this
+    // condition, free to drift away from the one the data operation is gated on.
+    let hasMovedTheRow = false;
 
     this.hot.runHooks('beforeDetachChild', parent, element);
 
@@ -810,14 +814,16 @@ class DataManager {
 
         this.data!.push(element);
       }
+
+      hasMovedTheRow = true;
     }
 
     this.rewriteCache();
 
-    if (indexWithinParent !== null && indexWithinParent !== undefined) {
+    if (hasMovedTheRow) {
       // Read the destination instead of reusing `movedElementRowIndex`: that one is derived
-      // arithmetically from the grandparent position, and a sibling with descendants breaks the
-      // formula. This is the same index the `afterDetachChild` hook below reports.
+      // arithmetically from the grandparent position, and a sibling that owns descendants breaks
+      // the formula.
       this.moveCellsMeta(childPhysicalIndex, this.getRowIndex(element), childCount + 1);
     }
 

--- a/handsontable/src/plugins/nestedRows/data/dataManager.ts
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.ts
@@ -755,8 +755,9 @@ class DataManager {
       return;
     }
 
-    // Kept separate from `childRowIndex`: the `?? 0` fallback below is safe for the hook arguments,
-    // but as a meta index it would splice the meta from the top of the grid on an unknown row.
+    // Kept separate from `childRowIndex`: that `?? 0` fallback is pre-existing and is left reporting
+    // the hook arguments exactly as it did. As a meta index the `0` would splice from the top of the
+    // grid, so `moveCellsMeta()` reads the raw result instead.
     const childPhysicalIndex = this.getRowIndex(element);
     const childRowIndex = childPhysicalIndex ?? 0;
     const childCount = this.countChildren(element);


### PR DESCRIPTION
### Context

The PR fixes cell meta being left behind when a row is detached from its parent through the
**"Detach from parent"** context menu item.

`DataManager#detachFromParent()` restructures the tree by hand: it splices `__children` and fires the
row hooks itself, so it never reaches `DataMap#createRow`/`removeRow` — the only two methods that keep
`MetaManager` in step. Detaching a child moves it out of its parent's subtree to a new position, so
every row between the old and the new position shifts, but their stored cell meta (comments,
`className`, everything else) stayed on the old row indexes and ended up on the wrong cells.

This is the same symptom class and the same context menu as #7727, which DEV-2605 / #13233 fixed for
the *insert* side. Detaching needs both halves of the move, so this adds a `moveCellsMeta()` helper
next to the existing `shiftCellsMeta()`: the block is removed at its old physical index and
re-inserted at its new one. Pre-existing, not a regression.

Three details are worth a reviewer's attention:

1. **The destination is read, never computed.** `getRowIndex(element)` is called after the final
   `rewriteCache()`, rather than reusing `movedElementRowIndex`, which is derived arithmetically from
   the grandparent position. A sibling that owns descendants breaks any `parentIndex + n` formula.
2. **The raw `getRowIndex()` result is kept out of the `?? 0` fallback** that the hook arguments use.
   As a meta index, that `0` would splice meta from the top of the grid whenever the cache does not
   know the row object.
3. **A move to the same index is skipped.** Detaching the last child of a last child re-parents it
   without moving any row, and a remove plus re-insert there would blank meta that is still on the
   right cell.

### Known limitation (deliberate)

The detached block's **own** meta is reset rather than carried across. `LazyFactoryMap` has no move
primitive, and the alternative — snapshotting through `getCellMetas()` — takes visual indexes,
materializes meta for every column, and fires `afterSetCellMeta` once per cell.

This is still strictly better than the current behavior: today that meta stays on the old physical
row, which by then holds a different record, so it corrupts an innocent row's cells. After this
change it is simply blank. Preserving it needs a move primitive in `LazyFactoryMap`, which is its own
change with its own unit tests — happy to open a follow-up ticket if you agree it is worth it.

### Noticed but deliberately not touched

All of the below is **pre-existing** and none of it is changed here. It is on the record so it is not
rediscovered later, and it is why `moveCellsMeta()` reads its destination index rather than reusing
`movedElementRowIndex`.

**1. The row-creation hooks report the wrong index in the grandparent branch.** Both are computed
arithmetically, which is exactly what this ticket warned against:

- `movedElementRowIndex = grandparentRowIndex + countChildren(grandparent)`, reported as `- 2`.
- `getChild(grandparent, countChildren(grandparent) - 1)` indexes direct `__children` with a
  **recursive** descendant count, so with any grandchildren present it reads past the end,
  `getRowIndex(null) ?? 0` yields `0`, and `beforeCreateRow` fires with `1`.

On `[{G, __children: [{P, __children: [{E}]}, {S}]}]`, detaching `E` reports `afterCreateRow` at
index `0` while `E` lands at row 3. This is not inert: `UndoRedo` builds a `CreateRowAction` straight
from `afterCreateRow`, and `UndoRedo#done()` blocks only the `UndoRedo.undo`, `UndoRedo.redo` and
`auto` sources — not `nestedRows`. So Ctrl+Z after a detach can run `alter('remove_row', 0, 1)` and
take out `G` with its whole subtree. Fixing it changes public hook argument values and undo behavior,
so it needs its own ticket rather than a quiet ride along with a cell-meta fix.

**2. `getRowIndexWithinParent()` returns `-1`, never `null`/`undefined`.** The existing guard tests
for the latter two, so a `-1` passes it and `parent.__children.splice(-1, 1)` removes the *last*
child instead of the element. The new meta code deliberately mirrors that guard through a flag set
inside the branch, rather than adding a second, differently-worded copy of the condition.

**3. `childRowIndex` keeps its `?? 0` fallback**, which feeds `removedRowIndexes` and the
`beforeRemoveRow`/`afterRemoveRow` arguments. On a `null` lookup it reports the removal at rows
`0..n`, and listeners that shift their own collections from that index (`customBorders`,
`mergeCells`) move the wrong entries. Unreachable through the context menu today, since
`getDataObject()` returns a live cached object.

**4. `RowMoveController#moveCellsMeta()` mixes the two index spaces.** It reads with
`getCellMetaAtRow()` (physical) and writes with `hot.spliceCellsMeta()` (visual, and it translates
again internally), passing the same indexes to both — so the row-move path puts meta on the wrong
rows as soon as a collapsed or trimmed row makes visual and physical diverge. Same rule this PR's
`AGENTS.md` entry now spells out. Worth its own ticket; the entry documents it in the meantime so
nobody copies the pattern.

### One existing spec changed, deliberately

`Formulas > preserveTextValue > should keep preserved text values escaped after detaching a row with
the Nested Rows plugin` (from #13213) asserted the **old** behavior, and its comment said so
outright: "The `cell` markings stay with their physical coordinates, they do not follow the moved
row." That is precisely what this PR changes, so the spec had to move with it.

Its data marks physical row 3 (`parent2`) with `preserveTextValue`, detaches the child at row 1, and
the child is appended last — landing on row 3. It previously expected the child to come out escaped
as `'0123456`, because it inherited the marking stranded on the index it happened to land on. Now
the marking follows `parent2` from row 3 to row 2 and keeps its escape, while the child gets fresh
meta at row 3 and is not escaped. Escaping a value the user never marked, purely because it inherited
a vacated physical index, is the same defect class this PR fixes.

The spec still discriminates rather than being weakened: it now **fails against the base branch**
(`Expected ''0123456' to equal '0123456'`), so it is a regression test for this change instead of an
assertion of the bug. Its title is unchanged and still accurate — the marked cell's preserved text
value does stay escaped across the detach.

Worth a reviewer's eye: `cell` is re-applied at physical coordinates on the next `updateSettings`
(`core.ts:4240`), so `cell`-declared markings remain coordinate-anchored on that path while they now
follow rows on a detach. Flagging in case the team wants that reconciled separately.

### How has this been tested?

Four regression tests were added to the existing `alter.spec.js`, in a describe block next to the
DEV-2605 ones. Each marks a cell **above** the moved range and one **below** it, and asserts the one
above did not move — a shift at the wrong index moves both.

- context menu "Detach from parent" on `getSimplerNestedData()`
- a deep subtree below the detached row, on `getMoreComplexNestedData()`
- a detached row that carries its own descendants, so the block `amount` is exercised (3, not 1)
- the same-index case, which pins detail 3 above

Verified that the first three **fail without the source change** (`Expected undefined to be
'below-cell'`) and pass with it. The fourth passes either way by design — it guards the fix against
over-reaching, and its comment says so.

```bash
npm run test:e2e --prefix handsontable --testPathPattern=nestedRows   # 180 specs, 0 failures
npm run test:e2e --prefix handsontable --testPathPattern=formulas     # 420 specs, 0 failures
npm run eslint --prefix handsontable                                  # 0 errors
npm run test:types --prefix handsontable
npm run build --prefix handsontable
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2626
2. Follow-up from the review on DEV-2605 / #13233 (the insert side, GitHub issue #7727)

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2626
