### PR TITLE
DEV-2790: Check and document changelog API reference links

### DIFF
--- a/.changelogs/README.md
+++ b/.changelogs/README.md
@@ -159,6 +159,10 @@ whose file or anchor cannot resolve. It is report-only, runs on every docs pull 
 candidate set is a heuristic: a backticked word that happens to match an option name is not proof the
 entry introduced that option. Judge each finding.
 
+It sees options, hooks, plugin classes, and `Core` members. **It does not see plugin methods**, and
+cannot: a bare `collapseAll()` belongs to both the `CollapsibleColumns` and the `NestedRows` plugin,
+and only the sentence around it says which. Link those by hand.
+
 ### Why the link cannot live in the entry `title`
 
 `bin/changelog` renders `title` verbatim into four destinations: the root `CHANGELOG.md`, the GitHub

--- a/.changelogs/README.md
+++ b/.changelogs/README.md
@@ -120,6 +120,55 @@ This command "consumes" all changelog entries, asserts that they're all valid, f
 It is side-effect free (as in it does nothing outside of your local copy of this repository), to undo just checkout the old versions of `.changelogs` and `CHANGELOG.md`.
 
 
+## Publishing to the docs changelog page
+
+`consume` and `sync` write the root `CHANGELOG.md`, and the release workflow copies that version's
+section into `docs/content/guides/upgrade-and-migration/changelog/changelog.md`. **Nothing writes the
+per-major page** `docs/content/guides/upgrade-and-migration/changelog-<N>/changelog-<N>.md`. Someone
+copies the section there by hand, demoting `###` to `####`, and that page is what the docs site and
+the version-comparison UI read.
+
+That hand step owns one editorial rule, and it is the reason this section exists: **every new option,
+hook, method, and plugin named in an `Added` entry links to its reference page.** The practice ran
+from 10.0.0 to 14.2.0, was never written down, and lapsed at 14.3.0 when the person doing it left
+(DEV-2790).
+
+Use the bracketed form, with a lowercase anchor:
+
+```markdown
+- Added an Enter key handler and a new [`searchMode`](@/api/options.md#searchmode) option to the
+  [`Filters`](@/api/filters.md) plugin. [#11871](https://github.com/handsontable/handsontable/pull/11871)
+```
+
+| Named thing | Link target |
+|---|---|
+| configuration option | `@/api/options.md#<lowercased name>` |
+| hook | `@/api/hooks.md#<lowercased name>` |
+| Core method | `@/api/core.md#<lowercased name>` |
+| plugin, or a plugin method | `@/api/<pluginName>.md`, `@/api/<pluginName>.md#<lowercased method>` |
+
+Anchors are the plain lowercased member name, because the reference page emits the name verbatim as a
+heading. `#minRowHeights` never resolves; `#minrowheights` does.
+
+Leave unlinked anything that has no reference page: theme tokens and CSS class names, TypeScript type
+names, external APIs such as `Intl.NumberFormat`, object keys that are not API members, and wrapper
+package names. A link to a page that does not document the name is worse than no link.
+
+`npm run docs:validate-changelog-links --prefix docs` lists the candidates and flags `@/api/` links
+whose file or anchor cannot resolve. It is report-only, runs on every docs pull request, and its
+candidate set is a heuristic: a backticked word that happens to match an option name is not proof the
+entry introduced that option. Judge each finding.
+
+### Why the link cannot live in the entry `title`
+
+`bin/changelog` renders `title` verbatim into four destinations: the root `CHANGELOG.md`, the GitHub
+release body, the docs changelog page, and the version-comparison UI. Only the docs page resolves
+`@/api/` links. On GitHub the same text renders as a link to a literal `@/api/...` path, which 404s,
+and the version-comparison UI drops the link and keeps the text. So an entry title that needs a docs
+link uses an absolute `https://handsontable.com/docs/...` URL, and reference linking happens later,
+on the docs page.
+
+
 ## No entry may be published twice
 
 `consume` and `sync` both check a pending entry against what `CHANGELOG.md` already publishes, and refuse to compile it when that match is conclusive; a less certain match only warns. Without that check the same change gets announced in two consecutive releases, which happened at most releases up to 18.1.0.

--- a/.claude/skills/changelog-creation/SKILL.md
+++ b/.claude/skills/changelog-creation/SKILL.md
@@ -77,6 +77,12 @@ Getting this wrong is not fatal — GitHub redirects `/issues/<n>` to `/pull/<n>
 - **Be specific.** Instead of "Fixed a bug", write "Fixed cell editor closing unexpectedly on scroll."
 - **Do not reference internal code.** Avoid titles like "Refactored DataMap" or "Updated metaSchema.js". Users do not know these internals.
 - **End with a period.**
+- **Never put an `@/api/...` docs link in the title.** That syntax resolves only on the docs site, and
+  `bin/changelog` renders the title verbatim into the root `CHANGELOG.md` and the GitHub release body
+  too, where it links to a literal `@/api/...` path and 404s. When a title needs a docs link, use an
+  absolute `https://handsontable.com/docs/...` URL. Reference linking for new options, hooks, methods,
+  and plugins happens later, on the docs changelog page - see
+  [`.changelogs/README.md`](../../../.changelogs/README.md).
 - **Breaking changes** (`"breaking": true`) appear first in the generated changelog. Make the title clearly describe what breaks and what to do instead.
 
 ## Framework Field

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: ./.github/actions/setup-workspace
       - name: Test plugins
         run: npm run docs:test:plugins --prefix docs
+      # Report-only: always exits 0, writes its findings to the step summary.
+      - name: Check changelog API reference links
+        run: npm run docs:validate-changelog-links --prefix docs
 
   angular-types:
     name: Angular types

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -456,6 +456,38 @@ Exception: the `server-side-*` recipes keep `tree/master/server-examples/...`.
 major, and receives no per-major repair, so a `prod-examples/<major>` copy of it
 would be a frozen unmaintained snapshot.
 
+### Reference links in changelog pages
+
+`content/guides/upgrade-and-migration/changelog-<N>/changelog-<N>.md` is hand-written: the release
+workflow writes the root `CHANGELOG.md` and the rolling `changelog/changelog.md`, and someone copies
+the version's section into the per-major page by hand, demoting `###` to `####`.
+
+When you edit a changelog page, **link every new option, hook, method, and plugin that an `Added`
+entry names**:
+
+```markdown
+- Added an Enter key handler and a new [`searchMode`](@/api/options.md#searchmode) option to the
+  [`Filters`](@/api/filters.md) plugin. [#11871](https://github.com/handsontable/handsontable/pull/11871)
+```
+
+Options go to `@/api/options.md`, hooks to `@/api/hooks.md`, Core methods to `@/api/core.md`, and a
+plugin or its method to `@/api/<pluginName>.md`. The anchor is the plain lowercased member name, so
+`#minRowHeights` never resolves and `#minrowheights` does.
+
+Leave unlinked whatever has no reference page - theme tokens, CSS class names, TypeScript type names,
+external APIs such as `Intl.NumberFormat`, object keys that are not API members, and wrapper package
+names. A link to a page that does not document the name is worse than no link.
+
+Run `npm run docs:validate-changelog-links` to list the candidates and to catch an `@/api/` link
+whose file or anchor cannot resolve. It is report-only, and its candidate set is a heuristic, so judge
+each finding rather than applying it blindly.
+
+The link cannot come from the `.changelogs/*.json` entry instead. `bin/changelog` renders an entry
+title verbatim into four destinations, and only the docs page resolves `@/api/` links: on GitHub the
+root `CHANGELOG.md` and the release body render a link to a literal `@/api/...` path, and the
+version-comparison UI drops the link and keeps the text. An entry title that needs a docs link uses
+an absolute `https://handsontable.com/docs/...` URL. Full rule: `.changelogs/README.md`.
+
 ---
 
 ## 2.8 Trademark Notices

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -480,7 +480,9 @@ names. A link to a page that does not document the name is worse than no link.
 
 Run `npm run docs:validate-changelog-links` to list the candidates and to catch an `@/api/` link
 whose file or anchor cannot resolve. It is report-only, and its candidate set is a heuristic, so judge
-each finding rather than applying it blindly.
+each finding rather than applying it blindly. It sees options, hooks, plugin classes, and `Core`
+members; **it does not see plugin methods**, because a bare `collapseAll()` belongs to two plugins and
+only the sentence says which, so link those by hand.
 
 The link cannot come from the `.changelogs/*.json` entry instead. `bin/changelog` renders an entry
 title verbatim into four destinations, and only the docs page resolves `@/api/` links: on GitHub the

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
     "docs:test:plugins": "node --test src/plugins/__tests__/*.test.mjs src/lib/__tests__/*.test.mjs src/components/__tests__/*.test.mjs src/scripts/__tests__/*.test.mjs cloudflare/__tests__/*.test.mjs deploy/__tests__/*.test.mjs scripts/__tests__/*.test.mjs scripts/jsdoc-convert/renderer/preProcessors/__tests__/*.test.mjs",
     "docs:test:runner-links": "node scripts/test-runner-links.mjs",
     "docs:validate-highlights": "node scripts/validate-version-highlights.mjs",
+    "docs:validate-changelog-links": "node scripts/check-changelog-api-links.mjs",
     "docs:lint": "eslint --ext .js,.mjs,.ts,.astro src content",
     "docs:lint:fix": "eslint --ext .js,.mjs,.ts,.astro src content --fix",
     "docs:docker:build:production": "cross-env BUILD_MODE=production npm run build && docker build -f docker/Dockerfile -t docs-md:production .",

--- a/docs/scripts/__tests__/check-changelog-api-links.test.mjs
+++ b/docs/scripts/__tests__/check-changelog-api-links.test.mjs
@@ -5,6 +5,7 @@ import {
   extractHookNames,
   extractPluginNames,
   extractApiFileSlugs,
+  extractCoreMemberNames,
   buildKnownFileSlugs,
   collectAddedSectionLines,
   collectBullets,
@@ -19,6 +20,7 @@ const api = {
   optionNames: new Set(['renderAllColumns', 'minRowHeights', 'rowHeights', 'filters']),
   hookNames: new Set(['beforeBeginEditing', 'beforeCompositionStart']),
   pluginNames: new Map([['Filters', 'filters'], ['NestedRows', 'nestedRows']]),
+  coreNames: new Set(['updateData', 'updateSettings']),
   fileSlugs: new Set(['options', 'hooks', 'core', 'filters', 'nestedRows']),
 };
 
@@ -80,14 +82,66 @@ test('extractHookNames takes REGISTERED_HOOKS and ignores quoted words inside it
   assert.deepEqual([...extractHookNames(source)], ['afterChange', 'beforeChange']);
 });
 
-test('extractPluginNames maps a class name to its directory, for both import and export forms', () => {
+test('extractPluginNames maps a class name to its page slug, for both import and export forms', () => {
   const source = [
     "import { AutoColumnSize } from './autoColumnSize';",
-    "export { BasePlugin } from './base';",
     "import { registerPlugin } from '../plugins';",
   ].join('\n');
 
-  assert.deepEqual([...extractPluginNames(source)], [['AutoColumnSize', 'autoColumnSize'], ['BasePlugin', 'base']]);
+  assert.deepEqual([...extractPluginNames(source)], [['AutoColumnSize', 'autoColumnSize']]);
+});
+
+test('extractPluginNames derives the slug from the class, not the directory', () => {
+  // `BasePlugin` comes from `./base`, and its page is `api/basePlugin.md`; `api/base.md` does not exist.
+  const slugs = extractPluginNames("export { BasePlugin } from './base';");
+
+  assert.equal(slugs.get('BasePlugin'), 'basePlugin');
+});
+
+test('extractCoreMemberNames takes a @memberof Core# block and skips a private one', () => {
+  const source = [
+    '  /**',
+    '   * Updates the grid data.',
+    '   *',
+    '   * @memberof Core#',
+    '   * @function updateData',
+    '   */',
+    '  this.updateData = function() {};',
+    '',
+    '  /**',
+    '   * @memberof Core#',
+    '   * @member isDestroyed',
+    '   * @type {boolean}',
+    '   */',
+    '  this.isDestroyed = false;',
+    '',
+    '  /**',
+    '   * @memberof Core#',
+    '   * @function repairSelection',
+    '   * @private',
+    '   */',
+    '  this.repairSelection = function() {};',
+  ].join('\n');
+
+  assert.deepEqual([...extractCoreMemberNames(source)].sort(), ['isDestroyed', 'updateData']);
+});
+
+test('resolveApiTarget resolves a Core member, after options and hooks', () => {
+  assert.deepEqual(resolveApiTarget('updateData', api), { file: 'core', anchor: 'updatedata' });
+});
+
+test('findUnlinkedApiNames reports a Core method named with call parentheses', () => {
+  const markdown = [
+    '#### Added',
+    '- Added a flag that survives an `updateSettings()` call.',
+  ].join('\n');
+
+  assert.deepEqual(findUnlinkedApiNames(markdown, api), [{
+    line: 2,
+    name: 'updateSettings',
+    misspelled: false,
+    suggestion: '[`updateSettings()`](@/api/core.md#updatesettings)',
+  }]);
 });
 
 test('extractApiFileSlugs reads every children list of the api sidebar', () => {

--- a/docs/scripts/__tests__/check-changelog-api-links.test.mjs
+++ b/docs/scripts/__tests__/check-changelog-api-links.test.mjs
@@ -1,0 +1,311 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  extractOptionNames,
+  extractHookNames,
+  extractPluginNames,
+  extractApiFileSlugs,
+  collectAddedSectionLines,
+  collectBullets,
+  resolveApiTarget,
+  resolveMisspelledApiTarget,
+  findUnlinkedApiNames,
+  findBrokenApiLinks,
+  formatSummary,
+} from '../check-changelog-api-links.mjs';
+
+const api = {
+  optionNames: new Set(['renderAllColumns', 'minRowHeights', 'rowHeights', 'filters']),
+  hookNames: new Set(['beforeBeginEditing', 'beforeCompositionStart']),
+  pluginNames: new Map([['Filters', 'filters'], ['NestedRows', 'nestedRows']]),
+  fileSlugs: new Set(['options', 'hooks', 'core', 'filters', 'nestedRows']),
+};
+
+test('extractOptionNames reads the property that follows a @memberof Options# block', () => {
+  const source = [
+    '    /**',
+    '     * The `activeHeaderClassName` option.',
+    '     *',
+    '     * @memberof Options#',
+    '     * @type {string}',
+    '     */',
+    "    activeHeaderClassName: 'ht__active_highlight',",
+  ].join('\n');
+
+  assert.deepEqual([...extractOptionNames(source)], ['activeHeaderClassName']);
+});
+
+test('extractOptionNames accepts the method-shorthand options', () => {
+  const source = [
+    '    /**',
+    '     * @memberof Options#',
+    '     */',
+    '    isEmptyCol(this: HotInstance, col: number) {',
+    '      return true;',
+    '    },',
+  ].join('\n');
+
+  assert.deepEqual([...extractOptionNames(source)], ['isEmptyCol']);
+});
+
+test('extractOptionNames ignores a property whose block carries no @memberof Options# tag', () => {
+  const source = [
+    '    /**',
+    '     * An internal property, not a documented option.',
+    '     */',
+    '    _internalFlag: false,',
+  ].join('\n');
+
+  assert.deepEqual([...extractOptionNames(source)], []);
+});
+
+test('extractHookNames takes REGISTERED_HOOKS and ignores quoted words inside its JSDoc blocks', () => {
+  const source = [
+    'export const REGISTERED_HOOKS = [',
+    '  /**',
+    '   * @event Hooks#afterChange',
+    '   * @example',
+    "   * hot.addHook('afterChange', () => {});",
+    '   */',
+    "  'afterChange',",
+    "  'beforeChange',",
+    '];',
+    '',
+    'export const REMOVED_HOOKS = new Map([',
+    "  ['modifyRow', '14.0.0'],",
+    ']);',
+  ].join('\n');
+
+  assert.deepEqual([...extractHookNames(source)], ['afterChange', 'beforeChange']);
+});
+
+test('extractPluginNames maps a class name to its directory, for both import and export forms', () => {
+  const source = [
+    "import { AutoColumnSize } from './autoColumnSize';",
+    "export { BasePlugin } from './base';",
+    "import { registerPlugin } from '../plugins';",
+  ].join('\n');
+
+  assert.deepEqual([...extractPluginNames(source)], [['AutoColumnSize', 'autoColumnSize'], ['BasePlugin', 'base']]);
+});
+
+test('extractApiFileSlugs reads every children list of the api sidebar', () => {
+  const source = [
+    'module.exports = {',
+    '  sidebar: [',
+    "    { title: 'Core API', children: ['core', 'hooks', 'options'] },",
+    "    { title: 'Cells', children: ['autofill', 'comments'] },",
+    '  ],',
+    '};',
+  ].join('\n');
+
+  assert.deepEqual([...extractApiFileSlugs(source)], ['core', 'hooks', 'options', 'autofill', 'comments']);
+});
+
+test('collectAddedSectionLines keeps only the Added section and stops at the next heading', () => {
+  const markdown = [
+    '#### Added',
+    '- an added entry',
+    '',
+    '#### Fixed',
+    '- a fixed entry',
+  ].join('\n');
+
+  assert.deepEqual(collectAddedSectionLines(markdown), [
+    { line: 2, text: '- an added entry' },
+    { line: 3, text: '' },
+  ]);
+});
+
+test('collectAddedSectionLines skips a fenced code block inside an Added section', () => {
+  const markdown = [
+    '#### Added',
+    '```js',
+    '- not a bullet: `renderAllColumns`',
+    '```',
+    '- a real bullet',
+  ].join('\n');
+
+  assert.deepEqual(collectAddedSectionLines(markdown), [{ line: 5, text: '- a real bullet' }]);
+});
+
+test('collectBullets joins a bullet that wraps over several lines', () => {
+  const bullets = collectBullets([
+    { line: 4, text: '- Added a new option,' },
+    { line: 5, text: '  `renderAllColumns`, which helps.' },
+    { line: 6, text: '- A second bullet.' },
+  ]);
+
+  assert.deepEqual(bullets, [
+    { line: 4, text: '- Added a new option, `renderAllColumns`, which helps.' },
+    { line: 6, text: '- A second bullet.' },
+  ]);
+});
+
+test('resolveApiTarget prefers the plugin page over an option of the same word', () => {
+  assert.deepEqual(resolveApiTarget('Filters', api), { file: 'filters', anchor: '' });
+  assert.deepEqual(resolveApiTarget('filters', api), { file: 'options', anchor: 'filters' });
+});
+
+test('resolveApiTarget lowercases the anchor and returns null for an unknown name', () => {
+  assert.deepEqual(resolveApiTarget('minRowHeights', api), { file: 'options', anchor: 'minrowheights' });
+  assert.deepEqual(resolveApiTarget('beforeBeginEditing', api), { file: 'hooks', anchor: 'beforebeginediting' });
+  assert.equal(resolveApiTarget('paginationButtonHoverBackground', api), null);
+});
+
+test('resolveMisspelledApiTarget corrects a name that differs only in case', () => {
+  assert.deepEqual(resolveMisspelledApiTarget('beforeCompositionstart', api), {
+    file: 'hooks',
+    anchor: 'beforecompositionstart',
+    canonicalName: 'beforeCompositionStart',
+  });
+  assert.equal(resolveMisspelledApiTarget('beforeCompositionStart', api), null);
+});
+
+test('findUnlinkedApiNames reports an option named in backticks without a link', () => {
+  const markdown = [
+    '#### Added',
+    '- Added a new `renderAllColumns` option. [#10599](https://github.com/handsontable/handsontable/pull/10599)',
+  ].join('\n');
+
+  assert.deepEqual(findUnlinkedApiNames(markdown, api), [{
+    line: 2,
+    name: 'renderAllColumns',
+    misspelled: false,
+    suggestion: '[`renderAllColumns`](@/api/options.md#renderallcolumns)',
+  }]);
+});
+
+test('findUnlinkedApiNames leaves an already linked name alone, whichever form the link takes', () => {
+  const markdown = [
+    '#### Added',
+    '- Added [`renderAllColumns`](@/api/options.md#renderallcolumns).',
+    '- Added [`minRowHeights`](https://handsontable.com/docs/javascript-data-grid/api/options/#minrowheights).',
+  ].join('\n');
+
+  assert.deepEqual(findUnlinkedApiNames(markdown, api), []);
+});
+
+test('findUnlinkedApiNames does not report a name that has no reference page', () => {
+  const markdown = [
+    '#### Added',
+    '- Added dedicated `paginationButtonHover` theme tokens and the `SanitizerContext` type.',
+    '- Added support for `Intl.NumberFormat` options.',
+  ].join('\n');
+
+  assert.deepEqual(findUnlinkedApiNames(markdown, api), []);
+});
+
+test('findUnlinkedApiNames reports a plugin class, a hook, and a method-call name', () => {
+  const markdown = [
+    '#### Added',
+    '- Added a public API to the `NestedRows` plugin: `collapseAll()`, and the new `beforeBeginEditing` hook.',
+  ].join('\n');
+  const findings = findUnlinkedApiNames(markdown, api);
+
+  assert.deepEqual(findings.map(({ name, suggestion }) => [name, suggestion]), [
+    ['NestedRows', '[`NestedRows`](@/api/nestedRows.md)'],
+    ['beforeBeginEditing', '[`beforeBeginEditing`](@/api/hooks.md#beforebeginediting)'],
+  ]);
+});
+
+test('findUnlinkedApiNames suggests the documented spelling for a miscased name', () => {
+  const markdown = [
+    '#### Added',
+    '- Fixed the Comments plugin for IME editing and added a new `beforeCompositionstart` hook.',
+  ].join('\n');
+
+  assert.deepEqual(findUnlinkedApiNames(markdown, api), [{
+    line: 2,
+    name: 'beforeCompositionstart',
+    misspelled: true,
+    suggestion: '[`beforeCompositionStart`](@/api/hooks.md#beforecompositionstart)',
+  }]);
+});
+
+test('findUnlinkedApiNames ignores a name outside an Added section', () => {
+  const markdown = [
+    '#### Fixed',
+    '- Fixed the `renderAllColumns` option.',
+  ].join('\n');
+
+  assert.deepEqual(findUnlinkedApiNames(markdown, api), []);
+});
+
+test('findUnlinkedApiNames reports each name once per bullet', () => {
+  const markdown = [
+    '#### Added',
+    '- Added `renderAllColumns`, because `renderAllColumns` helps.',
+  ].join('\n');
+
+  assert.equal(findUnlinkedApiNames(markdown, api).length, 1);
+});
+
+test('findBrokenApiLinks accepts a link whose file and anchor both resolve', () => {
+  const markdown = '- Added [`renderAllColumns`](@/api/options.md#renderallcolumns) and [`Filters`](@/api/filters.md).';
+
+  assert.deepEqual(findBrokenApiLinks(markdown, api), []);
+});
+
+test('findBrokenApiLinks reports a file slug that the api sidebar does not list', () => {
+  const markdown = '- Added [`thing`](@/api/notAPage.md#thing).';
+  const findings = findBrokenApiLinks(markdown, api);
+
+  assert.equal(findings.length, 1);
+  assert.match(findings[0].reason, /not listed in docs\/content\/api\/sidebar\.js/);
+});
+
+test('findBrokenApiLinks reports an anchor that is not lowercase', () => {
+  const markdown = '- Added [`minRowHeights`](@/api/options.md#minRowHeights).';
+  const findings = findBrokenApiLinks(markdown, api);
+
+  assert.equal(findings.length, 1);
+  assert.match(findings[0].reason, /must be lowercase - reference headings resolve to #minrowheights/);
+});
+
+test('findBrokenApiLinks reports an anchor that is not a member of the options or hooks page', () => {
+  const markdown = '- See [the section](@/api/options.md#copypaste-additional-options).';
+  const findings = findBrokenApiLinks(markdown, api);
+
+  assert.equal(findings.length, 1);
+  assert.deepEqual(findings[0], {
+    line: 1,
+    link: '@/api/options.md#copypaste-additional-options',
+    reason: '#copypaste-additional-options is not a member of api/options.md',
+  });
+});
+
+test('findBrokenApiLinks leaves an anchor on a page it cannot enumerate alone', () => {
+  const markdown = '- Added [`collapseAll()`](@/api/nestedRows.md#collapseall).';
+
+  assert.deepEqual(findBrokenApiLinks(markdown, api), []);
+});
+
+test('formatSummary states the clean case without a table', () => {
+  const summary = formatSummary({ unlinked: [], broken: [] });
+
+  assert.match(summary, /Every API name in an `Added` entry links to its reference page\./);
+  assert.doesNotMatch(summary, /\| Page \|/);
+});
+
+test('formatSummary tabulates both kinds of finding and marks a miscased name', () => {
+  const summary = formatSummary({
+    unlinked: [{
+      file: 'docs/content/guides/upgrade-and-migration/changelog-15/changelog-15.md',
+      line: 35,
+      name: 'beforeCompositionstart',
+      misspelled: true,
+      suggestion: '[`beforeCompositionStart`](@/api/hooks.md#beforecompositionstart)',
+    }],
+    broken: [{
+      file: 'docs/content/guides/upgrade-and-migration/changelog-16/changelog-16.md',
+      line: 42,
+      link: '@/api/options.md#minRowHeights',
+      reason: 'anchor #minRowHeights must be lowercase',
+    }],
+  });
+
+  assert.match(summary, /1 API name\(s\) named without a reference link/);
+  assert.match(summary, /cased differently in the source/);
+  assert.match(summary, /1 `@\/api\/` link\(s\) that cannot resolve/);
+});

--- a/docs/scripts/__tests__/check-changelog-api-links.test.mjs
+++ b/docs/scripts/__tests__/check-changelog-api-links.test.mjs
@@ -5,6 +5,7 @@ import {
   extractHookNames,
   extractPluginNames,
   extractApiFileSlugs,
+  buildKnownFileSlugs,
   collectAddedSectionLines,
   collectBullets,
   resolveApiTarget,
@@ -100,6 +101,14 @@ test('extractApiFileSlugs reads every children list of the api sidebar', () => {
   ].join('\n');
 
   assert.deepEqual([...extractApiFileSlugs(source)], ['core', 'hooks', 'options', 'autofill', 'comments']);
+});
+
+test('buildKnownFileSlugs accepts a plugin page the api sidebar does not list', () => {
+  const sidebar = "sidebar: [{ title: 'Core API', children: ['core', 'options'] }]";
+  const plugins = "import { DataProvider } from './dataProvider';";
+  const slugs = buildKnownFileSlugs(sidebar, plugins);
+
+  assert.deepEqual([...slugs].sort(), ['core', 'dataProvider', 'options']);
 });
 
 test('collectAddedSectionLines keeps only the Added section and stops at the next heading', () => {
@@ -247,12 +256,12 @@ test('findBrokenApiLinks accepts a link whose file and anchor both resolve', () 
   assert.deepEqual(findBrokenApiLinks(markdown, api), []);
 });
 
-test('findBrokenApiLinks reports a file slug that the api sidebar does not list', () => {
+test('findBrokenApiLinks reports a file slug that is neither a sidebar entry nor a plugin', () => {
   const markdown = '- Added [`thing`](@/api/notAPage.md#thing).';
   const findings = findBrokenApiLinks(markdown, api);
 
   assert.equal(findings.length, 1);
-  assert.match(findings[0].reason, /not listed in docs\/content\/api\/sidebar\.js/);
+  assert.match(findings[0].reason, /neither an api sidebar entry nor a plugin/);
 });
 
 test('findBrokenApiLinks reports an anchor that is not lowercase', () => {

--- a/docs/scripts/check-changelog-api-links.mjs
+++ b/docs/scripts/check-changelog-api-links.mjs
@@ -3,7 +3,9 @@
 //
 // The check is build-free on purpose: docs/content/api/*.md is generated from handsontable/tmp/
 // and gitignored, so no pull-request job has it. Option, hook and plugin names are read from the
-// committed core sources instead, and the api/*.md file slugs from docs/content/api/sidebar.js.
+// committed core sources instead, and the api/*.md file slugs from docs/content/api/sidebar.js plus
+// the plugin directories, since the generator emits a page per plugin whether the sidebar lists it
+// or not.
 //
 // It is report-only and always exits 0. The candidate set is a heuristic - a backticked word that
 // happens to match an option name is not proof the entry introduced that option - so a finding is
@@ -137,6 +139,25 @@ export function extractApiFileSlugs(source) {
   });
 
   return slugs;
+}
+
+/**
+ * Lists every api file slug a link may point at.
+ *
+ * `sidebar.js` describes the reference *navigation*, and the generator emits a page for every
+ * plugin whether the sidebar lists it or not - `api/dataProvider.md` is generated and reachable at
+ * its own permalink, but no sidebar entry names it. Taking the union keeps a link to such a page
+ * from being reported as unresolvable.
+ *
+ * @param {string} sidebarSource Contents of `docs/content/api/sidebar.js`.
+ * @param {string} pluginsSource Contents of `handsontable/src/plugins/index.ts`.
+ * @returns {Set<string>} File slugs, without the `.md` extension.
+ */
+export function buildKnownFileSlugs(sidebarSource, pluginsSource) {
+  return new Set([
+    ...extractApiFileSlugs(sidebarSource),
+    ...extractPluginNames(pluginsSource).values(),
+  ]);
 }
 
 /**
@@ -331,7 +352,7 @@ export function findBrokenApiLinks(markdown, { optionNames, hookNames, fileSlugs
       const report = reason => findings.push({ line: index + 1, link, reason });
 
       if (!fileSlugs.has(file)) {
-        report(`api/${file}.md is not listed in docs/content/api/sidebar.js`);
+        report(`api/${file}.md is neither an api sidebar entry nor a plugin`);
 
         return;
       }
@@ -380,7 +401,10 @@ export function checkChangelogPages({ directory = CHANGELOGS_DIR } = {}) {
     optionNames: extractOptionNames(readFileSync(METASCHEMA, 'utf8')),
     hookNames: extractHookNames(readFileSync(HOOK_CONSTANTS, 'utf8')),
     pluginNames: extractPluginNames(readFileSync(PLUGINS_INDEX, 'utf8')),
-    fileSlugs: extractApiFileSlugs(readFileSync(API_SIDEBAR, 'utf8')),
+    fileSlugs: buildKnownFileSlugs(
+      readFileSync(API_SIDEBAR, 'utf8'),
+      readFileSync(PLUGINS_INDEX, 'utf8'),
+    ),
   };
   const unlinked = [];
   const broken = [];

--- a/docs/scripts/check-changelog-api-links.mjs
+++ b/docs/scripts/check-changelog-api-links.mjs
@@ -1,0 +1,475 @@
+// Reports changelog "Added" entries that name a public API without linking it to its reference
+// page, and @/api/ links in the changelog pages whose file or anchor cannot resolve.
+//
+// The check is build-free on purpose: docs/content/api/*.md is generated from handsontable/tmp/
+// and gitignored, so no pull-request job has it. Option, hook and plugin names are read from the
+// committed core sources instead, and the api/*.md file slugs from docs/content/api/sidebar.js.
+//
+// It is report-only and always exits 0. The candidate set is a heuristic - a backticked word that
+// happens to match an option name is not proof the entry introduced that option - so a finding is
+// a prompt for a human, never a gate.
+//
+// Usage: node scripts/check-changelog-api-links.mjs
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const DOCS_ROOT = resolve(import.meta.dirname, '..');
+const REPO_ROOT = resolve(DOCS_ROOT, '..');
+const CHANGELOGS_DIR = join(DOCS_ROOT, 'content/guides/upgrade-and-migration');
+const METASCHEMA = join(REPO_ROOT, 'handsontable/src/dataMap/metaManager/metaSchema.ts');
+const HOOK_CONSTANTS = join(REPO_ROOT, 'handsontable/src/core/hooks/constants.ts');
+const PLUGINS_INDEX = join(REPO_ROOT, 'handsontable/src/plugins/index.ts');
+const API_SIDEBAR = join(DOCS_ROOT, 'content/api/sidebar.js');
+
+/**
+ * Reads the configuration option names out of `metaSchema.ts`.
+ *
+ * The module exports a function returning an object literal, so the names are taken from the
+ * declaration that follows each `@memberof Options#` JSDoc block. Both shapes count: a plain
+ * `name:` property and a `name(` method shorthand, which is how `isEmptyCol` and `isEmptyRow` are
+ * written.
+ *
+ * @param {string} source Contents of `metaSchema.ts`.
+ * @returns {Set<string>} Option names.
+ */
+export function extractOptionNames(source) {
+  const names = new Set();
+  const lines = source.split('\n');
+  let insideDocumentedBlock = false;
+
+  lines.forEach((line) => {
+    if (line.includes('@memberof Options#')) {
+      insideDocumentedBlock = true;
+
+      return;
+    }
+
+    if (!insideDocumentedBlock) {
+      return;
+    }
+
+    // Still inside the JSDoc block that carried the tag.
+    if (/^\s*(\/\*\*|\*)/.test(line)) {
+      return;
+    }
+
+    const declaration = line.match(/^\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z_$][\w$]*))\s*[:(]/);
+
+    if (declaration) {
+      names.add(declaration[1] ?? declaration[2] ?? declaration[3]);
+    }
+
+    insideDocumentedBlock = false;
+  });
+
+  return names;
+}
+
+/**
+ * Reads the hook names out of `core/hooks/constants.ts`.
+ *
+ * Only `REGISTERED_HOOKS` counts. `REMOVED_HOOKS` and `DEPRECATED_HOOKS` follow it in the same
+ * file and are deliberately left out: the reference page no longer documents them, so a link
+ * would not resolve.
+ *
+ * @param {string} source Contents of `constants.ts`.
+ * @returns {Set<string>} Hook names.
+ */
+export function extractHookNames(source) {
+  const start = source.indexOf('export const REGISTERED_HOOKS');
+
+  if (start === -1) {
+    return new Set();
+  }
+
+  const openingBracket = source.indexOf('[', start);
+  const closingBracket = source.indexOf('\n];', openingBracket);
+  const body = source.slice(openingBracket, closingBracket === -1 ? undefined : closingBracket);
+  const names = new Set();
+
+  // Match a whole line, not any quoted word: the array is interleaved with `@event` JSDoc blocks
+  // whose examples contain quoted strings of their own.
+  body.split('\n').forEach((line) => {
+    const entry = line.match(/^\s*'([A-Za-z][\w]*)',?\s*$/);
+
+    if (entry) {
+      names.add(entry[1]);
+    }
+  });
+
+  return names;
+}
+
+/**
+ * Reads the plugin class names out of `plugins/index.ts`, paired with the directory name that the
+ * reference page is generated from.
+ *
+ * @param {string} source Contents of `plugins/index.ts`.
+ * @returns {Map<string, string>} Class name to api file slug, for example `Filters` to `filters`.
+ */
+export function extractPluginNames(source) {
+  const plugins = new Map();
+  const pattern = /^(?:import|export)\s*\{\s*([A-Z][\w]*)\s*\}\s*from\s*'\.\/([\w]+)'/gm;
+
+  Array.from(source.matchAll(pattern)).forEach(([, className, directory]) => {
+    plugins.set(className, directory);
+  });
+
+  return plugins;
+}
+
+/**
+ * Reads the api file slugs out of `docs/content/api/sidebar.js`.
+ *
+ * That file is the only git-tracked description of the generated reference, which makes it the
+ * build-free source of truth for the `@/api/<file>.md` half of a link.
+ *
+ * @param {string} source Contents of `sidebar.js`.
+ * @returns {Set<string>} File slugs, without the `.md` extension.
+ */
+export function extractApiFileSlugs(source) {
+  const children = source.matchAll(/children:\s*\[([^\]]*)\]/g);
+  const slugs = new Set();
+
+  Array.from(children).forEach(([, list]) => {
+    Array.from(list.matchAll(/'([\w]+)'/g)).forEach(([, slug]) => slugs.add(slug));
+  });
+
+  return slugs;
+}
+
+/**
+ * Splits a markdown page into its `Added` sections, keeping each line's 1-based number.
+ *
+ * @param {string} markdown Page contents.
+ * @returns {Array<{ line: number, text: string }>} Lines that belong to an `Added` section.
+ */
+export function collectAddedSectionLines(markdown) {
+  const collected = [];
+  let insideAdded = false;
+  let insideCodeFence = false;
+
+  markdown.split('\n').forEach((text, index) => {
+    if (/^\s*```/.test(text)) {
+      insideCodeFence = !insideCodeFence;
+
+      return;
+    }
+
+    if (insideCodeFence) {
+      return;
+    }
+
+    const heading = text.match(/^(#{1,6})\s+(.*)$/);
+
+    if (heading) {
+      insideAdded = heading[2].trim() === 'Added';
+
+      return;
+    }
+
+    if (insideAdded) {
+      collected.push({ line: index + 1, text });
+    }
+  });
+
+  return collected;
+}
+
+/**
+ * Groups the lines of an `Added` section into whole bullets, so that a name and the link that
+ * covers it are seen together even when the entry wraps over several lines.
+ *
+ * @param {Array<{ line: number, text: string }>} lines Lines of an `Added` section.
+ * @returns {Array<{ line: number, text: string }>} Bullets, each starting at its own line number.
+ */
+export function collectBullets(lines) {
+  const bullets = [];
+
+  lines.forEach(({ line, text }) => {
+    if (/^\s*[-*]\s/.test(text)) {
+      bullets.push({ line, text: text.trim() });
+
+      return;
+    }
+
+    if (bullets.length > 0 && text.trim() !== '') {
+      bullets[bullets.length - 1].text += ` ${text.trim()}`;
+    }
+  });
+
+  return bullets;
+}
+
+/**
+ * Resolves a name to the reference page it should link to.
+ *
+ * A plugin class wins over an option of the same word, because the two differ only in case
+ * (`Filters` the plugin, `filters` the option) and the class form is the one an entry uses when it
+ * means the plugin.
+ *
+ * @param {string} name Candidate name, already stripped of its call parentheses.
+ * @param {object} api Known API names.
+ * @param {Set<string>} api.optionNames Option names.
+ * @param {Set<string>} api.hookNames Hook names.
+ * @param {Map<string, string>} api.pluginNames Plugin class name to api file slug.
+ * @returns {{ file: string, anchor: string }|null} Link target, or `null` when the name is not a
+ * documented API member.
+ */
+export function resolveApiTarget(name, { optionNames, hookNames, pluginNames }) {
+  if (pluginNames.has(name)) {
+    return { file: pluginNames.get(name), anchor: '' };
+  }
+
+  if (optionNames.has(name)) {
+    return { file: 'options', anchor: name.toLowerCase() };
+  }
+
+  if (hookNames.has(name)) {
+    return { file: 'hooks', anchor: name.toLowerCase() };
+  }
+
+  return null;
+}
+
+/**
+ * Resolves a name that differs from a documented API member only in letter case.
+ *
+ * A changelog entry copied by hand can carry a name whose casing does not match the source -
+ * `beforeCompositionstart` for the `beforeCompositionStart` hook, for example. Such a name reads
+ * as an API member but is not one, so it is worth reporting with the spelling corrected.
+ *
+ * @param {string} name Candidate name.
+ * @param {object} api Known API names, as taken by {@link resolveApiTarget}.
+ * @returns {{ file: string, anchor: string, canonicalName: string }|null} Link target carrying the
+ * documented spelling, or `null` when nothing matches.
+ */
+export function resolveMisspelledApiTarget(name, api) {
+  const candidates = [
+    ...api.pluginNames.keys(),
+    ...api.optionNames,
+    ...api.hookNames,
+  ];
+  const canonicalName = candidates.find(candidate => candidate.toLowerCase() === name.toLowerCase());
+
+  if (canonicalName === undefined || canonicalName === name) {
+    return null;
+  }
+
+  return { ...resolveApiTarget(canonicalName, api), canonicalName };
+}
+
+/**
+ * Finds `Added` entries that name a documented API member in backticks without linking it.
+ *
+ * A name already wrapped in a markdown link is left alone, whichever form the link takes - an
+ * internal `@/api/` link or an absolute `handsontable.com/docs` URL both count as linked.
+ *
+ * @param {string} markdown Page contents.
+ * @param {object} api Known API names, as taken by {@link resolveApiTarget}.
+ * @returns {Array<{ line: number, name: string, suggestion: string }>} Findings.
+ */
+export function findUnlinkedApiNames(markdown, api) {
+  const findings = [];
+
+  collectBullets(collectAddedSectionLines(markdown)).forEach(({ line, text }) => {
+    const seen = new Set();
+
+    Array.from(text.matchAll(/`([^`]+)`/g)).forEach((match) => {
+      const isLinked = text[match.index - 1] === '[';
+      const name = match[1].replace(/\(\)$/, '');
+
+      if (isLinked || seen.has(name) || !/^[A-Za-z_$][\w$]*$/.test(name)) {
+        return;
+      }
+
+      const target = resolveApiTarget(name, api) ?? resolveMisspelledApiTarget(name, api);
+
+      if (target === null) {
+        return;
+      }
+
+      const label = target.canonicalName === undefined
+        ? match[1]
+        : match[1].replace(name, target.canonicalName);
+
+      seen.add(name);
+      findings.push({
+        line,
+        name,
+        misspelled: target.canonicalName !== undefined,
+        suggestion: `[\`${label}\`](@/api/${target.file}.md${target.anchor ? `#${target.anchor}` : ''})`,
+      });
+    });
+  });
+
+  return findings;
+}
+
+/**
+ * Finds `@/api/` links whose file slug or anchor cannot resolve.
+ *
+ * Anchors are the plain lowercased member name, because the reference page emits the name verbatim
+ * as a heading. An anchor that carries a capital letter therefore never resolves, however real the
+ * member behind it is.
+ *
+ * @param {string} markdown Page contents.
+ * @param {object} api Known API names.
+ * @param {Set<string>} api.optionNames Option names.
+ * @param {Set<string>} api.hookNames Hook names.
+ * @param {Set<string>} api.fileSlugs Api file slugs from `sidebar.js`.
+ * @returns {Array<{ line: number, link: string, reason: string }>} Findings.
+ */
+export function findBrokenApiLinks(markdown, { optionNames, hookNames, fileSlugs }) {
+  const findings = [];
+  const anchorsOf = names => new Set(Array.from(names, name => name.toLowerCase()));
+  const knownAnchors = { options: anchorsOf(optionNames), hooks: anchorsOf(hookNames) };
+
+  markdown.split('\n').forEach((text, index) => {
+    Array.from(text.matchAll(/@\/api\/([\w]+)\.md(?:#([^)\s]+))?/g)).forEach(([link, file, anchor]) => {
+      const report = reason => findings.push({ line: index + 1, link, reason });
+
+      if (!fileSlugs.has(file)) {
+        report(`api/${file}.md is not listed in docs/content/api/sidebar.js`);
+
+        return;
+      }
+
+      if (anchor === undefined) {
+        return;
+      }
+
+      if (anchor !== anchor.toLowerCase()) {
+        report(`anchor #${anchor} must be lowercase - reference headings resolve to #${anchor.toLowerCase()}`);
+
+        return;
+      }
+
+      if (knownAnchors[file] !== undefined && !knownAnchors[file].has(anchor)) {
+        report(`#${anchor} is not a member of api/${file}.md`);
+      }
+    });
+  });
+
+  return findings;
+}
+
+/**
+ * Lists the changelog pages to check.
+ *
+ * @param {string} directory The `upgrade-and-migration` guides directory.
+ * @returns {string[]} Page paths, in ascending major order.
+ */
+export function listChangelogPages(directory) {
+  return readdirSync(directory, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && /^changelog-\d+$/.test(entry.name))
+    .sort((a, b) => Number(a.name.replace(/\D/g, '')) - Number(b.name.replace(/\D/g, '')))
+    .map(entry => join(directory, entry.name, `${entry.name}.md`));
+}
+
+/**
+ * Runs both checks over every changelog page.
+ *
+ * @param {object} [options] Options.
+ * @param {string} [options.directory] The `upgrade-and-migration` guides directory.
+ * @returns {{ unlinked: object[], broken: object[] }} Findings, each carrying its page path.
+ */
+export function checkChangelogPages({ directory = CHANGELOGS_DIR } = {}) {
+  const api = {
+    optionNames: extractOptionNames(readFileSync(METASCHEMA, 'utf8')),
+    hookNames: extractHookNames(readFileSync(HOOK_CONSTANTS, 'utf8')),
+    pluginNames: extractPluginNames(readFileSync(PLUGINS_INDEX, 'utf8')),
+    fileSlugs: extractApiFileSlugs(readFileSync(API_SIDEBAR, 'utf8')),
+  };
+  const unlinked = [];
+  const broken = [];
+
+  listChangelogPages(directory).forEach((page) => {
+    const markdown = readFileSync(page, 'utf8');
+    const file = page.slice(REPO_ROOT.length + 1);
+
+    findUnlinkedApiNames(markdown, api).forEach(finding => unlinked.push({ file, ...finding }));
+    findBrokenApiLinks(markdown, api).forEach(finding => broken.push({ file, ...finding }));
+  });
+
+  return { unlinked, broken };
+}
+
+/**
+ * Renders the findings as the markdown written to the workflow step summary.
+ *
+ * @param {{ unlinked: object[], broken: object[] }} findings Findings.
+ * @returns {string} Markdown.
+ */
+export function formatSummary({ unlinked, broken }) {
+  const lines = ['## Changelog API reference links', ''];
+
+  if (unlinked.length === 0 && broken.length === 0) {
+    lines.push('Every API name in an `Added` entry links to its reference page.');
+
+    return `${lines.join('\n')}\n`;
+  }
+
+  if (unlinked.length > 0) {
+    lines.push(
+      `### ${unlinked.length} API name(s) named without a reference link`,
+      '',
+      '| Page | Line | Name | Suggested link |',
+      '| --- | --- | --- | --- |',
+      ...unlinked.map(({ file, line, name, misspelled, suggestion }) =>
+        `| ${file} | ${line} | \`${name}\`${misspelled ? ' (cased differently in the source)' : ''} | \`${suggestion}\` |`),
+      '',
+    );
+  }
+
+  if (broken.length > 0) {
+    lines.push(
+      `### ${broken.length} \`@/api/\` link(s) that cannot resolve`,
+      '',
+      '| Page | Line | Link | Reason |',
+      '| --- | --- | --- | --- |',
+      ...broken.map(({ file, line, link, reason }) => `| ${file} | ${line} | \`${link}\` | ${reason} |`),
+      '',
+    );
+  }
+
+  lines.push(
+    'Linking is a docs-page step, not an entry-title one: an `@/api/` link in a `.changelogs/*.json`',
+    'title would break the root `CHANGELOG.md` and the GitHub release body. See `.changelogs/README.md`.',
+  );
+
+  return `${lines.join('\n')}\n`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { appendFileSync } = await import('node:fs');
+  const findings = checkChangelogPages();
+  const { unlinked, broken } = findings;
+
+  unlinked.forEach(({ file, line, name, misspelled, suggestion }) => {
+    const problem = misspelled
+      ? 'is cased differently in the source and has no reference link'
+      : 'has no reference link';
+
+    console.log(`${file}:${line}: \`${name}\` ${problem} - suggested: ${suggestion}`);
+  });
+
+  broken.forEach(({ file, line, link, reason }) => {
+    console.log(`${file}:${line}: ${link} - ${reason}`);
+  });
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, formatSummary(findings));
+  }
+
+  if (unlinked.length === 0 && broken.length === 0) {
+    console.log('Every API name in an `Added` entry links to its reference page.');
+  } else {
+    console.log(
+      `\n${unlinked.length} unlinked API name(s), ${broken.length} unresolvable @/api/ link(s).`,
+      '\nThis check is report-only. Link what belongs to the reference and leave the rest -',
+      'theme tokens, TypeScript type names and external APIs have no reference page.',
+    );
+  }
+}

--- a/docs/scripts/check-changelog-api-links.mjs
+++ b/docs/scripts/check-changelog-api-links.mjs
@@ -15,6 +15,7 @@
 
 import { readdirSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const DOCS_ROOT = resolve(import.meta.dirname, '..');
 const REPO_ROOT = resolve(DOCS_ROOT, '..');
@@ -22,6 +23,7 @@ const CHANGELOGS_DIR = join(DOCS_ROOT, 'content/guides/upgrade-and-migration');
 const METASCHEMA = join(REPO_ROOT, 'handsontable/src/dataMap/metaManager/metaSchema.ts');
 const HOOK_CONSTANTS = join(REPO_ROOT, 'handsontable/src/core/hooks/constants.ts');
 const PLUGINS_INDEX = join(REPO_ROOT, 'handsontable/src/plugins/index.ts');
+const CORE = join(REPO_ROOT, 'handsontable/src/core.ts');
 const API_SIDEBAR = join(DOCS_ROOT, 'content/api/sidebar.js');
 
 /**
@@ -104,21 +106,58 @@ export function extractHookNames(source) {
 }
 
 /**
- * Reads the plugin class names out of `plugins/index.ts`, paired with the directory name that the
- * reference page is generated from.
+ * Reads the plugin class names out of `plugins/index.ts`, paired with the api file slug of the page
+ * generated for each.
+ *
+ * The slug follows the **class** name with its first letter lowercased, not the directory. The two
+ * usually coincide, but `BasePlugin` is exported from `./base` and its page is `api/basePlugin.md`;
+ * `api/base.md` does not exist, and suggesting it would break the very rule this check enforces.
  *
  * @param {string} source Contents of `plugins/index.ts`.
  * @returns {Map<string, string>} Class name to api file slug, for example `Filters` to `filters`.
  */
 export function extractPluginNames(source) {
   const plugins = new Map();
-  const pattern = /^(?:import|export)\s*\{\s*([A-Z][\w]*)\s*\}\s*from\s*'\.\/([\w]+)'/gm;
+  const pattern = /^(?:import|export)\s*\{\s*([A-Z][\w]*)\s*\}\s*from\s*'\.\/[\w]+'/gm;
 
-  Array.from(source.matchAll(pattern)).forEach(([, className, directory]) => {
-    plugins.set(className, directory);
+  Array.from(source.matchAll(pattern)).forEach(([, className]) => {
+    plugins.set(className, `${className[0].toLowerCase()}${className.slice(1)}`);
   });
 
   return plugins;
+}
+
+/**
+ * Reads the `Core` members out of `core.ts`.
+ *
+ * Every one is declared with `@memberof Core#` plus a `@function` or `@member` tag naming it, and
+ * `api/core.md` emits that name verbatim as a heading. The extraction is deliberately conservative:
+ * measured against a generated `core.md` it finds 145 of the members it documents and invents none,
+ * because the page also carries every configuration option and a handful of internal members. That
+ * makes it safe to *suggest* a `core.md` link from, and unsafe to *reject* one with, which is why
+ * {@link findBrokenApiLinks} never validates a `core.md` anchor.
+ *
+ * @param {string} source Contents of `core.ts`.
+ * @returns {Set<string>} Core member names.
+ */
+export function extractCoreMemberNames(source) {
+  const names = new Set();
+
+  source.split('/**').slice(1).forEach((block) => {
+    const body = block.split('*/')[0];
+
+    if (!body.includes('@memberof Core#') || body.includes('@private')) {
+      return;
+    }
+
+    const named = body.match(/@(?:function|member)\s+([A-Za-z_$][\w$]*)/);
+
+    if (named) {
+      names.add(named[1]);
+    }
+  });
+
+  return names;
 }
 
 /**
@@ -235,10 +274,16 @@ export function collectBullets(lines) {
  * @param {Set<string>} api.optionNames Option names.
  * @param {Set<string>} api.hookNames Hook names.
  * @param {Map<string, string>} api.pluginNames Plugin class name to api file slug.
+ * @param {Set<string>} [api.coreNames] `Core` member names.
  * @returns {{ file: string, anchor: string }|null} Link target, or `null` when the name is not a
  * documented API member.
+ *
+ * A **plugin method** never resolves here, and cannot: a bare `collapseAll()` belongs to both the
+ * `CollapsibleColumns` and the `NestedRows` plugin, and only the sentence around it says which. The
+ * check therefore does not see plugin methods at all, and a human editing a changelog page still
+ * has to link those by hand. This is the one documented blind spot.
  */
-export function resolveApiTarget(name, { optionNames, hookNames, pluginNames }) {
+export function resolveApiTarget(name, { optionNames, hookNames, pluginNames, coreNames }) {
   if (pluginNames.has(name)) {
     return { file: pluginNames.get(name), anchor: '' };
   }
@@ -249,6 +294,10 @@ export function resolveApiTarget(name, { optionNames, hookNames, pluginNames }) 
 
   if (hookNames.has(name)) {
     return { file: 'hooks', anchor: name.toLowerCase() };
+  }
+
+  if (coreNames !== undefined && coreNames.has(name)) {
+    return { file: 'core', anchor: name.toLowerCase() };
   }
 
   return null;
@@ -271,6 +320,7 @@ export function resolveMisspelledApiTarget(name, api) {
     ...api.pluginNames.keys(),
     ...api.optionNames,
     ...api.hookNames,
+    ...(api.coreNames ?? []),
   ];
   const canonicalName = candidates.find(candidate => candidate.toLowerCase() === name.toLowerCase());
 
@@ -401,6 +451,7 @@ export function checkChangelogPages({ directory = CHANGELOGS_DIR } = {}) {
     optionNames: extractOptionNames(readFileSync(METASCHEMA, 'utf8')),
     hookNames: extractHookNames(readFileSync(HOOK_CONSTANTS, 'utf8')),
     pluginNames: extractPluginNames(readFileSync(PLUGINS_INDEX, 'utf8')),
+    coreNames: extractCoreMemberNames(readFileSync(CORE, 'utf8')),
     fileSlugs: buildKnownFileSlugs(
       readFileSync(API_SIDEBAR, 'utf8'),
       readFileSync(PLUGINS_INDEX, 'utf8'),
@@ -466,7 +517,7 @@ export function formatSummary({ unlinked, broken }) {
   return `${lines.join('\n')}\n`;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const { appendFileSync } = await import('node:fs');
   const findings = checkChangelogPages();
   const { unlinked, broken } = findings;


### PR DESCRIPTION
### Context

The PR documents and checks a docs convention that lapsed silently in April 2024, and it is the first of two PRs for DEV-2790. The second one backfills the missing links.

Changelog entries under `Added` used to link every new option, hook, method, and plugin to its reference page, like `` [`renderAllColumns`](@/api/options.md#renderallcolumns) ``. They stopped: a reader of `changelog-15` through `changelog-18` gets a GitHub PR number and nothing else, so finding out what `searchMode` or `minRowHeights` does means leaving the page and searching the docs by hand.

The links were never produced by tooling. They came from a manual editorial pass in a dedicated post-release PR titled `Docs: Edit <version> docs`, run 14 times between 2021 and 2024. The last one is `45225f48c4` (2024-03-05, the 14.2.0 page); the next release, `f48236aedc` (2024-04-16, 14.3.0), pasted the root `CHANGELOG.md` section verbatim with no follow-up pass, and every release since has done the same. `git log --all -S '@/api/' -- .changelogs/` and the same over `CHANGELOG.md` are both empty on every ref, so the pipeline never carried such a link. The practice lived only in one person's habit, with no checklist, script, or check encoding it, and ended when they did.

Note that the regression starts at **14.3.0**, not at 15.0 as the task describes it. The break sits inside `changelog-14.md`; 15 through 18 inherit it.

Two things this PR settles:

1. **The rule cannot live in a `.changelogs/*.json` entry title.** `bin/changelog` renders `title` verbatim into four destinations, and only the docs page resolves `@/api/` links. On GitHub the root `CHANGELOG.md` and the release body would link to a literal `@/api/...` path and 404, and the version-comparison UI drops the link and keeps the text. So linking stays a docs-page step, which is exactly where the lost pass sat. An entry title that needs a docs link uses an absolute `https://handsontable.com/docs/...` URL, the form `CHANGELOG.md` already uses 82 times.
2. **The check has to be build-free.** `docs/content/api/*.md` is generated from `handsontable/tmp/` and gitignored, and no pull-request job generates it without the full core build (which is also skipped on fork PRs). Option, hook, and plugin names therefore come from the committed core sources, and the valid `api/*.md` file slugs from `docs/content/api/sidebar.js` (the only version-controlled description of the generated reference) **plus the plugin directory names**. The union matters: the generator emits a page per plugin whether the sidebar lists it or not, and `api/dataProvider.md` is exactly that case, generated and reachable at `/api/data-provider` while no sidebar entry names it. Taking the sidebar alone reported a working link as unresolvable, which the backfill PR caught.

What is in the PR:

- `docs/scripts/check-changelog-api-links.mjs`, run by `npm run docs:validate-changelog-links`. It reports `Added` entries that name a documented API member in backticks without linking it, and `@/api/` links in the changelog pages whose file or anchor cannot resolve. Names are read from `metaSchema.ts` (172 options, accepting both the `name:` and the `name(` method-shorthand shapes so `isEmptyCol` and `isEmptyRow` are not missed), `core/hooks/constants.ts` (`REGISTERED_HOOKS` only, so the removed and deprecated maps do not produce links to pages that no longer document them), `plugins/index.ts` (43 plugins), and `core.ts` (145 `Core` members, from `@memberof Core#` plus a `@function` or `@member` tag, skipping `@private`).

  Two details are load-bearing. A plugin's page slug follows its **class** name with the first letter lowercased, not its directory: `BasePlugin` is exported from `./base` and its page is `api/basePlugin.md`, so keying on the directory would suggest an `api/base.md` that does not exist. And the `Core` extraction is used only to *suggest* a link, never to reject one - `api/core.md` also carries every configuration option and a few internal members, so the check deliberately validates anchors on `options.md` and `hooks.md` only.

  **The one blind spot, stated in the check and in both documents: it does not see plugin methods.** A bare `collapseAll()` belongs to both the `CollapsibleColumns` and the `NestedRows` plugin, and only the sentence around it says which, so a human still links those by hand.
- One step in `docs.yml`'s existing pull-request `plugins` job. **The check is report-only and always exits 0**, writing a table to the step summary, which needs no token and so works on fork and Dependabot runs. That is deliberate: the candidate set is a heuristic, the skip list is a judgement call, and a blocking gate would red CI over a theme token.
- The convention itself, written down for the first time, in three places at the right scope: a new `Publishing to the docs changelog page` section in `.changelogs/README.md` (the full rule, plus why the link cannot be in an entry title), a subsection in `docs/AGENTS.md` for agents editing a changelog page, and a one-line ban in the `changelog-creation` skill, which governs the JSON entry and so gets a pointer rather than the rule.

Running it against `develop` today reports 44 candidates, which is the worklist for the backfill PR. It also caught a real defect on the way: `changelog-15.md` names a `beforeCompositionstart` hook, while the registered hook is `beforeCompositionStart`.

Out of scope here, worth a follow-up: a build-free sweep of all of `docs/content` finds 11 `@/api/options.md#` anchors that do not resolve, from wrong casing (`#enterMoves`, `#fillHandle`, `#minRowHeights`, `#valueSetter`, `#themeName`) and from Core or plugin members pointed at `options.md` (`#redo`, `#splicerow`, `#uicontainer`). None of them is in a changelog page, so this check does not see them; widening its scope is a separate change.

`[skip changelog]`

### How has this been tested?

- 31 new unit tests, picked up by the existing `docs:test:plugins` glob with no workflow change:
  ```bash
  npm run docs:test:plugins --prefix docs    # 288 passed, 0 failed
  ```
  The tests were mutation-checked, not just run: removing the already-linked guard (`text[match.index - 1] === '['`) and removing the lowercase-anchor rule each turn a test red.
- The checker against the real pages, confirming it reports and still exits 0:
  ```bash
  npm run docs:validate-changelog-links --prefix docs; echo "exit=$?"   # 44 findings, exit=0
  GITHUB_STEP_SUMMARY=/tmp/summary.md npm run docs:validate-changelog-links --prefix docs   # writes the table
  ```
- The CI step was confirmed to actually report, from the workflow log of this PR's own `Docs / plugins` job, rather than assumed from a local run: it printed `38 unlinked API name(s), 0 unresolvable @/api/ link(s).` (Node resolves `process.argv[1]` to an absolute path even when the script is invoked relatively, so the entry-point guard matches. The guard now uses `pathToFileURL` anyway, matching `generate-version-highlights.mjs` and `test-runner-links.mjs`, because the naive `file://` form breaks on a path needing percent-encoding.)
- Lint, and the tooling suite that guards the workflow shapes:
  ```bash
  npm run docs:lint --prefix docs            # clean
  npm run test:tooling                       # 591 passed, 0 failed
  ```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2790

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2790

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and CI tooling only; the new check is advisory and does not fail builds or change runtime product behavior.
> 
> **Overview**
> Codifies a lapsed editorial rule (DEV-2790): when per-major changelog pages are updated by hand, **`Added` bullets should link new options, hooks, Core methods, and plugins** to `@/api/...` with **lowercase anchors**, and **`@/api/` must not appear in `.changelogs` entry titles** (those titles ship to GitHub `CHANGELOG.md` and release notes, where `@/api/` 404s).
> 
> Adds **`docs/scripts/check-changelog-api-links.mjs`** and **`npm run docs:validate-changelog-links`**, a **build-free, report-only** checker (always exit 0) that scans `changelog-<N>.md` pages using core sources (`metaSchema`, hooks, plugins, `core.ts`) plus `api/sidebar.js`. It flags unlinked API names in `Added` sections and broken `@/api/` links, with **31 unit tests** and a new step in the **Docs / plugins** CI job (findings go to the step summary).
> 
> Documentation updates: **`.changelogs/README.md`** (full workflow + title rule), **`docs/AGENTS.md`**, and the **changelog-creation** skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bba4bfa509888df24a1a1bbbf8a95bc4d07a98df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->