### PR TITLE
DEV-2812: Re-measure row heights after AutoRowSize#clearCache()

### DIFF
--- a/.changelogs/13404.json
+++ b/.changelogs/13404.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed row headers drifting out of alignment with their rows after calling `AutoRowSize#clearCache()`.",
+  "type": "fixed",
+  "issueOrPR": 13404,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/autoRowSize/AGENTS.md
+++ b/handsontable/src/plugins/autoRowSize/AGENTS.md
@@ -46,6 +46,44 @@ Changing `wordWrap`, `textEllipsis` or a renderer changes row heights, but `upda
 re-measure. Callers must follow it with `recalculateAllRowsHeight()`. That is documented in the class JSDoc
 and in the guides — it is the contract, not a bug.
 
+## Only a full render measures rows, and it measures only the visible band
+
+`calculateVisibleRowsHeight()` hangs off **`beforeRender`**, which `TableView#render()` raises — the engine's
+scroll draw does not. So scrolling measures nothing, and a render measures only the rows it draws. On an
+ordinary grid that is invisible, because `#onInit` sweeps every row up front through `calculateAllRowsHeight()`.
+
+Anything that empties the cache has to put that sweep back, or every row below the fold keeps the default
+height for good. That is not a cosmetic default: once a wide wrapping column is scrolled into view the data
+cell renders at its content height (a cell never renders shorter than its own text) while the row header
+honors the default, so the row headers slide out of alignment and the gap accumulates down the grid
+(DEV-2812, reported as DEV-2718).
+
+`clearCache()` with no argument therefore sets `#fullRecalculationScheduled`, and `#onBeforeRender` honors it.
+Three rules ride along:
+
+- **The full sweep runs *after* `calculateVisibleRowsHeight()`, never instead of it.**
+  `calculateAllRowsHeight()` measures only up to `syncLimit` rows synchronously and leaves the rest to an
+  idle sweep that schedules no redraw of its own, so a grid scrolled past that limit would draw its visible
+  band unmeasured — re-creating the defect on the frame that was supposed to repair it.
+- **The flag is held, not consumed, when the render cannot measure.** `recalculateAllRowsHeight()` is a no-op
+  on a hidden grid, and on a column-less one the measurement writes a near-empty height for every row that
+  nothing later corrects (`calculateVisibleRowsHeight()` bails out on that grid for the same reason, with the
+  comment "Keep last row heights unchanged for situation when all columns was deleted or trimmed"). Consuming
+  the flag in either case would leave the cache empty permanently.
+- **The flag is consumed before the sweep, not after.** The sweep resizes the overlays, and a re-entrant
+  render reaching the branch with the flag still set would recurse. The cost is that a renderer that throws
+  mid-sweep spends the flag — acceptable, since a throwing renderer has already broken the draw.
+
+`clearCache()` must **not** zero `measuredRows`: the public `isNeedRecalculate()` slices the height map by it,
+so zeroing it makes that method answer "nothing to recalculate" at the exact moment every height was dropped.
+`AutoColumnSize#clearCache()` leaves its counterpart alone too.
+
+**Known gap:** the selective forms — `clearCache([rows])` and `clearCacheByRange()` — have the same
+below-the-fold hole and schedule nothing. `#calculateSpecificRowsHeight()` measures named rows from the data
+without needing them on screen, so queueing them on `#visualRowsToRefresh` is the shape of the fix; it was
+left out of DEV-2812 because an unbounded range would then be measured synchronously in one render, which
+needs its own sizing decision. Tracked separately.
+
 ## Listeners stay bound while disabled — deliberately
 
 `disablePlugin()` leaves the height-recalculation listener active, because ManualRowResize's

--- a/handsontable/src/plugins/autoRowSize/AGENTS.md
+++ b/handsontable/src/plugins/autoRowSize/AGENTS.md
@@ -79,6 +79,12 @@ Three rules ride along:
   guards **both** its phases itself and calls `#abandonSweep()`. Skipping the async one leaves `inProgress`
   stuck at `true` for the instance's life — which silently disables the refresh queue too, since
   `#drainRowRefreshQueue()` refuses to run while a sweep is in flight.
+- **`#abandonSweep()` must empty the ghost table, or the retry it enables dies on arrival.**
+  `GhostTable#addRow()` pushes its row object **before** it runs the renderers and fills in `.table` only
+  once they have all returned, so a renderer that throws leaves a half-built entry behind —
+  `{ row: 100 }` with no `table`. `getHeights()` reads `.table` on every row it holds, and only the success
+  path calls `clean()`. Left there, the next sweep throws on that leftover instead of measuring, and so does
+  every sweep after it. Measured: one throw left 46 stale rows in the table.
 - **A guard on the row count rides along with the column one.** Nothing is at stake there — a sweep over no
   rows measures nothing — but holding the flag keeps the work owed until there is something to measure.
 

--- a/handsontable/src/plugins/autoRowSize/AGENTS.md
+++ b/handsontable/src/plugins/autoRowSize/AGENTS.md
@@ -87,6 +87,21 @@ drained in one synchronous pass, so clearing a very large range buys a correspon
 the next render — the same shape `#onBeforeChange` has always had, and the honest cost of the call the caller
 made. A physical row with no visual index (outside the dataset, or hidden by a trimming map) is skipped.
 
+## The refresh queue is held back, never dropped
+
+`#drainRowRefreshQueue()` is the single place the queue is measured, and it refuses two moments — **keeping**
+the queue both times, so the rows land at the first moment that can measure them:
+
+- **while a sweep is running**, because the sweep and this pass share one ghost table;
+- **while the grid has no columns**, because the measurement writes a near-empty height that, no longer being
+  `null`, is never re-measured once the columns come back. That is the same trap the scheduled full
+  recalculation is guarded against, and it reached the selective path first: `clearCache([5])` on a
+  column-less grid used to leave row 5 holding `0` for good.
+
+It is called from the render **and** from the sweep's completion branch. A sweep ends without a render of its
+own, so a queue held back by the first condition would otherwise wait for the next full render — which on a
+grid the user only scrolls never arrives.
+
 ## One sweep at a time
 
 `calculateAllRowsHeight()` cancels any sweep still in flight before starting its own, through the

--- a/handsontable/src/plugins/autoRowSize/AGENTS.md
+++ b/handsontable/src/plugins/autoRowSize/AGENTS.md
@@ -74,6 +74,13 @@ Three rules ride along:
   would let a re-entrant render reach the branch with the flag still set and recurse; spending it outright
   would leave every unmeasured row at the default height for the instance's life when a renderer throws (the
   ghost table runs the real renderers). Clearing it first and restoring it in a `catch` gets both.
+  That `catch` in `#onBeforeRender` covers only the **inline** phase. The sweep hands everything past
+  `syncLimit` to an idle task, which is a separate turn no caller's `try` can see, so `calculateAllRowsHeight()`
+  guards **both** its phases itself and calls `#abandonSweep()`. Skipping the async one leaves `inProgress`
+  stuck at `true` for the instance's life — which silently disables the refresh queue too, since
+  `#drainRowRefreshQueue()` refuses to run while a sweep is in flight.
+- **A guard on the row count rides along with the column one.** Nothing is at stake there — a sweep over no
+  rows measures nothing — but holding the flag keeps the work owed until there is something to measure.
 
 `clearCache()` must **not** zero `measuredRows`: the public `isNeedRecalculate()` slices the height map by it,
 so zeroing it makes that method answer "nothing to recalculate" at the exact moment every height was dropped.
@@ -98,9 +105,16 @@ the queue both times, so the rows land at the first moment that can measure them
   recalculation is guarded against, and it reached the selective path first: `clearCache([5])` on a
   column-less grid used to leave row 5 holding `0` for good.
 
-It is called from the render **and** from the sweep's completion branch. A sweep ends without a render of its
-own, so a queue held back by the first condition would otherwise wait for the next full render — which on a
-grid the user only scrolls never arrives.
+It is called from the render **and** from `calculateAllRowsHeight()` — from `loop()`'s completion branch, and
+from the top-level `else` that runs when the whole grid fitted inside `syncLimit` and `loop()` never ran at
+all. A sweep ends without a render of its own, so a queue held back by the first condition would otherwise
+wait for the next full render, which on a grid the user only scrolls never arrives. Both exits need the call:
+covering only one leaves the contract true on some grid sizes and false on others.
+
+`#queueClearedRowsForRefresh()` skips a row already in the queue, the way the other producers do
+(`#onBeforeChange` collects into a `Set`, `#onAfterFormulasValuesUpdate` checks before pushing). While the
+queue is held back, overlapping `clearCache` calls would otherwise pile the same row up and measure it once
+per copy.
 
 ## One sweep at a time
 

--- a/handsontable/src/plugins/autoRowSize/AGENTS.md
+++ b/handsontable/src/plugins/autoRowSize/AGENTS.md
@@ -70,19 +70,32 @@ Three rules ride along:
   nothing later corrects (`calculateVisibleRowsHeight()` bails out on that grid for the same reason, with the
   comment "Keep last row heights unchanged for situation when all columns was deleted or trimmed"). Consuming
   the flag in either case would leave the cache empty permanently.
-- **The flag is consumed before the sweep, not after.** The sweep resizes the overlays, and a re-entrant
-  render reaching the branch with the flag still set would recurse. The cost is that a renderer that throws
-  mid-sweep spends the flag — acceptable, since a throwing renderer has already broken the draw.
+- **The flag is consumed before the sweep, then re-owed if the sweep throws.** Holding it across the call
+  would let a re-entrant render reach the branch with the flag still set and recurse; spending it outright
+  would leave every unmeasured row at the default height for the instance's life when a renderer throws (the
+  ghost table runs the real renderers). Clearing it first and restoring it in a `catch` gets both.
 
 `clearCache()` must **not** zero `measuredRows`: the public `isNeedRecalculate()` slices the height map by it,
 so zeroing it makes that method answer "nothing to recalculate" at the exact moment every height was dropped.
 `AutoColumnSize#clearCache()` leaves its counterpart alone too.
 
-**Known gap:** the selective forms — `clearCache([rows])` and `clearCacheByRange()` — have the same
-below-the-fold hole and schedule nothing. `#calculateSpecificRowsHeight()` measures named rows from the data
-without needing them on screen, so queueing them on `#visualRowsToRefresh` is the shape of the fix; it was
-left out of DEV-2812 because an unbounded range would then be measured synchronously in one render, which
-needs its own sizing decision. Tracked separately.
+The **selective** forms — `clearCache([rows])` and `clearCacheByRange()` — have the same below-the-fold hole,
+and close it differently: they push the cleared rows onto `#visualRowsToRefresh` through
+`#queueClearedRowsForRefresh()`, so only those rows are re-measured rather than the whole grid.
+`#calculateSpecificRowsHeight()` reads a row from the data, so an off-screen row is no obstacle. That queue is
+drained in one synchronous pass, so clearing a very large range buys a correspondingly large measurement on
+the next render — the same shape `#onBeforeChange` has always had, and the honest cost of the call the caller
+made. A physical row with no visual index (outside the dataset, or hidden by a trimming map) is skipped.
+
+## One sweep at a time
+
+`calculateAllRowsHeight()` cancels any sweep still in flight before starting its own, through the
+instance-held `#idleSweepTimer`. Every sweep starts at row 0 and covers every row, so the new one subsumes
+whatever the old one had left. Two running together would double the work and race on `inProgress`: whichever
+finished first would clear it while the other was still writing heights, and `#onBeforeRender` reads that flag
+to decide whether the refresh queue is safe to drain. Entry points that can overlap in one frame: `#onInit`,
+`#onAfterLoadData`, the column-resize gesture, an explicit `recalculateAllRowsHeight()`, and now a
+`clearCache()` that schedules one.
 
 ## Listeners stay bound while disabled — deliberately
 

--- a/handsontable/src/plugins/autoRowSize/__tests__/rowHeightsInteraction.unit.ts
+++ b/handsontable/src/plugins/autoRowSize/__tests__/rowHeightsInteraction.unit.ts
@@ -163,6 +163,71 @@ describe('AutoRowSize selective cache clearing', () => {
     container.remove();
   });
 
+  it('should recover when a measurement throws in the idle part of a sweep', () => {
+    // The sweep measures `SYNC_CALCULATION_LIMIT` rows inline and hands the rest to an idle task,
+    // which is a separate turn - no caller's try/catch can see a throw from there. Left alone,
+    // `inProgress` would stay `true` for the instance's life, which also disables the refresh queue,
+    // and the recalculation would never be re-owed.
+    const container = document.createElement('div');
+
+    document.body.appendChild(container);
+
+    // 600 rows against a sync limit of 3 leaves plenty for the idle continuation, which measures
+    // `CALCULATION_STEP` (50) rows a turn.
+    const hot = new Handsontable(container, {
+      data: Array.from({ length: 600 }, (_, row) => [`r${row}`]),
+      autoRowSize: { syncLimit: 3 },
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+    const plugin = hot.getPlugin('autoRowSize');
+    const measure = plugin.calculateRowsHeight.bind(plugin);
+    let calls = 0;
+
+    plugin.calculateRowsHeight = (...args: unknown[]) => {
+      calls += 1;
+
+      // Not the inline pass and not the first idle turn - a later one, well inside the async phase.
+      if (calls === 4) {
+        throw new Error('renderer blew up mid-sweep');
+      }
+
+      return (measure as (...a: unknown[]) => void)(...args);
+    };
+
+    // `requestIdleTask` falls back to `requestAnimationFrame`, so running that straight away turns
+    // the idle continuation into a direct call. The continuation is still the code path under test -
+    // the recovery has to live inside `loop()` either way - and driving it here keeps the test off
+    // a fixed timer.
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+
+      return 0;
+    }) as typeof window.requestAnimationFrame;
+
+    try {
+      expect(() => plugin.recalculateAllRowsHeight()).toThrow('renderer blew up mid-sweep');
+    } finally {
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+    }
+
+    // The throw landed in the continuation, not the inline pass.
+    expect(calls).toBeGreaterThanOrEqual(4);
+    // The sweep is no longer believed to be running, so the refresh queue works again.
+    expect(plugin.inProgress).toBe(false);
+
+    // The unfinished measurement is owed to the next render, which starts a fresh sweep - and this
+    // grid is far larger than its sync limit, so that sweep goes async and says so.
+    plugin.calculateRowsHeight = measure;
+    hot.render();
+
+    expect(plugin.inProgress).toBe(true);
+
+    hot.destroy();
+    container.remove();
+  });
+
   // The other half of `#drainRowRefreshQueue()` - that a queue held back while a sweep is running
   // is drained when the sweep ends - has no unit test, and cannot have one here: jsdom reports no
   // layout, so every row falls inside the rendered band and the ordinary visible-band pass measures

--- a/handsontable/src/plugins/autoRowSize/__tests__/rowHeightsInteraction.unit.ts
+++ b/handsontable/src/plugins/autoRowSize/__tests__/rowHeightsInteraction.unit.ts
@@ -137,6 +137,37 @@ describe('AutoRowSize selective cache clearing', () => {
   // measures a cleared row whether or not it was queued. It is covered in
   // `tests/e2e/auto-row-size-clear-cache.spec.ts`, against a real viewport with a real fold.
 
+  it('should keep cleared rows queued rather than measuring them on a column-less grid', () => {
+    // With no columns there is nothing to measure, but the pass still writes a height - and once a
+    // row holds a number instead of `null` it is never measured again, so it stays at the default
+    // height for good when the columns come back. The queue is held instead, not drained.
+    const { hot, container } = buildAttachedGrid();
+    const plugin = hot.getPlugin('autoRowSize');
+
+    hot.updateSettings({ columns: [] });
+
+    expect(hot.countCols()).toBe(0);
+
+    plugin.clearCache([5]);
+    hot.render();
+
+    expect(plugin.rowHeightsMap.getValueAtIndex(5)).toBe(null);
+
+    // The row was held, not dropped: with a column back, it is measured.
+    hot.updateSettings({ columns: [{ data: 0 }] });
+    hot.render();
+
+    expect(plugin.rowHeightsMap.getValueAtIndex(5)).not.toBe(null);
+
+    hot.destroy();
+    container.remove();
+  });
+
+  // The other half of `#drainRowRefreshQueue()` - that a queue held back while a sweep is running
+  // is drained when the sweep ends - has no unit test, and cannot have one here: jsdom reports no
+  // layout, so every row falls inside the rendered band and the ordinary visible-band pass measures
+  // a queued row whether or not the queue was drained. The two states are indistinguishable.
+
   it('should still owe the full recalculation after a render whose measurement threw', () => {
     // The ghost table runs the real renderers, so a renderer that throws aborts the sweep. Spending
     // the flag there would leave every unmeasured row at the default height for good.

--- a/handsontable/src/plugins/autoRowSize/__tests__/rowHeightsInteraction.unit.ts
+++ b/handsontable/src/plugins/autoRowSize/__tests__/rowHeightsInteraction.unit.ts
@@ -55,6 +55,61 @@ describe('AutoRowSize and the rowHeights option', () => {
   });
 });
 
+describe('AutoRowSize#clearCache', () => {
+  it('should report that a recalculation is needed once every height has been dropped', () => {
+    // `isNeedRecalculate()` slices the height map by `measuredRows`, so zeroing that counter in
+    // `clearCache()` would make this answer "nothing to recalculate" at the exact moment every
+    // height was wiped - and any caller polling it would silently stop re-measuring.
+    const hot = buildGrid();
+    const plugin = hot.getPlugin('autoRowSize');
+
+    plugin.rowHeightsMap.setValueAtIndex(hot.toPhysicalRow(0), 40);
+    plugin.measuredRows = 3;
+
+    plugin.clearCache();
+
+    expect(plugin.isNeedRecalculate()).toBe(true);
+
+    hot.destroy();
+  });
+
+  it('should not spend the scheduled recalculation on a render that has no columns to measure', () => {
+    // A column-less grid still reports itself visible - `isVisible()` is a CSS-display check - so
+    // nothing but an explicit guard stops the sweep running against an empty column range. It would
+    // write a near-empty height for every row, and because those entries are no longer `null` they
+    // would never be re-measured: the rows stay stuck at the default height once the columns come
+    // back. `calculateVisibleRowsHeight()` bails out on this grid for the same reason.
+    //
+    // The container has to be IN the document: `isVisible()` answers `false` for a detached
+    // element, which would skip the whole branch and make this pass without measuring anything.
+    const container = document.createElement('div');
+
+    document.body.appendChild(container);
+
+    const hot = new Handsontable(container, {
+      data: [['a'], ['b'], ['c']],
+      autoRowSize: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+    const plugin = hot.getPlugin('autoRowSize');
+
+    expect(hot.view.isVisible()).toBe(true);
+
+    hot.updateSettings({ columns: [] });
+
+    expect(hot.countCols()).toBe(0);
+
+    plugin.clearCache();
+    hot.render();
+
+    // Nothing was measured, so nothing was recorded as measured either.
+    expect(plugin.rowHeightsMap.getValues().every((value: number | null) => value === null)).toBe(true);
+
+    hot.destroy();
+    container.remove();
+  });
+});
+
 describe('AutoRowSize default settings', () => {
   it('should not declare a `useHeaders` setting, because it never reads one', () => {
     // AutoColumnSize does read `useHeaders` - it decides whether a column header is rendered beside

--- a/handsontable/src/plugins/autoRowSize/__tests__/rowHeightsInteraction.unit.ts
+++ b/handsontable/src/plugins/autoRowSize/__tests__/rowHeightsInteraction.unit.ts
@@ -228,6 +228,63 @@ describe('AutoRowSize selective cache clearing', () => {
     container.remove();
   });
 
+  it('should leave the ghost table clean when a renderer throws mid-sweep', () => {
+    // The realistic shape of the throw above: it comes from a renderer, which the ghost table runs
+    // itself. `GhostTable#addRow` pushes its row object BEFORE running them and fills in `.table`
+    // only once they have returned, so a throw leaves a half-built entry behind - and `getHeights()`
+    // reads `.table` on every row it holds. Left there, the retry sweep dies on that leftover
+    // instead of measuring, and so does every sweep after it: the grid never recovers.
+    const container = document.createElement('div');
+
+    document.body.appendChild(container);
+
+    // Armed only after the grid is built: jsdom reports no layout, so the master draw renders every
+    // row, and a renderer that throws from the start takes the constructor down instead.
+    let failing = false;
+
+    const hot = new Handsontable(container, {
+      data: Array.from({ length: 600 }, (_, row) => [`r${row}`]),
+      autoRowSize: { syncLimit: 3 },
+      renderer(instance: unknown, td: HTMLElement, row: number, ...rest: unknown[]) {
+        if (failing && row === 100) {
+          throw new Error('renderer blew up mid-sweep');
+        }
+
+        td.textContent = String(rest[2] ?? '');
+      },
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+    const plugin = hot.getPlugin('autoRowSize');
+
+    // Row 100 lands in the idle continuation: the inline pass stops at `syncLimit`, and each turn
+    // after it covers `CALCULATION_STEP` rows.
+    failing = true;
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+
+      return 0;
+    }) as typeof window.requestAnimationFrame;
+
+    try {
+      expect(() => plugin.recalculateAllRowsHeight()).toThrow('renderer blew up mid-sweep');
+
+      // Nothing half-built is left behind, so the next pass has a table it can measure.
+      expect(plugin.ghostTable.rows).toHaveLength(0);
+
+      // The retry must actually measure, not die on a leftover row.
+      failing = false;
+
+      expect(() => plugin.recalculateAllRowsHeight()).not.toThrow();
+    } finally {
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+    }
+
+    hot.destroy();
+    container.remove();
+  });
+
   // The other half of `#drainRowRefreshQueue()` - that a queue held back while a sweep is running
   // is drained when the sweep ends - has no unit test, and cannot have one here: jsdom reports no
   // layout, so every row falls inside the rendered band and the ordinary visible-band pass measures

--- a/handsontable/src/plugins/autoRowSize/__tests__/rowHeightsInteraction.unit.ts
+++ b/handsontable/src/plugins/autoRowSize/__tests__/rowHeightsInteraction.unit.ts
@@ -110,6 +110,70 @@ describe('AutoRowSize#clearCache', () => {
   });
 });
 
+describe('AutoRowSize selective cache clearing', () => {
+  /**
+   * Builds a grid attached to the document, so `isVisible()` answers `true` and the render path
+   * under test is actually reached.
+   *
+   * @param {number} rows How many rows the grid holds.
+   * @returns {object} The instance and its container.
+   */
+  function buildAttachedGrid(rows = 30) {
+    const container = document.createElement('div');
+
+    document.body.appendChild(container);
+
+    const hot = new Handsontable(container, {
+      data: Array.from({ length: rows }, (_, row) => [`r${row}`]),
+      autoRowSize: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    return { hot, container };
+  }
+
+  // The "off-screen row gets re-measured" half of the selective forms is NOT asserted here: jsdom
+  // has no layout, so every row falls inside the rendered band and the ordinary visible-band pass
+  // measures a cleared row whether or not it was queued. It is covered in
+  // `tests/e2e/auto-row-size-clear-cache.spec.ts`, against a real viewport with a real fold.
+
+  it('should still owe the full recalculation after a render whose measurement threw', () => {
+    // The ghost table runs the real renderers, so a renderer that throws aborts the sweep. Spending
+    // the flag there would leave every unmeasured row at the default height for good.
+    //
+    // Asserted by counting the sweeps rather than by looking at the heights: the ordinary
+    // visible-band pass measures rows on the second render either way, and in jsdom - which reports
+    // no layout, so every row falls inside the rendered band - that would make this pass with the
+    // flag spent.
+    const { hot, container } = buildAttachedGrid();
+    const plugin = hot.getPlugin('autoRowSize');
+    let sweeps = 0;
+    let shouldThrow = true;
+
+    plugin.recalculateAllRowsHeight = () => {
+      sweeps += 1;
+
+      if (shouldThrow) {
+        throw new Error('renderer blew up mid-sweep');
+      }
+    };
+
+    plugin.clearCache();
+
+    expect(() => hot.render()).toThrow('renderer blew up mid-sweep');
+    expect(sweeps).toBe(1);
+
+    // The next render must attempt the sweep again, which only happens if the throw re-owed it.
+    shouldThrow = false;
+    hot.render();
+
+    expect(sweeps).toBe(2);
+
+    hot.destroy();
+    container.remove();
+  });
+});
+
 describe('AutoRowSize default settings', () => {
   it('should not declare a `useHeaders` setting, because it never reads one', () => {
     // AutoColumnSize does read `useHeaders` - it decides whether a column header is rendered beside

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -558,10 +558,19 @@ export class AutoRowSize extends BasePlugin {
         return;
       }
 
-      this.calculateRowsHeight({
-        from: current,
-        to: Math.min(current + AutoRowSize.CALCULATION_STEP, length)
-      }, colRange, overwriteCache);
+      try {
+        this.calculateRowsHeight({
+          from: current,
+          to: Math.min(current + AutoRowSize.CALCULATION_STEP, length)
+        }, colRange, overwriteCache);
+      } catch (error) {
+        // This runs inside an idle task, so the throw escapes whatever called
+        // `calculateAllRowsHeight()` - no caller's try/catch can see it. Leave the plugin
+        // recoverable before it goes.
+        this.#abandonSweep();
+
+        throw error;
+      }
 
       current = current + AutoRowSize.CALCULATION_STEP + 1;
 
@@ -586,7 +595,14 @@ export class AutoRowSize extends BasePlugin {
 
     // sync
     if (syncLimit >= 0) {
-      this.calculateRowsHeight({ from: 0, to: syncLimit }, colRange, overwriteCache);
+      try {
+        this.calculateRowsHeight({ from: 0, to: syncLimit }, colRange, overwriteCache);
+      } catch (error) {
+        this.#abandonSweep();
+
+        throw error;
+      }
+
       current = syncLimit + 1;
     }
     // async
@@ -594,8 +610,29 @@ export class AutoRowSize extends BasePlugin {
       loop();
     } else {
       this.inProgress = false;
+
+      // The whole grid fitted inside the sync limit, so `loop()` never ran and its completion
+      // branch - the other place the queue is drained - was never reached.
+      this.#drainRowRefreshQueue();
+
       this.hot.view.adjustElementsSize();
     }
+  }
+
+  /**
+   * Puts the plugin back into a state the next render can recover from, after a measurement threw
+   * part way through a sweep.
+   *
+   * Without it `inProgress` stays `true` for the instance's life, which does more than leave the
+   * heights half measured: `#drainRowRefreshQueue()` refuses to run while a sweep is in flight, so
+   * the refresh queue is silently disabled too. The full recalculation is re-owed, so the next
+   * render starts over.
+   */
+  #abandonSweep(): void {
+    cancelIdleTask(this.#idleSweepTimer);
+    this.#idleSweepTimer = 0;
+    this.inProgress = false;
+    this.#fullRecalculationScheduled = true;
   }
 
   /**
@@ -847,7 +884,10 @@ export class AutoRowSize extends BasePlugin {
       const visualRow = this.hot.toVisualRow(physicalRow);
 
       // A row outside the dataset, or one a trimming map hides, has no visual index to measure.
-      if (visualRow !== null) {
+      // Duplicates are skipped, the way the other producers of this queue do it: while the queue is
+      // held back (a column-less grid, or a sweep in flight) overlapping calls would otherwise pile
+      // the same row up and measure it once per copy.
+      if (visualRow !== null && !this.#visualRowsToRefresh.includes(visualRow)) {
         this.#visualRowsToRefresh.push(visualRow);
       }
     });
@@ -910,7 +950,9 @@ export class AutoRowSize extends BasePlugin {
     // The flag is held rather than consumed whenever this render cannot measure: while the grid is
     // hidden `recalculateAllRowsHeight()` is a no-op, and with no columns the measurement writes a
     // near-empty height for every row that nothing would ever correct (the same reason
-    // `calculateVisibleRowsHeight()` bails out on a column-less grid).
+    // `calculateVisibleRowsHeight()` bails out on a column-less grid). The row count is checked for
+    // the same shape of reason, though nothing is at stake: a sweep over no rows measures nothing,
+    // so holding the flag just keeps the work owed until there is something to measure.
     if (this.#fullRecalculationScheduled &&
         this.hot.countCols() > 0 &&
         this.hot.countRows() > 0 &&

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -334,13 +334,17 @@ export class AutoRowSize extends BasePlugin {
    *
    * Only a render measures rows, and it measures just the visible band, so an emptied cache leaves
    * every row below the fold unmeasured for good. Such a row falls back to the default height,
-   * which its own cell then refuses to honour once a wide wrapping column scrolls into view - a
+   * which its own cell then refuses to honor once a wide wrapping column scrolls into view - a
    * cell never renders shorter than its text - while the row header, having nothing to push it
-   * taller, does honour it. The two tables drift apart from there.
+   * taller, does honor it. The two tables drift apart from there.
    *
    * The flag makes the next render restore the measurements the way `#onInit` does. Deferring
    * rather than measuring inside `clearCache()` keeps repeated calls down to one recalculation and
    * leaves `clearCache()` as cheap as it has always been.
+   *
+   * "The next render" means a full one: `beforeRender` is raised by `TableView#render()`, not by
+   * the engine's scroll draw, so a caller that clears the cache and then only scrolls gets nothing.
+   * Every documented use of `clearCache()` pairs it with a redraw.
    *
    * @type {boolean}
    */
@@ -720,6 +724,14 @@ export class AutoRowSize extends BasePlugin {
    * Clears cache of calculated row heights. If you want to clear only selected rows pass an array with their indexes.
    * Otherwise whole cache will be cleared.
    *
+   * Clearing the whole cache schedules a full re-measurement, which runs on the next render. Note
+   * that a scroll is not a render in this sense - pair the call with {@link Core#render} the way the
+   * examples do, or the heights are not rebuilt.
+   *
+   * Passing an array clears those rows only and schedules nothing; call
+   * {@link AutoRowSize#recalculateAllRowsHeight} yourself if they must be re-measured before they
+   * are next drawn.
+   *
    * @param {number[]} [physicalRows] List of physical row indexes to clear.
    */
   clearCache(physicalRows?: number[]): void {
@@ -735,10 +747,12 @@ export class AutoRowSize extends BasePlugin {
     } else {
       this.rowHeightsMap.clear();
       // Nothing is measured any more, so the next render owes a full recalculation - see
-      // `#fullRecalculationScheduled`. The selective form above is deliberately left out: it clears
-      // named rows only, and recalculating the whole grid for them would be a far bigger pass than
-      // the caller asked for.
-      this.measuredRows = 0;
+      // `#fullRecalculationScheduled`.
+      //
+      // `measuredRows` is deliberately left alone. It is what the public `isNeedRecalculate()`
+      // slices, and zeroing it makes that method answer "nothing to recalculate" at the exact
+      // moment every height was dropped. AutoColumnSize leaves its counterpart alone for the same
+      // reason.
       this.#fullRecalculationScheduled = true;
     }
   }
@@ -803,24 +817,31 @@ export class AutoRowSize extends BasePlugin {
    * changes before the next render.
    */
   #onBeforeRender = () => {
-    // A wiped cache is restored in full before anything else, so the rows below the fold are
-    // measured too and not just the visible band. The flag is held until a render that can actually
-    // measure: `recalculateAllRowsHeight()` is a no-op while the grid is hidden, and consuming it
-    // there would leave the cache empty for good.
-    if (this.#fullRecalculationScheduled && this.hot.view.isVisible()) {
-      this.#fullRecalculationScheduled = false;
-      // The full pass overwrites every height, so anything queued by a data change is covered.
-      this.#visualRowsToRefresh = [];
-      this.recalculateAllRowsHeight();
-
-      return;
-    }
-
     this.calculateVisibleRowsHeight();
 
     if (!this.inProgress) {
       this.#calculateSpecificRowsHeight(this.#visualRowsToRefresh);
       this.#visualRowsToRefresh = [];
+    }
+
+    // A wiped cache is restored in full, so the rows below the fold are measured too and not just
+    // the visible band - see `#fullRecalculationScheduled`. It runs AFTER the visible band above,
+    // never instead of it: `calculateAllRowsHeight()` only measures up to `syncLimit` rows
+    // synchronously and leaves the rest to an idle sweep, so on a grid scrolled past that limit the
+    // band on screen would otherwise draw unmeasured, which is the very defect this repairs.
+    //
+    // The flag is held rather than consumed whenever this render cannot measure: while the grid is
+    // hidden `recalculateAllRowsHeight()` is a no-op, and with no columns the measurement writes a
+    // near-empty height for every row that nothing would ever correct (the same reason
+    // `calculateVisibleRowsHeight()` bails out on a column-less grid).
+    if (this.#fullRecalculationScheduled &&
+        this.hot.countCols() > 0 &&
+        this.hot.countRows() > 0 &&
+        this.hot.view.isVisible()) {
+      // Consumed before the call, not after: the sweep resizes the overlays, and a re-entrant
+      // render reaching this branch with the flag still set would recurse.
+      this.#fullRecalculationScheduled = false;
+      this.recalculateAllRowsHeight();
     }
   };
 

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -633,6 +633,13 @@ export class AutoRowSize extends BasePlugin {
     this.#idleSweepTimer = 0;
     this.inProgress = false;
     this.#fullRecalculationScheduled = true;
+
+    // The ghost table has to be emptied too, or the retry above dies on arrival. `GhostTable#addRow`
+    // pushes its row object BEFORE it runs the renderers and only fills in `.table` once they have
+    // all returned, so a renderer that throws leaves a half-built entry behind - and `getHeights()`
+    // reads `.table` on every row it holds. Only the success path calls `clean()`, so without this
+    // the next sweep throws on that leftover, and so does the one after it.
+    this.ghostTable.clean();
   }
 
   /**

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -328,6 +328,23 @@ export class AutoRowSize extends BasePlugin {
    * @type {boolean}
    */
   #columnResizeRecalcScheduled = false;
+  /**
+   * `true` when a full `clearCache()` wiped every measured height and the replacement pass has not
+   * run yet.
+   *
+   * Only a render measures rows, and it measures just the visible band, so an emptied cache leaves
+   * every row below the fold unmeasured for good. Such a row falls back to the default height,
+   * which its own cell then refuses to honour once a wide wrapping column scrolls into view - a
+   * cell never renders shorter than its text - while the row header, having nothing to push it
+   * taller, does honour it. The two tables drift apart from there.
+   *
+   * The flag makes the next render restore the measurements the way `#onInit` does. Deferring
+   * rather than measuring inside `clearCache()` keeps repeated calls down to one recalculation and
+   * leaves `clearCache()` as cheap as it has always been.
+   *
+   * @type {boolean}
+   */
+  #fullRecalculationScheduled = false;
 
   /**
    * Initializes the plugin, registers the row heights map, and sets up the row resize hook.
@@ -717,6 +734,12 @@ export class AutoRowSize extends BasePlugin {
 
     } else {
       this.rowHeightsMap.clear();
+      // Nothing is measured any more, so the next render owes a full recalculation - see
+      // `#fullRecalculationScheduled`. The selective form above is deliberately left out: it clears
+      // named rows only, and recalculating the whole grid for them would be a far bigger pass than
+      // the caller asked for.
+      this.measuredRows = 0;
+      this.#fullRecalculationScheduled = true;
     }
   }
 
@@ -780,6 +803,19 @@ export class AutoRowSize extends BasePlugin {
    * changes before the next render.
    */
   #onBeforeRender = () => {
+    // A wiped cache is restored in full before anything else, so the rows below the fold are
+    // measured too and not just the visible band. The flag is held until a render that can actually
+    // measure: `recalculateAllRowsHeight()` is a no-op while the grid is hidden, and consuming it
+    // there would leave the cache empty for good.
+    if (this.#fullRecalculationScheduled && this.hot.view.isVisible()) {
+      this.#fullRecalculationScheduled = false;
+      // The full pass overwrites every height, so anything queued by a data change is covered.
+      this.#visualRowsToRefresh = [];
+      this.recalculateAllRowsHeight();
+
+      return;
+    }
+
     this.calculateVisibleRowsHeight();
 
     if (!this.inProgress) {

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -349,6 +349,15 @@ export class AutoRowSize extends BasePlugin {
    * @type {boolean}
    */
   #fullRecalculationScheduled = false;
+  /**
+   * Handle of the idle task driving the in-flight full sweep, or `0` when none is running.
+   *
+   * Held on the instance rather than in `calculateAllRowsHeight()`'s closure so a new sweep can
+   * abandon the one before it - see the cancellation there.
+   *
+   * @type {number}
+   */
+  #idleSweepTimer = 0;
 
   /**
    * Initializes the plugin, registers the row heights map, and sets up the row resize hook.
@@ -528,14 +537,22 @@ export class AutoRowSize extends BasePlugin {
   ): void {
     let current = 0;
     const length = this.hot.countRows() - 1;
-    let timer = 0;
+
+    // A sweep already walking the grid is abandoned rather than left to run beside this one. Every
+    // sweep starts at row 0 and covers every row, so the new one measures everything the old one
+    // still had left. Two in flight would double the work and, worse, race on `inProgress`:
+    // whichever finished first would clear it while the other was still writing heights, and
+    // `#onBeforeRender` reads that flag to decide whether the refresh queue is safe to drain.
+    cancelIdleTask(this.#idleSweepTimer);
+    this.#idleSweepTimer = 0;
 
     this.inProgress = true;
 
     const loop = () => {
       // When hot was destroyed after calculating finished cancel frame
       if (!this.hot) {
-        cancelIdleTask(timer);
+        cancelIdleTask(this.#idleSweepTimer);
+        this.#idleSweepTimer = 0;
         this.inProgress = false;
 
         return;
@@ -549,9 +566,10 @@ export class AutoRowSize extends BasePlugin {
       current = current + AutoRowSize.CALCULATION_STEP + 1;
 
       if (current < length) {
-        timer = requestIdleTask(loop);
+        this.#idleSweepTimer = requestIdleTask(loop);
       } else {
-        cancelIdleTask(timer);
+        cancelIdleTask(this.#idleSweepTimer);
+        this.#idleSweepTimer = 0;
         this.inProgress = false;
 
         // @TODO Should call once per render cycle, currently fired separately in different plugins
@@ -728,9 +746,8 @@ export class AutoRowSize extends BasePlugin {
    * that a scroll is not a render in this sense - pair the call with {@link Core#render} the way the
    * examples do, or the heights are not rebuilt.
    *
-   * Passing an array clears those rows only and schedules nothing; call
-   * {@link AutoRowSize#recalculateAllRowsHeight} yourself if they must be re-measured before they
-   * are next drawn.
+   * Passing an array clears those rows only, and queues exactly those rows for re-measurement on
+   * the next render.
    *
    * @param {number[]} [physicalRows] List of physical row indexes to clear.
    */
@@ -743,6 +760,8 @@ export class AutoRowSize extends BasePlugin {
           this.rowHeightsMap.setValueAtIndex(physicalIndex, null);
         });
       }, true);
+
+      this.#queueClearedRowsForRefresh(physicalRows);
 
     } else {
       this.rowHeightsMap.clear();
@@ -758,18 +777,49 @@ export class AutoRowSize extends BasePlugin {
   }
 
   /**
-   * Clears cache by range.
+   * Clears cache by range. The cleared rows are queued for re-measurement on the next render.
    *
    * @param {object|number} range Row index or an object with `from` and `to` properties which define row range.
    */
   clearCacheByRange(range: number | { from: number, to: number }): void {
     const { from, to } = typeof range === 'number' ? { from: range, to: range } : range;
+    const clearedRows: number[] = [];
 
     this.hot.batchExecution(() => {
       rangeEach(Math.min(from, to), Math.max(from, to), (row) => {
         this.rowHeightsMap.setValueAtIndex(row, null);
+        clearedRows.push(row);
       });
     }, true);
+
+    this.#queueClearedRowsForRefresh(clearedRows);
+  }
+
+  /**
+   * Queues rows whose cached height was just dropped, so the next render measures them again.
+   *
+   * Without this they are only measured if and when they are drawn, and a render measures only the
+   * band it draws - so a cleared row below the fold keeps the default height, and once a wide
+   * wrapping column is scrolled into view its cell renders taller than the row header, which is the
+   * misalignment `#fullRecalculationScheduled` exists to prevent. `#calculateSpecificRowsHeight()`
+   * reads a row from the data rather than from the screen, so being off-screen is no obstacle.
+   *
+   * The queue is the same one data changes use, and it is drained in one synchronous pass, so
+   * clearing a very large range costs a correspondingly large measurement on the next render. That
+   * matches what the caller asked for, and it is the shape `#onBeforeChange` has always had; the
+   * alternative - leaving the rows silently wrong - is the defect.
+   *
+   * @param {number[]} physicalRows Physical row indexes whose heights were cleared.
+   */
+  #queueClearedRowsForRefresh(physicalRows: number[]): void {
+    physicalRows.forEach((physicalRow) => {
+      const visualRow = this.hot.toVisualRow(physicalRow);
+
+      // A row outside the dataset, or one a trimming map hides, has no visual index to measure.
+      if (visualRow !== null) {
+        this.#visualRowsToRefresh.push(visualRow);
+      }
+    });
   }
 
   /**
@@ -839,9 +889,18 @@ export class AutoRowSize extends BasePlugin {
         this.hot.countRows() > 0 &&
         this.hot.view.isVisible()) {
       // Consumed before the call, not after: the sweep resizes the overlays, and a re-entrant
-      // render reaching this branch with the flag still set would recurse.
+      // render reaching this branch with the flag still set would recurse. It is re-owed if the
+      // sweep throws - the ghost table runs the real renderers, so a renderer that throws would
+      // otherwise leave every unmeasured row at the default height for the instance's life.
       this.#fullRecalculationScheduled = false;
-      this.recalculateAllRowsHeight();
+
+      try {
+        this.recalculateAllRowsHeight();
+      } catch (error) {
+        this.#fullRecalculationScheduled = true;
+
+        throw error;
+      }
     }
   };
 

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -572,6 +572,11 @@ export class AutoRowSize extends BasePlugin {
         this.#idleSweepTimer = 0;
         this.inProgress = false;
 
+        // Rows queued while this sweep was running were held back, because the two share one ghost
+        // table. The sweep ends without a render of its own, so nothing else would pick them up
+        // until the next full render - which never comes on a grid the user only scrolls.
+        this.#drainRowRefreshQueue();
+
         // @TODO Should call once per render cycle, currently fired separately in different plugins
         this.hot.view.adjustElementsSize();
       }
@@ -591,6 +596,32 @@ export class AutoRowSize extends BasePlugin {
       this.inProgress = false;
       this.hot.view.adjustElementsSize();
     }
+  }
+
+  /**
+   * Measures the rows waiting in the refresh queue, if this moment can measure them at all.
+   *
+   * Two moments cannot, and both KEEP the queue rather than dropping it, so the rows are measured
+   * at the first moment that can:
+   *
+   * - while a full sweep is running, because the sweep and this pass share one ghost table;
+   * - while the grid has no columns, because the measurement would then write a near-empty height
+   *   which, no longer being `null`, is never re-measured when the columns come back. That is the
+   *   same trap the scheduled full recalculation is guarded against.
+   *
+   * Called from the render, and again when a sweep finishes - a sweep ends without a render of its
+   * own, so without that second call a queue held back by the first condition would wait for the
+   * next full render, which on a grid the user only scrolls never comes.
+   */
+  #drainRowRefreshQueue(): void {
+    if (this.inProgress || this.hot.countCols() === 0 || this.#visualRowsToRefresh.length === 0) {
+      return;
+    }
+
+    // Cleared after the call, not before: a measurement that throws leaves the rows queued for the
+    // next attempt rather than dropping them.
+    this.#calculateSpecificRowsHeight(this.#visualRowsToRefresh);
+    this.#visualRowsToRefresh = [];
   }
 
   /**
@@ -868,11 +899,7 @@ export class AutoRowSize extends BasePlugin {
    */
   #onBeforeRender = () => {
     this.calculateVisibleRowsHeight();
-
-    if (!this.inProgress) {
-      this.#calculateSpecificRowsHeight(this.#visualRowsToRefresh);
-      this.#visualRowsToRefresh = [];
-    }
+    this.#drainRowRefreshQueue();
 
     // A wiped cache is restored in full, so the rows below the fold are measured too and not just
     // the visible band - see `#fullRecalculationScheduled`. It runs AFTER the visible band above,

--- a/tests/e2e/auto-row-size-clear-cache.spec.ts
+++ b/tests/e2e/auto-row-size-clear-cache.spec.ts
@@ -48,6 +48,30 @@ test.describe('AutoRowSize after clearCache()', () => {
     expect(await grid.unmeasuredRenderedRows()).toBe(0);
   });
 
+  test('re-measures rows that clearCache(rows) dropped below the fold', async() => {
+    // The selective form has the same hole as the full one: a render measures only the band it
+    // draws, so a row cleared while it is off-screen would keep the default height until something
+    // drew it - and scrolling to it is not a render in that sense, so nothing ever does. The
+    // cleared rows are queued instead, and measured from the data.
+    //
+    // The rows cleared here are the last ones, and the scroll below goes to the very bottom, so
+    // they are certainly on screen when the measurement is checked. Clearing rows that the scroll
+    // never reaches makes this pass on unfixed code.
+    await grid.wipeRowHeightCacheForRows([35, 36, 37, 38, 39]);
+    await grid.scrollTo(100000, 100000);
+
+    expect(await grid.unmeasuredRenderedRows()).toBe(0);
+    expect(await grid.worstRowHeaderDrift()).toBeLessThanOrEqual(1);
+  });
+
+  test('re-measures rows that clearCacheByRange() dropped below the fold', async() => {
+    await grid.wipeRowHeightCacheByRange(35, 39);
+    await grid.scrollTo(100000, 100000);
+
+    expect(await grid.unmeasuredRenderedRows()).toBe(0);
+    expect(await grid.worstRowHeaderDrift()).toBeLessThanOrEqual(1);
+  });
+
   test('still lines up on a grid whose cache was never touched', async() => {
     // The control. A grid nobody wipes has always been correct, and it must stay that way - the
     // fix adds work to the render path, so this is what would catch it breaking the ordinary case.

--- a/tests/e2e/auto-row-size-clear-cache.spec.ts
+++ b/tests/e2e/auto-row-size-clear-cache.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '../fixtures/test';
+import { AutoRowSizeClearCachePage } from '../fixtures/pages/AutoRowSizeClearCachePage';
+
+/**
+ * DEV-2812. `AutoRowSize#clearCache()` used to empty every measured row height and schedule nothing
+ * to replace them. Rows are only measured during a render, and a render measures just the visible
+ * band, so every row below the fold stayed unmeasured and fell back to the default height.
+ *
+ * That is invisible until a wide wrapping column scrolls into view. The data cell then renders at
+ * its content height - a cell never renders shorter than its own text - while the row header, with
+ * nothing to push it taller, keeps the default. The two tables drift apart, and because each row's
+ * gap adds to the ones below it, the offset grows the further down the grid you look.
+ *
+ * All of this is content-driven geometry, which reads as zero in jsdom, so it can only be checked
+ * in a real browser.
+ */
+test.describe('AutoRowSize after clearCache()', () => {
+  let grid: AutoRowSizeClearCachePage;
+
+  test.beforeEach(async({ page, theme, bundle }) => {
+    grid = new AutoRowSizeClearCachePage(page, theme, bundle);
+    await grid.goto();
+  });
+
+  test('keeps the row headers aligned with their rows when scrolled sideways', async() => {
+    await grid.wipeRowHeightCache();
+
+    // Down first, so the rows under test are ones that were never on screen during the render that
+    // followed the wipe, then sideways to bring the wrapping columns in. Scrolling straight down
+    // never showed the defect: at rest the visible columns are narrow enough that the default
+    // height happens to be right.
+    await grid.scrollTo(600, 0);
+    await grid.scrollTo(600, 700);
+
+    // Asserted as a small tolerance rather than exactly 0: borders and box-model rounding move a
+    // row by a fraction of a pixel across themes. The defect is nothing like that size - it drops a
+    // whole wrapped line, which measured 40px per row and over 500px cumulatively.
+    expect(await grid.worstRowHeaderDrift()).toBeLessThanOrEqual(1);
+  });
+
+  test('measures the rows it renders after the cache is dropped', async() => {
+    await grid.wipeRowHeightCache();
+    await grid.scrollTo(600, 700);
+
+    // The cause, asserted directly. Without the replacement pass the plugin re-measured only the
+    // band that was visible at the moment of the wipe, so every row scrolled to afterwards stayed
+    // `null` in the height map and silently used the default.
+    expect(await grid.unmeasuredRenderedRows()).toBe(0);
+  });
+
+  test('still lines up on a grid whose cache was never touched', async() => {
+    // The control. A grid nobody wipes has always been correct, and it must stay that way - the
+    // fix adds work to the render path, so this is what would catch it breaking the ordinary case.
+    await grid.scrollTo(600, 700);
+
+    expect(await grid.worstRowHeaderDrift()).toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/fixtures/demo/auto-row-size-clear-cache.html
+++ b/tests/fixtures/demo/auto-row-size-clear-cache.html
@@ -97,6 +97,14 @@
 
     window.hot = hot;
 
+    // Counts draws so a test can wait for the grid to have actually repainted after a scroll.
+    // The rendered band cannot serve as that signal here: all four columns are always rendered, so
+    // a horizontal scroll leaves the band untouched while still repainting.
+    window.renderCount = 0;
+    hot.addHook('afterViewRender', function() {
+      window.renderCount += 1;
+    });
+
     /**
      * Reproduces the reported call: drop every measured height, then ask for a redraw. An
      * application does this to force the grid to re-measure after it has changed how cells render.

--- a/tests/fixtures/demo/auto-row-size-clear-cache.html
+++ b/tests/fixtures/demo/auto-row-size-clear-cache.html
@@ -113,6 +113,27 @@
       hot.getPlugin('autoRowSize').clearCache();
       hot.render();
     };
+
+    /**
+     * The selective form of the same call: drops the heights of named rows only.
+     *
+     * @param {number[]} rows Physical row indexes to drop.
+     */
+    window.wipeRowHeightCacheForRows = function(rows) {
+      hot.getPlugin('autoRowSize').clearCache(rows);
+      hot.render();
+    };
+
+    /**
+     * The range form.
+     *
+     * @param {number} from First physical row index.
+     * @param {number} to Last physical row index.
+     */
+    window.wipeRowHeightCacheByRange = function(from, to) {
+      hot.getPlugin('autoRowSize').clearCacheByRange({ from: from, to: to });
+      hot.render();
+    };
   </script>
 </body>
 </html>

--- a/tests/fixtures/demo/auto-row-size-clear-cache.html
+++ b/tests/fixtures/demo/auto-row-size-clear-cache.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>AutoRowSize clearCache e2e fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back.
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+  </style>
+</head>
+<body>
+  <!--
+    DEV-2812. `AutoRowSize#clearCache()` empties every measured row height. Only a render measures
+    rows again, and it measures just the visible band, so without a replacement pass every row below
+    the fold keeps the default height for good.
+
+    That stays invisible until a wide wrapping column scrolls into view: the data cell then renders
+    at its content height, because a cell never renders shorter than its own text, while the row
+    header - which has nothing to push it taller - keeps the default. The two tables drift apart and
+    the gap accumulates down the grid.
+
+    The grid is deliberately narrow, so the wrapping columns start off-screen and only appear once
+    the grid is scrolled sideways. Every height here is content-driven, which jsdom cannot measure,
+    so this can only be checked in a real browser.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The
+    // closing tag is split so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const SENTENCE = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.';
+    const ROWS = 40;
+    // Fixed, repeating lengths rather than random text: the rows must differ in height for a desync
+    // to show up at all, and the suite must measure the same grid on every run.
+    const LENGTHS = [18, 62, 34, 78, 26, 96, 44, 70];
+
+    /**
+     * A fragment of the sentence, repeated until it is long enough to reach the requested length.
+     *
+     * @param {number} length How many characters to return.
+     * @returns {string}
+     */
+    function text(length) {
+      let value = SENTENCE;
+
+      while (value.length < length) {
+        value += ` ${SENTENCE}`;
+      }
+
+      return value.slice(0, length).trim();
+    }
+
+    const data = Array.from({ length: ROWS }, (_, row) => [
+      `r${row}`,
+      text(LENGTHS[row % LENGTHS.length]),
+      text(LENGTHS[(row + 3) % LENGTHS.length]),
+      text(LENGTHS[(row + 5) % LENGTHS.length]),
+    ]);
+
+    const hot = new Handsontable(container, {
+      data,
+      // Narrower than the columns below add up to, so columns 1-3 start off-screen.
+      width: 360,
+      height: 300,
+      rowHeaders: true,
+      colHeaders: true,
+      wordWrap: true,
+      autoRowSize: true,
+      colWidths: [90, 200, 200, 200],
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    window.hot = hot;
+
+    /**
+     * Reproduces the reported call: drop every measured height, then ask for a redraw. An
+     * application does this to force the grid to re-measure after it has changed how cells render.
+     */
+    window.wipeRowHeightCache = function() {
+      hot.getPlugin('autoRowSize').clearCache();
+      hot.render();
+    };
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/AutoRowSizeClearCachePage.ts
+++ b/tests/fixtures/pages/AutoRowSizeClearCachePage.ts
@@ -34,28 +34,31 @@ export class AutoRowSizeClearCachePage {
   }
 
   /**
-   * Scrolls the grid, then waits for the scroll to have actually landed and been drawn.
+   * Scrolls the grid and lets the browser paint before anything is measured.
    *
    * Each offset is clamped to the grid's own range, so a caller can ask for "as far as it goes"
    * with a large number and not depend on a total width that differs per theme.
+   *
+   * This waits on animation frames rather than polling a condition, and that is deliberate: there
+   * is no condition left to poll. The browser clamps `scrollTop`/`scrollLeft` during the assignment,
+   * so they read back final on the very next line; Handsontable applies the scroll inside its own
+   * synchronous handler; the rendered band never moves horizontally here, because all four columns
+   * of this fixture are always rendered; and a horizontal scroll raises no `afterViewRender` at all.
+   * What is left to wait for is the paint itself, and a frame is the unit that names it. The
+   * measurements are exact once it has passed, since `getBoundingClientRect` forces layout.
    *
    * @param {number} top Vertical offset, in pixels.
    * @param {number} left Horizontal offset, in pixels.
    */
   async scrollTo(top: number, left: number): Promise<void> {
-    const landed = await this.holder.evaluate((holder, [t, l]) => {
+    await this.holder.evaluate((holder, [t, l]) => {
       holder.scrollTop = Math.min(t as number, holder.scrollHeight - holder.clientHeight);
       holder.scrollLeft = Math.min(l as number, holder.scrollWidth - holder.clientWidth);
-
-      return [holder.scrollTop, holder.scrollLeft];
     }, [top, left]);
 
-    // A real DOM condition rather than a sleep: the scroll has landed and a frame has been painted.
-    await expect.poll(() => this.holder.evaluate(h => [h.scrollTop, h.scrollLeft]))
-      .toEqual(landed);
-    await this.page.evaluate(
-      () => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
-    );
+    await this.page.evaluate(() => new Promise((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }));
   }
 
   /**
@@ -71,9 +74,22 @@ export class AutoRowSizeClearCachePage {
     return this.grid.evaluate((root) => {
       const masterRows = [...root.querySelectorAll('.ht_master .wtHolder table tbody tr')];
       const cloneRows = [...root.querySelectorAll('.ht_clone_inline_start .wtHolder table tbody tr')];
+
+      // Without this, an empty or short clone list would skip the loop and report a drift of 0 -
+      // the assertions would pass while measuring nothing, the control test included.
+      if (masterRows.length === 0) {
+        throw new Error('No master rows rendered; the drift measurement would be vacuous.');
+      }
+      if (masterRows.length !== cloneRows.length) {
+        throw new Error(
+          `Master rendered ${masterRows.length} rows but the row-header overlay rendered ` +
+          `${cloneRows.length}; the two tables cannot be compared row by row.`
+        );
+      }
+
       let worst = 0;
 
-      for (let i = 0; i < masterRows.length && i < cloneRows.length; i++) {
+      for (let i = 0; i < masterRows.length; i++) {
         const master = masterRows[i].getBoundingClientRect();
         const clone = cloneRows[i].getBoundingClientRect();
 
@@ -124,6 +140,10 @@ export class AutoRowSizeClearCachePage {
     await this.page.goto(
       `/tests/fixtures/demo/auto-row-size-clear-cache.html?theme=${this.theme}&bundle=${this.bundle}`
     );
+    // The bundle first, and with `waitForFunction` rather than `expect`: the dist file is several
+    // megabytes and every worker pulls its own copy, so a cold server outlasts the 10s `expect`
+    // timeout and the leg would fail pointing at an overlay class instead of the real cause.
+    await this.page.waitForFunction(() => 'Handsontable' in window);
     await expect(this.inlineStartOverlay).toBeVisible();
     await expect(this.grid.locator('.ht_master tbody tr').first()).toBeVisible();
   }

--- a/tests/fixtures/pages/AutoRowSizeClearCachePage.ts
+++ b/tests/fixtures/pages/AutoRowSizeClearCachePage.ts
@@ -34,6 +34,35 @@ export class AutoRowSizeClearCachePage {
   }
 
   /**
+   * Drops the heights of named rows only, then redraws - `clearCache(rows)`.
+   *
+   * @param {number[]} rows Physical row indexes to drop.
+   */
+  async wipeRowHeightCacheForRows(rows: number[]): Promise<void> {
+    await this.page.evaluate(
+      (target) => (window as unknown as {
+        wipeRowHeightCacheForRows: (rows: number[]) => void
+      }).wipeRowHeightCacheForRows(target),
+      rows
+    );
+  }
+
+  /**
+   * Drops the heights of a row range, then redraws - `clearCacheByRange()`.
+   *
+   * @param {number} from First physical row index.
+   * @param {number} to Last physical row index.
+   */
+  async wipeRowHeightCacheByRange(from: number, to: number): Promise<void> {
+    await this.page.evaluate(
+      ([f, t]) => (window as unknown as {
+        wipeRowHeightCacheByRange: (from: number, to: number) => void
+      }).wipeRowHeightCacheByRange(f, t),
+      [from, to]
+    );
+  }
+
+  /**
    * Scrolls the grid and lets the browser paint before anything is measured.
    *
    * Each offset is clamped to the grid's own range, so a caller can ask for "as far as it goes"

--- a/tests/fixtures/pages/AutoRowSizeClearCachePage.ts
+++ b/tests/fixtures/pages/AutoRowSizeClearCachePage.ts
@@ -1,0 +1,130 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the AutoRowSize `clearCache()` fixture.
+ *
+ * The reader sees this defect as row-header numbers sliding away from their rows, so the assertions
+ * compare the row-header cells in the inline-start overlay with the data rows in the master table,
+ * row by row.
+ */
+export class AutoRowSizeClearCachePage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly grid: Locator;
+  readonly inlineStartOverlay: Locator;
+  readonly holder: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.grid = page.getByTestId('grid');
+    this.inlineStartOverlay = this.grid.locator('.ht_clone_inline_start');
+    this.holder = this.grid.locator('.ht_master .wtHolder');
+  }
+
+  /**
+   * Drops every measured row height and asks for a redraw - the call the defect was reported for.
+   */
+  async wipeRowHeightCache(): Promise<void> {
+    await this.page.evaluate(
+      () => (window as unknown as { wipeRowHeightCache: () => void }).wipeRowHeightCache()
+    );
+  }
+
+  /**
+   * Scrolls the grid, then waits for the scroll to have actually landed and been drawn.
+   *
+   * Each offset is clamped to the grid's own range, so a caller can ask for "as far as it goes"
+   * with a large number and not depend on a total width that differs per theme.
+   *
+   * @param {number} top Vertical offset, in pixels.
+   * @param {number} left Horizontal offset, in pixels.
+   */
+  async scrollTo(top: number, left: number): Promise<void> {
+    const landed = await this.holder.evaluate((holder, [t, l]) => {
+      holder.scrollTop = Math.min(t as number, holder.scrollHeight - holder.clientHeight);
+      holder.scrollLeft = Math.min(l as number, holder.scrollWidth - holder.clientWidth);
+
+      return [holder.scrollTop, holder.scrollLeft];
+    }, [top, left]);
+
+    // A real DOM condition rather than a sleep: the scroll has landed and a frame has been painted.
+    await expect.poll(() => this.holder.evaluate(h => [h.scrollTop, h.scrollLeft]))
+      .toEqual(landed);
+    await this.page.evaluate(
+      () => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+    );
+  }
+
+  /**
+   * How far the row headers have drifted from their rows, in pixels - the largest disagreement
+   * across every rendered row, counting both the row's height and where its top edge sits.
+   *
+   * Reads the two tables that must stay in step: the master body, which holds the data cells, and
+   * the inline-start overlay, which holds the row headers.
+   *
+   * @returns {Promise<number>} `0` when every row lines up.
+   */
+  async worstRowHeaderDrift(): Promise<number> {
+    return this.grid.evaluate((root) => {
+      const masterRows = [...root.querySelectorAll('.ht_master .wtHolder table tbody tr')];
+      const cloneRows = [...root.querySelectorAll('.ht_clone_inline_start .wtHolder table tbody tr')];
+      let worst = 0;
+
+      for (let i = 0; i < masterRows.length && i < cloneRows.length; i++) {
+        const master = masterRows[i].getBoundingClientRect();
+        const clone = cloneRows[i].getBoundingClientRect();
+
+        worst = Math.max(
+          worst,
+          Math.abs(master.height - clone.height),
+          Math.abs(master.top - clone.top)
+        );
+      }
+
+      return worst;
+    });
+  }
+
+  /**
+   * How many of the rendered rows the plugin has no measured height for.
+   *
+   * The drift is only the symptom; an unmeasured row is the cause, and asserting on it keeps the
+   * test pointed at the defect rather than at one theme's pixel arithmetic.
+   *
+   * @returns {Promise<number>}
+   */
+  async unmeasuredRenderedRows(): Promise<number> {
+    return this.page.evaluate(() => {
+      const hot = (window as unknown as { hot: {
+        view: { getFirstRenderedVisibleRow(): number, getLastRenderedVisibleRow(): number },
+        toPhysicalRow(row: number): number | null,
+        getPlugin(name: string): { rowHeightsMap: { getValues(): (number | null)[] } },
+      } }).hot;
+      const heights = hot.getPlugin('autoRowSize').rowHeightsMap.getValues();
+      let unmeasured = 0;
+
+      for (let row = hot.view.getFirstRenderedVisibleRow();
+        row <= hot.view.getLastRenderedVisibleRow(); row++) {
+        const physicalRow = hot.toPhysicalRow(row) ?? row;
+
+        if (heights[physicalRow] === null || heights[physicalRow] === undefined) {
+          unmeasured += 1;
+        }
+      }
+
+      return unmeasured;
+    });
+  }
+
+  /** Navigate and wait for the grid to have rendered - a real DOM condition, never a sleep. */
+  async goto(): Promise<void> {
+    await this.page.goto(
+      `/tests/fixtures/demo/auto-row-size-clear-cache.html?theme=${this.theme}&bundle=${this.bundle}`
+    );
+    await expect(this.inlineStartOverlay).toBeVisible();
+    await expect(this.grid.locator('.ht_master tbody tr').first()).toBeVisible();
+  }
+}


### PR DESCRIPTION
### Context

The PR fixes row headers drifting out of alignment with their rows after an application calls `AutoRowSize#clearCache()`.

`clearCache()` empties every measured row height and schedules nothing to replace them. Rows are only measured by `calculateVisibleRowsHeight()`, which is registered on the `beforeRender` hook — the full-render hook — and it measures just the visible band. Scrolling performs a *view* render, so scrolling measures nothing. Every row that was not on screen during the next full render therefore stays unmeasured for good and falls back to the default row height.

That stays invisible until the grid is scrolled sideways and a wide wrapping column comes into view. The data cell then renders at its content height, because a cell can never render shorter than its own text, while the row header — which has nothing to push it taller — honors the default height it was given. The two tables disagree, and because each row's gap adds to the ones below it, the offset grows the further down the grid you look. Measured on `develop` with the reporting client's own demo: 40px per row, 540px cumulative.

`clearCache()` now leaves the plugin owing a full recalculation, and the next render honors it the way `#onInit` already does through `calculateAllRowsHeight()`. Deferring rather than measuring inside `clearCache()` keeps repeated calls down to a single recalculation and leaves `clearCache()` as cheap as it has always been.

Four rules make that safe, and each of them has a concrete failure behind it:

- **The full sweep runs after `calculateVisibleRowsHeight()`, never instead of it.** `calculateAllRowsHeight()` measures only up to `syncLimit` rows synchronously and hands the rest to an idle sweep that asks for no redraw, so on a grid scrolled past that limit the band on screen would draw unmeasured — re-creating the defect on the frame meant to repair it.
- **The flag is held, not consumed, when the render cannot measure.** `recalculateAllRowsHeight()` is a no-op on a hidden grid, and a column-less grid still reports itself visible — the sweep would then write a near-empty height for every row that nothing later corrects. `calculateVisibleRowsHeight()` already bails out on that grid for the same reason.
- **The flag is consumed before the sweep and re-owed if it throws.** The ghost table runs the real renderers. Holding it across the call would let a re-entrant render recurse; spending it outright would leave every unmeasured row at the default height for the instance's life.
- **`measuredRows` is left alone.** The public `isNeedRecalculate()` slices the height map by it, so zeroing it makes that method answer "nothing to recalculate" at the exact moment every height was dropped. `AutoColumnSize#clearCache()` leaves its counterpart alone too.

The selective forms — `clearCache([rows])` and `clearCacheByRange()` — had the identical below-the-fold hole and now close it differently: they queue exactly the rows they cleared onto the refresh queue, which `#calculateSpecificRowsHeight()` reads from the data, so only those rows are re-measured rather than the whole grid.

`calculateAllRowsHeight()` also cancels any sweep still in flight before starting its own. Two running together doubled the work and raced on `inProgress` — whichever finished first cleared it while the other was still writing heights, and `#onBeforeRender` reads that flag to decide whether the refresh queue is safe to drain.

Two notes for reviewers, both of which contradict the original report in DEV-2718:

1. **This is not a regression.** 16.2.0, 17.0.0, 18.0.0 and `develop` all break identically. The bisection table in DEV-2718 does not hold up — it appears to have measured the frame right after a scroll, before the repaint, which is briefly out of step on every version.
2. **The trigger is horizontal scrolling, not vertical**, and the minimal 3-column repro attached to DEV-2718 does not reproduce on any version: it has no horizontal scroll, so every row is measured correctly.

`renderAllColumns: true` does not help, which matches what the client reported.

### How has this been tested?

**New Playwright E2E** in `tests/e2e/auto-row-size-clear-cache.spec.ts`, on a fixture whose grid is narrower than its columns so the wrapping columns start off-screen. Five tests: the row headers stay aligned after a full wipe; no rendered row is left unmeasured; the two selective forms re-measure rows they cleared below the fold; and — as a control that the added render-path work does not break the ordinary case — a grid whose cache was never touched still lines up.

**New unit tests** in `handsontable/src/plugins/autoRowSize/__tests__/rowHeightsInteraction.unit.ts` for the parts that are logic rather than geometry: `isNeedRecalculate()` still reports work owed after a wipe, a column-less render does not spend the scheduled recalculation, and a sweep that throws re-owes it.

Every one of these was confirmed to **fail on the unfixed build for the right reason** and pass on the fixed one — the E2E at 519px drift and 12 unmeasured rows, the selective-form tests at 5 unmeasured rows, the column-less guard and the throw case by their own assertions. The below-the-fold behavior is deliberately covered in E2E rather than unit: jsdom reports no layout, so every row falls inside the rendered band and there is no fold to test against.

```bash
# new E2E coverage (30 = 5 tests x 6 theme/bundle projects)
cd tests && npx playwright test auto-row-size-clear-cache

# regression surfaces for the plugin and its neighbours
npm run test:e2e --prefix handsontable -- --testPathPattern=autoRowSize          # 55 specs, 0 failures
npm run test:e2e --prefix handsontable -- --testPathPattern=manualRowResize      # 75 specs, 0 failures
npm run test:e2e --prefix handsontable -- --testPathPattern=autoRowHeaderSize    # 5 specs, 0 failures
npm run test:unit --prefix handsontable -- --testPathPattern=rowHeightsInteraction  # 8 passed
npm run test:unit --prefix handsontable -- --testPathPattern=ghostTable             # 22 passed

npm run eslint --prefix handsontable      # 0 errors
npm run test:types --prefix handsontable  # clean
```

Also verified by hand against the client's own demo from the DEV-2718 attachment: the worst row-header drift goes from 540px to 0px, at every horizontal scroll position.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2812
2. DEV-2718 — the client report this was diagnosed from

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2812

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the render and async measurement pipeline for a core sizing plugin; mistakes could affect scrollbars, overlays, or performance on large grids after cache clears.
> 
> **Overview**
> Fixes **row headers drifting away from data rows** after `AutoRowSize#clearCache()` (and the selective `clearCache(rows)` / `clearCacheByRange()` APIs). Clearing heights used to leave off-screen rows at the default height while only the visible band was re-measured on render, so wrapped cells and row headers could disagree once wide columns scrolled into view.
> 
> A **full** `clearCache()` now sets `#fullRecalculationScheduled`; the next full render runs the visible-band pass first, then `recalculateAllRowsHeight()` (with guards for hidden, column-less, or empty grids, and re-owing the flag if measurement throws). **`measuredRows` is not reset** so `isNeedRecalculate()` stays truthful.
> 
> **Selective** clears enqueue affected rows on the existing refresh queue via `#drainRowRefreshQueue()`, which also waits while a sweep is in flight or there are no columns. Sweeps are **single-flight** (`#idleSweepTimer` cancellation), with `#abandonSweep()` resetting `inProgress`, cleaning the ghost table, and scheduling retry on renderer failures.
> 
> Adds **unit tests** for these edge cases and **Playwright E2E** for alignment and below-the-fold re-measurement in a real layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4364cf9ed6121649ab4915fd1bc975c5bfb831bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->