### PR TITLE
DEV-2824: Highlight the 18.1 features on the changes-between-versions page

### DIFF
--- a/docs/content/data/version-highlights/18.1.json
+++ b/docs/content/data/version-highlights/18.1.json
@@ -1,4 +1,25 @@
 {
   "version": "18.1",
-  "highlighted": []
+  "highlighted": [
+    {
+      "prNumber": 13194,
+      "tagline": "Shadow DOM and Salesforce support",
+      "whyItMatters": "The grid now works inside Shadow DOM and sandboxed hosts such as Salesforce Lightning Web Components: the cell editor stays open when clicked, copy and paste work, focus is released when it leaves the grid, an outside click clears the selection, and the grid's z-index values no longer paint over the host page's UI."
+    },
+    {
+      "prNumber": 12951,
+      "tagline": "Single-pass rendering",
+      "whyItMatters": "The grid predicts whether scrollbars will appear instead of rendering, measuring, and re-rendering, which cuts the work of the initial render and of every scroll step. It is one of over 20 performance changes in 18.1 that also cover sorting, filtering, index translation, and cell metadata memory - use the new `modifySinglePassLayout` hook to keep a table on the previous layout path."
+    },
+    {
+      "prNumber": 13076,
+      "tagline": "Resize and move a selection by dragging",
+      "whyItMatters": "The `selectionHandles` option shows draggable handles at each edge midpoint of a selected range, so you can resize the selection with a pointer. The `moveCells` option lets you drag a selection's border to move its cells to another location."
+    },
+    {
+      "prNumber": 13151,
+      "tagline": "New intl-datetime cell type",
+      "whyItMatters": "The `intl-datetime` cell type edits dates and times in one cell with a native date-time picker, and displays them through `Intl.DateTimeFormat` with the new `dateTimeFormat` option. Column sorting, filtering, and XLSX export work with it out of the box."
+    }
+  ]
 }

--- a/docs/content/data/version-highlights/18.1.json
+++ b/docs/content/data/version-highlights/18.1.json
@@ -9,7 +9,7 @@
     {
       "prNumber": 12951,
       "tagline": "Single-pass rendering",
-      "whyItMatters": "The grid predicts whether scrollbars will appear instead of rendering, measuring, and re-rendering, which cuts the work of the initial render and of every scroll step. It is one of over 20 performance changes in 18.1 that also cover sorting, filtering, index translation, and cell metadata memory - use the new `modifySinglePassLayout` hook to keep a table on the previous layout path."
+      "whyItMatters": "The grid predicts whether scrollbars will appear instead of rendering, measuring, and re-rendering, which cuts the work of the initial render and of every scroll step. It is one of over 20 performance changes in 18.1 that also cover sorting, filtering, index translation, and cell metadata memory. Use the new `modifySinglePassLayout` hook to keep a table on the previous layout path."
     },
     {
       "prNumber": 13076,

--- a/docs/src/components/VersionComparison/VersionComparison.tsx
+++ b/docs/src/components/VersionComparison/VersionComparison.tsx
@@ -142,22 +142,26 @@ function matchesFilter(entry: VersionEntry, filter: FilterKind): boolean {
   }
 }
 
-// Breaking highlights are also surfaced on the New tab for now, so a major
-// release's headline features (often breaking, e.g. a TypeScript migration or a
-// new layout system) stay visible on the default landing view. Set this to false
-// to revert to showing breaking highlights only on the Breaking and All tabs.
-const SHOW_BREAKING_HIGHLIGHTS_ON_NEW = true;
+// Every highlight is also surfaced on the New tab, so a release's headline
+// features stay visible on the default landing view whichever changelog section
+// they were filed under. An author picks at most five highlights per release
+// (see docs/scripts/validate-version-highlights.mjs), and the section a feature
+// lands in is an implementation detail of the changelog: 18.1's Shadow DOM
+// support sits under Fixed and its single-pass rendering under Changed. Set this
+// to false to revert to showing a highlight only on All and on the tab matching
+// its own category.
+const SHOW_HIGHLIGHTS_ON_NEW = true;
 
 // Whether a highlighted entry renders as a featured card under the active filter.
 // A highlight always shows on All and on the tab matching its own category
 // (a deprecated highlight on Deprecated, a breaking one on Breaking, and so on),
 // so it never leaks onto an unrelated tab. The one exception is the revertable
-// rule above that also promotes breaking highlights onto New.
+// rule above that also promotes every highlight onto New.
 function isFeatured(entry: VersionEntry, filter: FilterKind): boolean {
   if (!entry.highlighted) return false;
   if (filter === 'all') return true;
   if (matchesFilter(entry, filter)) return true;
-  return SHOW_BREAKING_HIGHLIGHTS_ON_NEW && filter === 'new' && entry.breaking;
+  return SHOW_HIGHLIGHTS_ON_NEW && filter === 'new';
 }
 
 interface FilterTabsProps {
@@ -296,8 +300,27 @@ const COMPACT_THRESHOLD = 5;
 
 function ReleaseGroup({ version, entries, filter }: { version: string; entries: VersionEntry[]; filter: FilterKind }) {
   const [expanded, setExpanded] = useState(false);
-  const featured = entries.filter((e) => isFeatured(e, filter));
-  const compact = entries.filter((e) => !isFeatured(e, filter));
+  // One PR can be cited by two changelog bullets in different sections (18.1's
+  // #12951 is both an `added` hook and a `changed` render path; 16.1's #11790 is
+  // both `added` and `deprecated`). Both bullets carry the same highlight, so
+  // only the first renders as a featured card and the other keeps its place in
+  // the compact list - but only on a tab its own category belongs to, so a
+  // promoted highlight does not drag a second bullet onto the New tab.
+  const featured: VersionEntry[] = [];
+  const compact: VersionEntry[] = [];
+  const featuredPrNumbers = new Set<number>();
+
+  for (const entry of entries) {
+    const alreadyFeatured = entry.prNumber !== null && featuredPrNumbers.has(entry.prNumber);
+
+    if (isFeatured(entry, filter) && !alreadyFeatured) {
+      if (entry.prNumber !== null) featuredPrNumbers.add(entry.prNumber);
+      featured.push(entry);
+    } else if (!alreadyFeatured || matchesFilter(entry, filter)) {
+      compact.push(entry);
+    }
+  }
+
   const isCollapsible = compact.length > COMPACT_THRESHOLD;
   const shown = !isCollapsible || expanded
     ? compact

--- a/docs/src/components/VersionComparison/VersionComparison.tsx
+++ b/docs/src/components/VersionComparison/VersionComparison.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { ChangeCategory, FilterKind, ReleaseSummary, VersionComparisonData, VersionEntry } from './types';
+import { isFeatured, matchesFilter, partitionEntries } from './featuredEntries';
 
 function readData(): VersionComparisonData {
   const el = document.getElementById('version-comparison-data');
@@ -131,38 +132,6 @@ const FILTER_LABELS: Record<FilterKind, string> = {
   breaking: 'Breaking',
   all: 'All',
 };
-
-function matchesFilter(entry: VersionEntry, filter: FilterKind): boolean {
-  switch (filter) {
-    case 'all': return true;
-    case 'breaking': return entry.breaking;
-    case 'deprecated': return entry.category === 'deprecated' && !entry.breaking;
-    case 'new': return entry.category === 'added' && !entry.breaking;
-    case 'fixed': return entry.category === 'fixed' && !entry.breaking;
-  }
-}
-
-// Every highlight is also surfaced on the New tab, so a release's headline
-// features stay visible on the default landing view whichever changelog section
-// they were filed under. An author picks at most five highlights per release
-// (see docs/scripts/validate-version-highlights.mjs), and the section a feature
-// lands in is an implementation detail of the changelog: 18.1's Shadow DOM
-// support sits under Fixed and its single-pass rendering under Changed. Set this
-// to false to revert to showing a highlight only on All and on the tab matching
-// its own category.
-const SHOW_HIGHLIGHTS_ON_NEW = true;
-
-// Whether a highlighted entry renders as a featured card under the active filter.
-// A highlight always shows on All and on the tab matching its own category
-// (a deprecated highlight on Deprecated, a breaking one on Breaking, and so on),
-// so it never leaks onto an unrelated tab. The one exception is the revertable
-// rule above that also promotes every highlight onto New.
-function isFeatured(entry: VersionEntry, filter: FilterKind): boolean {
-  if (!entry.highlighted) return false;
-  if (filter === 'all') return true;
-  if (matchesFilter(entry, filter)) return true;
-  return SHOW_HIGHLIGHTS_ON_NEW && filter === 'new';
-}
 
 interface FilterTabsProps {
   value: FilterKind;
@@ -300,27 +269,7 @@ const COMPACT_THRESHOLD = 5;
 
 function ReleaseGroup({ version, entries, filter }: { version: string; entries: VersionEntry[]; filter: FilterKind }) {
   const [expanded, setExpanded] = useState(false);
-  // One PR can be cited by two changelog bullets in different sections (18.1's
-  // #12951 is both an `added` hook and a `changed` render path; 16.1's #11790 is
-  // both `added` and `deprecated`). Both bullets carry the same highlight, so
-  // only the first renders as a featured card and the other keeps its place in
-  // the compact list - but only on a tab its own category belongs to, so a
-  // promoted highlight does not drag a second bullet onto the New tab.
-  const featured: VersionEntry[] = [];
-  const compact: VersionEntry[] = [];
-  const featuredPrNumbers = new Set<number>();
-
-  for (const entry of entries) {
-    const alreadyFeatured = entry.prNumber !== null && featuredPrNumbers.has(entry.prNumber);
-
-    if (isFeatured(entry, filter) && !alreadyFeatured) {
-      if (entry.prNumber !== null) featuredPrNumbers.add(entry.prNumber);
-      featured.push(entry);
-    } else if (!alreadyFeatured || matchesFilter(entry, filter)) {
-      compact.push(entry);
-    }
-  }
-
+  const { featured, compact } = partitionEntries(entries, filter);
   const isCollapsible = compact.length > COMPACT_THRESHOLD;
   const shown = !isCollapsible || expanded
     ? compact

--- a/docs/src/components/VersionComparison/featuredEntries.ts
+++ b/docs/src/components/VersionComparison/featuredEntries.ts
@@ -1,0 +1,76 @@
+import type { FilterKind, VersionEntry } from './types';
+
+/**
+ * Whether an entry belongs to the tab the reader picked. Drives both the tab
+ * counts and the compact list.
+ */
+export function matchesFilter(entry: VersionEntry, filter: FilterKind): boolean {
+  switch (filter) {
+    case 'all': return true;
+    case 'breaking': return entry.breaking;
+    case 'deprecated': return entry.category === 'deprecated' && !entry.breaking;
+    case 'new': return entry.category === 'added' && !entry.breaking;
+    case 'fixed': return entry.category === 'fixed' && !entry.breaking;
+  }
+}
+
+// Every highlight is also surfaced on the New tab, so a release's headline
+// features stay visible on the default landing view whichever changelog section
+// they were filed under. An author picks at most five highlights per release
+// (see docs/scripts/validate-version-highlights.mjs), and the section a feature
+// lands in is an implementation detail of the changelog: 18.1's Shadow DOM
+// support sits under Fixed and its single-pass rendering under Changed. Set this
+// to false to revert to showing a highlight only on All and on the tab matching
+// its own category.
+export const SHOW_HIGHLIGHTS_ON_NEW = true;
+
+/**
+ * Whether a highlighted entry renders as a featured card under the active
+ * filter. A highlight always shows on All and on the tab matching its own
+ * category (a deprecated highlight on Deprecated, a breaking one on Breaking,
+ * and so on), so it never leaks onto an unrelated tab. The one exception is the
+ * revertable rule above that also promotes every highlight onto New.
+ */
+export function isFeatured(entry: VersionEntry, filter: FilterKind): boolean {
+  if (!entry.highlighted) return false;
+  if (filter === 'all') return true;
+  if (matchesFilter(entry, filter)) return true;
+  return SHOW_HIGHLIGHTS_ON_NEW && filter === 'new';
+}
+
+/**
+ * Splits one release's entries into featured cards and compact rows.
+ *
+ * One PR can be cited by two changelog bullets in different sections (18.1's
+ * #12951 is both an `added` hook and a `changed` render path; 16.1's #11790 is
+ * both `added` and `deprecated`). Both bullets carry the same highlight, so only
+ * the first renders as a featured card - which also means the card's pill comes
+ * from the section that appears first in the changelog. The other bullet keeps
+ * its place in the compact list, but only on a tab its own category belongs to,
+ * so a promoted highlight does not drag a second bullet onto the New tab.
+ *
+ * Expects entries already narrowed by `isFeatured(e, filter) || matchesFilter(e,
+ * filter)`, which is what the page's visible set holds. An entry outside that
+ * set is dropped rather than listed.
+ */
+export function partitionEntries(
+  entries: VersionEntry[],
+  filter: FilterKind,
+): { featured: VersionEntry[]; compact: VersionEntry[] } {
+  const featured: VersionEntry[] = [];
+  const compact: VersionEntry[] = [];
+  const featuredPrNumbers = new Set<number>();
+
+  for (const entry of entries) {
+    const alreadyFeatured = entry.prNumber !== null && featuredPrNumbers.has(entry.prNumber);
+
+    if (isFeatured(entry, filter) && !alreadyFeatured) {
+      if (entry.prNumber !== null) featuredPrNumbers.add(entry.prNumber);
+      featured.push(entry);
+    } else if (matchesFilter(entry, filter)) {
+      compact.push(entry);
+    }
+  }
+
+  return { featured, compact };
+}

--- a/docs/src/components/__tests__/version-comparison-featured.test.mjs
+++ b/docs/src/components/__tests__/version-comparison-featured.test.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import ts from 'typescript';
+
+const modulePath = fileURLToPath(
+  new URL('../VersionComparison/featuredEntries.ts', import.meta.url),
+);
+const transpiled = ts.transpileModule(readFileSync(modulePath, 'utf8'), {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+  },
+}).outputText;
+
+const { isFeatured, matchesFilter, partitionEntries } = await import(
+  `data:text/javascript;charset=utf-8,${encodeURIComponent(transpiled)}`
+);
+
+function entry(overrides = {}) {
+  return {
+    version: '18.1.0',
+    releaseDate: '2026-09-01',
+    category: 'added',
+    breaking: false,
+    framework: 'core',
+    prNumber: 1,
+    prKind: 'pull',
+    title: 'A change',
+    highlighted: false,
+    ...overrides,
+  };
+}
+
+// The page hands each release group the entries its filter admits. Mirroring
+// that here keeps the fixtures honest about partitionEntries' precondition.
+function visible(entries, filter) {
+  return entries.filter((e) => isFeatured(e, filter) || matchesFilter(e, filter));
+}
+
+function partitionVisible(entries, filter) {
+  return partitionEntries(visible(entries, filter), filter);
+}
+
+test('a highlight filed under Fixed is featured on the New tab', () => {
+  const shadowDom = entry({ category: 'fixed', prNumber: 13194, highlighted: true });
+  const { featured, compact } = partitionVisible([shadowDom], 'new');
+
+  assert.deepEqual(featured.map((e) => e.prNumber), [13194]);
+  assert.deepEqual(compact, []);
+});
+
+test('a highlight still shows on the tab matching its own category', () => {
+  const shadowDom = entry({ category: 'fixed', prNumber: 13194, highlighted: true });
+  const { featured } = partitionVisible([shadowDom], 'fixed');
+
+  assert.deepEqual(featured.map((e) => e.prNumber), [13194]);
+});
+
+test('a highlight does not leak onto an unrelated tab', () => {
+  const shadowDom = entry({ category: 'fixed', prNumber: 13194, highlighted: true });
+
+  for (const filter of ['deprecated', 'breaking']) {
+    assert.equal(isFeatured(shadowDom, filter), false, `leaked onto ${filter}`);
+    const { featured, compact } = partitionVisible([shadowDom], filter);
+    assert.deepEqual(featured, [], `leaked onto ${filter}`);
+    assert.deepEqual(compact, [], `leaked onto ${filter}`);
+  }
+});
+
+test('one PR cited by two bullets renders a single card, and the first bullet wins', () => {
+  // #12951 is cited under `#### Added` (the hook) and `#### Changed` (the
+  // render path). The changelog order decides which pill the card carries.
+  const addedBullet = entry({ category: 'added', prNumber: 12951, highlighted: true, title: 'hook' });
+  const changedBullet = entry({ category: 'changed', prNumber: 12951, highlighted: true, title: 'render path' });
+
+  const onAll = partitionVisible([addedBullet, changedBullet], 'all');
+  assert.deepEqual(onAll.featured.map((e) => e.category), ['added']);
+  assert.deepEqual(onAll.compact.map((e) => e.category), ['changed']);
+
+  const onNew = partitionVisible([addedBullet, changedBullet], 'new');
+  assert.deepEqual(onNew.featured.map((e) => e.category), ['added']);
+  // The `changed` bullet belongs to no New-tab category, so a promoted
+  // highlight must not drag it into the compact list there.
+  assert.deepEqual(onNew.compact, []);
+});
+
+test('the losing bullet keeps its place when its own category matches the tab', () => {
+  // 16.1's #11790 is cited under both `#### Added` and `#### Deprecated`.
+  const addedBullet = entry({ version: '16.1.0', category: 'added', prNumber: 11790, highlighted: true });
+  const deprecatedBullet = entry({ version: '16.1.0', category: 'deprecated', prNumber: 11790, highlighted: true });
+
+  const onDeprecated = partitionVisible([addedBullet, deprecatedBullet], 'deprecated');
+  assert.deepEqual(onDeprecated.featured.map((e) => e.category), ['deprecated']);
+  assert.deepEqual(onDeprecated.compact, []);
+});
+
+test('entries with no PR citation are never deduplicated against each other', () => {
+  const first = entry({ prNumber: null, prKind: null, title: 'first' });
+  const second = entry({ prNumber: null, prKind: null, title: 'second' });
+  const { featured, compact } = partitionVisible([first, second], 'new');
+
+  assert.deepEqual(featured, []);
+  assert.deepEqual(compact.map((e) => e.title), ['first', 'second']);
+});
+
+test('a plain entry lands in the compact list on its own tab only', () => {
+  const fix = entry({ category: 'fixed', prNumber: 13220 });
+
+  assert.deepEqual(partitionVisible([fix], 'fixed').compact.map((e) => e.prNumber), [13220]);
+  assert.deepEqual(partitionVisible([fix], 'new').compact, []);
+  assert.deepEqual(partitionVisible([fix], 'all').compact.map((e) => e.prNumber), [13220]);
+});
+
+test('a breaking highlight is featured on Breaking and on New', () => {
+  const breakingChange = entry({ category: 'changed', breaking: true, prNumber: 12011, highlighted: true });
+
+  assert.deepEqual(partitionVisible([breakingChange], 'breaking').featured.map((e) => e.prNumber), [12011]);
+  assert.deepEqual(partitionVisible([breakingChange], 'new').featured.map((e) => e.prNumber), [12011]);
+});


### PR DESCRIPTION
### Context

The PR adds the editorial highlights for 18.1 to the "Changes between versions" page, so the release's headline features render as featured cards instead of plain changelog bullets:

- Shadow DOM and Salesforce support ([#13194](https://github.com/handsontable/handsontable/pull/13194))
- Single-pass rendering, standing in for the release's performance work ([#12951](https://github.com/handsontable/handsontable/pull/12951))
- Resize and move a selection by dragging ([#13076](https://github.com/handsontable/handsontable/pull/13076))
- The new `intl-datetime` cell type ([#13151](https://github.com/handsontable/handsontable/pull/13151))

`docs/content/data/version-highlights/18.1.json` was an empty scaffold until now, so the 18.1 group had no cards at all.

Two changes in `VersionComparison.tsx` were needed to make those four cards actually reach the page the task links to (`?from=15.0&to=18.1`, which resolves to the **New** tab):

1. **Every highlight is now promoted onto the New tab**, not only breaking ones. The previous rule (`SHOW_BREAKING_HIGHLIGHTS_ON_NEW`) worked for every earlier release because each non-`added` highlight happened to also be breaking. 18.1 is the first release whose headline feature is filed under `#### Fixed` (Shadow DOM) with the performance work under `#### Changed`, and no data-only mapping can put those on the New tab, because no `added` bullet exists for them. The constant is kept and renamed (`SHOW_HIGHLIGHTS_ON_NEW`) so the rule stays revertable in one line.
2. **Featured cards are deduplicated by PR number.** One PR can be cited by two changelog bullets in different sections: 18.1's #12951 is both an `added` hook and a `changed` render path, and 16.1's #11790 is both `added` and `deprecated`. Without this, change 1 would render "Classic theme" twice on the New tab of the 16.1 group, and #12951 twice on 18.1. The losing bullet keeps its place in the compact list on tabs its own category belongs to, and is dropped on the New tab so a promoted highlight cannot drag an unrelated-category bullet onto it.

Three notes for the reviewer:

- A cherry-pick to `prod-docs/*` needs **both** files. `18.1.json` alone leaves the Shadow DOM card off the default New tab, because the promotion rule lives in `VersionComparison.tsx`.
- The tab counts come from `matchesFilter` alone, so the promoted Shadow DOM card shows on **New** without being counted in the New tab's number. That mismatch already existed for promoted breaking highlights, so it is not a regression, but it is now visible on every release.
- The `codeBefore` / `codeAfter` fields are validated and loaded but not rendered by `FeaturedEntry` today, so the new entries omit them.

### How has this been tested?

Docs-only change. Verified in a browser against a local dev server (`npx astro dev` in `docs/`) at `/docs/javascript-data-grid/changes-between-versions/?from=15.0&to=18.1`:

- The default **New** tab renders four featured cards for 18.1.0: #12951, #13076, #13151 (New pill) and #13194 (Fixed pill).
- The 16.1.0 group still renders exactly one "Classic theme" card on both **New** and **All** (no duplicate).
- On **All**, #12951 renders one card, with its second bullet in the compact list.

```bash
npm --prefix docs run docs:validate-highlights   # All highlight files are valid.
npm --prefix docs run docs:test:plugins          # 257 pass, 0 fail
npm --prefix docs run docs:lint
docs/node_modules/.bin/tsc --noEmit --jsx react-jsx --module esnext --moduleResolution bundler \
  --target es2022 --strict --skipLibCheck --types react \
  docs/src/components/VersionComparison/VersionComparison.tsx
```

`[skip changelog]`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2824

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) - one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2824

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only data and presentation logic for the version comparison page; no grid runtime or auth/data paths affected.
> 
> **Overview**
> Adds **four editorial featured cards** for release **18.1** (Shadow DOM/Salesforce, single-pass rendering, selection drag resize/move, `intl-datetime`) by filling `docs/content/data/version-highlights/18.1.json`, which was previously an empty scaffold.
> 
> Updates the **Changes between versions** UI so those cards show on the default **New** tab even when changelog bullets are under **Fixed** or **Changed**: the old “breaking-only” promotion becomes **`SHOW_HIGHLIGHTS_ON_NEW`**, which surfaces **every** highlighted PR on New (still revertable in one constant).
> 
> Refactors featured/compact splitting into **`featuredEntries.ts`** and adds **`partitionEntries`** to **dedupe featured cards by PR number** when one PR appears in multiple changelog sections; secondary bullets stay in the compact list only on tabs that match their category. **`VersionComparison.tsx`** wires in the module, and new **unit tests** lock in promotion, deduplication, and tab behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a7f41a1b5451ae88797c4502779f7506c4ca46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->