### PR TITLE
RELEASE-881: Bring the four READMEs to one Key Features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@
 &nbsp;&nbsp;✅&nbsp; [Server-side data](https://handsontable.com/docs/javascript-data-grid/server-side-data/) <br>
 &nbsp;&nbsp;✅&nbsp; [Notifications](https://handsontable.com/docs/javascript-data-grid/notification/) <br>
 &nbsp;&nbsp;✅&nbsp; [Export to Excel](https://handsontable.com/docs/javascript-data-grid/export-to-excel/) <br>
+&nbsp;&nbsp;✅&nbsp; [Date and time editing](https://handsontable.com/docs/javascript-data-grid/cell-type/) <br>
+&nbsp;&nbsp;✅&nbsp; [Shadow DOM / Web Components support](https://handsontable.com/docs/javascript-data-grid/shadow-dom/) <br>
 
 <br>
 

--- a/wrappers/angular-wrapper/README.md
+++ b/wrappers/angular-wrapper/README.md
@@ -12,7 +12,7 @@
 
   <p>With its spreadsheet-like editing features, it's perfect for building data-rich internal apps. It allows users to enter, edit, validate, and process data from various sources. Common use cases include resource planning software (ERP), inventory management systems, digital platforms, and data modeling applications.</p>
 
-<a href="https://handsontable.com">Website</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/angular-data-grid">Documentation</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/angular-data-grid/themes">Themes</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/angular-data-grid/api">API</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://github.com/handsontable/handsontable/discussions">Community</a>
+<a href="https://handsontable.com">Website</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/angular-data-grid">Documentation</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/angular-data-grid/themes">Themes</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/angular-data-grid/api">API</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://forum.handsontable.com/">Community</a>
 
   <br>
 
@@ -55,6 +55,11 @@
 &nbsp;&nbsp;✅&nbsp; [Hiding columns](https://handsontable.com/docs/angular-data-grid/column-hiding/) <br>
 &nbsp;&nbsp;✅&nbsp; [Right-click context menu](https://handsontable.com/docs/angular-data-grid/context-menu/) <br>
 &nbsp;&nbsp;✅&nbsp; [Row pagination](https://handsontable.com/docs/angular-data-grid/rows-pagination/) <br>
+&nbsp;&nbsp;✅&nbsp; [Server-side data](https://handsontable.com/docs/angular-data-grid/server-side-data/) <br>
+&nbsp;&nbsp;✅&nbsp; [Notifications](https://handsontable.com/docs/angular-data-grid/notification/) <br>
+&nbsp;&nbsp;✅&nbsp; [Export to Excel](https://handsontable.com/docs/angular-data-grid/export-to-excel/) <br>
+&nbsp;&nbsp;✅&nbsp; [Date and time editing](https://handsontable.com/docs/angular-data-grid/cell-type/) <br>
+&nbsp;&nbsp;✅&nbsp; [Shadow DOM / Web Components support](https://handsontable.com/docs/angular-data-grid/shadow-dom/) <br>
 
 <div id="installation">
 
@@ -198,7 +203,7 @@ At first glance, it might seem that a data table, spreadsheet, and data grid are
 **We're here to help!**
 
 If you're using Handsontable with a free, non-commercial license, you can:
-- Join the conversation on [GitHub Discussions](https://github.com/handsontable/handsontable/discussions) to share ideas, suggest features, or discuss changes.
+- Get quick help from our [**Ask AI** assistant](https://handsontable.com/docs/angular-data-grid/ai-docs-assistant/) available in the documentation.
 - Report any bugs you find on our [GitHub Issue Board](https://github.com/handsontable/handsontable/issues).
 - Connect with other developers and find answers on our [Developer Forum](https://forum.handsontable.com).
 
@@ -238,4 +243,4 @@ Created and maintained by the [Handsontable Team](https://handsontable.com/team)
 
 ---
 
-© 2012 - 2025 Handsoncode
+© 2012 - 2026 Handsoncode

--- a/wrappers/react-wrapper/README.md
+++ b/wrappers/react-wrapper/README.md
@@ -13,7 +13,7 @@
 
   <p>With its spreadsheet-like editing features, it’s perfect for building data-rich internal apps. It allows users to enter, edit, validate, and process data from various sources. Common use cases include resource planning software (ERP), inventory management systems, digital platforms, and data modeling applications.</p>
 
-<a href="https://handsontable.com">Website</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/react-data-grid">Documentation</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/react-data-grid/themes">Themes</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/react-data-grid/api">API</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://github.com/handsontable/handsontable/discussions">Community</a>
+<a href="https://handsontable.com">Website</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/react-data-grid">Documentation</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/react-data-grid/themes">Themes</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/react-data-grid/api">API</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://forum.handsontable.com/">Community</a>
 
   <br>
 
@@ -56,6 +56,11 @@
 &nbsp;&nbsp;✅&nbsp; [Hiding columns](https://handsontable.com/docs/react-data-grid/column-hiding/) <br>
 &nbsp;&nbsp;✅&nbsp; [Right-click context menu](https://handsontable.com/docs/react-data-grid/context-menu/) <br>
 &nbsp;&nbsp;✅&nbsp; [Row pagination](https://handsontable.com/docs/react-data-grid/rows-pagination/) <br>
+&nbsp;&nbsp;✅&nbsp; [Server-side data](https://handsontable.com/docs/react-data-grid/server-side-data/) <br>
+&nbsp;&nbsp;✅&nbsp; [Notifications](https://handsontable.com/docs/react-data-grid/notification/) <br>
+&nbsp;&nbsp;✅&nbsp; [Export to Excel](https://handsontable.com/docs/react-data-grid/export-to-excel/) <br>
+&nbsp;&nbsp;✅&nbsp; [Date and time editing](https://handsontable.com/docs/react-data-grid/cell-type/) <br>
+&nbsp;&nbsp;✅&nbsp; [Shadow DOM / Web Components support](https://handsontable.com/docs/react-data-grid/shadow-dom/) <br>
 
 <div id="installation">
 
@@ -186,7 +191,7 @@ At first glance, it might seem that a data table, spreadsheet, and data grid are
 **We're here to help!**
 
 If you're using Handsontable with a free, non-commercial license, you can:
-- Join the conversation on [GitHub Discussions](https://github.com/handsontable/handsontable/discussions) to share ideas, suggest features, or discuss changes.
+- Get quick help from our [**Ask AI** assistant](https://handsontable.com/docs/react-data-grid/ai-docs-assistant/) available in the documentation.
 - Report any bugs you find on our [GitHub Issue Board](https://github.com/handsontable/handsontable/issues).
 - Connect with other developers and find answers on our [Developer Forum](https://forum.handsontable.com).
 
@@ -226,4 +231,4 @@ Created and maintained by the [Handsontable Team](https://handsontable.com/team)
 
 ---
 
-© 2012 - 2025 Handsoncode
+© 2012 - 2026 Handsoncode

--- a/wrappers/vue3/README.md
+++ b/wrappers/vue3/README.md
@@ -8,11 +8,11 @@
   <br><br>
   <h3>The official <img src="https://raw.githubusercontent.com/handsontable/handsontable/develop/resources/icons/vue-icon.svg" width="16" height="16"> Vue 3 wrapper for Handsontable.
     <br>
-    <a href="https://handsontable.com/docs" target="_blank">JavaScript Data Grid</a> with a spreadsheet-like look and feel.</h3>
+    <a href="https://handsontable.com/docs/vue-data-grid" target="_blank">JavaScript Data Grid</a> with a spreadsheet-like look and feel.</h3>
 
   <p>With its spreadsheet-like editing features, it’s perfect for building data-rich internal apps. It allows users to enter, edit, validate, and process data from various sources. Common use cases include resource planning software (ERP), inventory management systems, digital platforms, and data modeling applications.</p>
 
-<a href="https://handsontable.com">Website</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/javascript-data-grid/vue3-installation/">Documentation</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/themes">Themes</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/api">API</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://github.com/handsontable/handsontable/discussions">Community</a>
+<a href="https://handsontable.com">Website</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/vue-data-grid">Documentation</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/vue-data-grid/themes">Themes</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://handsontable.com/docs/vue-data-grid/api">API</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="https://forum.handsontable.com/">Community</a>
 
   <br>
 
@@ -36,25 +36,30 @@
 
 ## ✨ Key Features
 
-&nbsp;&nbsp;✅&nbsp; [Built-in themes](https://handsontable.com/docs/themes/) <br>
-&nbsp;&nbsp;✅&nbsp; [Flexible API](https://handsontable.com/docs/api/) <br>
-&nbsp;&nbsp;✅&nbsp; [Virtualization](https://handsontable.com/docs/row-virtualization/) <br>
-&nbsp;&nbsp;✅&nbsp; [IME support](https://handsontable.com/docs/ime-support/) <br>
-&nbsp;&nbsp;✅&nbsp; [Internationalization](https://handsontable.com/docs/language/) <br>
-&nbsp;&nbsp;✅&nbsp; [RTL support](https://handsontable.com/docs/layout-direction/) <br>
-&nbsp;&nbsp;✅&nbsp; [Accessibility](https://handsontable.com/docs/accessibility/) <br>
-&nbsp;&nbsp;✅&nbsp; [Keyboard shortcuts](https://handsontable.com/docs/keyboard-shortcuts/) <br>
-&nbsp;&nbsp;✅&nbsp; [Sorting data](https://handsontable.com/docs/rows-sorting/) <br>
-&nbsp;&nbsp;✅&nbsp; [Filtering data](https://handsontable.com/docs/column-filter/) <br>
-&nbsp;&nbsp;✅&nbsp; [400 built-in formulas](https://handsontable.com/docs/formula-calculation/) <br>
-&nbsp;&nbsp;✅&nbsp; [Configurable selection](https://handsontable.com/docs/selection/) <br>
-&nbsp;&nbsp;✅&nbsp; [Data validation](https://handsontable.com/docs/cell-validator/) <br>
-&nbsp;&nbsp;✅&nbsp; [Conditional formatting](https://handsontable.com/docs/conditional-formatting/) <br>
-&nbsp;&nbsp;✅&nbsp; [Merged cells](https://handsontable.com/docs/merge-cells/) <br>
-&nbsp;&nbsp;✅&nbsp; [Pinned/frozen columns](https://handsontable.com/docs/column-freezing/) <br>
-&nbsp;&nbsp;✅&nbsp; [Hiding columns](https://handsontable.com/docs/column-hiding/) <br>
-&nbsp;&nbsp;✅&nbsp; [Right-click context menu](https://handsontable.com/docs/context-menu/) <br>
-&nbsp;&nbsp;✅&nbsp; [Row pagination](https://handsontable.com/docs/rows-pagination/) <br>
+&nbsp;&nbsp;✅&nbsp; [Built-in themes](https://handsontable.com/docs/vue-data-grid/themes/) <br>
+&nbsp;&nbsp;✅&nbsp; [Flexible API](https://handsontable.com/docs/vue-data-grid/api/) <br>
+&nbsp;&nbsp;✅&nbsp; [Virtualization](https://handsontable.com/docs/vue-data-grid/row-virtualization/) <br>
+&nbsp;&nbsp;✅&nbsp; [IME support](https://handsontable.com/docs/vue-data-grid/ime-support/) <br>
+&nbsp;&nbsp;✅&nbsp; [Internationalization](https://handsontable.com/docs/vue-data-grid/language/) <br>
+&nbsp;&nbsp;✅&nbsp; [RTL support](https://handsontable.com/docs/vue-data-grid/layout-direction/) <br>
+&nbsp;&nbsp;✅&nbsp; [Accessibility](https://handsontable.com/docs/vue-data-grid/accessibility/) <br>
+&nbsp;&nbsp;✅&nbsp; [Keyboard shortcuts](https://handsontable.com/docs/vue-data-grid/keyboard-shortcuts/) <br>
+&nbsp;&nbsp;✅&nbsp; [Sorting data](https://handsontable.com/docs/vue-data-grid/rows-sorting/) <br>
+&nbsp;&nbsp;✅&nbsp; [Filtering data](https://handsontable.com/docs/vue-data-grid/column-filter/) <br>
+&nbsp;&nbsp;✅&nbsp; [400 built-in formulas](https://handsontable.com/docs/vue-data-grid/formula-calculation/) <br>
+&nbsp;&nbsp;✅&nbsp; [Configurable selection](https://handsontable.com/docs/vue-data-grid/selection/) <br>
+&nbsp;&nbsp;✅&nbsp; [Data validation](https://handsontable.com/docs/vue-data-grid/cell-validator/) <br>
+&nbsp;&nbsp;✅&nbsp; [Conditional formatting](https://handsontable.com/docs/vue-data-grid/conditional-formatting/) <br>
+&nbsp;&nbsp;✅&nbsp; [Merged cells](https://handsontable.com/docs/vue-data-grid/merge-cells/) <br>
+&nbsp;&nbsp;✅&nbsp; [Pinned/frozen columns](https://handsontable.com/docs/vue-data-grid/column-freezing/) <br>
+&nbsp;&nbsp;✅&nbsp; [Hiding columns](https://handsontable.com/docs/vue-data-grid/column-hiding/) <br>
+&nbsp;&nbsp;✅&nbsp; [Right-click context menu](https://handsontable.com/docs/vue-data-grid/context-menu/) <br>
+&nbsp;&nbsp;✅&nbsp; [Row pagination](https://handsontable.com/docs/vue-data-grid/rows-pagination/) <br>
+&nbsp;&nbsp;✅&nbsp; [Server-side data](https://handsontable.com/docs/vue-data-grid/server-side-data/) <br>
+&nbsp;&nbsp;✅&nbsp; [Notifications](https://handsontable.com/docs/vue-data-grid/notification/) <br>
+&nbsp;&nbsp;✅&nbsp; [Export to Excel](https://handsontable.com/docs/vue-data-grid/export-to-excel/) <br>
+&nbsp;&nbsp;✅&nbsp; [Date and time editing](https://handsontable.com/docs/vue-data-grid/cell-type/) <br>
+&nbsp;&nbsp;✅&nbsp; [Shadow DOM / Web Components support](https://handsontable.com/docs/vue-data-grid/shadow-dom/) <br>
 
 <div id="installation">
 
@@ -71,7 +76,7 @@ Below is the installation guide for the Handsontable with Vue 3 wrapper. If you'
 npm install handsontable @handsontable/vue3
 ```
 
-You can load it directly from [jsDelivr](https:jsdelivr.com/package/npm/@handsontable/vue3) as well.
+You can load it directly from [jsDelivr](https://www.jsdelivr.com/package/npm/@handsontable/vue3) as well.
 ```html
 <script src="https://cdn.jsdelivr.net/npm/handsontable/dist/handsontable.full.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@handsontable/vue3/dist/vue-handsontable.min.js"></script>
@@ -81,7 +86,7 @@ The component will be available as `Handsontable.vue.HotTable`.
 
 ### Usage
 
-Use this data grid as you would any other component in your application. [Options](https://handsontable.com/docs/api/options/) can be set as `HotTable` props.
+Use this data grid as you would any other component in your application. [Options](https://handsontable.com/docs/vue-data-grid/api/options/) can be set as `HotTable` props.
 
 **Vue 3 Component**
 ```vue
@@ -165,7 +170,7 @@ To stay aligned with design, you can rely on the:
 
 - [Website](https://handsontable.com)
 - [Demo](https://handsontable.com/demo)
-- [Documentation](https://handsontable.com/docs/javascript-data-grid/vue3-installation/)
+- [Documentation](https://handsontable.com/docs/vue-data-grid)
 - [npm](https://www.npmjs.com/package/@handsontable/vue3)
 - [CDN](https://www.jsdelivr.com/package/npm/@handsontable/vue3)
 - [Forum](https://forum.handsontable.com/)
@@ -200,7 +205,7 @@ At first glance, it might seem that a data table, spreadsheet, and data grid are
 **We're here to help!**
 
 If you're using Handsontable with a free, non-commercial license, you can:
-- Join the conversation on [GitHub Discussions](https://github.com/handsontable/handsontable/discussions) to share ideas, suggest features, or discuss changes.
+- Get quick help from our [**Ask AI** assistant](https://handsontable.com/docs/vue-data-grid/ai-docs-assistant/) available in the documentation.
 - Report any bugs you find on our [GitHub Issue Board](https://github.com/handsontable/handsontable/issues).
 - Connect with other developers and find answers on our [Developer Forum](https://forum.handsontable.com).
 
@@ -240,4 +245,4 @@ Created and maintained by the [Handsontable Team](https://handsontable.com/team)
 
 ---
 
-© 2012 - 2025 Handsoncode
+© 2012 - 2026 Handsoncode


### PR DESCRIPTION
### Context

Post-release check of the READMEs for 18.1. The review on the task proposed two new "Key Features" bullets for the root README, and the follow-up asked for the same treatment across every README, wrappers included.

Applying it to the wrappers surfaced that they were already three bullets behind root (Server-side data, Notifications, Export to Excel), so adding only the two new ones would have left them permanently out of parity. All four lists now carry the same 24 entries in the same order, each on its own framework's docs prefix.

Two decisions worth recording.

**No theme CSS import was added.** The task cited a missing stylesheet import as a separate, already-tracked problem. That turned out to be a false lead: #13428 rendered the README snippet headless with and without the stylesheets and got byte-identical computed styles, because 17.0.0 added `injectCoreCss: true` and applies the default `main` theme through the JS theme engine. Nothing to restore.

**Shadow DOM links to `/shadow-dom/`, not to the migration guide.** The proposed diff pointed at the 18.0-to-18.1 migration guide with a note to swap it if a dedicated page appeared. One exists, shipped by #13194 alongside the feature itself, and it covers web components and Salesforce LWC. The README ships to npm on every publish, so a per-release migration link would go stale at 18.2.

#### What changed per file

| File | Change |
|---|---|
| `README.md` | Two new bullets, 22 to 24 |
| `wrappers/react-wrapper/README.md` | Five new bullets, dead Community link, Ask AI bullet, copyright year |
| `wrappers/angular-wrapper/README.md` | Same as React |
| `wrappers/vue3/README.md` | Same, plus the docs prefix sweep and the jsDelivr URL |

**The Vue README moves onto the `vue-data-grid` docs prefix.** It was the only one still using bare `/docs/<slug>/` links. Its "Row pagination" link was a live 404, and the other 18 redirected Vue readers onto the JavaScript docs. Every slug was checked on the Vue prefix first and all return 200 directly. The three prefix-root links keep the no-trailing-slash form that React and Angular already use. The bare `/docs/license-key/` link stays as it is, since all four READMEs share that form.

**The retired GitHub Discussions links are gone.** `github.com/handsontable/handsontable/discussions` returns 404. Each wrapper linked it twice, in the Community header and as the first Support bullet. Both now match the root README, which moved off Discussions in #12751. Only those two lines were touched; the neighbouring Support bullets are unchanged.

Also in scope, both flagged during review: the wrappers' `© 2012 - 2025` footer is bumped to 2026, and the Vue README's jsDelivr link was missing its slashes (`https:jsdelivr.com/...`).

#### Deliberately not done

Reported back on the task instead of fixed here, since the README's owner should make these calls:

- A wider 18.1 feature sweep. Selection handles and cell moving, `colorScheme` and `density`, `HYPERLINK` formula rendering, the NestedRows collapse and expand API, and single-pass rendering all have live docs pages and are bullet-worthy.
- Label drift. Root says "Frozen rows and columns" and "Hiding rows and columns" where the wrappers say "Pinned/frozen columns" and "Hiding columns". Same targets, different words.
- Root is now the mixed-prefix outlier. Its first 18 links are bare and redirect, while all three wrappers are clean after this change.
- Structural drift in the installation sections, and the image-host split between root and the wrappers.

### Test evidence (required for source changes)

Markdown only. No source file is touched, so the presence gate reports a pass with nothing to add (confirmed locally by the pre-push hook), and no changelog entry is required.

- Unit tests added/modified (`*.unit.js`): none, no source change
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none, no source change
- Type tests (`*.types.ts`) updated if public API changed: none, no public API change
- For a bug fix, the spec that fails without this fix: not applicable, the dead links are verified over HTTP below
- Demo page / recorded trace (for UI changes): not applicable

### Commands run

Every URL the diff adds or changes, checked against production:

```bash
git diff -U0 develop -- README.md wrappers | grep '^+' \
  | grep -o 'https://[^)"< ]*' | sort -u \
  | while read -r u; do printf '%s -> ' "$u"; \
      curl -s -o /dev/null -w '%{http_code} %{redirect_url}\n' "$u"; done
```

52 URLs, all 200. The only redirects are the six prefix-root links (`.../docs/<framework>-data-grid`, `.../themes`, `.../api`), which 308 to their trailing-slash form. That is the shape React and Angular already ship.

The four feature lists match, framework segment stripped:

```
$ wc -l *.list
      24 README.md.list
      24 wrappers_react-wrapper_README.md.list
      24 wrappers_angular-wrapper_README.md.list
      24 wrappers_vue3_README.md.list
$ diff wrappers_react-wrapper_README.md.list wrappers_angular-wrapper_README.md.list
$ diff wrappers_react-wrapper_README.md.list wrappers_vue3_README.md.list
```

The three wrappers are now identical. Root differs only on the two known label-drift lines listed above.

No dead link survives, and no CSS import crept in:

```
$ grep -rn "handsontable/discussions\|https:jsdelivr\|2012 - 2025" README.md wrappers/*/README.md
$ grep -rn "\.css\|ht-theme" README.md wrappers/*/README.md
(only preview image filenames)
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. RELEASE-881

### Affected project(s):

- [x] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [x] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/RELEASE-881

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation and link updates; no runtime or API changes.
> 
> **Overview**
> **Aligns the four package READMEs** so they share the same **24-item Key Features** list (same order, framework-specific doc URLs).
> 
> The root `README.md` gains **Date and time editing** and **Shadow DOM / Web Components support**. React and Angular wrapper READMEs catch up with five bullets (server-side data, notifications, export to Excel, plus those two) so they match root instead of staying three behind.
> 
> **Link and support copy fixes:** dead **GitHub Discussions** links become the **developer forum** in wrapper headers; Support swaps the Discussions bullet for **Ask AI** (React/Angular/Vue). Vue’s README moves doc links to the **`vue-data-grid`** prefix (fixes a broken pagination link and stops sending Vue readers to generic JS docs), corrects the **jsDelivr** URL, and updates a few nav/resource links. Wrapper footers bump copyright to **2026**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5bb0f8b759c302c0270107da0f2ef9950095219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->