### PR TITLE
Docs: Vue Markdown routes, skills-page versions, sanitizer upgrade guidance (18.1 cherry-pick)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -325,7 +325,7 @@ function commonJsonIntegration() {
   const matter = _require('gray-matter');
   const semver = _require('semver');
   const contentDir = resolve(__dirname, 'content');
-  const PREFIXES = ['javascript-data-grid', 'react-data-grid', 'angular-data-grid'];
+  const PREFIXES = ['javascript-data-grid', 'react-data-grid', 'angular-data-grid', 'vue-data-grid'];
   const MIN_DOCS_VERSION = '9.0';
 
   // ── Version helpers ──────────────────────────────────────────────────────
@@ -578,7 +578,7 @@ function markdownRoutesIntegration() {
   const matter = _require('gray-matter');
   const contentDir = resolve(__dirname, 'content');
   const publicMdDir = resolve(__dirname, 'public', '_md');
-  const PREFIXES = ['javascript-data-grid', 'react-data-grid', 'angular-data-grid'];
+  const PREFIXES = ['javascript-data-grid', 'react-data-grid', 'angular-data-grid', 'vue-data-grid'];
 
   /**
    * Assembles one output file: an H1 from the frontmatter title, then the body

--- a/docs/content/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md
+++ b/docs/content/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md
@@ -19,7 +19,7 @@ Skills for Claude Code are bundled instructions that give Claude deep knowledge 
 
 The <a href="https://github.com/handsontable/handsontable-skills" target="_blank" rel="noopener noreferrer">repo</a> ships two skills:
 
-- **handsontable** -- the data grid component. Covers React, Angular, Vue, and vanilla JS setup, configuration, theming, cell types, sorting, filtering, formulas, hooks, performance, and v17 migration.
+- **handsontable** -- the data grid component. Covers React, Angular, Vue, and vanilla JS setup, configuration, theming, cell types, sorting, filtering, formulas, hooks, performance, and version migration.
 - **hyperformula** -- the headless calculation engine. Covers instance creation, CRUD, custom functions, named expressions, error handling, batch operations, and Node.js usage.
 
 Use **handsontable** when you're building a visible grid in a web app. Use **hyperformula** when you're evaluating formulas programmatically without a UI -- server-side calculations, pricing engines, what-if analysis. Claude loads whichever is relevant based on what you ask.
@@ -37,6 +37,6 @@ For Cowork or Claude.ai web, download the zip from the latest GitHub release and
 
 ## Versioned to match releases
 
-Each skill is tagged to the product version it targets -- `handsontable/v17.0.0` is the skill for Handsontable 17, `hyperformula/v3.2.0` is the skill for HyperFormula 3.2. You always know which API surface Claude is working from.
+Each skill is tagged to the product version it targets -- `handsontable/v{{$currentVersion}}` is the skill for Handsontable {{$currentVersion}}, and each HyperFormula release gets a matching `hyperformula/v*` tag. You always know which API surface Claude is working from.
 
 <a href="https://github.com/handsontable/handsontable-skills" target="_blank" rel="noopener noreferrer">Browse the Skills for Claude Code</a>

--- a/docs/content/guides/security/security/security.md
+++ b/docs/content/guides/security/security/security.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Security - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Security
+menuTag: updated
 ---
 Learn about the security measures we take to make sure you can safely implement Handsontable in your client-side application.
 
@@ -119,6 +120,24 @@ new Handsontable(container, {
   // ... other options
 });
 ```
+
+### Upgrading from v18.0 to v18.1
+
+If your sanitizer branches on its second argument, two `source` values changed in v18.1:
+
+- `'innerHTML'` is no longer passed by any part of the grid. The offscreen pass that measures [`nestedHeaders`](@/api/options.md#nestedheaders) widths now reports `'header'`, the same value as the rendered header, so one label no longer reaches your sanitizer under two different names.
+- `'dialog'` is now passed for [dialog](@/api/dialog.md) content. In v18.0, that content arrived with `source` set to `undefined`, so it moves out of whatever branch handled `undefined` -- usually the default one -- and into a `'dialog'` branch you may not have written.
+
+A sanitizer that ignores its second argument needs no changes.
+
+v18.1 also added sanitization to two surfaces that were previously written without consulting the sanitizer:
+
+- `'password'` -- content rendered by the [`password`](@/guides/cell-types/password-cell-type/password-cell-type.md) cell type.
+- `'CopyPaste.paste.sourceData'` -- Handsontable's own clipboard payload, used when copying and pasting between two grid instances. See [the note on this source](#what-the-sanitizer-does-not-cover) before deciding how to treat it.
+
+Additionally, as of v18.1, pasted markup is read through `DOMParser`, which builds a document with no browsing context -- HTML pasted from the clipboard cannot load resources or run scripts while it is parsed, regardless of the `sanitizer` configuration.
+
+For step-by-step instructions and code examples, see the [migration guide](@/guides/upgrade-and-migration/migrating-from-18.0-to-18.1/migrating-from-18.0-to-18.1.md).
 
 **Trusted Types and CSP:** If you enforce Trusted Types (e.g. `require-trusted-types-for 'script'`), use a [Trusted Type policy](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) in your sanitizer and return its `createHTML` result. Add the policy name to your Content-Security-Policy `trusted-types` directive (e.g. `trusted-types default handsontable`); otherwise policy creation will be blocked.
 


### PR DESCRIPTION
## Summary

Cherry-picks three docs fixes merged to `develop` today — #13406, #13407, #13408 — onto `prod-docs/18.1`, since the production docs deploy only builds from `prod-docs/**` and all three fix defects visible on the live site:

- **#13408 (SU-874):** adds `vue-data-grid` to both `PREFIXES` arrays, so Copy Markdown stops 404ing on Vue pages, the Docs Assistant regains Vue page grounding, and Vue URLs appear in `common.json`. Clean pick.
- **#13406 (SU-875):** replaces the stale `handsontable/v17.0.0` skill-tag literal with `{{$currentVersion}}` on the Skills for Claude Code page. Clean pick; resolves to `18.1.0` on this branch (verified through `template-variables.mjs`).
- **#13407 (DEV-2802):** adds the "Upgrading from v18.0 to v18.1" sanitizer subsection to the Security guide. This pick conflicted because develop's Security guide carries the post-18.1 Trusted Types rewrite — resolved by inserting only the upgrade subsection and keeping this branch's existing Trusted Types paragraph, so no 18.2-era content ships to 18.1.

## Test plan

- The same changes were verified on develop with a full local docs build (packages + docs): `dist/_md/` gained a complete 336-file `vue-data-grid/` tree and `common.json` gained the Vue URLs.
- On this branch: `framework-loader.mjs` already renders Vue (same `FRAMEWORKS` list as develop), `handsontable/package.json` is `18.1.0`, and the conflict resolution was reviewed line-by-line — the diff touches only the three intended files (+23/−4).

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only and Astro build-prefix changes; no product runtime or auth/data-path changes.
> 
> **Overview**
> Cherry-picks three live-docs fixes onto the **18.1** production docs branch: Vue framework output, current skill tags, and Security guide notes for the v18.1 sanitizer behavior.
> 
> **`astro.config.mjs`** now includes **`vue-data-grid`** in the `PREFIXES` used by **`commonJsonIntegration`** and **`markdownRoutesIntegration`**, so Vue pages get **`common.json`** URLs, generated **`_md/`** Copy Markdown routes, and Docs Assistant grounding like the other frameworks.
> 
> The **Skills for Claude Code** page drops the hardcoded **`handsontable/v17.0.0`** example in favor of **`{{$currentVersion}}`** (resolves to the branch’s Handsontable version at build time) and generalizes the skills copy from “v17 migration” to “version migration.”
> 
> The **Security** guide is marked **`menuTag: updated`** and adds **Upgrading from v18.0 to v18.1**: renamed/added sanitizer **`source`** values (`innerHTML` → **`header`**, **`dialog`** no longer `undefined`), new **`password`** and **`CopyPaste.paste.sourceData`** surfaces, **`DOMParser`** for pasted HTML, with a link to the migration guide—without replacing this branch’s existing Trusted Types paragraph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b2cdc439e897be8934d3c92d333494803e285a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->