### PR TITLE
Docs: keep the Skills for Claude Code page's version strings current

### DIFF
--- a/docs/content/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md
+++ b/docs/content/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md
@@ -19,7 +19,7 @@ Skills for Claude Code are bundled instructions that give Claude deep knowledge 
 
 The <a href="https://github.com/handsontable/handsontable-skills" target="_blank" rel="noopener noreferrer">repo</a> ships two skills:
 
-- **handsontable** -- the data grid component. Covers React, Angular, Vue, and vanilla JS setup, configuration, theming, cell types, sorting, filtering, formulas, hooks, performance, and v17 migration.
+- **handsontable** -- the data grid component. Covers React, Angular, Vue, and vanilla JS setup, configuration, theming, cell types, sorting, filtering, formulas, hooks, performance, and version migration.
 - **hyperformula** -- the headless calculation engine. Covers instance creation, CRUD, custom functions, named expressions, error handling, batch operations, and Node.js usage.
 
 Use **handsontable** when you're building a visible grid in a web app. Use **hyperformula** when you're evaluating formulas programmatically without a UI -- server-side calculations, pricing engines, what-if analysis. Claude loads whichever is relevant based on what you ask.
@@ -37,6 +37,6 @@ For Cowork or Claude.ai web, download the zip from the latest GitHub release and
 
 ## Versioned to match releases
 
-Each skill is tagged to the product version it targets -- `handsontable/v17.0.0` is the skill for Handsontable 17, `hyperformula/v3.2.0` is the skill for HyperFormula 3.2. You always know which API surface Claude is working from.
+Each skill is tagged to the product version it targets -- `handsontable/v{{$currentVersion}}` is the skill for Handsontable {{$currentVersion}}, and each HyperFormula release gets a matching `hyperformula/v*` tag. You always know which API surface Claude is working from.
 
 <a href="https://github.com/handsontable/handsontable-skills" target="_blank" rel="noopener noreferrer">Browse the Skills for Claude Code</a>


### PR DESCRIPTION
## Summary

The [Skills for Claude Code](https://handsontable.com/docs/javascript-data-grid/skills-for-claude-code/) page advertised `handsontable/v17.0.0` and `hyperformula/v3.2.0` as the current skill tags, and described the skill's coverage as "v17 migration" — two releases stale on a page whose pitch is that Claude works from current APIs.

- The Handsontable tag literal becomes `{{$currentVersion}}`, which the docs build already resolves through `template-variables.mjs`, so the page tracks each release automatically.
- The HyperFormula sentence becomes version-agnostic ("each HyperFormula release gets a matching `hyperformula/v*` tag") — there is no build-time source for the HyperFormula release version (the monorepo's installed `hyperformula` lags the latest release), so a literal or a derived variable would both go stale or be wrong.
- "v17 migration" becomes "version migration".

## Test plan

- Ran `replaceTemplateVariables()` from `docs/src/plugins/template-variables.mjs` over the edited page with `version: '18.1.0'`: the paragraph renders as "`handsontable/v18.1.0` is the skill for Handsontable 18.1.0", with no unresolved `{{$...}}` left in the output.
- The fix targets the live 18.1 docs, so after merge this needs the usual cherry-pick to `prod-docs/18.1`.

[skip changelog]

ClickUp: SU-875

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and template placeholders; no runtime or product code changes.
> 
> **Overview**
> Updates the **Skills for Claude Code** guide so version examples stay accurate as Handsontable ships new releases.
> 
> The handsontable skill bullet no longer says **v17 migration**; it refers to **version migration** generically. In **Versioned to match releases**, the Handsontable tag and product version use **`{{$currentVersion}}`** (resolved at docs build from `package.json`) instead of hardcoded **v17.0.0**. HyperFormula is described with a **`hyperformula/v*`** pattern per release rather than a fixed **v3.2.0** tag, since there is no reliable build-time HF version in the monorepo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa3f030f2061ab22c25c7042d542c38035e9a677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->