### PR TITLE
DEV-2833: Fix "undefined" prefix in the Open in AI prompt links

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -564,6 +564,20 @@ The custom loader (`src/plugins/framework-loader.mjs`) renders every source page
 - `npm run dev` must work with the default Node heap. Do not add `NODE_OPTIONS=--max-old-space-size` workarounds; shrink the data store instead.
 - Plugin unit tests run with `node --test src/plugins/__tests__/*.test.mjs`.
 
+### Starting the dev server from an agent session
+
+`npm run dev` dies with `Dev server failed to start within 30s.` and exit 1 in every agent session, and the message is a lie - nothing in the config is broken. Astro 7's `astro dev` calls `isRunByAgent()`, and on a hit it force-enables **background mode**: it spawns a detached child, polls for that child's lock file for 30 seconds, then SIGTERMs the child and exits non-zero. This docs config never boots that fast, so the wrapper always kills a server that was on its way up. Run the server process itself instead:
+
+```bash
+ASTRO_DEV_BACKGROUND=1 npx astro dev
+```
+
+That env var is what the spawned child receives, so setting it makes the foreground process *be* the server and skips the timeout wrapper entirely. Do not raise the timeout (it is hardcoded in `astro/dist/cli/dev/background.js`) and do not conclude the config is at fault.
+
+### The dev server 500s in a fresh worktree until the core CSS exists
+
+Every page returns HTTP 500 with `[postcss] ENOENT: no such file or directory, open '../../../handsontable/styles/handsontable.min.css'`. `src/styles/handsontable-import.css` imports the **built** stylesheet from the core package, and `git worktree` materializes tracked files only, so a new worktree has no `handsontable/styles/`. Build the core package, or copy `handsontable/styles/` in from a checkout that already has it. Then **restart the dev server** - postcss caches the resolution failure, so a running server keeps 500ing after the file appears.
+
 ---
 
 ## 2.13 Example-Runner Error Handling

--- a/docs/src/components/PageSidebar.astro
+++ b/docs/src/components/PageSidebar.astro
@@ -20,10 +20,14 @@ const { actions, prompt: userPrompt } = config;
 const { pageActions } = (Astro.locals as any).starlightRoute.entry.data;
 const showActions = pageActions || typeof pageActions === 'undefined';
 
-const prompt = userPrompt?.includes('{url}')
-  ? userPrompt?.replace('{url}', currentUrl)
-  : `${userPrompt} ${currentUrl}`;
-const encodedPrompt = encodeURIComponent(prompt as string);
+// `prompt` is optional in starlight-page-actions and has no default in the
+// plugin's config, so fall back to its injected translation. Without this the
+// template literal below stringifies `undefined` into every "Open in ..." link.
+const promptTemplate = userPrompt ?? Astro.locals.t('prompt.default');
+const prompt = promptTemplate.includes('{url}')
+  ? promptTemplate.replace('{url}', currentUrl)
+  : `${promptTemplate} ${currentUrl}`;
+const encodedPrompt = encodeURIComponent(prompt);
 
 interface ActionLink {
   label: string;

--- a/docs/src/components/__tests__/page-sidebar-ai-prompt.test.mjs
+++ b/docs/src/components/__tests__/page-sidebar-ai-prompt.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const sidebarPath = fileURLToPath(new URL('../PageSidebar.astro', import.meta.url));
+const sidebarSource = readFileSync(sidebarPath, 'utf8');
+
+const PAGE_URL = 'https://handsontable.com/docs/angular-data-grid/row-parent-child/';
+const PLUGIN_DEFAULT_PROMPT = 'Read {url}. I want to ask questions about it.';
+
+// The statements that turn starlight-page-actions' optional `prompt` config into
+// the query string of every "Open in ..." link. `prompt` has no default in the
+// plugin's config object, so an unguarded template literal stringifies
+// `undefined` into the link and every AI vendor opens with "undefined <url>".
+// `as <Type>` assertions are stripped so the block stays runnable as plain JS —
+// without it `new Function` throws a SyntaxError and the assertions below would
+// go red for the wrong reason.
+const promptBlock = sidebarSource
+  .slice(
+    sidebarSource.indexOf('const promptTemplate ='),
+    sidebarSource.indexOf('interface ActionLink')
+  )
+  .replace(/ as [A-Za-z_$][\w$]*/g, '');
+
+/**
+ * Runs the component's prompt-building statements against a stubbed config value.
+ *
+ * @param {string|undefined} userPrompt The `prompt` value from the plugin config.
+ * @returns {{prompt: string, encodedPrompt: string}} The built prompt and its encoded form.
+ */
+function buildPrompt(userPrompt) {
+  // eslint-disable-next-line no-new-func
+  const run = new Function(
+    'userPrompt',
+    'currentUrl',
+    'Astro',
+    `${promptBlock}\nreturn { prompt, encodedPrompt };`
+  );
+
+  return run(userPrompt, PAGE_URL, {
+    locals: { t: () => PLUGIN_DEFAULT_PROMPT },
+  });
+}
+
+test('an unconfigured prompt falls back to the plugin default, never "undefined"', () => {
+  const { prompt, encodedPrompt } = buildPrompt(undefined);
+
+  assert.doesNotMatch(prompt, /undefined/);
+  assert.doesNotMatch(encodedPrompt, /undefined/);
+  assert.equal(prompt, `Read ${PAGE_URL}. I want to ask questions about it.`);
+});
+
+test('a configured prompt has its {url} placeholder replaced with the page URL', () => {
+  const { prompt } = buildPrompt('Summarize {url} for me.');
+
+  assert.equal(prompt, `Summarize ${PAGE_URL} for me.`);
+});
+
+test('a configured prompt without {url} gets the page URL appended', () => {
+  const { prompt } = buildPrompt('Summarize this page.');
+
+  assert.equal(prompt, `Summarize this page. ${PAGE_URL}`);
+});
+
+test('both "Open in ..." links send the encoded prompt', () => {
+  assert.match(sidebarSource, /https:\/\/chatgpt\.com\/\?q=\$\{encodedPrompt\}/);
+  assert.match(sidebarSource, /https:\/\/claude\.ai\/new\?q=\$\{encodedPrompt\}/);
+});


### PR DESCRIPTION
### Context

The PR fixes the **Open in ChatGPT** and **Open in Claude** buttons in the docs right sidebar, which open the AI vendor with the literal word `undefined` in front of the page URL. It affects every docs page.

Reproduced on the live site with a plain `curl`:

```bash
curl -sL "https://handsontable.com/docs/angular-data-grid/row-parent-child/" \
  | grep -o 'https://chatgpt.com/?q=[^"]*'
# https://chatgpt.com/?q=undefined%20https%3A%2F%2Fhandsontable.com%2Fdocs%2Fangular-data-grid%2Frow-parent-child%2F
```

So the AI chat opens prefilled with:

```
undefined https://handsontable.com/docs/angular-data-grid/row-parent-child/
```

**Cause.** `docs/src/components/PageSidebar.astro` builds the prompt from the `starlight-page-actions` config:

```js
const prompt = userPrompt?.includes('{url}')
  ? userPrompt?.replace('{url}', currentUrl)
  : `${userPrompt} ${currentUrl}`;
```

`starlightPageActions()` is called in `docs/astro.config.mjs` with no options, and the plugin's `defaultConfig` has no `prompt` key — only `actions` and `share`. `actions.chatgpt` and `actions.claude` both default to `true`, so the buttons render, but `userPrompt` is `undefined`. The optional chain makes the ternary take the `else` branch, and the template literal stringifies `undefined` straight into the query string.

The plugin's own `overrides/PageTitle.astro` has the guard this component is missing:

```js
const promptTemplate = userPrompt ?? Astro.locals.t("prompt.default");
```

`PageSidebar.astro` re-implements that block but dropped that one line. The docs site overrides both `PageTitle` and `PageSidebar`, so the plugin's guarded version never renders here. Present since the VuePress → Astro Starlight migration (#12195).

**Fix.** Restore the fallback. With no `prompt` configured, the links now carry the plugin's injected translation:

```
Read https://handsontable.com/docs/angular-data-grid/row-parent-child/. I want to ask questions about it.
```

The `{url}` placeholder and the append-the-URL branch both keep working, so configuring a `prompt` in `astro.config.mjs` later needs no further change.

### How has this been tested?

New regression test at `docs/src/components/__tests__/page-sidebar-ai-prompt.test.mjs`. It extracts the component's prompt-building statements from the `.astro` source and runs them against a stubbed config, so it asserts behavior rather than matching source text. It covers all three branches: no configured prompt, a prompt with `{url}`, and a prompt without `{url}`.

Verified it actually catches this bug — reverted the component to the old code and the first case went red with the exact reported string:

```
AssertionError: The input was expected to not match /undefined/. Input:
'undefined https://handsontable.com/docs/angular-data-grid/row-parent-child/'
```

```bash
npm run docs:test:plugins --prefix docs   # 300/300 pass (296 before, +4 new)
npm run docs:lint --prefix docs           # clean
```

Also confirmed against a real render, not just the diff — `astro dev` plus a `curl` of the same page:

```bash
curl -s "http://localhost:4321/docs/angular-data-grid/row-parent-child/" \
  | grep -o 'https://claude.ai/new?q=[^"]*'
# https://claude.ai/new?q=Read%20http%3A%2F%2Flocalhost%3A4321%2Fdocs%2Fangular-data-grid%2Frow-parent-child%2F.%20I%20want%20to%20ask%20questions%20about%20it.
```

That render step mattered: it is the only way to confirm `Astro.locals.t('prompt.default')` resolves to the English string rather than returning the key itself.

### Second commit: `docs/AGENTS.md`

Verifying this against a real render in a fresh worktree hit two dev-server traps that cost more time than the fix did, so they are written down in `docs/AGENTS.md` §2.12:

- `npm run dev` always dies with `Dev server failed to start within 30s.` in an agent session. Astro 7 detects the agent, force-enables background mode, and SIGTERMs the child it spawned when this config does not boot inside its hardcoded 30s. `ASTRO_DEV_BACKGROUND=1 npx astro dev` runs the real server in the foreground.
- A fresh worktree 500s on every docs page with `[postcss] ENOENT ... handsontable/styles/handsontable.min.css`, because `git worktree` materializes tracked files only and that stylesheet is a build output. The postcss cache holds the failure, so the server needs a restart after the file appears.

### Note for the reviewer

Production docs build from `prod-docs/<major>.<minor>`, which cherry-picks from `develop` selectively. This fix does not reach handsontable.com/docs until it is cherry-picked there.

Optional follow-up, deliberately not done here: the prompt points the AI at the HTML page. The docs already serve clean Markdown for the same page (`/docs/_md/<slug>.md` returns `200 text/markdown`, and the "Copy Markdown" button uses it). Pointing the AI links at that instead would give the model the page content without the nav and grid markup. That is a product decision, so it is left out of a bug fix.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2833

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2833
