### PR TITLE
PRO-370: Let plugins disable cleanly: Comments, Formulas, and Loading

### DIFF
--- a/.changelogs/13410.json
+++ b/.changelogs/13410.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the `Comments` plugin throwing when enabled a second time, and the `Formulas`, `Comments`, and `Loading` plugins keeping their hooks registered after being disabled.",
+  "type": "fixed",
+  "issueOrPR": 13410,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/.config/plugin/eslint/__tests__/require-tracked-hook-in-enable.test.mjs
+++ b/handsontable/.config/plugin/eslint/__tests__/require-tracked-hook-in-enable.test.mjs
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import { createRequire } from 'node:module';
+import { RuleTester } from 'eslint';
+
+const rule = createRequire(import.meta.url)('../rules/require-tracked-hook-in-enable');
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+test('require-tracked-hook-in-enable', () => {
+  ruleTester.run('require-tracked-hook-in-enable', rule, {
+    valid: [
+      {
+        code: `
+          class P {
+            enablePlugin() {
+              this.addHook('afterInit', () => {});
+            }
+          }
+        `,
+      },
+      {
+        code: `
+          class P {
+            constructor() {
+              this.hot.addHook('afterInit', () => {});
+            }
+            init() {
+              this.hot.addHook('afterInit', () => {});
+            }
+          }
+        `,
+      },
+      {
+        code: `
+          class P {
+            enablePlugin() {
+              other.addHook('afterInit', () => {});
+              this.hot.removeHook('afterInit', fn);
+            }
+          }
+        `,
+      },
+    ],
+    invalid: [
+      {
+        code: `
+          class P {
+            enablePlugin() {
+              this.hot.addHook('afterInit', () => {});
+            }
+          }
+        `,
+        output: `
+          class P {
+            enablePlugin() {
+              this.addHook('afterInit', () => {});
+            }
+          }
+        `,
+        errors: [{ messageId: 'useTrackedAddHook' }],
+      },
+      {
+        code: `
+          class P {
+            enablePlugin() {
+              if (this.enabled) {
+                return;
+              }
+              [1].forEach(() => {
+                this.hot.addHook('afterInit', () => {});
+              });
+            }
+          }
+        `,
+        output: `
+          class P {
+            enablePlugin() {
+              if (this.enabled) {
+                return;
+              }
+              [1].forEach(() => {
+                this.addHook('afterInit', () => {});
+              });
+            }
+          }
+        `,
+        errors: [{ messageId: 'useTrackedAddHook' }],
+      },
+    ],
+  });
+});

--- a/handsontable/.config/plugin/eslint/__tests__/require-tracked-hook-in-enable.test.mjs
+++ b/handsontable/.config/plugin/eslint/__tests__/require-tracked-hook-in-enable.test.mjs
@@ -52,14 +52,20 @@ test('require-tracked-hook-in-enable', () => {
             }
           }
         `,
-        output: `
+        output: null,
+        errors: [{
+          messageId: 'useTrackedAddHook',
+          suggestions: [{
+            messageId: 'replaceWithTrackedAddHook',
+            output: `
           class P {
             enablePlugin() {
               this.addHook('afterInit', () => {});
             }
           }
         `,
-        errors: [{ messageId: 'useTrackedAddHook' }],
+          }],
+        }],
       },
       {
         code: `
@@ -74,7 +80,12 @@ test('require-tracked-hook-in-enable', () => {
             }
           }
         `,
-        output: `
+        output: null,
+        errors: [{
+          messageId: 'useTrackedAddHook',
+          suggestions: [{
+            messageId: 'replaceWithTrackedAddHook',
+            output: `
           class P {
             enablePlugin() {
               if (this.enabled) {
@@ -86,7 +97,8 @@ test('require-tracked-hook-in-enable', () => {
             }
           }
         `,
-        errors: [{ messageId: 'useTrackedAddHook' }],
+          }],
+        }],
       },
     ],
   });

--- a/handsontable/.config/plugin/eslint/index.js
+++ b/handsontable/.config/plugin/eslint/index.js
@@ -12,6 +12,7 @@ module.exports = {
   },
   rules: {
     'restricted-module-imports': require('./rules/restricted-module-imports'),
+    'require-tracked-hook-in-enable': require('./rules/require-tracked-hook-in-enable'),
     'require-async-in-it': require('./rules/require-async-in-it'),
     'require-await': require('./rules/require-await'),
     'no-native-error-throw': require('./rules/no-native-error-throw'),

--- a/handsontable/.config/plugin/eslint/rules/require-tracked-hook-in-enable.js
+++ b/handsontable/.config/plugin/eslint/rules/require-tracked-hook-in-enable.js
@@ -8,7 +8,7 @@ module.exports = {
       recommended: false,
     },
 
-    fixable: 'code',
+    hasSuggestions: true,
 
     messages: {
       useTrackedAddHook: 'Use this.addHook() rather than this.hot.addHook() inside enablePlugin(). ' +
@@ -16,6 +16,7 @@ module.exports = {
         'instance keeps running after the plugin is disabled — usually against state the plugin ' +
         'has already torn down. Register it in the constructor or init() when it genuinely has to ' +
         'outlive a disable.',
+      replaceWithTrackedAddHook: 'Replace this.hot.addHook() with the tracked this.addHook().',
     },
 
     schema: [],
@@ -62,9 +63,12 @@ module.exports = {
         context.report({
           node,
           messageId: 'useTrackedAddHook',
-          fix(fixer) {
-            return fixer.replaceText(callee.object, 'this');
-          },
+          suggest: [{
+            messageId: 'replaceWithTrackedAddHook',
+            fix(fixer) {
+              return fixer.replaceText(callee.object, 'this');
+            },
+          }],
         });
       },
     };

--- a/handsontable/.config/plugin/eslint/rules/require-tracked-hook-in-enable.js
+++ b/handsontable/.config/plugin/eslint/rules/require-tracked-hook-in-enable.js
@@ -1,0 +1,72 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      description: 'Requires plugins to register hooks through the tracked BasePlugin#addHook inside enablePlugin',
+      category: 'Custom',
+      recommended: false,
+    },
+
+    fixable: 'code',
+
+    messages: {
+      useTrackedAddHook: 'Use this.addHook() rather than this.hot.addHook() inside enablePlugin(). ' +
+        'BasePlugin only removes the hooks it registered itself, so a hook added straight to the ' +
+        'instance keeps running after the plugin is disabled — usually against state the plugin ' +
+        'has already torn down. Register it in the constructor or init() when it genuinely has to ' +
+        'outlive a disable.',
+    },
+
+    schema: [],
+  },
+
+  create(context) {
+    /**
+     * Reports whether a node sits inside the body of an `enablePlugin` method.
+     *
+     * @param {object} node The node to test.
+     * @returns {boolean} `true` when an `enablePlugin` method encloses it.
+     */
+    function isWithinEnablePlugin(node) {
+      let current = node.parent;
+
+      while (current) {
+        if (current.type === 'MethodDefinition' && current.key && current.key.name === 'enablePlugin') {
+          return true;
+        }
+
+        current = current.parent;
+      }
+
+      return false;
+    }
+
+    return {
+      CallExpression(node) {
+        const { callee } = node;
+
+        if (callee.type !== 'MemberExpression' || callee.property.name !== 'addHook') {
+          return;
+        }
+
+        const target = callee.object;
+        const isInstanceCall = target.type === 'MemberExpression'
+          && target.object.type === 'ThisExpression'
+          && target.property.name === 'hot';
+
+        if (!isInstanceCall || !isWithinEnablePlugin(node)) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'useTrackedAddHook',
+          fix(fixer) {
+            return fixer.replaceText(callee.object, 'this');
+          },
+        });
+      },
+    };
+  },
+};

--- a/handsontable/.eslintrc.js
+++ b/handsontable/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
   rules: {
     'compat/compat': 'error',
     'handsontable/no-native-error-throw': 'error',
+    'handsontable/require-tracked-hook-in-enable': 'error',
     'no-restricted-syntax': [
       'error',
       'ForInStatement',

--- a/handsontable/AGENTS.md
+++ b/handsontable/AGENTS.md
@@ -17,11 +17,13 @@ This is the core data grid package. **TypeScript** - source files in `src/` are 
 - No direct cross-plugin imports - use hooks for inter-plugin communication, or `hot.getPlugin('Name')` if API access is required
 - Never use raw `setTimeout` - use `this.hot._registerTimeout(fn, delay)` instead; it auto-clears on `hot.destroy()`, preventing memory leaks
 - DRY: reuse existing helpers and mixins; if code repeats, extract a generic helper rather than duplicating
+- Plugin file doing more than two things → split it (see `src/plugins/sheetsBar/` for the sliced layout)
 - Method ordering: public methods first, then private listeners
 - In text and comments, always write `Handsontable`, never `HOT` (a `hot` variable holding an instance is fine)
 - Never call `String.prototype.toLocaleLowerCase`/`toLocaleUpperCase` directly — use `localeLowerCase()` from `helpers/string` (faster, locale-correct, crash-safe). Enforced by `no-restricted-syntax`. See `.ai/CONVENTIONS.md`.
 - Never call a JavaScript method newer than `../browser-targets.js` (Chrome >= 130, Edge >= 130, Firefox >= 132, Safari >= 18.2, iOS >= 18.2 — the pinned Baseline 2024 set). swc lowers syntax only and adds no core-js polyfills, so such a call throws `X is not a function` on a supported browser. Two gates catch this: `tsconfig.json` pins `lib` to `ES_TARGET` (`es2024`) from `../browser-targets.js`, so an above-floor built-in is a type error in `.ts` files; `no-restricted-syntax` covers the same methods plus the 12 remaining `.js` files in `src/` (`allowJs` is off). That rule bans one name, `with` → `arr.slice()` plus an index assignment, and it is above the floor on two engines at once: `core-js-compat` puts `Array#with` at Firefox 140 (against our 132) and `TypedArray#with` at Safari/iOS 26.0 (against our 18.2). Verify any new method's floor against `core-js-compat`'s `data.json` before using it, and add it to the rule when it sits above the floor.
 - `throwWithCause()` assigns `cause` after construction instead of passing the constructor options bag. The options-bag overload is ES2022 (Chrome 94 / Firefox 91 / Safari 15.0) and now sits well inside the floor, so this is no longer a compatibility requirement — it is kept because an engine that accepts the options bag and drops it silently leaves `error.cause` undefined and breaks `error.cause?.handsontable === true` detection with no visible failure. Do not "simplify" it back to `new Error(msg, { cause })` without adding a test that would catch that.
+- `IndexMapper#getIndexesSequence()` returns the mapper's live internal array, not a copy — always copy it with `.slice()` before storing or caching it (`src/plugins/sheetsBar/viewState.ts`), or a later reorder silently corrupts the stored snapshot.
 
 ## Plugin Lifecycle
 
@@ -172,6 +174,7 @@ Source `.ts` files (`src/**/*.ts`, excluding walkontable and test/type files) an
 | `window.scrollTo(...)` | `this.hot.rootWindow.scrollTo(...)` |
 | `document.querySelector(...)` | `this.hot.rootDocument.querySelector(...)` |
 | `console.warn(...)` | `import { warn } from 'helpers/console'; warn(...);` |
+| `this.hot.addHook(...)` inside `enablePlugin()` | `this.addHook(...)` — tracked hooks are removed by `disablePlugin()`; enforced by `handsontable/require-tracked-hook-in-enable` (lexical match only; aliases/helpers are not caught). Rule tests: `npm run test:eslint-rules` in `handsontable/` (run by the Lint core CI job — RuleTester imports `eslint`, so the dependency-free root `test:tooling` job cannot run them) |
 | Missing JSDoc comment (`jsdoc/require-jsdoc`) on a class/method/field/function | Add a multiline block above it with a blank line before `/**` and after `*/` — `/**` on its own line, then ` * Description.`, then ` */`; no `@private` tag on `#`-fields; no `@param`/`@returns` in `.ts` files |
 
 ## Build

--- a/handsontable/AGENTS.md
+++ b/handsontable/AGENTS.md
@@ -17,13 +17,11 @@ This is the core data grid package. **TypeScript** - source files in `src/` are 
 - No direct cross-plugin imports - use hooks for inter-plugin communication, or `hot.getPlugin('Name')` if API access is required
 - Never use raw `setTimeout` - use `this.hot._registerTimeout(fn, delay)` instead; it auto-clears on `hot.destroy()`, preventing memory leaks
 - DRY: reuse existing helpers and mixins; if code repeats, extract a generic helper rather than duplicating
-- Plugin file doing more than two things → split it (see `src/plugins/sheetsBar/` for the sliced layout)
 - Method ordering: public methods first, then private listeners
 - In text and comments, always write `Handsontable`, never `HOT` (a `hot` variable holding an instance is fine)
 - Never call `String.prototype.toLocaleLowerCase`/`toLocaleUpperCase` directly — use `localeLowerCase()` from `helpers/string` (faster, locale-correct, crash-safe). Enforced by `no-restricted-syntax`. See `.ai/CONVENTIONS.md`.
 - Never call a JavaScript method newer than `../browser-targets.js` (Chrome >= 130, Edge >= 130, Firefox >= 132, Safari >= 18.2, iOS >= 18.2 — the pinned Baseline 2024 set). swc lowers syntax only and adds no core-js polyfills, so such a call throws `X is not a function` on a supported browser. Two gates catch this: `tsconfig.json` pins `lib` to `ES_TARGET` (`es2024`) from `../browser-targets.js`, so an above-floor built-in is a type error in `.ts` files; `no-restricted-syntax` covers the same methods plus the 12 remaining `.js` files in `src/` (`allowJs` is off). That rule bans one name, `with` → `arr.slice()` plus an index assignment, and it is above the floor on two engines at once: `core-js-compat` puts `Array#with` at Firefox 140 (against our 132) and `TypedArray#with` at Safari/iOS 26.0 (against our 18.2). Verify any new method's floor against `core-js-compat`'s `data.json` before using it, and add it to the rule when it sits above the floor.
 - `throwWithCause()` assigns `cause` after construction instead of passing the constructor options bag. The options-bag overload is ES2022 (Chrome 94 / Firefox 91 / Safari 15.0) and now sits well inside the floor, so this is no longer a compatibility requirement — it is kept because an engine that accepts the options bag and drops it silently leaves `error.cause` undefined and breaks `error.cause?.handsontable === true` detection with no visible failure. Do not "simplify" it back to `new Error(msg, { cause })` without adding a test that would catch that.
-- `IndexMapper#getIndexesSequence()` returns the mapper's live internal array, not a copy — always copy it with `.slice()` before storing or caching it (`src/plugins/sheetsBar/viewState.ts`), or a later reorder silently corrupts the stored snapshot.
 
 ## Plugin Lifecycle
 
@@ -174,7 +172,7 @@ Source `.ts` files (`src/**/*.ts`, excluding walkontable and test/type files) an
 | `window.scrollTo(...)` | `this.hot.rootWindow.scrollTo(...)` |
 | `document.querySelector(...)` | `this.hot.rootDocument.querySelector(...)` |
 | `console.warn(...)` | `import { warn } from 'helpers/console'; warn(...);` |
-| `this.hot.addHook(...)` inside `enablePlugin()` | `this.addHook(...)` — tracked hooks are removed by `disablePlugin()`; enforced by `handsontable/require-tracked-hook-in-enable` (lexical match only; aliases/helpers are not caught). Rule tests: `npm run test:eslint-rules` in `handsontable/` (run by the Lint core CI job — RuleTester imports `eslint`, so the dependency-free root `test:tooling` job cannot run them) |
+| `this.hot.addHook(...)` inside `enablePlugin()` | `this.addHook(...)` — tracked hooks are removed by `disablePlugin()`; enforced by `handsontable/require-tracked-hook-in-enable` (lexical match only: an alias, a helper, or `this.hot.addHookOnce()` is not caught — `BasePlugin` has no tracked `addHookOnce`, so a `once` hook registered in `enablePlugin()` has to be reasoned about by hand). Rule tests: `npm run test:eslint-rules` in `handsontable/` (run by the Lint core CI job — RuleTester imports `eslint`, so the dependency-free root `test:tooling` job cannot run them) |
 | Missing JSDoc comment (`jsdoc/require-jsdoc`) on a class/method/field/function | Add a multiline block above it with a blank line before `/**` and after `*/` — `/**` on its own line, then ` * Description.`, then ` */`; no `@private` tag on `#`-fields; no `@param`/`@returns` in `.ts` files |
 
 ## Build

--- a/handsontable/scripts/tasks.json
+++ b/handsontable/scripts/tasks.json
@@ -137,7 +137,7 @@
       "mode": "inherit"
     },
     "test:eslint-rules": {
-      "cmd": "node --test .config/plugin/eslint/__tests__/no-fixed-sleep-in-spec.test.mjs",
+      "cmd": "node --test .config/plugin/eslint/__tests__/no-fixed-sleep-in-spec.test.mjs .config/plugin/eslint/__tests__/require-tracked-hook-in-enable.test.mjs",
       "deps": [],
       "mode": "inherit",
       "note": "RuleTester coverage of the custom ESLint rules. Imports `eslint`, so it needs this package's node_modules — that is why it is NOT in the root `test:tooling` glob (CI's `tooling tests` job installs nothing); the `Lint / core` job runs it. Literal paths only, no glob: `node --test` exits 1 (`Could not find`) only when nothing in the list matched AND no pattern is a glob — a glob anywhere turns a missing path into a green `tests 0`, and a second literal file that still exists masks a renamed first one the same way, so a rename would leave the step passing with nothing, or less, run. Add a new rule's test file here by name; test/__tests__/eslintRulesTask.unit.js pins the list in both directions (every file in __tests__ named, every named file present) and bans glob characters."

--- a/handsontable/src/plugins/__tests__/hooksReleasedOnDisable.unit.js
+++ b/handsontable/src/plugins/__tests__/hooksReleasedOnDisable.unit.js
@@ -1,0 +1,62 @@
+import HyperFormula from 'hyperformula';
+import Handsontable from '../../base';
+import { Hooks } from '../../core/hooks';
+import { registerPlugin } from '../registry';
+import { Comments } from '../comments/comments';
+import { Dialog } from '../dialog/dialog';
+import { Formulas } from '../formulas/formulas';
+import { Loading } from '../loading/loading';
+
+describe('Plugin hooks released on disable', () => {
+  let container;
+  let hot;
+
+  beforeAll(() => {
+    registerPlugin(Comments);
+    registerPlugin(Dialog);
+    registerPlugin(Formulas);
+    registerPlugin(Loading);
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    hot?.destroy();
+    hot = null;
+    container.remove();
+  });
+
+  /**
+   * Counts the callbacks registered on the instance for the given hook.
+   *
+   * @param {string} hookName The hook to count.
+   * @returns {number} The number of callbacks.
+   */
+  function hookCount(hookName) {
+    return Hooks.getSingleton().getBucket(hot).getHooks(hookName).length;
+  }
+
+  it.each([
+    ['formulas', { formulas: { engine: HyperFormula } }, 'afterRowMove'],
+    ['comments', { comments: true }, 'afterSetTheme'],
+    ['loading', { loading: true }, 'afterDialogFocus'],
+  ])('removes the hooks the %s plugin registered when it is disabled', (pluginKey, settings, hookName) => {
+    hot = new Handsontable(container, {
+      data: [['1', '2']],
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    const before = hookCount(hookName);
+
+    hot.updateSettings(settings);
+
+    expect(hookCount(hookName)).toBeGreaterThan(before);
+
+    hot.updateSettings({ [pluginKey]: false });
+
+    expect(hookCount(hookName)).toBe(before);
+  });
+});

--- a/handsontable/src/plugins/__tests__/hooksReleasedOnDisable.unit.js
+++ b/handsontable/src/plugins/__tests__/hooksReleasedOnDisable.unit.js
@@ -43,7 +43,7 @@ describe('Plugin hooks released on disable', () => {
     ['formulas', { formulas: { engine: HyperFormula } }, 'afterRowMove'],
     ['comments', { comments: true }, 'afterSetTheme'],
     ['loading', { loading: true }, 'afterDialogFocus'],
-  ])('removes the hooks the %s plugin registered when it is disabled', (pluginKey, settings, hookName) => {
+  ])('releases the hooks the %s plugin owns on disable and registers them again', (pluginKey, settings, hookName) => {
     hot = new Handsontable(container, {
       data: [['1', '2']],
       licenseKey: 'non-commercial-and-evaluation',
@@ -58,5 +58,9 @@ describe('Plugin hooks released on disable', () => {
     hot.updateSettings({ [pluginKey]: false });
 
     expect(hookCount(hookName)).toBe(before);
+
+    hot.updateSettings(settings);
+
+    expect(hookCount(hookName)).toBeGreaterThan(before);
   });
 });

--- a/handsontable/src/plugins/base/AGENTS.md
+++ b/handsontable/src/plugins/base/AGENTS.md
@@ -65,12 +65,15 @@ Details that bite:
   callback in `#hooks` so `disablePlugin()` can remove it; a hook registered straight on the instance
   survives `disablePlugin()` and can fire against a disabled plugin. **The exception is deliberate and
   real** — about two dozen `this.hot.addHook` / `addHookOnce` sites exist across the plugins (filters,
-  dropdownMenu, columnSorting, search, comments, customBorders, columnSummary, formulas, loading,
-  contextMenu/menu), several precisely *because* the listener must outlive `disablePlugin()`:
-  `../loading/` registers `afterDialogFocus` once behind a `#dialogPlugin === null` guard, and the auto-size
-  plugins keep their recalculation listener bound so double-click autofit still works while disabled. So do
+  dropdownMenu, columnSorting, search, customBorders, columnSummary, formulas, contextMenu/menu), several
+  precisely *because* the listener must outlive `disablePlugin()`: the auto-size plugins keep their
+  recalculation listener bound so double-click autofit still works while disabled. So do
   not convert these in a compliance pass — an instance-level hook needs a guard that tolerates being
-  disabled, and the reason belongs in a comment.
+  disabled, and the reason belongs in a comment. `../loading/`'s `afterDialogFocus` used to be listed here
+  and no longer is: it was registered once behind a `#dialogPlugin === null` guard only to keep
+  `updatePlugin()` from doubling it, which the tracked `addHook` handles by itself, and the guard was
+  dropping the hook for good on the first `updateSettings()` (#13410). Inside `enablePlugin()` the tracked
+  form is also enforced by the `handsontable/require-tracked-hook-in-enable` lint rule.
 - **Prefer arrow function class fields, passed directly**: `this.addHook('afterX', this.#onAfterX)`. This is
   the house rule (`../../../AGENTS.md` states it as Required) and it is what makes a listener nameable,
   greppable and individually removable with `removeHooks(name)`. Two corrections to how it is usually

--- a/handsontable/src/plugins/comments/AGENTS.md
+++ b/handsontable/src/plugins/comments/AGENTS.md
@@ -65,6 +65,34 @@ hide is a plain `setTimeout`. The API is `show(range)` / `hide()` / `cancelHidin
 Its internal flag records whether the last action was a show or a hide. Anything that hides the tooltip
 clears that flag — which is exactly the shadow-DOM double-binding failure above.
 
+## What survives a disable, and what has to be registered again
+
+`disablePlugin()` removes every hook registered through the tracked `this.addHook()`, but the objects the
+plugin built stay: `#editor` and `#displaySwitch` are created behind `if (!...)` guards and live until
+`destroy()`. So the two kinds of listener go in opposite places, and #13410 got both wrong before it fixed
+them:
+
+- **`afterSetTheme` is registered on every `enablePlugin()`**, outside the `#editor` create guard. Inside
+  it, the hook is removed by the first disable and never comes back, and a theme change then stops hiding
+  the editor.
+- **The `DisplaySwitch` `hide` / `show` local hooks are registered inside the create guard**, with the
+  switch itself. `addLocalHook` in `../../mixins/localHooks.ts` pushes without a dedupe check, so
+  registering them per enable leaves another pair behind on each round trip and one hover ends up running
+  `showAtCell()` once per past enable. The editor's `resize` hook sits inside its guard for the same
+  reason.
+
+The shortcut context is a third case: `ShortcutManager` can create a context but never drop one, so
+`plugin:comments` is immortal.
+
+- `registerShortcuts()` takes it with `getOrCreateContext(SHORTCUTS_CONTEXT_NAME)`. `getContext` would
+  throw `The "plugin:comments" context is already registered` on the second enable.
+- `unregisterShortcuts()` calls `removeShortcutsByGroup(SHORTCUTS_GROUP)` on **both** `grid` and
+  `plugin:comments`. Skipping the plugin context leaves a second copy of every shortcut in it after a
+  re-enable.
+- `disablePlugin()` also checks `getActiveContextName()` and hands the keyboard back to `grid`. Disabling
+  the plugin while its editor had the focus otherwise leaves the emptied plugin context active, and the
+  grid ignores the keyboard until the next click.
+
 ## Editor positioning
 
 - **Reset the editor position to (0, 0) before measuring**, or the previous position influences the
@@ -83,7 +111,8 @@ clears that flag — which is exactly the shadow-DOM double-binding failure abov
 
 - The menu the items land in: `../contextMenu/AGENTS.md`.
 - Theme reaction: this plugin listens on `afterSetTheme` — `useTheme()` does not go through
-  `updateSettings`, so nothing else would notice.
+  `updateSettings`, so nothing else would notice. The hook is re-registered on every enable; see
+  [What survives a disable](#what-survives-a-disable-and-what-has-to-be-registered-again).
 - Cell meta storage and eviction: `../../dataMap/metaManager/AGENTS.md`.
 - Plugin contract, lifecycle, priorities: `../base/AGENTS.md`.
 

--- a/handsontable/src/plugins/comments/__tests__/comments.unit.js
+++ b/handsontable/src/plugins/comments/__tests__/comments.unit.js
@@ -72,4 +72,21 @@ describe('Comments plugin lifecycle', () => {
 
     expect(manager.getActiveContextName()).toBe('grid');
   });
+
+  it('keeps hiding the editor on theme changes after a disable/enable round trip', () => {
+    hot = new Handsontable(container, {
+      data: [['a']],
+      comments: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    hot.updateSettings({ comments: false });
+    hot.updateSettings({ comments: true });
+
+    const hide = jest.spyOn(hot.getPlugin('comments'), 'hide');
+
+    hot.runHooks('afterSetTheme', 'ht-theme-main', false);
+
+    expect(hide).toHaveBeenCalledTimes(1);
+  });
 });

--- a/handsontable/src/plugins/comments/__tests__/comments.unit.js
+++ b/handsontable/src/plugins/comments/__tests__/comments.unit.js
@@ -1,6 +1,7 @@
 import Handsontable from '../../../base';
 import { registerPlugin } from '../../registry';
 import { Comments } from '../comments';
+import DisplaySwitch from '../displaySwitch';
 
 describe('Comments plugin lifecycle', () => {
   let container;
@@ -71,6 +72,28 @@ describe('Comments plugin lifecycle', () => {
     hot.updateSettings({ comments: false });
 
     expect(manager.getActiveContextName()).toBe('grid');
+  });
+
+  it('registers the display switch listeners once, however many times it is enabled', () => {
+    const addLocalHook = jest.spyOn(DisplaySwitch.prototype, 'addLocalHook');
+
+    hot = new Handsontable(container, {
+      data: [['a']],
+      comments: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    hot.updateSettings({ comments: false });
+    hot.updateSettings({ comments: true });
+    hot.updateSettings({ comments: false });
+    hot.updateSettings({ comments: true });
+
+    const keys = addLocalHook.mock.calls.map(([key]) => key);
+
+    expect(keys.filter(key => key === 'hide')).toHaveLength(1);
+    expect(keys.filter(key => key === 'show')).toHaveLength(1);
+
+    addLocalHook.mockRestore();
   });
 
   it('keeps hiding the editor on theme changes after a disable/enable round trip', () => {

--- a/handsontable/src/plugins/comments/__tests__/comments.unit.js
+++ b/handsontable/src/plugins/comments/__tests__/comments.unit.js
@@ -1,0 +1,75 @@
+import Handsontable from '../../../base';
+import { registerPlugin } from '../../registry';
+import { Comments } from '../comments';
+
+describe('Comments plugin lifecycle', () => {
+  let container;
+  let hot;
+
+  beforeAll(() => {
+    registerPlugin(Comments);
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    hot?.destroy();
+    hot = null;
+    container.remove();
+  });
+
+  it('can be switched off and on again', () => {
+    hot = new Handsontable(container, {
+      data: [['a']],
+      comments: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    // The plugin owns a shortcut context, and the manager has no way to drop one — so a second
+    // enable has to reuse the context rather than claim it again.
+    expect(() => {
+      hot.updateSettings({ comments: false });
+      hot.updateSettings({ comments: true });
+      hot.updateSettings({ comments: false });
+      hot.updateSettings({ comments: true });
+    }).not.toThrow();
+
+    expect(hot.getPlugin('comments').enabled).toBe(true);
+  });
+
+  it('leaves one copy of its shortcuts behind after a re-enable', () => {
+    hot = new Handsontable(container, {
+      data: [['a']],
+      comments: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    const context = () => hot.getShortcutManager().getContext('plugin:comments');
+    const before = context().getShortcuts(['Escape']).length;
+
+    hot.updateSettings({ comments: false });
+    hot.updateSettings({ comments: true });
+
+    expect(context().getShortcuts(['Escape']).length).toBe(before);
+  });
+
+  it('hands the keyboard back to the grid when disabled while its editor has focus', () => {
+    hot = new Handsontable(container, {
+      data: [['a']],
+      comments: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    const manager = hot.getShortcutManager();
+
+    hot.getPlugin('comments').showAtCell(0, 0);
+    manager.setActiveContextName('plugin:comments');
+
+    hot.updateSettings({ comments: false });
+
+    expect(manager.getActiveContextName()).toBe('grid');
+  });
+});

--- a/handsontable/src/plugins/comments/comments.ts
+++ b/handsontable/src/plugins/comments/comments.ts
@@ -330,6 +330,8 @@ export class Comments extends BasePlugin {
 
     if (!this.#displaySwitch) {
       this.#displaySwitch = new DisplaySwitch(this.getSetting<number>('displayDelay'));
+      this.#displaySwitch.addLocalHook('hide', () => this.hide());
+      this.#displaySwitch.addLocalHook('show', (row: number, col: number) => this.showAtCell(row, col));
     }
 
     this.addHook('afterContextMenuDefaultOptions',
@@ -342,9 +344,6 @@ export class Comments extends BasePlugin {
     this.addHook('afterBeginEditing', () => this.hide());
     this.addHook('afterDocumentKeyDown', this.#onAfterDocumentKeyDown);
     this.addHook('beforeCompositionStart', this.#onAfterDocumentKeyDown);
-
-    this.#displaySwitch?.addLocalHook('hide', () => this.hide());
-    this.#displaySwitch?.addLocalHook('show', (row: number, col: number) => this.showAtCell(row, col));
 
     this.registerShortcuts();
     this.registerListeners();

--- a/handsontable/src/plugins/comments/comments.ts
+++ b/handsontable/src/plugins/comments/comments.ts
@@ -317,7 +317,7 @@ export class Comments extends BasePlugin {
       this.#editor = new CommentEditor(this.hot.rootDocument, this.hot.isRtl(), this.hot.rootPortalElement);
       this.#editor?.addLocalHook('resize',
         (width: number, height: number) => this.#onEditorResize(width, height));
-      this.hot.addHook('afterSetTheme', (themeName: string, firstRun: boolean) => {
+      this.addHook('afterSetTheme', (themeName: string, firstRun: boolean) => {
         if (!firstRun) {
           this.hide();
         }
@@ -362,6 +362,14 @@ export class Comments extends BasePlugin {
    * Disables the plugin functionality for this Handsontable instance.
    */
   disablePlugin(): void {
+    const manager = this.hot.getShortcutManager();
+
+    this.hide();
+
+    if (manager.getActiveContextName() === SHORTCUTS_CONTEXT_NAME) {
+      manager.setActiveContextName('grid');
+    }
+
     this.unregisterShortcuts();
     // The marker class is written on the element by `afterRenderer`, from the cell meta. Once the
     // hook is gone only a paint removes it, so under `renderMode: 'onChange'` every cell must paint.
@@ -377,7 +385,7 @@ export class Comments extends BasePlugin {
   registerShortcuts() {
     const manager = this.hot.getShortcutManager();
     const gridContext = manager.getContext('grid');
-    const pluginContext = manager.addContext(SHORTCUTS_CONTEXT_NAME);
+    const pluginContext = manager.getOrCreateContext(SHORTCUTS_CONTEXT_NAME);
 
     gridContext?.addShortcut({
       keys: [['Control', 'Alt', 'M']],
@@ -445,9 +453,14 @@ export class Comments extends BasePlugin {
    * @private
    */
   unregisterShortcuts() {
-    this.hot.getShortcutManager()
-      .getContext('grid')
-      ?.removeShortcutsByGroup(SHORTCUTS_GROUP);
+    const manager = this.hot.getShortcutManager();
+
+    manager.getContext('grid')?.removeShortcutsByGroup(SHORTCUTS_GROUP);
+
+    // The plugin's own context outlives a disable — the manager has no way to drop one — so its
+    // shortcuts are cleared here as well. Re-enabling reuses the context, and without this it
+    // would carry a second copy of every shortcut in it.
+    manager.getContext(SHORTCUTS_CONTEXT_NAME)?.removeShortcutsByGroup(SHORTCUTS_GROUP);
   }
 
   /**

--- a/handsontable/src/plugins/comments/comments.ts
+++ b/handsontable/src/plugins/comments/comments.ts
@@ -317,12 +317,16 @@ export class Comments extends BasePlugin {
       this.#editor = new CommentEditor(this.hot.rootDocument, this.hot.isRtl(), this.hot.rootPortalElement);
       this.#editor?.addLocalHook('resize',
         (width: number, height: number) => this.#onEditorResize(width, height));
-      this.addHook('afterSetTheme', (themeName: string, firstRun: boolean) => {
-        if (!firstRun) {
-          this.hide();
-        }
-      });
     }
+
+    // Registered on every enable, not only when the editor is first built: tracked hooks are
+    // removed by disablePlugin() while the editor instance survives it, so a hook inside the
+    // first-create guard would be gone for good after one disable/enable round trip.
+    this.addHook('afterSetTheme', (themeName: string, firstRun: boolean) => {
+      if (!firstRun) {
+        this.hide();
+      }
+    });
 
     if (!this.#displaySwitch) {
       this.#displaySwitch = new DisplaySwitch(this.getSetting<number>('displayDelay'));

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -674,50 +674,50 @@ export class Formulas extends BasePlugin {
     this.rowAxisSyncer = this.indexSyncer.getForAxis('row');
     this.columnAxisSyncer = this.indexSyncer.getForAxis('column');
 
-    this.hot.addHook('afterRowSequenceChange', this.rowAxisSyncer!.getIndexesChangeSyncMethod());
-    this.hot.addHook('afterColumnSequenceChange', this.columnAxisSyncer!.getIndexesChangeSyncMethod());
+    this.addHook('afterRowSequenceChange', this.rowAxisSyncer!.getIndexesChangeSyncMethod());
+    this.addHook('afterColumnSequenceChange', this.columnAxisSyncer!.getIndexesChangeSyncMethod());
 
-    this.hot.addHook('beforeRowMove',
+    this.addHook('beforeRowMove',
       (movedRows: number[], finalIndex: number, _dropIndex: number | undefined, movePossible: boolean) => {
         this.rowAxisSyncer!.storeMovesInformation(movedRows, finalIndex, movePossible);
       });
 
-    this.hot.addHook('beforeColumnMove',
+    this.addHook('beforeColumnMove',
       (movedColumns: number[], finalIndex: number, _dropIndex: number | undefined, movePossible: boolean) => {
         this.columnAxisSyncer!.storeMovesInformation(movedColumns, finalIndex, movePossible);
       });
 
-    this.hot.addHook('afterRowMove',
+    this.addHook('afterRowMove',
       (_movedRows: number[], _finalIndex: number, _dropIndex: number | undefined,
        movePossible: boolean, orderChanged: boolean) => {
         this.rowAxisSyncer!.calculateAndSyncMoves(movePossible, orderChanged);
       });
 
-    this.hot.addHook('afterColumnMove',
+    this.addHook('afterColumnMove',
       (_movedColumns: number[], _finalIndex: number, _dropIndex: number | undefined,
        movePossible: boolean, orderChanged: boolean) => {
         this.columnAxisSyncer!.calculateAndSyncMoves(movePossible, orderChanged);
       });
 
-    this.hot.addHook('beforeColumnFreeze', (column: number, freezePerformed: boolean) => {
+    this.addHook('beforeColumnFreeze', (column: number, freezePerformed: boolean) => {
       const fixedColumnsStart = this.hot.getSettings().fixedColumnsStart;
 
       this.columnAxisSyncer!.storeMovesInformation(
         [column], fixedColumnsStart!, freezePerformed);
     });
 
-    this.hot.addHook('afterColumnFreeze', (_column: number, freezePerformed: boolean) => {
+    this.addHook('afterColumnFreeze', (_column: number, freezePerformed: boolean) => {
       this.columnAxisSyncer!.calculateAndSyncMoves(freezePerformed, freezePerformed);
     });
 
-    this.hot.addHook('beforeColumnUnfreeze', (column: number, unfreezePerformed: boolean) => {
+    this.addHook('beforeColumnUnfreeze', (column: number, unfreezePerformed: boolean) => {
       const fixedColumnsStart = this.hot.getSettings().fixedColumnsStart;
 
       this.columnAxisSyncer!.storeMovesInformation(
         [column], fixedColumnsStart! - 1, unfreezePerformed);
     });
 
-    this.hot.addHook('afterColumnUnfreeze', (_column: number, unfreezePerformed: boolean) => {
+    this.addHook('afterColumnUnfreeze', (_column: number, unfreezePerformed: boolean) => {
       this.columnAxisSyncer!.calculateAndSyncMoves(unfreezePerformed, unfreezePerformed);
     });
 

--- a/handsontable/src/plugins/loading/AGENTS.md
+++ b/handsontable/src/plugins/loading/AGENTS.md
@@ -14,9 +14,13 @@ plugin.
   `isVisible()`, `show()`, `hide()`, `update()` — delegates to the dialog. Every one of those methods
   re-checks `this.#dialogPlugin?.isEnabled()` before acting, because a user can switch `dialog: false` back
   off at any time.
-- **The dialog reference and the `afterDialogFocus` hook are wired once**, guarded on
-  `#dialogPlugin === null`. `updatePlugin()` runs the usual `disablePlugin(); enablePlugin();` cycle, so
-  without that guard the hook would be registered again on every settings update.
+- **The dialog reference is resolved once**, guarded on `#dialogPlugin === null`, and it outlives a
+  disable. **The `afterDialogFocus` hook is not**: it is registered with the tracked `this.addHook(...)` on
+  every `enablePlugin()`, outside that guard, so `disablePlugin()` drops it and the next enable puts it
+  back. `updatePlugin()` runs the usual `disablePlugin(); enablePlugin();` cycle, and the tracked
+  registration is what keeps that from doubling the hook. Registering it inside the guard is the older
+  shape and it silently loses the hook on the first `updateSettings()` (fixed in #13410, covered by
+  `src/plugins/__tests__/hooksReleasedOnDisable.unit.js`).
 
 ## `show()` is idempotent, and vetoable only on a real open
 

--- a/handsontable/src/plugins/loading/loading.ts
+++ b/handsontable/src/plugins/loading/loading.ts
@@ -210,9 +210,12 @@ export class Loading extends BasePlugin {
       if (!this.#dialogPlugin?.isEnabled()) {
         this.hot.getSettings().dialog = true;
       }
-
-      this.hot.addHook('afterDialogFocus', () => this.#onAfterDialogFocus());
     }
+
+    // Registered on every enable, not only on the first: disabling the plugin removes its hooks
+    // while the dialog reference above survives, so a hook inside that branch would be gone
+    // after the first updateSettings.
+    this.addHook('afterDialogFocus', () => this.#onAfterDialogFocus());
 
     super.enablePlugin();
   }


### PR DESCRIPTION
### Context

The PR fixes three plugin-lifecycle defects found while building the SheetsBar plugin (stacked under #13409, which needs them for its per-sheet settings switching):

- The `Comments` plugin threw `The "plugin:comments" context is already registered` when enabled a second time, and disabling it while its editor had the focus left an empty shortcut context holding the keyboard until a click. It now reuses the context, clears only its own shortcut group, hides the editor, and hands the grid context back.
- `Formulas`, `Comments`, and `Loading` registered hooks in `enablePlugin()` through the untracked `hot.addHook()`, so the hooks kept firing after the plugin was disabled — a disabled `Formulas` kept calling into a dead engine (`getSheetWidth` errors). They register tracked hooks now, and a new lint rule (`handsontable/require-tracked-hook-in-enable`, with autofix) keeps it that way.
- The hook-release test this adds caught `Loading` registering its `afterDialogFocus` hook only on the first enable, so any `updateSettings()` call silently dropped it; the hook registers on every enable now.

### How has this been tested?

- `npm run test:unit --prefix handsontable --testPathPattern="comments|hooksReleasedOnDisable|formulas|loading"` — including a test that counts each plugin's hooks before and after a disable, and Comments re-enable/keyboard-handback tests. Mutation-checked: each test fails with its fix reverted.
- `npm run test:eslint-rules` in `handsontable/` — RuleTester coverage for the new rule (runs in the Lint core CI job; the rule test imports `eslint`, so it stays out of the dependency-free root `test:tooling` job).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. PRO-370

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core plugin enable/disable paths (Comments shortcuts, Formulas engine sync hooks, Loading/dialog focus); regressions would show as duplicate hooks, broken re-enable, or stale listeners after disable.
> 
> **Overview**
> Fixes plugin lifecycle bugs when toggling **Comments**, **Formulas**, or **Loading** off and on via `updateSettings()`.
> 
> **Comments** no longer throws on a second enable (`getOrCreateContext` for `plugin:comments`), duplicate shortcuts after re-enable are avoided by clearing the plugin shortcut group on disable, focus returns to `grid` when disabled with the editor open, and hook/local-listener registration is split correctly between “every enable” (`afterSetTheme` via tracked `this.addHook`) vs “create once” (`DisplaySwitch` local hooks).
> 
> **Formulas** and **Loading** (and related **Comments** hooks) now register instance hooks through **`this.addHook()`** so `disablePlugin()` tears them down; **Loading**’s `afterDialogFocus` is re-registered on each enable instead of being lost after the first settings update.
> 
> Adds ESLint rule **`handsontable/require-tracked-hook-in-enable`**, unit tests for hook counts and Comments lifecycle, and changelog **#13410**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b5483c92d7300242d0ea87ab79dd30a994d9c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->