### PR TITLE
DEV-2843: Build PR bodies from the live template in the pr-creation skill

### DIFF
--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -105,16 +105,29 @@ gh pr create --draft --base develop \
   --body-file /tmp/pr-body-DEV-xxx.md
 ```
 
+**Start from the live template, every time.** Run `cat .github/PULL_REQUEST_TEMPLATE.md` and mirror every `###` heading and every checklist line it carries — including `MANUAL QA NEEDED`, left unticked when no manual QA is needed. That line is machine-read by the Checks scope router (`checks.yml`), so keep its wording, and its absence means the gate can never be armed on that PR without editing the description. The copy below is a convenience: `.github/scripts/__tests__/pr-template-skill-sync.test.mjs` pins its headings and checklist lines to the template, and when the two disagree the template wins.
+
 The body file template (write this with the Write tool, backticks and all, no escaping):
 
-```markdown
+````markdown
 ### Context
 
-<why this change is needed; link the task and explain the problem>
+The PR fixes/adds/changes <what>. <Why the change is needed; link the task and explain the problem.>
 
-### How has this been tested?
+### Test evidence (required for source changes)
 
-- <tests you added or ran, with commands>
+- Unit tests added/modified (`*.unit.js`): <paths, or "none — covered by <path>">
+- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): <paths>
+- Type tests (`*.types.ts`) updated if public API changed: <paths, or "none">
+- For a bug fix — the spec that fails without this fix: <name>
+- Demo page / recorded trace (for UI changes): <link, or "none">
+
+### Commands run
+
+```bash
+<the test commands you ran, one per block>
+```
+<their final output lines>
 
 ### Types of changes
 
@@ -139,9 +152,10 @@ The body file template (write this with the Write tool, backticks and all, no es
 - [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
 - [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
 - [ ] My change requires a change to the documentation.
+- [ ] MANUAL QA NEEDED — <!-- one line: WHAT to check and why automation can't judge it. Also add the red `Requires Manual QA` label (that exact name — it already exists; `QA needed` and `Verified by QA` are different labels). Ticking holds the Tests run for a manual-qa environment approval by a designated reviewer (never whoever triggered the run). The box is read once per run, so if you change it after the pipeline ran, press "Re-run all jobs". This line is machine-read — keep its wording. -->
 
 ClickUp task: https://app.clickup.com/t/9015210959/DEV-xxx
-```
+````
 
 - **Commit messages:** Descriptive, max 80 characters. Include task ID (e.g. `DEV-627: Fix filter column index`).
 - Include the ClickUp task ID in the PR title when applicable.

--- a/.github/scripts/__tests__/pr-template-skill-sync.test.mjs
+++ b/.github/scripts/__tests__/pr-template-skill-sync.test.mjs
@@ -12,36 +12,58 @@ const root = repoRoot();
 const template = readFileSync(path.join(root, '.github/PULL_REQUEST_TEMPLATE.md'), 'utf8');
 const skill = readFileSync(path.join(root, '.claude/skills/pr-creation/SKILL.md'), 'utf8');
 
+// The skill embeds the body template as one fenced block (```` markdown … ````, four backticks so the
+// inner ```bash blocks nest). Compare against THAT block, not the whole skill prose, so a heading
+// mentioned in passing elsewhere cannot stand in for one the body template dropped, duplicated, or
+// reordered.
+const bodyBlockMatch = skill.match(/````markdown\n([\s\S]*?)\n````/);
+
+assert.ok(bodyBlockMatch, 'the pr-creation skill must embed the body template in a ````markdown block');
+const skillBody = bodyBlockMatch[1];
+
+const headings = text => text.match(/^### .*$/gm) ?? [];
+
 // A checklist line's HTML comment (the template's instructions) trails the text, so the text is
 // whatever precedes the first `<!--`. Cut, not regex-stripped: this is a comparison of two documents
-// the repository owns, not a sanitizer, and the comment never has to be removed from the middle.
+// the repository owns, not a sanitizer, and the comment never has to be removed from the middle. Tick
+// state is normalized away — the skill's copy may prefill boxes the template leaves blank.
 const withoutComment = line => line.split('<!--')[0].trimEnd();
 const checklistLines = text => text.split('\n')
   .filter(line => /^- \[[ xX]\] /.test(line))
   .map(line => withoutComment(line.replace(/^- \[[ xX]\] /, '- [ ] ')));
 
-test('every heading of the PR template appears in the pr-creation skill', () => {
-  const headings = template.match(/^### .*$/gm) ?? [];
+test('the skill body template mirrors the PR template headings, in order', () => {
+  const templateHeadings = headings(template);
 
-  assert.ok(headings.length >= 6, 'the template lost its headings');
-
-  for (const heading of headings) {
-    assert.ok(skill.includes(heading), `${heading} is in .github/PULL_REQUEST_TEMPLATE.md but not in the pr-creation skill`);
-  }
+  assert.ok(templateHeadings.length >= 6, 'the template lost its headings');
+  // deepEqual is order-preserving and two-directional: a stale, duplicated, reordered, or missing
+  // heading on either side fails.
+  assert.deepEqual(headings(skillBody), templateHeadings,
+    'the pr-creation skill body template no longer mirrors .github/PULL_REQUEST_TEMPLATE.md headings');
 });
 
-test('every checklist line of the PR template appears in the skill, whether ticked or not', () => {
-  const skillLines = new Set(checklistLines(skill));
+test('the skill body template mirrors the PR template checklist, in order', () => {
+  const templateChecklist = checklistLines(template);
 
-  for (const line of checklistLines(template)) {
-    assert.ok(skillLines.has(line), `checklist line missing from the pr-creation skill: ${line}`);
-  }
+  assert.ok(templateChecklist.length >= 4, 'the template lost its checklist');
+  assert.deepEqual(checklistLines(skillBody), templateChecklist,
+    'the pr-creation skill body template no longer mirrors .github/PULL_REQUEST_TEMPLATE.md checklist');
 });
 
-test('the MANUAL QA NEEDED line keeps the wording the Checks scope router reads', () => {
+test('the MANUAL QA NEEDED line keeps the exact matcher the Checks scope router reads', () => {
   const checks = readFileSync(path.join(root, '.github/workflows/checks.yml'), 'utf8');
 
-  assert.match(checks, /MANUAL QA NEEDED/, 'checks.yml no longer reads the line; update this test with the new contract');
+  // Pin the executable matcher itself, not the phrase: a comment mentioning "MANUAL QA NEEDED" must
+  // not keep this green while the regex the router runs drifts.
+  assert.ok(
+    checks.includes(String.raw`/^\s*-\s*\[[xX]\]\s+MANUAL QA NEEDED/m.test(pr.body`),
+    'checks.yml no longer runs the MANUAL QA NEEDED matcher this test pins; update both together',
+  );
+  // The template and the skill both carry the line UNTICKED, so the matcher stays dormant until a
+  // human ticks it. The matcher requires `[xX]`; the unticked `[ ]` here must not match it.
   assert.match(template, /^- \[ \] MANUAL QA NEEDED — /m);
-  assert.match(skill, /^- \[ \] MANUAL QA NEEDED — /m, 'the skill must show the line unticked, ready to be ticked');
+  assert.match(skillBody, /^- \[ \] MANUAL QA NEEDED — /m,
+    'the skill body template must show the line unticked, ready to be ticked');
+  assert.doesNotMatch('- [ ] MANUAL QA NEEDED — x', /^\s*-\s*\[[xX]\]\s+MANUAL QA NEEDED/m,
+    'sanity: the matcher only fires on a ticked box');
 });

--- a/.github/scripts/__tests__/pr-template-skill-sync.test.mjs
+++ b/.github/scripts/__tests__/pr-template-skill-sync.test.mjs
@@ -12,10 +12,13 @@ const root = repoRoot();
 const template = readFileSync(path.join(root, '.github/PULL_REQUEST_TEMPLATE.md'), 'utf8');
 const skill = readFileSync(path.join(root, '.claude/skills/pr-creation/SKILL.md'), 'utf8');
 
-const stripComments = text => text.replace(/<!--[\s\S]*?-->/g, '').trim();
+// A checklist line's HTML comment (the template's instructions) trails the text, so the text is
+// whatever precedes the first `<!--`. Cut, not regex-stripped: this is a comparison of two documents
+// the repository owns, not a sanitizer, and the comment never has to be removed from the middle.
+const withoutComment = line => line.split('<!--')[0].trimEnd();
 const checklistLines = text => text.split('\n')
   .filter(line => /^- \[[ xX]\] /.test(line))
-  .map(line => stripComments(line.replace(/^- \[[ xX]\] /, '- [ ] ')));
+  .map(line => withoutComment(line.replace(/^- \[[ xX]\] /, '- [ ] ')));
 
 test('every heading of the PR template appears in the pr-creation skill', () => {
   const headings = template.match(/^### .*$/gm) ?? [];

--- a/.github/scripts/__tests__/pr-template-skill-sync.test.mjs
+++ b/.github/scripts/__tests__/pr-template-skill-sync.test.mjs
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { repoRoot } from '../lib/repo-root.mjs';
+
+// The pr-creation skill carries a copy of the PR template so a body can be written without opening
+// the template. A copy drifts: DEV-2063 added the machine-read `MANUAL QA NEEDED` line and two new
+// sections to the template on 2026-09-03, and every PR opened through the skill for the next week
+// lacked them. These tests fail the tooling suite the moment the two disagree again.
+const root = repoRoot();
+const template = readFileSync(path.join(root, '.github/PULL_REQUEST_TEMPLATE.md'), 'utf8');
+const skill = readFileSync(path.join(root, '.claude/skills/pr-creation/SKILL.md'), 'utf8');
+
+const stripComments = text => text.replace(/<!--[\s\S]*?-->/g, '').trim();
+const checklistLines = text => text.split('\n')
+  .filter(line => /^- \[[ xX]\] /.test(line))
+  .map(line => stripComments(line.replace(/^- \[[ xX]\] /, '- [ ] ')));
+
+test('every heading of the PR template appears in the pr-creation skill', () => {
+  const headings = template.match(/^### .*$/gm) ?? [];
+
+  assert.ok(headings.length >= 6, 'the template lost its headings');
+
+  for (const heading of headings) {
+    assert.ok(skill.includes(heading), `${heading} is in .github/PULL_REQUEST_TEMPLATE.md but not in the pr-creation skill`);
+  }
+});
+
+test('every checklist line of the PR template appears in the skill, whether ticked or not', () => {
+  const skillLines = new Set(checklistLines(skill));
+
+  for (const line of checklistLines(template)) {
+    assert.ok(skillLines.has(line), `checklist line missing from the pr-creation skill: ${line}`);
+  }
+});
+
+test('the MANUAL QA NEEDED line keeps the wording the Checks scope router reads', () => {
+  const checks = readFileSync(path.join(root, '.github/workflows/checks.yml'), 'utf8');
+
+  assert.match(checks, /MANUAL QA NEEDED/, 'checks.yml no longer reads the line; update this test with the new contract');
+  assert.match(template, /^- \[ \] MANUAL QA NEEDED — /m);
+  assert.match(skill, /^- \[ \] MANUAL QA NEEDED — /m, 'the skill must show the line unticked, ready to be ticked');
+});


### PR DESCRIPTION
### Context

The PR changes the `pr-creation` skill so a PR body is built from the live `.github/PULL_REQUEST_TEMPLATE.md`, not from the skill's own copy of it.

The skill carried an inline body template that predated DEV-2063 (#13179, 2026-09-03), which added the machine-read `- [ ] MANUAL QA NEEDED — …` line and the "Test evidence" / "Commands run" sections. Every PR opened through the skill since then lacked the manual-QA box and still used "How has this been tested?" – found on 2026-09-08 on four open PRs (#13424, #13432, #13433, #13434), whose bodies were fixed by hand.

Two changes:

1. The skill's body template now mirrors the live template section for section, with the `MANUAL QA NEEDED` line present and unticked, and the skill tells the writer to `cat .github/PULL_REQUEST_TEMPLATE.md` first and treat the template as the source of truth.
2. `.github/scripts/__tests__/pr-template-skill-sync.test.mjs` pins the two together: every `###` heading and every checklist line of the template must appear in the skill (ticked or not, HTML comments ignored), and the `MANUAL QA NEEDED` line must keep the wording `checks.yml` reads. It runs in the root `test:tooling` glob, so the tooling-tests job fails the next time the template changes without the skill.

Docs and tooling only – no library code changes. `[skip changelog]`

### Test evidence (required for source changes)

- Unit tests added/modified (`*.unit.js`): none — no source change.
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none.
- Type tests (`*.types.ts`) updated if public API changed: none.
- For a bug fix — the spec that fails without this fix: `.github/scripts/__tests__/pr-template-skill-sync.test.mjs` fails against the previous skill text (missing headings and the missing `MANUAL QA NEEDED` line).
- Demo page / recorded trace (for UI changes): none.

### Commands run

```bash
node --test .github/scripts/__tests__/pr-template-skill-sync.test.mjs
```
`# pass 3`, `# fail 0`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2843

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.
- [ ] MANUAL QA NEEDED — <!-- one line: WHAT to check and why automation can't judge it. Also add the red `Requires Manual QA` label (that exact name — it already exists; `QA needed` and `Verified by QA` are different labels). Ticking holds the Tests run for a manual-qa environment approval by a designated reviewer (never whoever triggered the run). The box is read once per run, so if you change it after the pipeline ran, press "Re-run all jobs". This line is machine-read — keep its wording. -->

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2843

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI tooling only; no runtime library or product code changes.
> 
> **Overview**
> Fixes drift between the **pr-creation** skill’s embedded PR body and `.github/PULL_REQUEST_TEMPLATE.md` (notably the machine-read **MANUAL QA NEEDED** checkbox and **Test evidence** / **Commands run** sections added in DEV-2063).
> 
> The skill now tells authors to **`cat .github/PULL_REQUEST_TEMPLATE.md`** and treat it as source of truth, and its convenience copy is updated to match. The embedded example uses a four-backtick `markdown` fence so nested `bash` blocks render correctly.
> 
> Adds **`pr-template-skill-sync.test.mjs`** in the tooling test suite: it asserts the skill’s fenced body template mirrors the live template’s `###` headings and checklist lines (order, tick state normalized), and that the unticked **MANUAL QA NEEDED** line stays aligned with the regex **`checks.yml`** uses to route manual QA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b29c7c0d1d03155d5f2c14a8bea8544601283cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->