### PR TITLE
DEV-2769: Wait for the bundle through the shared helper, not an inline copy

### DIFF
--- a/tests/fixtures/pages/AutoHeightScrollbarZoomPage.ts
+++ b/tests/fixtures/pages/AutoHeightScrollbarZoomPage.ts
@@ -1,4 +1,5 @@
 import { type Page, type Locator, expect } from '@playwright/test';
+import { awaitBundle } from '../bundle';
 
 /**
  * Page Object for the auto-height-scrollbar-zoom fixture (DEV-2525): a `height: 'auto'` grid with
@@ -29,12 +30,11 @@ export class AutoHeightScrollbarZoomPage {
       `/tests/fixtures/demo/auto-height-scrollbar-zoom.html` +
       `?theme=${this.theme}&bundle=${this.bundle}&zoom=${zoom}&rows=${rows}`
     );
-    // Wait for the bundle itself before anything else. The `document.write`-injected script and the
+    // Wait for the bundle itself before anything else: the `document.write`-injected script and the
     // block that constructs the grid are separate, so a page can look ready while `Handsontable` is
     // still undefined, and the failure then surfaces inside a later `page.evaluate` far from its
-    // cause. `waitForFunction`, not `expect`: the plain UMD bundle is ~6 MB and every worker pulls
-    // its own copy, which outlasts the 10s `expect` timeout on a cold server.
-    await this.page.waitForFunction(() => 'Handsontable' in window, undefined, { polling: 100 });
+    // cause. The helper owns the reasoning and the polling interval.
+    await awaitBundle(this.page);
     await expect(this.cell(0, 0)).toBeVisible();
     await expect(this.lastRow()).toBeAttached();
   }

--- a/tests/fixtures/pages/EditorOpenCheckboxFocusPage.ts
+++ b/tests/fixtures/pages/EditorOpenCheckboxFocusPage.ts
@@ -1,4 +1,5 @@
 import { type Locator, type Page, expect } from '@playwright/test';
+import { awaitBundle } from '../bundle';
 
 // Deliberately not `extends Window`: `windowTypes.ts` already declares `hot` globally with the
 // full instance type, and narrowing it here would be a TS2430 conflict. Every access is cast.
@@ -39,7 +40,7 @@ export class EditorOpenCheckboxFocusPage {
     // Waiting for the bundle itself, not only for a cell: the injected bundle script and the
     // block that builds the grid are separate, so a cell that is missing cannot otherwise be told
     // apart from a bundle that has not arrived yet.
-    await this.page.waitForFunction(() => 'Handsontable' in window, undefined, { polling: 100 });
+    await awaitBundle(this.page);
 
     await expect(this.cell(0, 0)).toBeVisible();
   }

--- a/tests/fixtures/pages/IframeWidthWindowScrollPage.ts
+++ b/tests/fixtures/pages/IframeWidthWindowScrollPage.ts
@@ -1,4 +1,5 @@
 import { type Page, expect } from '@playwright/test';
+import { BUNDLE_POLLING_MS, awaitBundle } from '../bundle';
 
 /**
  * Page Object for the cross-realm fixture: the grid's DOM lives in an iframe while the
@@ -28,9 +29,13 @@ export class IframeWidthWindowScrollPage {
   async goto(): Promise<void> {
     await this.page.goto(
       `/tests/fixtures/demo/iframe-width-window-scroll.html?theme=${this.theme}&bundle=${this.bundle}`);
-    await this.page.waitForFunction(() => 'Handsontable' in window, undefined, { polling: 100 });
+    await awaitBundle(this.page);
+    // The fixture's own flag, on the same interval: it builds the grid asynchronously, so `ready`
+    // is what says the iframe's stylesheets applied and the first render ran.
     await this.page.waitForFunction(
-      () => (window as unknown as { ready: boolean }).ready === true, undefined, { polling: 100 },
+      () => (window as unknown as { ready: boolean }).ready === true,
+      undefined,
+      { polling: BUNDLE_POLLING_MS },
     );
     await expect
       .poll(async () => (await this.holderState()).scrollWidth)

--- a/tests/fixtures/pages/WidthWindowScrollPage.ts
+++ b/tests/fixtures/pages/WidthWindowScrollPage.ts
@@ -1,4 +1,5 @@
 import { type Page, type Locator, expect } from '@playwright/test';
+import { awaitBundle } from '../bundle';
 
 /**
  * Page Object for the width-only window-scroll fixture: a grid with a definite
@@ -38,7 +39,7 @@ export class WidthWindowScrollPage {
    */
   async goto(): Promise<void> {
     await this.page.goto(`/tests/fixtures/demo/width-window-scroll.html?theme=${this.theme}&bundle=${this.bundle}`);
-    await this.page.waitForFunction(() => 'Handsontable' in window, undefined, { polling: 100 });
+    await awaitBundle(this.page);
     await this.waitForRender();
   }
 


### PR DESCRIPTION
### Context

The PR corrects a shortcut taken in #13421. That PR fixed a red `develop` by giving five `waitForFunction()` calls an explicit polling interval, which cleared the lint error but wrote `{ polling: 100 }` inline five times over. #13364 had already shipped the right tool for it, `awaitBundle()` in `tests/fixtures/bundle.ts`, and `tests/AGENTS.md` says so plainly:

> Do not inline a copy: the lint catches a missing `{ polling }`, but only the helper keeps the value from drifting between page objects.

So the lint went green on code that violated the convention the lint exists to serve. Roughly ten page objects already call the helper; these four were the only ones left reaching for the literal, which is exactly the drift the helper was introduced to end.

Four `goto()` methods now call `awaitBundle(this.page)`. The helper carries the reasoning those inline comments were duplicating - why `waitForFunction` and not `expect` (the plain UMD bundle is ~6 MB and every worker pulls its own copy, so a cold server outlasts the 10s `expect` timeout), and why a timer interval and not the `requestAnimationFrame` default (parallel workers starve rAF callbacks, so the default times out on a healthy page) - so each site keeps only the part specific to its own fixture.

The fifth call is not a bundle wait: `IframeWidthWindowScrollPage` also waits on the fixture's own `ready` flag, which signals that the iframe's stylesheets applied and the first render ran. That one stays a direct `waitForFunction`, now with `BUNDLE_POLLING_MS` rather than a second copy of the number.

No behavior changes: `BUNDLE_POLLING_MS` is 100, the value the inline calls used.

`[skip changelog]`

### How has this been tested?

- The command whose failure started this thread, at the current trunk tip:
  ```bash
  npm run lint    # exit 0, 0 errors
  ```
  The 1928 remaining warnings are the pre-existing `sleep()` advisories, warn-only and untouched.
- The four converted `goto()` methods wait on the same predicate at the same interval as before, so the E2E legs that drive them are unaffected.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2769

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2769

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test fixture page-object refactors only; no production or runtime behavior change.
> 
> **Overview**
> Replaces duplicated inline `waitForFunction` bundle waits in four Playwright page objects with the shared **`awaitBundle()`** helper from `tests/fixtures/bundle.ts`, matching the convention documented in `tests/AGENTS.md` and aligning the last holdouts with ~10 other page objects.
> 
> **`AutoHeightScrollbarZoomPage`**, **`EditorOpenCheckboxFocusPage`**, and **`WidthWindowScrollPage`** now call `awaitBundle(this.page)` in `goto()` instead of `{ polling: 100 }` on `'Handsontable' in window`. Comments at those sites defer polling/`expect` rationale to the helper.
> 
> **`IframeWidthWindowScrollPage`** uses `awaitBundle` for the bundle and **`BUNDLE_POLLING_MS`** for the fixture’s separate `ready` wait (still a direct `waitForFunction`), so the interval is not duplicated. Behavior is unchanged because `BUNDLE_POLLING_MS` is 100.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98226eef7cc3d7b21ba8c4b275f406a4a62f705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->