### PR TITLE
Docs: add v18.0-to-v18.1 sanitizer upgrade guidance to the Security guide

### DIFF
--- a/docs/content/guides/security/security/security.md
+++ b/docs/content/guides/security/security/security.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Security - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Security
+menuTag: updated
 ---
 Learn about the security measures we take to make sure you can safely implement Handsontable in your client-side application.
 

--- a/docs/content/guides/security/security/security.md
+++ b/docs/content/guides/security/security/security.md
@@ -122,6 +122,24 @@ new Handsontable(container, {
 });
 ```
 
+### Upgrading from v18.0 to v18.1
+
+If your sanitizer branches on its second argument, two `source` values changed in v18.1:
+
+- `'innerHTML'` is no longer passed by any part of the grid. The offscreen pass that measures [`nestedHeaders`](@/api/options.md#nestedheaders) widths now reports `'header'`, the same value as the rendered header, so one label no longer reaches your sanitizer under two different names.
+- `'dialog'` is now passed for [dialog](@/api/dialog.md) content. In v18.0, that content arrived with `source` set to `undefined`, so it moves out of whatever branch handled `undefined` -- usually the default one -- and into a `'dialog'` branch you may not have written.
+
+A sanitizer that ignores its second argument needs no changes.
+
+v18.1 also added sanitization to two surfaces that were previously written without consulting the sanitizer:
+
+- `'password'` -- content rendered by the [`password`](@/guides/cell-types/password-cell-type/password-cell-type.md) cell type.
+- `'CopyPaste.paste.sourceData'` -- Handsontable's own clipboard payload, used when copying and pasting between two grid instances. See [the note on this source](#what-the-sanitizer-does-not-cover) before deciding how to treat it.
+
+Additionally, as of v18.1, pasted markup is read through `DOMParser`, which builds a document with no browsing context -- HTML pasted from the clipboard cannot load resources or run scripts while it is parsed, regardless of the `sanitizer` configuration.
+
+For step-by-step instructions and code examples, see the [migration guide](@/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md).
+
 ### Trusted Types and CSP
 
 The [Trusted Types API](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) enforces that values reaching a DOM sink came from a policy you wrote. It is not a sanitizer, and it does not replace one. It can require that a sanitizer exists; it cannot be one. A policy such as `createHTML: (input) => input` satisfies the browser and provides no protection at all. What sanitizes is the function you call inside the policy.


### PR DESCRIPTION
## Summary

The Security guide documents the current v18.1 sanitizer source values, but a reader upgrading from v18.0 had no summary of what changed. This adds an "Upgrading from v18.0 to v18.1" subsection covering:

- `'innerHTML'` folded into `'header'` (the offscreen nested-header measurement pass now reports the same source as the rendered header),
- `'dialog'` replacing `undefined` for dialog content,
- the two newly sanitized surfaces, `'password'` and `'CopyPaste.paste.sourceData'`,
- pasted markup now parsing through `DOMParser` (no browsing context), so clipboard HTML cannot load resources or run scripts during parsing regardless of sanitizer configuration.

It closes with a link to the [18.0 → 18.1 migration guide](https://handsontable.com/docs/javascript-data-grid/migration-from-18.0-to-18.1/), which carries the step-by-step examples, so the guide summarizes rather than duplicates.

## Test plan

- Each claim was verified against the 18.0 → 18.1 migration guide sections 6 and 7.
- The `DOMParser` claim was verified against the tags: `18.0.0` parses clipboard markup through live-DOM `innerHTML`, while `18.1.0` introduces `DOMParser` in `parseTable.ts` and `copyPaste.ts`.
- Internal links use existing anchors/paths (`#what-the-sanitizer-does-not-cover`, the migration guide page, `@/api/dialog.md`, the password cell type guide).

[skip changelog]

ClickUp: DEV-2802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the Security guide; no runtime or API code is modified.
> 
> **Overview**
> Adds an **Upgrading from v18.0 to v18.1** subsection under Content sanitizing in the Security guide, so upgraders get a short summary of sanitizer behavior changes without rereading the full migration doc.
> 
> It documents **`source` renames**: `'innerHTML'` is gone (nested-header measurement now uses `'header'`), and dialog HTML now passes `'dialog'` instead of `undefined`. It notes that sanitizer functions that ignore the second argument are unaffected.
> 
> It also calls out **new sanitized surfaces** (`'password'`, `'CopyPaste.paste.sourceData'`) and that **clipboard HTML is parsed via `DOMParser`** (no browsing context during parse). The section links to the existing 18.0→18.1 migration guide for examples.
> 
> Frontmatter gets **`menuTag: updated`** for the sidebar badge on this substantive edit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ca8047837ef585f56fcb00980d5c6ba38782eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->