### PR TITLE
Docs: add vue-data-grid to the Markdown route generator and common.json

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -325,7 +325,7 @@ function commonJsonIntegration() {
   const matter = _require('gray-matter');
   const semver = _require('semver');
   const contentDir = resolve(__dirname, 'content');
-  const PREFIXES = ['javascript-data-grid', 'react-data-grid', 'angular-data-grid'];
+  const PREFIXES = ['javascript-data-grid', 'react-data-grid', 'angular-data-grid', 'vue-data-grid'];
   const MIN_DOCS_VERSION = '9.0';
 
   // ── Version helpers ──────────────────────────────────────────────────────
@@ -578,7 +578,7 @@ function markdownRoutesIntegration() {
   const matter = _require('gray-matter');
   const contentDir = resolve(__dirname, 'content');
   const publicMdDir = resolve(__dirname, 'public', '_md');
-  const PREFIXES = ['javascript-data-grid', 'react-data-grid', 'angular-data-grid'];
+  const PREFIXES = ['javascript-data-grid', 'react-data-grid', 'angular-data-grid', 'vue-data-grid'];
 
   /**
    * Assembles one output file: an H1 from the frontmatter title, then the body


### PR DESCRIPTION
## Summary

The two `PREFIXES` arrays in `docs/astro.config.mjs` listed only `javascript-data-grid`, `react-data-grid`, and `angular-data-grid`, while the content loader renders four frameworks including Vue. Consequences, all silent:

- The **Copy Markdown** button 404s on every Vue docs page (`/docs/_md/vue-data-grid/*.md` was never written).
- The Docs Assistant's `fetchPageMarkdown()` returns `null` on Vue pages, so it answers Vue questions without the page content.
- Vue URLs are absent from `/data/common.json`, the URL list the version-switcher dropdowns use for redirects.

Adds `'vue-data-grid'` to both arrays — one in `markdownRoutesIntegration()` and one in `commonJsonIntegration()`, the same omission in both. The `_md` consumers (`PageSidebar.astro`, `pageContext.ts`) derive slugs from the current path generically and need no changes.

## Test plan

- Full local docs build (packages built first, mirroring the staging workflow): `dist/_md/vue-data-grid/` now contains 336 `.md` files — the same count as each other framework — and `dist/data/common.json` carries 336 `vue-data-grid` URLs (previously 0).
- The generated Vue Markdown is byte-identical to the React output for the same page, confirming the generator is framework-agnostic and Vue gets exactly the established behavior.
- The fix targets the live 18.1 docs, so after merge this needs the usual cherry-pick to `prod-docs/18.1`.

[skip changelog]

ClickUp: SU-874

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only alignment with existing Vue docs routes; no auth, data, or runtime app logic changes.
> 
> **Overview**
> Vue docs were already rendered in Starlight, but the Astro build integrations that emit **Copy Markdown** assets and **`/data/common.json`** only listed three framework prefixes. This PR adds **`vue-data-grid`** to both `PREFIXES` arrays in `commonJsonIntegration()` and `markdownRoutesIntegration()`.
> 
> After the change, builds write Vue pages under `dist/_md/vue-data-grid/` (same pattern as JS/React/Angular) and include Vue URLs in `common.json` for version-switcher redirects. No consumer changes are required—`_md` slug resolution stays path-based.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48c32c0cb1b3a0b397053f0b63a528e7b8b0654c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->