### PR TITLE
DEV-2769: Give the merged page fixtures an explicit polling interval

### DIFF
--- a/tests/fixtures/pages/AutoHeightScrollbarZoomPage.ts
+++ b/tests/fixtures/pages/AutoHeightScrollbarZoomPage.ts
@@ -34,7 +34,7 @@ export class AutoHeightScrollbarZoomPage {
     // still undefined, and the failure then surfaces inside a later `page.evaluate` far from its
     // cause. `waitForFunction`, not `expect`: the plain UMD bundle is ~6 MB and every worker pulls
     // its own copy, which outlasts the 10s `expect` timeout on a cold server.
-    await this.page.waitForFunction(() => 'Handsontable' in window);
+    await this.page.waitForFunction(() => 'Handsontable' in window, undefined, { polling: 100 });
     await expect(this.cell(0, 0)).toBeVisible();
     await expect(this.lastRow()).toBeAttached();
   }

--- a/tests/fixtures/pages/EditorOpenCheckboxFocusPage.ts
+++ b/tests/fixtures/pages/EditorOpenCheckboxFocusPage.ts
@@ -39,7 +39,7 @@ export class EditorOpenCheckboxFocusPage {
     // Waiting for the bundle itself, not only for a cell: the injected bundle script and the
     // block that builds the grid are separate, so a cell that is missing cannot otherwise be told
     // apart from a bundle that has not arrived yet.
-    await this.page.waitForFunction(() => 'Handsontable' in window);
+    await this.page.waitForFunction(() => 'Handsontable' in window, undefined, { polling: 100 });
 
     await expect(this.cell(0, 0)).toBeVisible();
   }

--- a/tests/fixtures/pages/IframeWidthWindowScrollPage.ts
+++ b/tests/fixtures/pages/IframeWidthWindowScrollPage.ts
@@ -28,8 +28,10 @@ export class IframeWidthWindowScrollPage {
   async goto(): Promise<void> {
     await this.page.goto(
       `/tests/fixtures/demo/iframe-width-window-scroll.html?theme=${this.theme}&bundle=${this.bundle}`);
-    await this.page.waitForFunction(() => 'Handsontable' in window);
-    await this.page.waitForFunction(() => (window as unknown as { ready: boolean }).ready === true);
+    await this.page.waitForFunction(() => 'Handsontable' in window, undefined, { polling: 100 });
+    await this.page.waitForFunction(
+      () => (window as unknown as { ready: boolean }).ready === true, undefined, { polling: 100 },
+    );
     await expect
       .poll(async () => (await this.holderState()).scrollWidth)
       .toBeGreaterThan(0);

--- a/tests/fixtures/pages/WidthWindowScrollPage.ts
+++ b/tests/fixtures/pages/WidthWindowScrollPage.ts
@@ -38,7 +38,7 @@ export class WidthWindowScrollPage {
    */
   async goto(): Promise<void> {
     await this.page.goto(`/tests/fixtures/demo/width-window-scroll.html?theme=${this.theme}&bundle=${this.bundle}`);
-    await this.page.waitForFunction(() => 'Handsontable' in window);
+    await this.page.waitForFunction(() => 'Handsontable' in window, undefined, { polling: 100 });
     await this.waitForRender();
   }
 


### PR DESCRIPTION
### Context

The PR fixes a red `develop`. `Lint / core` currently fails on the trunk itself, so every pull request opened from it inherits the failure regardless of what it changes.

Two pull requests that were each green in isolation landed close together and conflict semantically, not textually:

- #13364 added the `waitForFunction() needs an explicit polling interval` ESLint rule.
- #13392 added four page fixtures under `tests/fixtures/pages/` that call `waitForFunction()` with no options argument.

Neither PR's CI could see the other, and git merged both cleanly, so the rule and its five violations arrived on `develop` together. Reproduced at `bd953c1dad`, the current trunk tip, with the exact command the failing job runs:

```
✖ 5 problems (5 errors, 0 warnings)
tests/fixtures/pages/AutoHeightScrollbarZoomPage.ts
tests/fixtures/pages/EditorOpenCheckboxFocusPage.ts
tests/fixtures/pages/IframeWidthWindowScrollPage.ts
tests/fixtures/pages/WidthWindowScrollPage.ts
```

The fix is the one the rule's own message prescribes: pass `undefined, { polling: 100 }` as the options argument at all five call sites, matching `IncrementalRenderPage.ts`, `HiddenInitRerenderPage.ts`, and `MergeCellsInitRendersPage.ts`. Four are the identical `'Handsontable' in window` bundle probe; the fifth is the iframe page's `ready` flag.

This is not a lint-appeasement change. The rule exists because the default polls on `requestAnimationFrame`, which parallel Playwright workers starve, so a healthy page times out with nothing wrong on it. These four fixtures are exactly the shape the rule was written for: each waits on a ~6 MB UMD bundle to finish parsing while every other worker pulls its own copy.

Found while chasing a `Lint / core` failure on #13419, a one-line docs change that touches no TypeScript at all.

`[skip changelog]`

### How has this been tested?

- The exact command the failing CI step runs, before and after, at the trunk tip:
  ```bash
  npm run lint
  # before: exit 1, 5 problems (5 errors, 0 warnings)
  # after:  exit 0, 0 polling errors
  ```
  The 1928 remaining warnings are the pre-existing `sleep()` advisories, which are warn-only and unchanged by this PR.
- No test behavior changes: `polling: 100` alters how often the predicate is evaluated, not what it asserts.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2769

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2769

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness lint compliance only; predicates and assertions are unchanged.
> 
> **Overview**
> Restores **`Lint / core`** on `develop` by satisfying the new ESLint rule that **`waitForFunction()` must pass an explicit polling interval**.
> 
> Across four Playwright page objects under `tests/fixtures/pages/`, every bundle/`ready` wait now uses **`undefined, { polling: 100 }`**, aligned with fixtures like `IncrementalRenderPage`. That replaces the default **`requestAnimationFrame`** polling, which parallel workers can starve and cause flaky timeouts while large UMD bundles load—without changing what each wait asserts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6db23b508b2d9dcf79cb16ab908331900a6258f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->