### PR TITLE
DEV-2840: Wait for the bundle through awaitBundle() in AutoRowSizeClearCachePage

### DIFF
--- a/tests/fixtures/pages/AutoRowSizeClearCachePage.ts
+++ b/tests/fixtures/pages/AutoRowSizeClearCachePage.ts
@@ -1,4 +1,5 @@
 import { type Page, type Locator, expect } from '@playwright/test';
+import { awaitBundle } from '../bundle';
 
 /**
  * Page Object for the AutoRowSize `clearCache()` fixture.
@@ -169,10 +170,10 @@ export class AutoRowSizeClearCachePage {
     await this.page.goto(
       `/tests/fixtures/demo/auto-row-size-clear-cache.html?theme=${this.theme}&bundle=${this.bundle}`
     );
-    // The bundle first, and with `waitForFunction` rather than `expect`: the dist file is several
-    // megabytes and every worker pulls its own copy, so a cold server outlasts the 10s `expect`
-    // timeout and the leg would fail pointing at an overlay class instead of the real cause.
-    await this.page.waitForFunction(() => 'Handsontable' in window);
+    // The bundle first, or the leg would fail pointing at an overlay class instead of the real
+    // cause. `awaitBundle()` owns both the `waitForFunction`-over-`expect` choice and the polling
+    // interval, so the wait is not re-inlined here - see its docstring for why each one matters.
+    await awaitBundle(this.page);
     await expect(this.inlineStartOverlay).toBeVisible();
     await expect(this.grid.locator('.ht_master tbody tr').first()).toBeVisible();
   }


### PR DESCRIPTION
### Context

The PR fixes `Lint / core` failing on **every** pull request branched off `develop`:

```
tests/fixtures/pages/AutoRowSizeClearCachePage.ts
  175:11  error  waitForFunction() needs an explicit polling interval — pass `undefined,
  { polling: 100 }` (or another interval) as the options argument. The default polls on
  requestAnimationFrame, which parallel workers starve, so a healthy page times out with
  nothing wrong on it. See tests/AGENTS.md (Determinism)   no-restricted-syntax

✖ 1 problem (1 error, 0 warnings)
```

The offending line is `await this.page.waitForFunction(() => 'Handsontable' in window);` — no polling interval.

**How it got in.** The rule and the file arrived in the wrong order:

| Event | Merged |
|---|---|
| #13364 (DEV-2769) adds the `no-restricted-syntax` rule banning the rAF default | **07:37Z** |
| #13404 (DEV-2812) adds `AutoRowSizeClearCachePage.ts` with the violating line | **10:14Z** |

Two things let it through. #13404's own `Lint / core` is **red** — it merged with that check failing. And `lint.yml` is `workflow_call`-only, invoked from `test.yml` on pull requests; its header comment says "a merged PR already proved lint, so no trunk runs", so **`develop` runs no lint job**. Nothing re-checked trunk after the merge, which is why the breakage is invisible on `develop` while failing every new PR.

Found while working on DEV-2832 (#13426), whose only red check was this file — a file that does not exist on that branch.

### The fix is the shared helper, not a literal interval

`tests/fixtures/bundle.ts` already exports `awaitBundle(page)` for exactly this wait, and **24 other page objects call it**. Its own docstring says every page object's `goto()` calls it right after `page.goto()`, and that "this helper is where the interval lives". `BUNDLE_POLLING_MS` exists so the interval "cannot drift between page objects the way the inline copies did".

So passing `{ polling: 100 }` inline would satisfy the linter while recreating precisely the drift the helper was factored out to prevent. This calls the helper instead.

The inline comment restated, in shorter form, reasoning already documented on `awaitBundle()` — the `waitForFunction`-over-`expect` choice and the timer-over-rAF choice. It now points at that docstring rather than paraphrasing it.

### Test evidence (required for source changes)

No production source changed — this is a Playwright page object under `tests/fixtures/`, and the change is a swap to an existing helper with the awaited condition and polling behavior unchanged. The commit carries a `Refactor-only:` trailer.

- Unit tests added/modified (`*.unit.js`): none — no core source touched
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none — the page object's existing specs from #13404 cover it unchanged
- Type tests (`*.types.ts`) updated if public API changed: none — no public API change
- For a bug fix — the spec that fails without this fix: not a spec; the gate is `Lint / core`, reproduced below
- Demo page / recorded trace (for UI changes): n/a

Verified both directions locally rather than assuming:

```
# with the original line restored — reproduces the CI error exactly
$ npx eslint --ext .ts fixtures/pages/AutoRowSizeClearCachePage.ts
  176:11  error  waitForFunction() needs an explicit polling interval …  no-restricted-syntax
✖ 1 problem (1 error, 0 warnings)

# with the fix
$ npx eslint --ext .ts fixtures/pages/AutoRowSizeClearCachePage.ts
(clean)
```

### Commands run

```
$ cd tests && npx eslint --ext .ts e2e fixtures     # the exact command `npm run lint --prefix tests` runs
(no output — clean, exit 0)
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2840
2. Introduced by #13404 (DEV-2812); rule added in #13364 (DEV-2769)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

None of the above — the change is confined to the Playwright functional suite (`tests/`), which is not one of the listed packages.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation. — no; `tests/AGENTS.md` already documents the determinism rule this restores compliance with.

### Worth a separate decision

`develop` running no lint job is what turned one bad merge into a branch-wide block: the failure never showed on trunk, and instead surfaced on unrelated pull requests whose authors had no way to connect it to their own work. Worth deciding whether the trunk push should call `lint.yml` too, so a red merge is caught on `develop` where it happened. Not changed here — it is a CI-policy call, and this PR is meant to be the minimum that unblocks everyone.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2840

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only page object change; behavior matches the existing shared bundle-wait helper used elsewhere in the suite.
> 
> **Overview**
> Fixes **`Lint / core`** on PRs by aligning `AutoRowSizeClearCachePage` with the other Playwright page objects.
> 
> In **`goto()`**, the inlined `page.waitForFunction(() => 'Handsontable' in window)` (no polling options) is replaced with **`awaitBundle(this.page)`**, which uses the shared **`BUNDLE_POLLING_MS`** interval and satisfies the **`no-restricted-syntax`** rule. The comment now references **`awaitBundle()`**’s docstring instead of duplicating that rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47de20b119efbedca9998538f8b0e85c4e48650c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->