### PR TITLE
DEV-2813: Clear the stray text selection before every visual screenshot

### DIFF
--- a/visual-tests/AGENTS.md
+++ b/visual-tests/AGENTS.md
@@ -67,7 +67,7 @@ itself — no notifier plugin is configured. The pull request comment is written
 `.reg/comment.md` and posted by the `marocchino/sticky-pull-request-comment` step in `visual.yml`, which is
 why it carries the approval instructions as well as the counts.
 
-Six things about this pipeline are worth knowing before changing it.
+Seven things about this pipeline are worth knowing before changing it.
 
 - **`reg-suit run` exits 0 no matter what it finds.** A comparison result never fails it; fetch, publish
   and comparison-runtime errors do. Notifier errors are the one class it deliberately swallows
@@ -116,6 +116,18 @@ Six things about this pipeline are worth knowing before changing it.
 - **A golden record is just a previous build's `actual/` directory.** reg-suit fetches
   `<expectedKey>/actual/**` into the local `expected/` dir, so the goldens and a normal build share one
   format. There is no separate baseline artifact to maintain.
+- **A single flaky capture on `develop` reds every open pull request, and it does not look like a flake.**
+  The `Reconcile the golden records` step runs on every non-pull-request event and `aws s3 sync --delete`s
+  that build's own render over `base/<branch>/actual`, unreviewed — so a green `develop` build that
+  happened to photograph a transient state makes that state the reference. The build reports no failure
+  and no retry; it simply captured something else. It then persists, because most `develop` runs are
+  cancelled by the next push (2 of 10 finished on the day this was found), so the next reseed can be hours
+  away. **The diagnostic is byte equality across pull requests:** if two unrelated pull requests fail on
+  the same item, `shasum -a 256` their `actual/<item>` from the two reports. Identical bytes mean the
+  render is deterministic and the golden record is the odd one out — neither pull request is at fault, and
+  `visual-approved` on one of them fixes nothing for the others. Confirmed on `columns-filter-2` under
+  WebKit, where the poisoned record carried a stray browser text-selection highlight on a column header;
+  `test-runner.ts` now clears that selection before every capture.
 
 Snapshot keys, set in `.github/workflows/visual.yml`:
 

--- a/visual-tests/AGENTS.md
+++ b/visual-tests/AGENTS.md
@@ -127,7 +127,12 @@ Seven things about this pipeline are worth knowing before changing it.
   render is deterministic and the golden record is the odd one out — neither pull request is at fault, and
   `visual-approved` on one of them fixes nothing for the others. Confirmed on `columns-filter-2` under
   WebKit, where the poisoned record carried a stray browser text-selection highlight on a column header;
-  `test-runner.ts` now clears that selection before every capture.
+  `test-runner.ts` now clears that selection before every capture. **`visual.handsontable.com` is behind a
+  CDN, so reading a golden record back can hand you a stale copy** — during that investigation it served
+  the superseded image for nearly an hour after `develop` had reseeded, which reads exactly like a
+  baseline nobody has fixed yet. Always bust the cache before concluding anything from a golden record:
+  `curl -H 'Cache-Control: no-cache' '<url>?cb=$RANDOM'`. The reg-suit reports are per-commit paths and
+  never restated, so only the `base/<branch>/` prefix has this problem.
 
 Snapshot keys, set in `.github/workflows/visual.yml`:
 

--- a/visual-tests/src/test-runner.ts
+++ b/visual-tests/src/test-runner.ts
@@ -42,12 +42,49 @@ function waitForScrollbarClearanceToSettle(page: Page) {
 }
 
 /**
- * Makes every `screenshot()` on this page wait for that settle first. Wrapping the page is what makes
- * it uniform: the specs call `tablePage.screenshot()` directly, in a few hundred places.
+ * Drops the browser's own text-selection highlight, which a click sequence can leave behind.
  *
- * A timeout does not fail the test. The band is held open for as long as a pointer rests beside the
+ * A filter flow can end with the column header's label selected - seen on `columns-filter-2` under
+ * WebKit - and nothing in the grid takes it away: `clearTextSelection()` runs on a mousedown inside
+ * the grid, and the last click of that flow lands in the dropdown menu. The highlight paints the
+ * browser default over whatever text it covers, so the same spec publishes two correct-looking
+ * images on nothing but where the run happened to leave the caret.
+ *
+ * Handsontable's own cell selection is drawn by the grid and is untouched.
+ *
+ * A focused editor is left alone. `removeAllRanges()` also collapses the selection inside a focused
+ * text control, and `DateEditor#focus()` selects its value on purpose, so a screenshot of an open
+ * editor would lose the highlight it exists to capture. An empty control - the grid's own focus
+ * catcher - has nothing to lose and must not block the clear.
+ *
+ * @param {Page} page The page about to be captured.
+ * @returns {Promise<void>} Resolves once no stray native selection is left.
+ */
+function clearNativeTextSelection(page: Page) {
+  // The callback runs in the browser, where `window` and `document` are the right globals to use.
+  /* eslint-disable no-restricted-globals */
+  return page.evaluate(() => {
+    const active = document.activeElement;
+    const isTextControl = active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement;
+
+    if (isTextControl && active.value !== '') {
+      return;
+    }
+
+    window.getSelection()?.removeAllRanges();
+  });
+  /* eslint-enable no-restricted-globals */
+}
+
+/**
+ * Makes every `screenshot()` on this page wait for that settle first, and drop any stray native text
+ * selection. Wrapping the page is what makes it uniform: the specs call `tablePage.screenshot()`
+ * directly, in a few hundred places.
+ *
+ * Neither step fails the test. The band is held open for as long as a pointer rests beside the
  * scrollbar, and a spec that leaves the mouse there would otherwise turn a visual check into a hang -
- * so a stuck band costs the old flaky screenshot, not a red suite.
+ * so a stuck band costs the old flaky screenshot, not a red suite. The selection clear is best-effort
+ * for the same reason: a page torn down mid-capture must not turn into a failure.
  *
  * @param {Page} page The page to instrument.
  */
@@ -63,6 +100,7 @@ function installScrollbarClearanceSettle(page: Page) {
   // eslint-disable-next-line no-param-reassign
   page.screenshot = (async(options?: Parameters<Page['screenshot']>[0]) => {
     await waitForScrollbarClearanceToSettle(page).catch(() => {});
+    await clearNativeTextSelection(page).catch(() => {});
 
     return capture(options);
   }) as Page['screenshot'];

--- a/visual-tests/src/test-runner.ts
+++ b/visual-tests/src/test-runner.ts
@@ -50,12 +50,22 @@ function waitForScrollbarClearanceToSettle(page: Page) {
  * browser default over whatever text it covers, so the same spec publishes two correct-looking
  * images on nothing but where the run happened to leave the caret.
  *
- * Handsontable's own cell selection is drawn by the grid and is untouched.
+ * The grid's own cell selection is drawn by Handsontable and is not a native selection - with one
+ * exception. `CopyPaste` puts a real TD into a native range for its Safari clipboard path
+ * (`makeElementContentEditableAndSelectItsContent`), so this does reach it. That range carries the
+ * `invisibleSelection` class, which hides it, so clearing it changes no pixel today.
  *
- * A focused editor is left alone. `removeAllRanges()` also collapses the selection inside a focused
- * text control, and `DateEditor#focus()` selects its value on purpose, so a screenshot of an open
- * editor would lose the highlight it exists to capture. An empty control - the grid's own focus
- * catcher - has nothing to lose and must not block the clear.
+ * `fragmentSelection` is the case to watch. It is a real setting whose whole point is a visible
+ * native selection spanning TDs (`tableView.ts`), and no visual spec turns it on. A spec that did
+ * would need this clear skipped, or its selection is stripped before the capture with nothing on
+ * screen to explain why.
+ *
+ * A focused text control is left alone, because `removeAllRanges()` collapses the selection inside
+ * one and an open editor is often captured with its value selected. The test is `selectionStart`
+ * being a number, which holds only for controls that own a text selection. Reading `value` instead
+ * would skip the clear whenever a checkbox, radio, range or color input has focus - each of those
+ * reports a non-empty default (`"on"`, `"50"`, `"#000000"`) - and a stray selection elsewhere on the
+ * page would then survive into the screenshot.
  *
  * @param {Page} page The page about to be captured.
  * @returns {Promise<void>} Resolves once no stray native selection is left.
@@ -65,9 +75,11 @@ function clearNativeTextSelection(page: Page) {
   /* eslint-disable no-restricted-globals */
   return page.evaluate(() => {
     const active = document.activeElement;
-    const isTextControl = active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement;
+    const ownsTextSelection =
+      (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) &&
+      typeof active.selectionStart === 'number';
 
-    if (isTextControl && active.value !== '') {
+    if (ownsTextSelection) {
       return;
     }
 


### PR DESCRIPTION
### Context

The PR fixes a visual-test flake that reds **other people's** pull requests.

`Visual / Compare` started failing on `cross-browser/webkit/columns-filter-2.png` for pull requests
that have nothing to do with filters — #13402 and #13281 both hit it on 2026-09-07. Neither pull
request is at fault. The stored golden record is wrong: it was captured with the browser's own
text-selection highlight sitting on the "Sell date" column header.

**The evidence that it is the baseline, not the pull request:**

- The whole difference is 3560 pixels in a 123 × 32 box on one column header, out of a 2560 × 1440
  image. The other 1645 screenshots pass.
- Inside that box the golden record is `rgb(166, 209, 227)` and every pull request render is
  `rgb(215, 242, 226)`. The first is the second blended with `rgb(0, 105, 217)` at 23% — the
  browser's default text-selection colour.
- #13402 and #13281 rendered **byte-identical** screenshots (sha256 `56ee456e…`), both differing from
  the same golden record (`53f3e401…`). The pull request side is deterministic; the baseline is the
  odd one out.
- Timeline: the `develop` build that finished at 12:00 stored a clean record, the one that finished at
  13:18 stored the highlighted one. #13402's runs before 13:18 passed; the run after it failed.
- The `develop` build that stored the bad record was **green** — `116 passed`, no retries. The test
  did not fail. It photographed a different state.

**Why it persists.** `Reconcile the golden records` in `visual.yml` runs on every non-pull-request
event and `aws s3 sync --delete`s that build's own render over `base/<branch>/actual`, unreviewed. One
unlucky capture becomes the reference for every open pull request, and it stays there because most
`develop` runs are cancelled by the next push — 2 of 10 finished on the day this was found.

**Where the highlight comes from.** It is absent from screenshot 1 of the spec (after the Country
filter) and present in screenshot 2 (after the Sell date condition filter), so something in
`filterByCondition()` creates it. Nothing removes it: `TableView` calls `clearTextSelection()` on a
mousedown **inside the grid** (`handsontable/src/tableView.ts:555`), and the last click of that flow
lands in the dropdown menu, which sits outside the grid's root element.

The exact action that creates the selection is **not confirmed**, and the fix does not depend on it.
Pinning it down would need a WebKit build plus many runs to catch a rare state.

### The change

`visual-tests/src/test-runner.ts` already wraps `page.screenshot()` to wait out one transient state
(the scrollbar clearance band, #10370). This adds a second step to the same wrapper: drop the stray
native text selection before every capture. That removes the state rather than masking it, which is
why it is preferred over injecting `::selection { background: transparent }`.

**A focused editor is deliberately skipped.** The first version of this had no guard and would have
broken four screenshots. Measured in Chrome:

```
textarea selected      selectionStart-End = 0-11
after removeAllRanges  selectionStart-End = 0-0     <- collapsed
input selected         selectionStart-End = 0-6
after removeAllRanges  selectionStart-End = 0-0     <- collapsed
```

`window.getSelection().removeAllRanges()` also collapses the selection **inside** a focused
`<input>`/`<textarea>`. `DateEditor#focus()` calls `this.TEXTAREA.select()` on purpose
(`handsontable/src/editors/dateEditor/dateEditor.ts:87`), and
`tests/js-only/editors/date/picker-position*.spec.ts` screenshots that open editor — so an unguarded
clear would have silently changed those baselines.

The guard skips a focused text control **that has a value**. Using "has a value" rather than "has a
non-collapsed selection" keeps it correct for `<input type="date">`, where `selectionStart` reads
`null`. The grid's own focus catcher is empty, so it does not block the clear.

`visual-tests/AGENTS.md` gains a seventh bullet in the pipeline list, recording both the
poisoned-baseline mechanism and the byte-equality check that identifies it, so the next person does
not re-derive it from scratch.

### How has this been tested?

Verified the guard against real Chrome with a standalone Playwright script covering the three states
the wrapper can meet:

| case | expected | result |
|---|---|---|
| open editor, value selected | selection preserved | preserved (`0-10` before and after) |
| stray page selection, focus on an empty control | selection cleared | cleared |
| stray page selection, nothing focused | selection cleared | cleared |

Also confirmed statically that the change cannot disturb anything else:

- No spec captures a page-level text selection on purpose — `fragmentSelection` appears nowhere under
  `visual-tests/` or `examples/next/visual-tests/`.
- `selection.spec.ts` asserts Handsontable's **cell** selection, which the grid draws itself.
  `removeAllRanges()` does not touch it.
- Nothing in `handsontable/src` listens for the `selectionchange` event.
- The clear is best-effort (`.catch(() => {})`), matching the existing scrollbar wait, so a page torn
  down mid-capture cannot turn a visual check red.

```bash
npm run lint --prefix visual-tests   # 0 errors
```

### Reviewer notes

**1. `Visual / Compare` on this pull request is red, with 13 changed screenshots. Please read this
before approving them.** I predicted the changes would be golden records carrying an incidental
selection. That prediction was wrong, and the actual result is worth a reviewer's judgement:

| screenshots | what changed | assessment |
|---|---|---|
| 10 × `js-only/dialog/dialog-{focus,pagination}-2.png` (5 theme variants each) | text antialiasing across the grid behind the dialog. Mean brightness is unchanged (247.57 → 247.45) but glyph edges differ on ~3× more pixels | see below |
| `cross-browser/chromium/focus-basic-two-tables-demo-{1,3}.png` | not investigated | also flaked on #13381 today, independent of this change |
| `cross-browser/chromium/selection-arabic-rtl-demo-2.png` | cell-selection range one column narrower at its edge | also flaked on #13281 today, independent of this change |

On the dialog ten: both specs load a dialog with `background: 'semi-transparent'`, so the grid text
behind it is composited through a translucent layer, where a small rasterization difference moves
every glyph edge. Only screenshot **2** changed in both specs — the one taken right after the *first*
`Tab`. Screenshot 1 (straight after load) and screenshot 3 (after a second `Tab`) are untouched in
all five themes.

That pattern points at the extra `page.evaluate()` round-trip letting a first-focus repaint settle,
rather than at `removeAllRanges()` doing something — a selection clear would hit all three shots
equally. If that reading is right, the change removes a second latent flake. **It is a hypothesis, not
a measurement**, so please sanity-check the ten before approving.

Notably, `columns-filter-2` — the screenshot this whole ticket is about — now **passes**, because
`develop` reseeded a clean record at 14:11 before this build ran.

**2. The flake is only fully gone once this is in `develop`'s own seed build.** Until then a `develop`
build can still write a poisoned record.

**3. `thresholdPixel` was deliberately not touched.** It is 150 and the original difference was 3560
pixels, so raising it would not have helped and the weakening gate would flag it.

**4. A late find, in the second commit.** `visual.handsontable.com` is CDN-cached, and it served a
superseded golden record for nearly an hour after `develop` had already reseeded — which reads exactly
like a baseline nobody has fixed. The `AGENTS.md` bullet now carries the cache-buster next to the
diagnostic that reads a golden record back.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2813
2. Seen on #13402 and #13281, neither of which caused it.

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Visual test harness only (`visual-tests/`). No shipped package changes.

[skip changelog] — test-harness only, no source change.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2813

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-test harness only; no production Handsontable code. Main caveat is future specs with `fragmentSelection` or intentional page-level selection, which the new clear would strip unless guarded.
> 
> **Overview**
> Addresses visual flakes where a **poisoned golden record** (e.g. WebKit `columns-filter-2` with a column-header text-selection highlight) fails unrelated PRs. The harness now calls **`clearNativeTextSelection`** on every wrapped **`page.screenshot()`**, after the existing scrollbar settle step, using **`getSelection().removeAllRanges()`** unless focus is on an input/textarea that owns a text selection (`selectionStart` is a number), so open editors keep their selected values.
> 
> Both pre-capture steps stay **best-effort** (`.catch(() => {})`) so teardown mid-capture does not fail tests. **`visual-tests/AGENTS.md`** adds a seventh pipeline note: unreviewed `develop` reseeds can broadcast one bad capture to all PRs, how to confirm with **byte-identical `actual/`** across PRs, and **CDN cache-busting** when inspecting `base/<branch>/` goldens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1485157e531efd0c7f2a0cc9d97400f06618254d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->