### PR TITLE
DEV-2850: Apply sampling settings on updateSettings in the auto-size plugins

### DIFF
--- a/.changelogs/13443.json
+++ b/.changelogs/13443.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed the `AutoRowSize` and `AutoColumnSize` sampling options (`samplingRatio`, `allowSampleDuplicates`, and `useHeaders`) being silently ignored when changed through `updateSettings()`. They now apply, and the measured sizes are recalculated when one of them actually changes.",
+  "title": "Fixed the `AutoRowSize`, `AutoColumnSize`, and `AutoRowHeaderSize` sampling options (`samplingRatio`, `allowSampleDuplicates`, and `useHeaders`) being silently ignored when changed through `updateSettings()`. They now apply, and the measured sizes are recalculated when one of them actually changes. All three plugins also read `samplingRatio` the same way now: it must be a whole number above zero, and any other value falls back to the default of 3.",
   "type": "fixed",
   "issueOrPR": 13443,
   "breaking": false,

--- a/.changelogs/13443.json
+++ b/.changelogs/13443.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the `AutoRowSize` and `AutoColumnSize` sampling options (`samplingRatio`, `allowSampleDuplicates`, and `useHeaders`) being silently ignored when changed through `updateSettings()`. They now apply, and the measured sizes are recalculated when one of them actually changes.",
+  "type": "fixed",
+  "issueOrPR": 13443,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13443.json
+++ b/.changelogs/13443.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed the `AutoRowSize`, `AutoColumnSize`, and `AutoRowHeaderSize` sampling options (`samplingRatio`, `allowSampleDuplicates`, and `useHeaders`) being silently ignored when changed through `updateSettings()`. They now apply, and the measured sizes are recalculated when one of them actually changes. All three plugins also read `samplingRatio` the same way now: it must be a whole number above zero, and any other value falls back to the default of 3.",
+  "title": "Fixed the `AutoRowSize` and `AutoColumnSize` sampling options (`samplingRatio` and `allowSampleDuplicates`, plus `useHeaders` on `AutoColumnSize`) being silently ignored when changed through `updateSettings()`. They now apply, and the measured sizes are recalculated when one of them actually changes. Fixed `AutoRowHeaderSize` resetting its own `samplingRatio` and `allowSampleDuplicates` to the defaults whenever an `updateSettings()` call did not mention the plugin. All three plugins also read `samplingRatio` the same way now: it must be a whole number above zero, and any other value falls back to the default of 3.",
   "type": "fixed",
   "issueOrPR": 13443,
   "breaking": false,

--- a/handsontable/src/plugins/autoColumnSize/AGENTS.md
+++ b/handsontable/src/plugins/autoColumnSize/AGENTS.md
@@ -88,6 +88,14 @@ stored it raw. Anything that is not a whole number above zero resolves to `null`
 not cosmetic: `parseInt` turned `true` and `[]` into `NaN`, and because `NaN !== NaN` the change check
 reported a change on *every* `updateSettings()` call and never converged.
 
+**`applySamplingOptions()` is the only way into those two options — do not add a per-option setter back.**
+`SamplesGenerator` used to carry `setSampleCount()` and `setAllowDuplicates()`, and both were removed once
+all three plugins moved to the shared method, because they wrote `customSampleCount` **raw**: a caller
+passing `-1`, `2.5` or `'6'` could reach a state the plugins can no longer produce, which is exactly the
+disagreement `resolveSampleCount()` exists to end. Removing them was safe rather than breaking because the
+class is exported from no public entry point and the two plugins that expose the instance mark it
+`@private` (`AutoRowHeaderSize` keeps it in a `#` field), so it is not in the published API surface.
+
 `AutoRowSize` follows the same shape; its own `AGENTS.md` carries the note about the
 `updateSettings`-does-not-recalculate contract this sits under.
 

--- a/handsontable/src/plugins/autoColumnSize/AGENTS.md
+++ b/handsontable/src/plugins/autoColumnSize/AGENTS.md
@@ -44,6 +44,25 @@ over the whole row range, **before the first paint**. Everything past the limit 
 
 The async loop must cancel its frame when the instance was destroyed mid-calculation.
 
+## The sampling settings are re-read in `updatePlugin()`, and only a real change clears the cache
+
+`samplingRatio`, `allowSampleDuplicates` and `useHeaders` are applied in `#applySamplingSettings()`, called
+from **both** `enablePlugin()` and `updatePlugin()`. Reading them in `enablePlugin()` alone is not enough:
+that method returns early on an already-enabled plugin, and `BasePlugin` only re-runs the enable/disable pair
+when the plugin's enabled state itself changed — so a plain settings change never reaches it. All three were
+silently ignored when they arrived through `updateSettings()` (DEV-2850).
+
+When one of them actually changed, `updatePlugin()` calls `clearCache()`: the three decide *which cells get
+measured at all*, so widths measured under the previous values describe a different sample.
+
+**Clear only on a real change.** `SETTING_KEYS` is `true` here, so `updatePlugin()` runs on *every*
+`updateSettings()` call, and the React and Angular wrappers re-send unchanged settings on every update (React
+on every commit). An unconditional `clearCache()` would re-measure every column on each of them — which the
+`skipUnchangedWrites` rule below exists to avoid in the first place.
+`SamplesGenerator#applySamplingOptions()` reports whether either sampling option changed, and `useHeaders` is
+compared against `ghostTable.getSetting('useHeaders')`. `AutoRowSize` follows the same shape; its own
+`AGENTS.md` carries the note about the `updateSettings`-does-not-recalculate contract this sits under.
+
 ## The refresh queue avoids full rescans (DEV-2097)
 
 An edit does not automatically rescan its column. Changed cells are queued as width probes, and a full

--- a/handsontable/src/plugins/autoColumnSize/AGENTS.md
+++ b/handsontable/src/plugins/autoColumnSize/AGENTS.md
@@ -44,24 +44,52 @@ over the whole row range, **before the first paint**. Everything past the limit 
 
 The async loop must cancel its frame when the instance was destroyed mid-calculation.
 
-## The sampling settings are re-read in `updatePlugin()`, and only a real change clears the cache
+## The sampling settings are re-read in `updatePlugin()`, and only a real change re-measures
 
 `samplingRatio`, `allowSampleDuplicates` and `useHeaders` are applied in `#applySamplingSettings()`, called
 from **both** `enablePlugin()` and `updatePlugin()`. Reading them in `enablePlugin()` alone is not enough:
 that method returns early on an already-enabled plugin, and `BasePlugin` only re-runs the enable/disable pair
 when the plugin's enabled state itself changed — so a plain settings change never reaches it. All three were
-silently ignored when they arrived through `updateSettings()` (DEV-2850).
+silently ignored when they arrived through `updateSettings()` (DEV-2850). Four rules ride along:
 
-When one of them actually changed, `updatePlugin()` calls `clearCache()`: the three decide *which cells get
-measured at all*, so widths measured under the previous values describe a different sample.
+- **Restore the stored settings first when the payload omits this plugin's key.** `SETTING_KEYS` is `true`,
+  so an update that never mentions `autoColumnSize` still reaches `updatePlugin()` — and `onUpdateSettings`
+  has already fed `updatePluginSettings()` that missing key as `undefined`, which **wipes** the stored
+  settings (this plugin declares no `SETTINGS_VALIDATORS`, so the assignment falls straight through). Read
+  them in that state and you get the *defaults*, so re-applying would reset the user's `samplingRatio`, flip
+  `useHeaders` back to `true`, and re-measure every column on an unrelated `updateSettings({ readOnly: true })`.
+  Restore from `hot.getSettings()[PLUGIN_KEY]`, which is untouched — the same repair `manualColumnResize`
+  makes for the same base-class reason (`../manualResize/AGENTS.md`). **This is the common path:** the Vue
+  wrapper omits every settings key whose value is unchanged (`wrappers/vue3/src/helpers.ts`, `simpleEqual`),
+  so a Vue app sends a payload *without* `autoColumnSize` on virtually every prop change.
+- **Re-measure with `recalculateAllColumnsWidth()`, not `clearCache()`.** A bare clear empties every measured
+  width, but the only render-time measurement is `calculateVisibleColumnsWidth()` — so every column outside
+  the viewport would keep the default width until it is scrolled into view, shrinking the table width and the
+  horizontal scroll extent. `#onAfterLoadData` is the model for "everything is stale". `AutoRowSize` can use
+  its own `clearCache()` only because that method sets `#fullRecalculationScheduled`, which its
+  `#onBeforeRender` honors; this plugin has no equivalent flag. The trade is that
+  `recalculateAllColumnsWidth()` is a no-op on a grid that is not visible, which leaves the previous widths
+  in place — the same limitation `#onAfterLoadData` already has, and a smaller wrong than a grid of default
+  widths. It also clears `#columnWidthsToRefresh`, so the header-change entries queued earlier in
+  `updatePlugin()` are not measured a second time in the same render.
+- **Re-measure only on a real change.** `updatePlugin()` runs on *every* `updateSettings()` call, and the
+  React and Angular wrappers re-send unchanged settings on every update (React on every commit). An
+  unconditional re-measure would walk every column on each of them — which the `skipUnchangedWrites` rule
+  below exists to avoid in the first place.
+- **`useHeaders` is compared against `#appliedUseHeaders`, never against `ghostTable.getSetting()`.** The
+  ghost table's copy is render-time scratch state that `#measureCellsWidth()` deliberately flips to `false`
+  and restores in a `finally`. Reading it here would tie the change detection to that restore being perfect,
+  and a future path that flipped it without restoring would report a phantom change and re-measure the whole
+  grid on the next `updateSettings()`.
 
-**Clear only on a real change.** `SETTING_KEYS` is `true` here, so `updatePlugin()` runs on *every*
-`updateSettings()` call, and the React and Angular wrappers re-send unchanged settings on every update (React
-on every commit). An unconditional `clearCache()` would re-measure every column on each of them — which the
-`skipUnchangedWrites` rule below exists to avoid in the first place.
-`SamplesGenerator#applySamplingOptions()` reports whether either sampling option changed, and `useHeaders` is
-compared against `ghostTable.getSetting('useHeaders')`. `AutoRowSize` follows the same shape; its own
-`AGENTS.md` carries the note about the `updateSettings`-does-not-recalculate contract this sits under.
+`samplingRatio` is resolved by `SamplesGenerator.resolveSampleCount()` rather than by each plugin, so all
+three sampling plugins agree on what the option means — this plugin used to `parseInt` it while `AutoRowSize`
+stored it raw. Anything that is not a whole number above zero resolves to `null` (the default). That guard is
+not cosmetic: `parseInt` turned `true` and `[]` into `NaN`, and because `NaN !== NaN` the change check
+reported a change on *every* `updateSettings()` call and never converged.
+
+`AutoRowSize` follows the same shape; its own `AGENTS.md` carries the note about the
+`updateSettings`-does-not-recalculate contract this sits under.
 
 ## The refresh queue avoids full rescans (DEV-2097)
 

--- a/handsontable/src/plugins/autoColumnSize/__tests__/samplingSettings.unit.ts
+++ b/handsontable/src/plugins/autoColumnSize/__tests__/samplingSettings.unit.ts
@@ -77,14 +77,17 @@ describe('AutoColumnSize sampling settings', () => {
     hot.destroy();
   });
 
-  it('should drop the measured widths when a sampling setting changes', () => {
+  it('should re-measure every column when a sampling setting changes', () => {
+    // `recalculateAllColumnsWidth()`, not `clearCache()`: a bare clear empties every measured
+    // width, but the only render-time measurement covers the visible band, so every column outside
+    // the viewport would keep the default width until scrolled into view.
     const hot = buildGrid();
     const plugin = hot.getPlugin('autoColumnSize');
-    const clearCache = spyOn(plugin, 'clearCache').and.callThrough();
+    const recalculateAll = spyOn(plugin, 'recalculateAllColumnsWidth').and.callThrough();
 
     hot.updateSettings({ autoColumnSize: { samplingRatio: 6 } });
 
-    expect(clearCache).toHaveBeenCalled();
+    expect(recalculateAll).toHaveBeenCalled();
 
     hot.destroy();
   });
@@ -92,14 +95,42 @@ describe('AutoColumnSize sampling settings', () => {
   it('should keep the measured widths when the settings are re-sent unchanged', () => {
     // `SETTING_KEYS` is `true` for this plugin, so `updatePlugin` runs on every `updateSettings`
     // call - and the React and Angular wrappers re-send unchanged settings on every update. An
-    // unconditional cache clear would re-measure every column on each of them.
+    // unconditional re-measure would walk every column on each of them.
     const hot = buildGrid({ autoColumnSize: { samplingRatio: 6, allowSampleDuplicates: true } });
     const plugin = hot.getPlugin('autoColumnSize');
-    const clearCache = spyOn(plugin, 'clearCache').and.callThrough();
+    const recalculateAll = spyOn(plugin, 'recalculateAllColumnsWidth').and.callThrough();
 
     hot.updateSettings({ autoColumnSize: { samplingRatio: 6, allowSampleDuplicates: true } });
 
-    expect(clearCache).not.toHaveBeenCalled();
+    expect(recalculateAll).not.toHaveBeenCalled();
+
+    hot.destroy();
+  });
+
+  it('should keep the sampling settings when an update does not mention this plugin', () => {
+    // The path that matters most, and the one the "re-sent unchanged" test above cannot reach.
+    // `BasePlugin#onUpdateSettings` feeds `updatePluginSettings()` with `newSettings[PLUGIN_KEY]`,
+    // which is `undefined` here - it wipes the stored settings, so reading them back gives the
+    // defaults. Without the restore in `updatePlugin`, this reset `samplingRatio` from 6 to 3,
+    // flipped `useHeaders` back to `true`, and re-measured every column.
+    //
+    // The Vue wrapper makes this the normal case rather than an edge case: it omits every settings
+    // key whose value has not changed, so `autoColumnSize` is absent from nearly every payload it
+    // sends.
+    const hot = buildGrid({
+      colHeaders: true,
+      autoColumnSize: { samplingRatio: 6, allowSampleDuplicates: true, useHeaders: false },
+    });
+    const plugin = hot.getPlugin('autoColumnSize');
+    const recalculateAll = spyOn(plugin, 'recalculateAllColumnsWidth').and.callThrough();
+
+    hot.updateSettings({ readOnly: true });
+
+    expect(plugin.samplesGenerator.getSampleCount()).toBe(6);
+    expect(plugin.samplesGenerator.allowDuplicates).toBe(true);
+    expect(plugin.getSetting('samplingRatio')).toBe(6);
+    expect(plugin.ghostTable.getSetting('useHeaders')).toBe(false);
+    expect(recalculateAll).not.toHaveBeenCalled();
 
     hot.destroy();
   });

--- a/handsontable/src/plugins/autoColumnSize/__tests__/samplingSettings.unit.ts
+++ b/handsontable/src/plugins/autoColumnSize/__tests__/samplingSettings.unit.ts
@@ -1,0 +1,106 @@
+import Handsontable from 'handsontable/base';
+import { registerPlugin, AutoColumnSize } from 'handsontable/plugins';
+
+registerPlugin(AutoColumnSize);
+
+/**
+ * Builds a grid with AutoColumnSize on.
+ *
+ * @param {object} settings Settings merged over the defaults.
+ * @returns {object} The Handsontable instance.
+ */
+function buildGrid(settings: Record<string, unknown> = {}) {
+  return new Handsontable(document.createElement('div'), {
+    data: [['a', 'b'], ['c', 'd']],
+    autoColumnSize: true,
+    licenseKey: 'non-commercial-and-evaluation',
+    ...settings,
+  });
+}
+
+describe('AutoColumnSize sampling settings', () => {
+  it('should apply `samplingRatio` given in the initial settings', () => {
+    const hot = buildGrid({ autoColumnSize: { samplingRatio: 6 } });
+
+    expect(hot.getPlugin('autoColumnSize').samplesGenerator.getSampleCount()).toBe(6);
+
+    hot.destroy();
+  });
+
+  it('should apply `samplingRatio` arriving through `updateSettings`', () => {
+    // `enablePlugin` returns early on an already-enabled plugin and was the only place reading
+    // this setting. `updatePlugin` existed but only refreshed changed headers, so the new value
+    // was stored and never reached the samples generator.
+    const hot = buildGrid();
+    const plugin = hot.getPlugin('autoColumnSize');
+
+    hot.updateSettings({ autoColumnSize: { samplingRatio: 6 } });
+
+    expect(plugin.getSetting('samplingRatio')).toBe(6);
+    expect(plugin.samplesGenerator.getSampleCount()).toBe(6);
+
+    hot.destroy();
+  });
+
+  it('should apply `allowSampleDuplicates` arriving through `updateSettings`', () => {
+    const hot = buildGrid();
+    const plugin = hot.getPlugin('autoColumnSize');
+
+    expect(plugin.samplesGenerator.allowDuplicates).toBe(false);
+
+    hot.updateSettings({ autoColumnSize: { allowSampleDuplicates: true } });
+
+    expect(plugin.samplesGenerator.allowDuplicates).toBe(true);
+
+    hot.destroy();
+  });
+
+  it('should apply `useHeaders` arriving through `updateSettings`', () => {
+    const hot = buildGrid({ colHeaders: true });
+    const plugin = hot.getPlugin('autoColumnSize');
+
+    hot.updateSettings({ autoColumnSize: { useHeaders: false } });
+
+    expect(plugin.ghostTable.getSetting('useHeaders')).toBe(false);
+
+    hot.destroy();
+  });
+
+  it('should restore the default sample count when `samplingRatio` is set back to `null`', () => {
+    const hot = buildGrid({ autoColumnSize: { samplingRatio: 6 } });
+    const plugin = hot.getPlugin('autoColumnSize');
+
+    hot.updateSettings({ autoColumnSize: { samplingRatio: null } });
+
+    expect(plugin.samplesGenerator.getSampleCount()).toBe(3);
+
+    hot.destroy();
+  });
+
+  it('should drop the measured widths when a sampling setting changes', () => {
+    const hot = buildGrid();
+    const plugin = hot.getPlugin('autoColumnSize');
+    const clearCache = spyOn(plugin, 'clearCache').and.callThrough();
+
+    hot.updateSettings({ autoColumnSize: { samplingRatio: 6 } });
+
+    expect(clearCache).toHaveBeenCalled();
+
+    hot.destroy();
+  });
+
+  it('should keep the measured widths when the settings are re-sent unchanged', () => {
+    // `SETTING_KEYS` is `true` for this plugin, so `updatePlugin` runs on every `updateSettings`
+    // call - and the React and Angular wrappers re-send unchanged settings on every update. An
+    // unconditional cache clear would re-measure every column on each of them.
+    const hot = buildGrid({ autoColumnSize: { samplingRatio: 6, allowSampleDuplicates: true } });
+    const plugin = hot.getPlugin('autoColumnSize');
+    const clearCache = spyOn(plugin, 'clearCache').and.callThrough();
+
+    hot.updateSettings({ autoColumnSize: { samplingRatio: 6, allowSampleDuplicates: true } });
+
+    expect(clearCache).not.toHaveBeenCalled();
+
+    hot.destroy();
+  });
+});

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
@@ -86,6 +86,11 @@ type ColumnSamples = ReturnType<SamplesGenerator['generateSample']>;
  *   }
  * ```
  *
+ * The sampling options and `useHeaders` all take effect when you change them with
+ * {@link Core#updateSettings}, and the column widths are recalculated so the new sampling is
+ * applied to columns that were already measured. `samplingRatio` must be a whole number above
+ * zero; any other value falls back to the default.
+ *
  * ::: tip
  * If you use custom renderers or custom styles that produce non-standard column widths, and you call
  * {@link Core#scrollViewportTo}, make sure `AutoColumnSize` is enabled. Without it, `scrollViewportTo()` calculates
@@ -352,6 +357,16 @@ export class AutoColumnSize extends BasePlugin {
    */
   #columnSamplesCache: Map<number, ColumnSamples> = new Map();
   /**
+   * The `useHeaders` option value as this plugin last applied it.
+   *
+   * Kept separately from the ghost table's own copy of the setting, which `#measureCellsWidth()`
+   * flips and restores while probing, so the settings-change detection never reads a value that
+   * belongs to a measurement in flight.
+   *
+   * @type {*}
+   */
+  #appliedUseHeaders: unknown = undefined;
+  /**
    * Disposer function for the column widths map observer. Called on disable to clean up.
    *
    * @type {Function|null}
@@ -416,8 +431,20 @@ export class AutoColumnSize extends BasePlugin {
 
   /**
    * Updates the plugin's state. This method is executed when {@link Core#updateSettings} is invoked.
+   *
+   * @param {object} [newSettings] The settings passed to `updateSettings`.
    */
-  updatePlugin(): void {
+  updatePlugin(newSettings?: Record<string, unknown>): void {
+    // `SETTING_KEYS` is `true`, so an update that never mentions this plugin still arrives here -
+    // and `BasePlugin#onUpdateSettings` has already fed `updatePluginSettings()` the missing key as
+    // `undefined`, wiping the stored settings. Restore them from the merged settings before reading
+    // them, or an unrelated `updateSettings({ readOnly: true })` would read the defaults, reset the
+    // user's `samplingRatio`, and re-measure every column. The Vue wrapper makes this the common
+    // case, not the rare one: it omits every key whose value is unchanged.
+    if (newSettings !== undefined && newSettings[PLUGIN_KEY] === undefined) {
+      this.updatePluginSettings(this.hot.getSettings()[PLUGIN_KEY]);
+    }
+
     this.findColumnsWhereHeaderWasChanged().forEach((visualColumn) => {
       this.#columnWidthsToRefresh.set(visualColumn, null);
     });
@@ -428,11 +455,17 @@ export class AutoColumnSize extends BasePlugin {
     // `allowSampleDuplicates` and `useHeaders` were silently ignored whenever they arrived through
     // `updateSettings`.
     //
-    // The measured widths are dropped only when one of them actually changed. The framework
-    // wrappers re-send unchanged settings on every update (React on every commit), so clearing the
-    // cache unconditionally would re-measure every column on each of them.
+    // The widths are re-measured only when one of them actually changed - re-measuring on every
+    // update would undo the work the `skipUnchangedWrites` map exists to avoid.
+    //
+    // `recalculateAllColumnsWidth()` rather than `clearCache()`: a bare clear empties every
+    // measured width, but the only render-time measurement is `calculateVisibleColumnsWidth()`, so
+    // every column outside the viewport would keep the default width until it is scrolled into
+    // view. This mirrors `#onAfterLoadData`, the other "everything is stale" path. On a grid that
+    // is not visible it is a no-op, which leaves the previous widths in place - the same
+    // limitation that path already has, and a smaller wrong than a grid of default widths.
     if (this.#applySamplingSettings()) {
-      this.clearCache();
+      this.recalculateAllColumnsWidth();
     }
 
     // Settings may remap the data that feeds the samples (e.g. a new `columns` definition), so
@@ -448,14 +481,18 @@ export class AutoColumnSize extends BasePlugin {
    * @returns {boolean} `true` when a setting changed, which means the measured widths are stale.
    */
   #applySamplingSettings(): boolean {
-    const samplingRatio = this.getSetting<number | null>('samplingRatio');
     const useHeaders = this.getSetting('useHeaders');
-    const hasHeadersChanged = this.ghostTable.getSetting('useHeaders') !== useHeaders;
+    // Compared against the last value this method applied, not against
+    // `ghostTable.getSetting('useHeaders')`: the ghost table's copy is render-time scratch state
+    // that `#measureCellsWidth()` deliberately flips and restores, and reading it here would tie
+    // the change detection to that restore being perfect.
+    const hasHeadersChanged = this.#appliedUseHeaders !== useHeaders;
 
+    this.#appliedUseHeaders = useHeaders;
     this.ghostTable.setSetting('useHeaders', useHeaders);
 
     const hasSamplingChanged = this.samplesGenerator.applySamplingOptions({
-      sampleCount: samplingRatio && !isNaN(samplingRatio) ? parseInt(String(samplingRatio), 10) : null,
+      samplingRatio: this.getSetting('samplingRatio'),
       allowDuplicates: this.getSetting<boolean>('allowSampleDuplicates'),
     });
 

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
@@ -392,14 +392,7 @@ export class AutoColumnSize extends BasePlugin {
       return;
     }
 
-    this.ghostTable.setSetting('useHeaders', this.getSetting('useHeaders'));
-    this.samplesGenerator.setAllowDuplicates(this.getSetting<boolean>('allowSampleDuplicates'));
-
-    const samplingRatio = this.getSetting<number | null>('samplingRatio');
-
-    if (samplingRatio && !isNaN(samplingRatio)) {
-      this.samplesGenerator.setSampleCount(parseInt(String(samplingRatio), 10));
-    }
+    this.#applySamplingSettings();
 
     this.addHook('afterLoadData', this.#onAfterLoadData);
     this.addHook('beforeChangeRender', this.#onBeforeChange);
@@ -428,10 +421,45 @@ export class AutoColumnSize extends BasePlugin {
     this.findColumnsWhereHeaderWasChanged().forEach((visualColumn) => {
       this.#columnWidthsToRefresh.set(visualColumn, null);
     });
+
+    // The sampling settings have to be re-read here, not only in `enablePlugin`: that method
+    // returns early on an already-enabled plugin, and `BasePlugin` only re-runs the enable/disable
+    // pair when the plugin's enabled state itself changed. Without this, `samplingRatio`,
+    // `allowSampleDuplicates` and `useHeaders` were silently ignored whenever they arrived through
+    // `updateSettings`.
+    //
+    // The measured widths are dropped only when one of them actually changed. The framework
+    // wrappers re-send unchanged settings on every update (React on every commit), so clearing the
+    // cache unconditionally would re-measure every column on each of them.
+    if (this.#applySamplingSettings()) {
+      this.clearCache();
+    }
+
     // Settings may remap the data that feeds the samples (e.g. a new `columns` definition), so
     // the cached samples cannot be trusted — the next re-measure falls back to a full scan.
     this.#columnSamplesCache.clear();
     super.updatePlugin();
+  }
+
+  /**
+   * Reads the sampling-related settings and applies them to the samples generator and the ghost
+   * table.
+   *
+   * @returns {boolean} `true` when a setting changed, which means the measured widths are stale.
+   */
+  #applySamplingSettings(): boolean {
+    const samplingRatio = this.getSetting<number | null>('samplingRatio');
+    const useHeaders = this.getSetting('useHeaders');
+    const hasHeadersChanged = this.ghostTable.getSetting('useHeaders') !== useHeaders;
+
+    this.ghostTable.setSetting('useHeaders', useHeaders);
+
+    const hasSamplingChanged = this.samplesGenerator.applySamplingOptions({
+      sampleCount: samplingRatio && !isNaN(samplingRatio) ? parseInt(String(samplingRatio), 10) : null,
+      allowDuplicates: this.getSetting<boolean>('allowSampleDuplicates'),
+    });
+
+    return hasHeadersChanged || hasSamplingChanged;
   }
 
   /**

--- a/handsontable/src/plugins/autoRowHeaderSize/AGENTS.md
+++ b/handsontable/src/plugins/autoRowHeaderSize/AGENTS.md
@@ -72,6 +72,29 @@ measurement still stands — laying samples out is the expensive half, and this 
 
 A row with no renderable index is hidden, so no header of it is drawn and none is measured.
 
+## `updatePlugin()` restores the stored settings before it re-enables
+
+`updatePlugin()` runs `disablePlugin(); enablePlugin();`, which is what makes this plugin re-read its
+sampling settings for free — unlike `AutoRowSize` and `AutoColumnSize`, whose `enablePlugin()` early return
+made those settings inert on an update (DEV-2850).
+
+It still needs one repair first. `BasePlugin#onUpdateSettings` feeds `updatePluginSettings()` with
+`newSettings[PLUGIN_KEY]`, and an update that never mentions `autoRowHeaderSize` carries that as `undefined`,
+which **wipes** the stored settings (this plugin declares no `SETTINGS_VALIDATORS`, so the assignment falls
+straight through). The re-enable then reads the *defaults*, so `allowSampleDuplicates: true` silently
+reverted to `false` on every unrelated `updateSettings()` call. `updatePlugin()` therefore restores the
+option from `hot.getSettings()[PLUGIN_KEY]` when the payload omits the key — the same repair
+`manualRowResize` makes for the same reason (`../manualResize/AGENTS.md`). The Vue wrapper makes this the
+common path: it omits every settings key whose value is unchanged.
+
+`samplingRatio` and `allowSampleDuplicates` go through the shared
+`SamplesGenerator#applySamplingOptions()`, so this plugin resolves the option exactly as the other two do.
+Do not reintroduce a local `parseInt` copy: the three used to disagree about what a string, a fractional, or
+a non-numeric ratio meant.
+
+Its unconditional `clearCache()` on every update is left as it was — a deliberately blunt choice for a
+per-level sampler measuring only the row headers, not the trimmed-down one the other two plugins need.
+
 ## Where to look next
 
 - The sibling auto-size plugins and their shared sampling pipeline: `../autoColumnSize/AGENTS.md`,

--- a/handsontable/src/plugins/autoRowHeaderSize/__tests__/autoRowHeaderSize.unit.ts
+++ b/handsontable/src/plugins/autoRowHeaderSize/__tests__/autoRowHeaderSize.unit.ts
@@ -310,6 +310,30 @@ describe('AutoRowHeaderSize', () => {
 
       hot.destroy();
     });
+
+    it('should keep the sampling settings when an update does not mention this plugin', () => {
+      const { hot, labelSpy } = buildRepeatedLabelGrid({
+        autoRowHeaderSize: { allowSampleDuplicates: true, samplingRatio: 5 },
+      });
+      const plugin = hot.getPlugin('autoRowHeaderSize');
+
+      // A payload with no `autoRowHeaderSize` key. `SETTING_KEYS` is `true`, so it still reaches
+      // `updatePlugin()` - and `BasePlugin` has by then fed the missing key in as `undefined`,
+      // wiping the stored settings. Without the restore, the re-enable reads the defaults, so
+      // duplicates stop being sampled and this measures 1 label instead of 5.
+      hot.updateSettings({ colHeaders: true });
+
+      expect(plugin.getSetting('allowSampleDuplicates')).toBe(true);
+      expect(plugin.getSetting('samplingRatio')).toBe(5);
+
+      plugin.clearCache();
+      labelSpy.mockClear();
+      plugin.getRowHeaderWidth();
+
+      expect(renderedCount(labelSpy as never, 20)).toBe(5);
+
+      hot.destroy();
+    });
   });
   describe('multiple row header levels', () => {
     /**

--- a/handsontable/src/plugins/autoRowHeaderSize/autoRowHeaderSize.ts
+++ b/handsontable/src/plugins/autoRowHeaderSize/autoRowHeaderSize.ts
@@ -332,13 +332,12 @@ export class AutoRowHeaderSize extends BasePlugin {
       return;
     }
 
-    this.#samplesGenerator.setAllowDuplicates(this.getSetting<boolean>('allowSampleDuplicates'));
-
-    const samplingRatio = this.getSetting<number | null>('samplingRatio');
-
-    if (samplingRatio && !isNaN(samplingRatio)) {
-      this.#samplesGenerator.setSampleCount(parseInt(String(samplingRatio), 10));
-    }
+    // Shared with AutoRowSize and AutoColumnSize so the same option name resolves the same way on
+    // all three - a raw `samplingRatio` used to be stored differently by each of them.
+    this.#samplesGenerator.applySamplingOptions({
+      samplingRatio: this.getSetting('samplingRatio'),
+      allowDuplicates: this.getSetting<boolean>('allowSampleDuplicates'),
+    });
 
     // Pinned ahead of the default order, the way {@link AutoColumnSize} pins `modifyColWidth`. This
     // handler answers with its own measurement and drops the incoming width, so it has to run
@@ -365,8 +364,19 @@ export class AutoRowHeaderSize extends BasePlugin {
 
   /**
    * Updates the plugin's state.
+   *
+   * @param {object} [newSettings] The settings passed to `updateSettings`.
    */
-  updatePlugin(): void {
+  updatePlugin(newSettings?: Record<string, unknown>): void {
+    // `BasePlugin#onUpdateSettings` feeds `updatePluginSettings()` with `newSettings[PLUGIN_KEY]`,
+    // which an update that does not mention this plugin carries as `undefined` - wiping the stored
+    // settings. The re-enable below then reads the defaults, so `allowSampleDuplicates: true`
+    // silently reverted to `false` on every unrelated `updateSettings` call. Restore the option
+    // from the merged settings first.
+    if (newSettings !== undefined && newSettings[PLUGIN_KEY] === undefined) {
+      this.updatePluginSettings(this.hot.getSettings()[PLUGIN_KEY]);
+    }
+
     this.clearCache();
     this.disablePlugin();
     this.enablePlugin();

--- a/handsontable/src/plugins/autoRowSize/AGENTS.md
+++ b/handsontable/src/plugins/autoRowSize/AGENTS.md
@@ -40,11 +40,29 @@ when every height is already cached.
 - **The first rendered row gets +1px** to compensate for its `border-top-width`. That compensation is
   per-render, not baked into the cached height.
 
-## `updateSettings` does not recalculate
+## `updateSettings` does not recalculate — with one exception
 
 Changing `wordWrap`, `textEllipsis` or a renderer changes row heights, but `updateSettings()` alone does not
 re-measure. Callers must follow it with `recalculateAllRowsHeight()`. That is documented in the class JSDoc
 and in the guides — it is the contract, not a bug.
+
+**The exception is this plugin's own sampling settings.** `updatePlugin()` re-reads `samplingRatio` and
+`allowSampleDuplicates` and, when either actually changed, calls `clearCache()` — which schedules the full
+recalculation. That is not a widening of the rule above: those two settings decide *which cells get measured
+at all*, so heights measured under the previous values describe a different sample and cannot be kept.
+Leaving them applied only to rows measured after the change is what made the setting look inert (DEV-2850).
+
+Two rules hold that in place, and both are load-bearing:
+
+- **The settings must be re-read in `updatePlugin()`, not only in `enablePlugin()`.** `enablePlugin()`
+  returns early on an already-enabled plugin, and `BasePlugin` only re-runs the enable/disable pair when the
+  plugin's enabled state itself changed — so a plain settings change never reaches it. This is exactly how
+  `samplingRatio` came to be silently ignored on every `updateSettings()` call.
+- **Clear the cache only when a value actually changed.** `SETTING_KEYS` is `true` here, so `updatePlugin()`
+  runs on *every* `updateSettings()` call, and the React and Angular wrappers re-send unchanged settings on
+  every update (React on every commit). An unconditional `clearCache()` would therefore re-measure every row
+  on every commit. `SamplesGenerator#applySamplingOptions()` returns whether anything changed, which is what
+  that decision reads; `AutoColumnSize` uses the same method for the same reason.
 
 ## Only a full render measures rows, and it measures only the visible band
 

--- a/handsontable/src/plugins/autoRowSize/AGENTS.md
+++ b/handsontable/src/plugins/autoRowSize/AGENTS.md
@@ -52,17 +52,35 @@ recalculation. That is not a widening of the rule above: those two settings deci
 at all*, so heights measured under the previous values describe a different sample and cannot be kept.
 Leaving them applied only to rows measured after the change is what made the setting look inert (DEV-2850).
 
-Two rules hold that in place, and both are load-bearing:
+Three rules hold that in place, and all three are load-bearing:
 
 - **The settings must be re-read in `updatePlugin()`, not only in `enablePlugin()`.** `enablePlugin()`
   returns early on an already-enabled plugin, and `BasePlugin` only re-runs the enable/disable pair when the
   plugin's enabled state itself changed — so a plain settings change never reaches it. This is exactly how
   `samplingRatio` came to be silently ignored on every `updateSettings()` call.
-- **Clear the cache only when a value actually changed.** `SETTING_KEYS` is `true` here, so `updatePlugin()`
-  runs on *every* `updateSettings()` call, and the React and Angular wrappers re-send unchanged settings on
-  every update (React on every commit). An unconditional `clearCache()` would therefore re-measure every row
-  on every commit. `SamplesGenerator#applySamplingOptions()` returns whether anything changed, which is what
-  that decision reads; `AutoColumnSize` uses the same method for the same reason.
+- **Restore the stored settings first when the payload omits this plugin's key.** `SETTING_KEYS` is `true`,
+  so an update that never mentions `autoRowSize` still reaches `updatePlugin()` — and `onUpdateSettings` has
+  already fed `updatePluginSettings()` that missing key as `undefined`, which **wipes** the stored settings
+  (neither auto-size plugin declares `SETTINGS_VALIDATORS`, so the assignment falls straight through). Read
+  them in that state and you get the *defaults*, so re-applying would reset the user's `samplingRatio` and
+  re-measure the whole grid on an unrelated `updateSettings({ colHeaders: true })`. Restore from
+  `hot.getSettings()[PLUGIN_KEY]`, which is untouched — the same repair, for the same base-class reason, that
+  `manualRowResize` does (`../manualResize/AGENTS.md`, "Listing a foreign option in `SETTING_KEYS`").
+  **This is the common path, not an edge case:** the Vue wrapper omits every settings key whose value is
+  unchanged (`wrappers/vue3/src/helpers.ts`, `simpleEqual`), so a Vue app sends a payload *without*
+  `autoRowSize` on virtually every prop change.
+- **Clear the cache only when a value actually changed.** `updatePlugin()` runs on every `updateSettings()`
+  call, and the React and Angular wrappers re-send unchanged settings on every update (React on every
+  commit). An unconditional `clearCache()` would therefore re-measure every row on every commit.
+  `SamplesGenerator#applySamplingOptions()` returns whether anything changed, which is what that decision
+  reads; `AutoColumnSize` uses the same method for the same reason.
+
+`samplingRatio` is resolved by `SamplesGenerator.resolveSampleCount()` rather than by each plugin, so all
+three sampling plugins agree on what the option means. Anything that is not a whole number above zero
+resolves to `null` (the default). That guard is not cosmetic: parsed raw, `true` and `[]` became `NaN`, and
+because `NaN !== NaN` the change check reported a change on *every* `updateSettings()` call and never
+converged; a negative value produced a `needed` count that collected no samples at all; and `'6'` compared
+as different from `6`.
 
 ## Only a full render measures rows, and it measures only the visible band
 

--- a/handsontable/src/plugins/autoRowSize/__tests__/samplingSettings.unit.ts
+++ b/handsontable/src/plugins/autoRowSize/__tests__/samplingSettings.unit.ts
@@ -92,4 +92,28 @@ describe('AutoRowSize sampling settings', () => {
 
     hot.destroy();
   });
+
+  it('should keep the sampling settings when an update does not mention this plugin', () => {
+    // The path that matters most, and the one the "re-sent unchanged" test above cannot reach.
+    // `BasePlugin#onUpdateSettings` feeds `updatePluginSettings()` with `newSettings[PLUGIN_KEY]`,
+    // which is `undefined` here - it wipes the stored settings, so reading them back gives the
+    // defaults. Without the restore in `updatePlugin`, this reset `samplingRatio` from 6 to 3,
+    // flipped `allowSampleDuplicates` back to `false`, and dropped every measured height.
+    //
+    // The Vue wrapper makes this the normal case rather than an edge case: it omits every settings
+    // key whose value has not changed, so `autoRowSize` is absent from nearly every payload it
+    // sends.
+    const hot = buildGrid({ autoRowSize: { samplingRatio: 6, allowSampleDuplicates: true } });
+    const plugin = hot.getPlugin('autoRowSize');
+    const clearCache = spyOn(plugin, 'clearCache').and.callThrough();
+
+    hot.updateSettings({ colHeaders: true });
+
+    expect(plugin.samplesGenerator.getSampleCount()).toBe(6);
+    expect(plugin.samplesGenerator.allowDuplicates).toBe(true);
+    expect(plugin.getSetting('samplingRatio')).toBe(6);
+    expect(clearCache).not.toHaveBeenCalled();
+
+    hot.destroy();
+  });
 });

--- a/handsontable/src/plugins/autoRowSize/__tests__/samplingSettings.unit.ts
+++ b/handsontable/src/plugins/autoRowSize/__tests__/samplingSettings.unit.ts
@@ -1,0 +1,95 @@
+import Handsontable from 'handsontable/base';
+import { registerPlugin, AutoRowSize } from 'handsontable/plugins';
+
+registerPlugin(AutoRowSize);
+
+/**
+ * Builds a grid with AutoRowSize on.
+ *
+ * @param {object} settings Settings merged over the defaults.
+ * @returns {object} The Handsontable instance.
+ */
+function buildGrid(settings: Record<string, unknown> = {}) {
+  return new Handsontable(document.createElement('div'), {
+    data: [['a'], ['b'], ['c']],
+    autoRowSize: true,
+    licenseKey: 'non-commercial-and-evaluation',
+    ...settings,
+  });
+}
+
+describe('AutoRowSize sampling settings', () => {
+  it('should apply `samplingRatio` given in the initial settings', () => {
+    const hot = buildGrid({ autoRowSize: { samplingRatio: 6 } });
+
+    expect(hot.getPlugin('autoRowSize').samplesGenerator.getSampleCount()).toBe(6);
+
+    hot.destroy();
+  });
+
+  it('should apply `samplingRatio` arriving through `updateSettings`', () => {
+    // `enablePlugin` returns early on an already-enabled plugin and was the only place reading
+    // this setting, so the new value was stored but never reached the samples generator. A user
+    // raising the ratio at runtime saw no change at all.
+    const hot = buildGrid();
+    const plugin = hot.getPlugin('autoRowSize');
+
+    hot.updateSettings({ autoRowSize: { samplingRatio: 6 } });
+
+    expect(plugin.getSetting('samplingRatio')).toBe(6);
+    expect(plugin.samplesGenerator.getSampleCount()).toBe(6);
+
+    hot.destroy();
+  });
+
+  it('should apply `allowSampleDuplicates` arriving through `updateSettings`', () => {
+    const hot = buildGrid();
+    const plugin = hot.getPlugin('autoRowSize');
+
+    expect(plugin.samplesGenerator.allowDuplicates).toBe(false);
+
+    hot.updateSettings({ autoRowSize: { allowSampleDuplicates: true } });
+
+    expect(plugin.samplesGenerator.allowDuplicates).toBe(true);
+
+    hot.destroy();
+  });
+
+  it('should restore the default sample count when `samplingRatio` is set back to `null`', () => {
+    const hot = buildGrid({ autoRowSize: { samplingRatio: 6 } });
+    const plugin = hot.getPlugin('autoRowSize');
+
+    hot.updateSettings({ autoRowSize: { samplingRatio: null } });
+
+    expect(plugin.samplesGenerator.getSampleCount()).toBe(3);
+
+    hot.destroy();
+  });
+
+  it('should drop the measured heights when a sampling setting changes', () => {
+    const hot = buildGrid();
+    const plugin = hot.getPlugin('autoRowSize');
+    const clearCache = spyOn(plugin, 'clearCache').and.callThrough();
+
+    hot.updateSettings({ autoRowSize: { samplingRatio: 6 } });
+
+    expect(clearCache).toHaveBeenCalled();
+
+    hot.destroy();
+  });
+
+  it('should keep the measured heights when the settings are re-sent unchanged', () => {
+    // `SETTING_KEYS` is `true` for this plugin, so `updatePlugin` runs on every `updateSettings`
+    // call - and the React and Angular wrappers re-send unchanged settings on every update. An
+    // unconditional cache clear would re-measure every row on each of them.
+    const hot = buildGrid({ autoRowSize: { samplingRatio: 6, allowSampleDuplicates: true } });
+    const plugin = hot.getPlugin('autoRowSize');
+    const clearCache = spyOn(plugin, 'clearCache').and.callThrough();
+
+    hot.updateSettings({ autoRowSize: { samplingRatio: 6, allowSampleDuplicates: true } });
+
+    expect(clearCache).not.toHaveBeenCalled();
+
+    hot.destroy();
+  });
+});

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -395,13 +395,7 @@ export class AutoRowSize extends BasePlugin {
       return;
     }
 
-    this.samplesGenerator.setAllowDuplicates(this.getSetting<boolean>('allowSampleDuplicates'));
-
-    const samplingRatio = this.getSetting<number | null>('samplingRatio');
-
-    if (samplingRatio && !isNaN(samplingRatio)) {
-      this.samplesGenerator.setSampleCount(samplingRatio);
-    }
+    this.#applySamplingSettings();
 
     this.addHook('afterLoadData', this.#onAfterLoadData);
     this.addHook('beforeChangeRender', this.#onBeforeChange);
@@ -421,6 +415,40 @@ export class AutoRowSize extends BasePlugin {
     addClass(this.hot.rootElement, AUTO_ROW_SIZE_CLASS_NAME);
 
     super.enablePlugin();
+  }
+
+  /**
+   * Updates the plugin's state after the table settings change.
+   *
+   * The sampling settings have to be re-read here, not only in `enablePlugin`: that method returns
+   * early on an already-enabled plugin, and `BasePlugin` only re-runs the enable/disable pair when
+   * the plugin's enabled state itself changed. Without this, `samplingRatio` and
+   * `allowSampleDuplicates` were silently ignored whenever they arrived through `updateSettings`.
+   *
+   * The measured heights are dropped only when a sampling setting actually changed. The framework
+   * wrappers re-send unchanged settings on every update (React on every commit), so clearing the
+   * cache unconditionally would re-measure every row on each of them.
+   */
+  updatePlugin(): void {
+    if (this.#applySamplingSettings()) {
+      this.clearCache();
+    }
+
+    super.updatePlugin();
+  }
+
+  /**
+   * Reads the sampling-related settings and applies them to the samples generator.
+   *
+   * @returns {boolean} `true` when a setting changed, which means the measured heights are stale.
+   */
+  #applySamplingSettings(): boolean {
+    const samplingRatio = this.getSetting<number | null>('samplingRatio');
+
+    return this.samplesGenerator.applySamplingOptions({
+      sampleCount: samplingRatio && !isNaN(samplingRatio) ? samplingRatio : null,
+      allowDuplicates: this.getSetting<boolean>('allowSampleDuplicates'),
+    });
   }
 
   /**

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -61,6 +61,10 @@ const AUTO_ROW_SIZE_CLASS_NAME = 'htAutoRowSize';
  * autoRowSize: {allowSampleDuplicates: true},
  * ```
  *
+ * Both sampling options take effect when you change them with {@link Core#updateSettings}, and the
+ * row heights are recalculated so the new sampling is applied to rows that were already measured.
+ * `samplingRatio` must be a whole number above zero; any other value falls back to the default.
+ *
  * Enable this option when rows with the same value can still render at different heights - for example, with multiline
  * text, or with custom renderers that vary a row's height based on its position or other data. Without it, the plugin
  * may sample only one of those rows and apply its height to the rest, leading to incorrect row heights.
@@ -428,8 +432,19 @@ export class AutoRowSize extends BasePlugin {
    * The measured heights are dropped only when a sampling setting actually changed. The framework
    * wrappers re-send unchanged settings on every update (React on every commit), so clearing the
    * cache unconditionally would re-measure every row on each of them.
+   *
+   * @param {object} [newSettings] The settings passed to `updateSettings`.
    */
-  updatePlugin(): void {
+  updatePlugin(newSettings?: Record<string, unknown>): void {
+    // `SETTING_KEYS` is `true`, so an update that never mentions this plugin still arrives here -
+    // and `BasePlugin#onUpdateSettings` has already fed `updatePluginSettings()` the missing key as
+    // `undefined`, wiping the stored settings. Restore them from the merged settings before reading
+    // them, or an unrelated `updateSettings({ colHeaders: true })` would read the defaults, reset
+    // the user's `samplingRatio`, and drop every measured height.
+    if (newSettings !== undefined && newSettings[PLUGIN_KEY] === undefined) {
+      this.updatePluginSettings(this.hot.getSettings()[PLUGIN_KEY]);
+    }
+
     if (this.#applySamplingSettings()) {
       this.clearCache();
     }
@@ -443,10 +458,8 @@ export class AutoRowSize extends BasePlugin {
    * @returns {boolean} `true` when a setting changed, which means the measured heights are stale.
    */
   #applySamplingSettings(): boolean {
-    const samplingRatio = this.getSetting<number | null>('samplingRatio');
-
     return this.samplesGenerator.applySamplingOptions({
-      sampleCount: samplingRatio && !isNaN(samplingRatio) ? samplingRatio : null,
+      samplingRatio: this.getSetting('samplingRatio'),
       allowDuplicates: this.getSetting<boolean>('allowSampleDuplicates'),
     });
   }

--- a/handsontable/src/utils/__tests__/samplesGenerator.unit.ts
+++ b/handsontable/src/utils/__tests__/samplesGenerator.unit.ts
@@ -25,6 +25,50 @@ describe('SamplesGenerator', () => {
     expect(sg.allowDuplicates).toBe(true);
   });
 
+  describe('applySamplingOptions', () => {
+    it('should apply both options', () => {
+      const sg = new SamplesGenerator();
+
+      sg.applySamplingOptions({ sampleCount: 10, allowDuplicates: true });
+
+      expect(sg.getSampleCount()).toBe(10);
+      expect(sg.allowDuplicates).toBe(true);
+    });
+
+    it('should restore the default sample count when `sampleCount` is `null`', () => {
+      const sg = new SamplesGenerator();
+
+      sg.applySamplingOptions({ sampleCount: 10, allowDuplicates: false });
+      sg.applySamplingOptions({ sampleCount: null, allowDuplicates: false });
+
+      expect(sg.getSampleCount()).toBe(SamplesGenerator.SAMPLE_COUNT);
+    });
+
+    it('should report `true` when the sample count changes', () => {
+      const sg = new SamplesGenerator();
+
+      expect(sg.applySamplingOptions({ sampleCount: 6, allowDuplicates: false })).toBe(true);
+    });
+
+    it('should report `true` when the duplicates policy changes', () => {
+      const sg = new SamplesGenerator();
+
+      expect(sg.applySamplingOptions({ sampleCount: null, allowDuplicates: true })).toBe(true);
+    });
+
+    it('should report `false` when neither option changes', () => {
+      const sg = new SamplesGenerator();
+
+      sg.applySamplingOptions({ sampleCount: 6, allowDuplicates: true });
+
+      // The auto-size plugins clear their measured sizes on a `true`, and they re-apply these
+      // options on every `updateSettings` call. Re-sending the same values must not report a
+      // change, or the wrappers (which re-send unchanged settings) would force a re-measure on
+      // every update.
+      expect(sg.applySamplingOptions({ sampleCount: 6, allowDuplicates: true })).toBe(false);
+    });
+  });
+
   it('should internally call `generateSamples` when calling `generateRowSamples`', () => {
     const sg = new SamplesGenerator();
 

--- a/handsontable/src/utils/__tests__/samplesGenerator.unit.ts
+++ b/handsontable/src/utils/__tests__/samplesGenerator.unit.ts
@@ -9,22 +9,6 @@ describe('SamplesGenerator', () => {
     }).toThrowWithCause('Unsupported sample type', { handsontable: true });
   });
 
-  it('should be possible to set samples count', () => {
-    const sg = new SamplesGenerator();
-
-    sg.setSampleCount(10);
-
-    expect(sg.getSampleCount()).toBe(10);
-  });
-
-  it('should be possible to allow using duplicates', () => {
-    const sg = new SamplesGenerator();
-
-    sg.setAllowDuplicates(true);
-
-    expect(sg.allowDuplicates).toBe(true);
-  });
-
   describe('resolveSampleCount', () => {
     it('should accept a whole number above zero', () => {
       expect(SamplesGenerator.resolveSampleCount(6)).toBe(6);

--- a/handsontable/src/utils/__tests__/samplesGenerator.unit.ts
+++ b/handsontable/src/utils/__tests__/samplesGenerator.unit.ts
@@ -25,21 +25,50 @@ describe('SamplesGenerator', () => {
     expect(sg.allowDuplicates).toBe(true);
   });
 
+  describe('resolveSampleCount', () => {
+    it('should accept a whole number above zero', () => {
+      expect(SamplesGenerator.resolveSampleCount(6)).toBe(6);
+    });
+
+    it('should accept a numeric string, so it compares equal to the same number', () => {
+      // Stored raw, the string '6' compared as different from the number 6, and re-sending the
+      // same intent as a numeric literal reported a change.
+      expect(SamplesGenerator.resolveSampleCount('6')).toBe(6);
+    });
+
+    it('should floor a fractional value', () => {
+      expect(SamplesGenerator.resolveSampleCount(2.5)).toBe(2);
+    });
+
+    it('should resolve values that cannot be a sample count to `null`', () => {
+      // `true` and `[]` used to parse to NaN. Because `NaN !== NaN`, every later comparison
+      // reported a change and the size cache was dropped on every `updateSettings` call, forever.
+      // A negative count produced a `needed` value that collected no samples at all.
+      expect(SamplesGenerator.resolveSampleCount(true)).toBe(null);
+      expect(SamplesGenerator.resolveSampleCount([])).toBe(null);
+      expect(SamplesGenerator.resolveSampleCount(' ')).toBe(null);
+      expect(SamplesGenerator.resolveSampleCount(-1)).toBe(null);
+      expect(SamplesGenerator.resolveSampleCount(0)).toBe(null);
+      expect(SamplesGenerator.resolveSampleCount(null)).toBe(null);
+      expect(SamplesGenerator.resolveSampleCount(undefined)).toBe(null);
+    });
+  });
+
   describe('applySamplingOptions', () => {
     it('should apply both options', () => {
       const sg = new SamplesGenerator();
 
-      sg.applySamplingOptions({ sampleCount: 10, allowDuplicates: true });
+      sg.applySamplingOptions({ samplingRatio: 10, allowDuplicates: true });
 
       expect(sg.getSampleCount()).toBe(10);
       expect(sg.allowDuplicates).toBe(true);
     });
 
-    it('should restore the default sample count when `sampleCount` is `null`', () => {
+    it('should restore the default sample count when `samplingRatio` is `null`', () => {
       const sg = new SamplesGenerator();
 
-      sg.applySamplingOptions({ sampleCount: 10, allowDuplicates: false });
-      sg.applySamplingOptions({ sampleCount: null, allowDuplicates: false });
+      sg.applySamplingOptions({ samplingRatio: 10, allowDuplicates: false });
+      sg.applySamplingOptions({ samplingRatio: null, allowDuplicates: false });
 
       expect(sg.getSampleCount()).toBe(SamplesGenerator.SAMPLE_COUNT);
     });
@@ -47,25 +76,42 @@ describe('SamplesGenerator', () => {
     it('should report `true` when the sample count changes', () => {
       const sg = new SamplesGenerator();
 
-      expect(sg.applySamplingOptions({ sampleCount: 6, allowDuplicates: false })).toBe(true);
+      expect(sg.applySamplingOptions({ samplingRatio: 6, allowDuplicates: false })).toBe(true);
     });
 
     it('should report `true` when the duplicates policy changes', () => {
       const sg = new SamplesGenerator();
 
-      expect(sg.applySamplingOptions({ sampleCount: null, allowDuplicates: true })).toBe(true);
+      expect(sg.applySamplingOptions({ samplingRatio: null, allowDuplicates: true })).toBe(true);
     });
 
     it('should report `false` when neither option changes', () => {
       const sg = new SamplesGenerator();
 
-      sg.applySamplingOptions({ sampleCount: 6, allowDuplicates: true });
+      sg.applySamplingOptions({ samplingRatio: 6, allowDuplicates: true });
 
-      // The auto-size plugins clear their measured sizes on a `true`, and they re-apply these
-      // options on every `updateSettings` call. Re-sending the same values must not report a
-      // change, or the wrappers (which re-send unchanged settings) would force a re-measure on
-      // every update.
-      expect(sg.applySamplingOptions({ sampleCount: 6, allowDuplicates: true })).toBe(false);
+      // The auto-size plugins re-measure on a `true`, and they re-apply these options on every
+      // `updateSettings` call. Re-sending the same values must not report a change, or every
+      // update would force a re-measure.
+      expect(sg.applySamplingOptions({ samplingRatio: 6, allowDuplicates: true })).toBe(false);
+    });
+
+    it('should report `false` when an unusable ratio is re-sent', () => {
+      const sg = new SamplesGenerator();
+
+      // Both resolve to `null`. Left as NaN this never converged: the comparison was NaN !== NaN,
+      // so the plugins re-measured on every single `updateSettings` call.
+      sg.applySamplingOptions({ samplingRatio: true, allowDuplicates: false });
+
+      expect(sg.applySamplingOptions({ samplingRatio: true, allowDuplicates: false })).toBe(false);
+    });
+
+    it('should report `false` when the same ratio arrives as a string and then a number', () => {
+      const sg = new SamplesGenerator();
+
+      sg.applySamplingOptions({ samplingRatio: '6', allowDuplicates: false });
+
+      expect(sg.applySamplingOptions({ samplingRatio: 6, allowDuplicates: false })).toBe(false);
     });
   });
 

--- a/handsontable/src/utils/samplesGenerator.ts
+++ b/handsontable/src/utils/samplesGenerator.ts
@@ -7,7 +7,7 @@ type DataFactoryResult = false | { value: unknown; bundleSeed?: string };
 type DataFactory = (row: number, col: number, instance: SamplesGenerator) => DataFactoryResult;
 type SampleEntry = { needed: number; strings: Array<{ value: unknown; col?: number; row?: number }> };
 type SampleRange = { from: number; to: number } | number[];
-type SamplingOptions = { sampleCount: number | null; allowDuplicates: boolean };
+type SamplingOptions = { samplingRatio: unknown; allowDuplicates: boolean };
 
 /**
  * @class SamplesGenerator
@@ -95,22 +95,42 @@ class SamplesGenerator {
   }
 
   /**
+   * Resolves a `samplingRatio` option into a usable sample count.
+   *
+   * Anything that is not a whole number above zero resolves to `null`, meaning the default
+   * {@link SamplesGenerator.SAMPLE_COUNT}. That covers the option being absent, but also the values
+   * that used to be stored raw and then quietly broke the sampler: `true` and `[]` became `NaN`,
+   * which made every later comparison report a change because `NaN !== NaN`; a negative number
+   * became a `needed` count that collected no samples at all; and the string `'6'` compared as
+   * different from the number `6`.
+   *
+   * @param {*} samplingRatio The raw option value.
+   * @returns {number|null} The sample count to use, or `null` for the default.
+   */
+  static resolveSampleCount(samplingRatio: unknown): number | null {
+    const sampleCount = parseInt(String(samplingRatio), 10);
+
+    return Number.isInteger(sampleCount) && sampleCount > 0 ? sampleCount : null;
+  }
+
+  /**
    * Applies both sampling options at once and reports whether either of them changed.
    *
    * Callers use the return value to decide whether the sizes they measured earlier are still
    * usable. Both options change which cells end up in a sample, so a size measured under the
    * previous options cannot be trusted once they change - the auto-size plugins answer a `true`
-   * here by clearing their size cache.
+   * here by re-measuring.
    *
-   * Passing `null` as `sampleCount` restores the default, {@link SamplesGenerator.SAMPLE_COUNT}.
+   * The raw `samplingRatio` is resolved here rather than by each caller, so that every plugin
+   * reading the option agrees on what it means. See {@link SamplesGenerator.resolveSampleCount}.
    *
    * @param {object} options The sampling options to apply.
-   * @param {number|null} options.sampleCount Number of samples to collect per value length, or
-   * `null` for the default.
+   * @param {*} options.samplingRatio The raw `samplingRatio` option value.
    * @param {boolean} options.allowDuplicates `true` to allow duplicate values.
    * @returns {boolean} `true` when at least one option changed its value.
    */
-  applySamplingOptions({ sampleCount, allowDuplicates }: SamplingOptions): boolean {
+  applySamplingOptions({ samplingRatio, allowDuplicates }: SamplingOptions): boolean {
+    const sampleCount = SamplesGenerator.resolveSampleCount(samplingRatio);
     const hasChanged = sampleCount !== this.customSampleCount || allowDuplicates !== this.allowDuplicates;
 
     this.customSampleCount = sampleCount;

--- a/handsontable/src/utils/samplesGenerator.ts
+++ b/handsontable/src/utils/samplesGenerator.ts
@@ -7,6 +7,7 @@ type DataFactoryResult = false | { value: unknown; bundleSeed?: string };
 type DataFactory = (row: number, col: number, instance: SamplesGenerator) => DataFactoryResult;
 type SampleEntry = { needed: number; strings: Array<{ value: unknown; col?: number; row?: number }> };
 type SampleRange = { from: number; to: number } | number[];
+type SamplingOptions = { sampleCount: number | null; allowDuplicates: boolean };
 
 /**
  * @class SamplesGenerator
@@ -91,6 +92,31 @@ class SamplesGenerator {
    */
   setAllowDuplicates(allowDuplicates: boolean) {
     this.allowDuplicates = allowDuplicates as boolean;
+  }
+
+  /**
+   * Applies both sampling options at once and reports whether either of them changed.
+   *
+   * Callers use the return value to decide whether the sizes they measured earlier are still
+   * usable. Both options change which cells end up in a sample, so a size measured under the
+   * previous options cannot be trusted once they change - the auto-size plugins answer a `true`
+   * here by clearing their size cache.
+   *
+   * Passing `null` as `sampleCount` restores the default, {@link SamplesGenerator.SAMPLE_COUNT}.
+   *
+   * @param {object} options The sampling options to apply.
+   * @param {number|null} options.sampleCount Number of samples to collect per value length, or
+   * `null` for the default.
+   * @param {boolean} options.allowDuplicates `true` to allow duplicate values.
+   * @returns {boolean} `true` when at least one option changed its value.
+   */
+  applySamplingOptions({ sampleCount, allowDuplicates }: SamplingOptions): boolean {
+    const hasChanged = sampleCount !== this.customSampleCount || allowDuplicates !== this.allowDuplicates;
+
+    this.customSampleCount = sampleCount;
+    this.allowDuplicates = allowDuplicates;
+
+    return hasChanged;
   }
 
   /**

--- a/handsontable/src/utils/samplesGenerator.ts
+++ b/handsontable/src/utils/samplesGenerator.ts
@@ -77,24 +77,6 @@ class SamplesGenerator {
   }
 
   /**
-   * Set the sample count.
-   *
-   * @param {number} sampleCount Number of samples to be collected.
-   */
-  setSampleCount(sampleCount: number) {
-    this.customSampleCount = sampleCount;
-  }
-
-  /**
-   * Set if the generator should accept duplicate values.
-   *
-   * @param {boolean} allowDuplicates `true` to allow duplicate values.
-   */
-  setAllowDuplicates(allowDuplicates: boolean) {
-    this.allowDuplicates = allowDuplicates as boolean;
-  }
-
-  /**
    * Resolves a `samplingRatio` option into a usable sample count.
    *
    * Anything that is not a whole number above zero resolves to `null`, meaning the default

--- a/tests/e2e/auto-size-sampling-settings.spec.ts
+++ b/tests/e2e/auto-size-sampling-settings.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '../fixtures/test';
+import { AutoSizeSamplingSettingsPage } from '../fixtures/pages/AutoSizeSamplingSettingsPage';
+
+/**
+ * DEV-2850. The auto-size sampling options only ever took effect as INITIAL settings. Passing
+ * `samplingRatio` or `allowSampleDuplicates` to `updateSettings()` was silently ignored: the value
+ * was stored and readable, but it never reached the samples generator.
+ *
+ * Making it apply then exposed a second problem, which is what the last test here guards. Because
+ * `SETTING_KEYS` is `true`, an update that never mentions the plugin still reaches `updatePlugin()`,
+ * and `BasePlugin` has by then fed the plugin its own missing key as `undefined` - wiping the stored
+ * settings. Reading them in that state returns the DEFAULTS, so the ratio just set was reset and
+ * every measured height dropped. The Vue wrapper sends exactly that payload shape on nearly every
+ * prop change, since it omits the keys whose values have not changed.
+ *
+ * Row 1 of the fixture holds four values of one length, so the default cap of three samples per
+ * length leaves the last column unsampled - and that column is the only narrow one, so its text is
+ * the only text that wraps. All of it is content-driven geometry, which reads as zero in jsdom, so
+ * it can only be checked in a real browser.
+ */
+test.describe('Auto-size sampling settings through updateSettings()', () => {
+  let grid: AutoSizeSamplingSettingsPage;
+
+  test.beforeEach(async({ page, theme, bundle }) => {
+    grid = new AutoSizeSamplingSettingsPage(page, theme, bundle);
+    await grid.goto();
+  });
+
+  test('applies a samplingRatio raised at runtime', async() => {
+    // The control: the option is at its default, so the sampler is capped at three per length.
+    expect(await grid.sampleCount()).toBe(3);
+
+    const before = await grid.measuredRowHeights();
+
+    await grid.setSamplingRatio(6);
+
+    // The setting reached the sampler - this alone used to be false.
+    expect(await grid.sampleCount()).toBe(6);
+
+    // And the heights were measured again with it. Row 1 is the one that changes: the column the
+    // old cap dropped is the only one whose text wraps, so bringing it into the sample is what
+    // makes the row's measured height cover the wrapped lines. Asserted as "grew", not as an exact
+    // pixel count, because the line height differs across the three themes.
+    const after = await grid.measuredRowHeights();
+
+    expect(after[1]).toBeGreaterThan(before[1] as number);
+
+    // The rows that hold only short values are unaffected - so the re-measure is doing real work
+    // rather than inflating everything.
+    expect(after[0]).toBe(before[0]);
+    expect(after[2]).toBe(before[2]);
+    expect(after[3]).toBe(before[3]);
+  });
+
+  test('lines the row headers up with their rows once the ratio covers every column', async() => {
+    await grid.setSamplingRatio(6);
+
+    // The user-visible half. With the wrapping column unsampled, its cell renders three lines tall
+    // - a cell never renders shorter than its own text - while the row header, with nothing to push
+    // it taller, keeps the one-line height the measurement reported. Once the column is sampled the
+    // two tables agree.
+    //
+    // A small tolerance rather than exactly 0: borders and box-model rounding move a row by a
+    // fraction of a pixel across themes. The defect is nothing like that size - it drops two whole
+    // wrapped lines.
+    expect(await grid.worstRowHeaderDrift()).toBeLessThanOrEqual(1);
+  });
+
+  test('keeps the raised samplingRatio when an unrelated setting changes', async() => {
+    await grid.setSamplingRatio(6);
+
+    const heightsBefore = await grid.measuredRowHeights();
+    const renderedBefore = await grid.renderedRowHeights();
+
+    // A payload with no `autoRowSize` key. Nothing about it should touch row heights.
+    await grid.changeUnrelatedSetting();
+
+    // Without the restore, this reset the ratio to the default and re-measured every row, so the
+    // wrapping row silently shrank back and the row headers drifted again.
+    expect(await grid.sampleCount()).toBe(6);
+    expect(await grid.measuredRowHeights()).toEqual(heightsBefore);
+    expect(await grid.renderedRowHeights()).toEqual(renderedBefore);
+    expect(await grid.worstRowHeaderDrift()).toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/fixtures/demo/auto-size-sampling-settings.html
+++ b/tests/fixtures/demo/auto-size-sampling-settings.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Auto-size sampling settings e2e fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back.
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+  </style>
+</head>
+<body>
+  <!--
+    DEV-2850. The sampling options (`samplingRatio`, `allowSampleDuplicates`) used to take effect
+    only as INITIAL settings — passing them to `updateSettings()` was silently ignored, and a later
+    fix then had to make sure an update that never mentions the plugin does not reset them.
+
+    The data shape is the one from DEV-2842, which is what makes the option observable at all.
+    `SamplesGenerator` buckets a row's values by string length and keeps at most `samplingRatio`
+    (default 3) per bucket. Row 1 holds FOUR values of exactly the same length, so the bucket fills
+    with columns 0, 1 and 2 and column 3 is never sampled.
+
+    Column 3 is also the only narrow one, so its text is the only text that wraps. With the default
+    ratio the row is therefore measured as a single line while its column-3 cell renders three lines
+    tall — a cell never renders shorter than its own text — and the row header, with nothing to push
+    it taller, keeps the one-line height. Raising the ratio past 3 brings column 3 into the sample
+    and the measurement becomes correct.
+
+    Every height here is content-driven, which jsdom reports as zero, so this can only be checked in
+    a real browser.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The
+    // closing tag is split so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    // Four DISTINCT strings of exactly the same length. Distinct so duplicate detection plays no
+    // part - the per-length cap is what drops the fourth one - and the same length so all four land
+    // in one bucket.
+    const SAME_LENGTH_ROW = [
+      'Alpha alpha alpha alpha alpha aa',
+      'Bravo bravo bravo bravo bravo bb',
+      'Delta delta delta delta delta dd',
+      'Gamma gamma gamma gamma gamma gg',
+    ];
+
+    if (new Set(SAME_LENGTH_ROW.map(value => value.length)).size !== 1) {
+      throw new Error('The sampled row must hold values of one single length.');
+    }
+    if (new Set(SAME_LENGTH_ROW).size !== SAME_LENGTH_ROW.length) {
+      throw new Error('The sampled row must hold distinct values.');
+    }
+
+    const data = [
+      ['r0 a', 'r0 b', 'r0 c', 'r0 d'],
+      SAME_LENGTH_ROW.slice(),
+      ['r2 a', 'r2 b', 'r2 c', 'r2 d'],
+      ['r3 a', 'r3 b', 'r3 c', 'r3 d'],
+    ];
+
+    const hot = new Handsontable(container, {
+      data,
+      width: 1120,
+      height: 400,
+      rowHeaders: true,
+      colHeaders: true,
+      wordWrap: true,
+      autoRowSize: true,
+      // The last column is the narrow one, so it is the only column whose text wraps - and it is
+      // also the one the default sampling drops.
+      colWidths: [320, 320, 320, 70],
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    window.hot = hot;
+
+    // Counts draws so a test can wait for the grid to have actually repainted after a settings
+    // change, instead of waiting on a fixed delay.
+    window.renderCount = 0;
+    hot.addHook('afterViewRender', function() {
+      window.renderCount += 1;
+    });
+
+    /**
+     * Raises the sampling ratio at runtime — the call that used to do nothing at all.
+     *
+     * @param {number} samplingRatio How many samples per value length to collect.
+     */
+    window.setSamplingRatio = function(samplingRatio) {
+      hot.updateSettings({ autoRowSize: { samplingRatio: samplingRatio } });
+    };
+
+    /**
+     * Changes a setting that has nothing to do with this plugin and no effect on row heights.
+     *
+     * The payload deliberately carries no `autoRowSize` key. `BasePlugin` feeds the plugin that
+     * missing key as `undefined`, which wipes its stored settings, so a plugin that re-reads them
+     * here without restoring them first would fall back to the defaults - resetting the ratio set
+     * above and re-measuring every row. The Vue wrapper sends exactly this shape on nearly every
+     * prop change, because it omits the keys whose values have not changed.
+     */
+    window.changeUnrelatedSetting = function() {
+      hot.updateSettings({ readOnly: true });
+    };
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/auto-size-sampling-settings.html
+++ b/tests/fixtures/demo/auto-size-sampling-settings.html
@@ -82,19 +82,29 @@
       ['r3 a', 'r3 b', 'r3 c', 'r3 d'],
     ];
 
-    const hot = new Handsontable(container, {
-      data,
-      width: 1120,
-      height: 400,
-      rowHeaders: true,
-      colHeaders: true,
-      wordWrap: true,
-      autoRowSize: true,
-      // The last column is the narrow one, so it is the only column whose text wraps - and it is
-      // also the one the default sampling drops.
-      colWidths: [320, 320, 320, 70],
-      licenseKey: 'non-commercial-and-evaluation',
-    });
+    let hot;
+
+    // Built loudly: a constructor throw is captured where the page object can read and rethrow it.
+    // Without this it would surface as a `toBeVisible()` timeout on an overlay locator, which says
+    // nothing about the real cause.
+    try {
+      hot = new Handsontable(container, {
+        data,
+        width: 1120,
+        height: 400,
+        rowHeaders: true,
+        colHeaders: true,
+        wordWrap: true,
+        autoRowSize: true,
+        // The last column is the narrow one, so it is the only column whose text wraps - and it is
+        // also the one the default sampling drops.
+        colWidths: [320, 320, 320, 70],
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+    } catch (error) {
+      window.htBuildError = String((error && error.stack) || error);
+      throw error;
+    }
 
     window.hot = hot;
 

--- a/tests/fixtures/pages/AutoSizeSamplingSettingsPage.ts
+++ b/tests/fixtures/pages/AutoSizeSamplingSettingsPage.ts
@@ -1,0 +1,175 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+import { awaitBundle, BUNDLE_POLLING_MS } from '../bundle';
+
+/**
+ * Page Object for the auto-size sampling-settings fixture (DEV-2850).
+ *
+ * The reader sees the effect of these options as row heights: a row whose tallest cell the sampler
+ * skipped is measured too short, and its row-header number then slides away from its row. So the
+ * assertions read the rendered geometry - the master body against the row-header overlay - and the
+ * plugin's own measured heights, rather than only the settings the plugin stored.
+ */
+export class AutoSizeSamplingSettingsPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly grid: Locator;
+  readonly inlineStartOverlay: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.grid = page.getByTestId('grid');
+    this.inlineStartOverlay = this.grid.locator('.ht_clone_inline_start');
+  }
+
+  /**
+   * Raises the sampling ratio through `updateSettings()` and waits for the redraw it causes.
+   *
+   * @param {number} samplingRatio How many samples per value length to collect.
+   */
+  async setSamplingRatio(samplingRatio: number): Promise<void> {
+    await this.#runAndAwaitRender(
+      (ratio) => (window as unknown as {
+        setSamplingRatio: (value: number) => void
+      }).setSamplingRatio(ratio as number),
+      samplingRatio
+    );
+  }
+
+  /**
+   * Changes an unrelated setting through `updateSettings()` and waits for the redraw it causes.
+   *
+   * The payload carries no `autoRowSize` key, which is the shape that used to reset the options set
+   * above - see the fixture's own comment for why.
+   */
+  async changeUnrelatedSetting(): Promise<void> {
+    await this.#runAndAwaitRender(
+      () => (window as unknown as { changeUnrelatedSetting: () => void }).changeUnrelatedSetting()
+    );
+  }
+
+  /**
+   * The sample count the generator is actually using.
+   *
+   * The stored setting is not the same thing - the whole defect was a setting that arrived and was
+   * never applied - so this reads the value the sampler will use.
+   *
+   * @returns {Promise<number>}
+   */
+  async sampleCount(): Promise<number> {
+    return this.page.evaluate(() => (window as unknown as { hot: {
+      getPlugin(name: string): { samplesGenerator: { getSampleCount(): number } },
+    } }).hot.getPlugin('autoRowSize').samplesGenerator.getSampleCount());
+  }
+
+  /**
+   * The heights the plugin has measured, one per physical row.
+   *
+   * @returns {Promise<(number | null)[]>}
+   */
+  async measuredRowHeights(): Promise<(number | null)[]> {
+    return this.page.evaluate(() => (window as unknown as { hot: {
+      getPlugin(name: string): { rowHeightsMap: { getValues(): (number | null)[] } },
+    } }).hot.getPlugin('autoRowSize').rowHeightsMap.getValues());
+  }
+
+  /**
+   * The rendered height of every row in the master table.
+   *
+   * @returns {Promise<number[]>}
+   */
+  async renderedRowHeights(): Promise<number[]> {
+    return this.grid.evaluate((root) => {
+      const rows = [...root.querySelectorAll('.ht_master .wtHolder table tbody tr')];
+
+      // A vacuous read would let every comparison below pass while measuring nothing.
+      if (rows.length === 0) {
+        throw new Error('No master rows rendered; the height measurement would be vacuous.');
+      }
+
+      return rows.map(row => Math.round(row.getBoundingClientRect().height * 100) / 100);
+    });
+  }
+
+  /**
+   * How far the row headers have drifted from their rows, in pixels - the largest disagreement
+   * across every rendered row, counting both the row's height and where its top edge sits.
+   *
+   * @returns {Promise<number>} `0` when every row lines up.
+   */
+  async worstRowHeaderDrift(): Promise<number> {
+    return this.grid.evaluate((root) => {
+      const masterRows = [...root.querySelectorAll('.ht_master .wtHolder table tbody tr')];
+      const cloneRows = [...root.querySelectorAll('.ht_clone_inline_start .wtHolder table tbody tr')];
+
+      // Without these, an empty or short clone list would skip the loop and report a drift of 0 -
+      // every assertion would pass while measuring nothing.
+      if (masterRows.length === 0) {
+        throw new Error('No master rows rendered; the drift measurement would be vacuous.');
+      }
+      if (masterRows.length !== cloneRows.length) {
+        throw new Error(
+          `Master rendered ${masterRows.length} rows but the row-header overlay rendered ` +
+          `${cloneRows.length}; the two tables cannot be compared row by row.`
+        );
+      }
+
+      let worst = 0;
+
+      for (let i = 0; i < masterRows.length; i++) {
+        const master = masterRows[i].getBoundingClientRect();
+        const clone = cloneRows[i].getBoundingClientRect();
+
+        worst = Math.max(
+          worst,
+          Math.abs(master.height - clone.height),
+          Math.abs(master.top - clone.top)
+        );
+      }
+
+      return worst;
+    });
+  }
+
+  /**
+   * Runs one of the fixture's settings helpers and waits until the grid has actually repainted.
+   *
+   * The draw counter is the signal rather than a fixed delay: `updateSettings()` redraws
+   * synchronously, but the measurement that follows it can be scheduled, so the assertion has to
+   * wait for a real event. Polling on a timer for the same reason `awaitBundle()` does - parallel
+   * workers starve `requestAnimationFrame`.
+   *
+   * @param {Function} action The helper to call in the page.
+   * @param {*} [argument] A single argument to forward to it.
+   */
+  async #runAndAwaitRender(action: (argument?: unknown) => void, argument?: unknown): Promise<void> {
+    const before = await this.page.evaluate(() => (window as unknown as { renderCount: number }).renderCount);
+
+    await this.page.evaluate(action, argument);
+
+    await this.page.waitForFunction(
+      (previous) => (window as unknown as { renderCount: number }).renderCount > (previous as number),
+      before,
+      { polling: BUNDLE_POLLING_MS }
+    );
+    // A second settled frame, so a measurement that landed on the following draw is included.
+    await this.page.evaluate(() => new Promise((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }));
+  }
+
+  /** Navigate and wait for the grid to have rendered - a real DOM condition, never a sleep. */
+  async goto(): Promise<void> {
+    await this.page.goto(
+      `/tests/fixtures/demo/auto-size-sampling-settings.html?theme=${this.theme}&bundle=${this.bundle}`
+    );
+    // The bundle first, or the leg would fail pointing at an overlay class instead of the real
+    // cause. `awaitBundle()` owns both the `waitForFunction`-over-`expect` choice and the polling
+    // interval - see its docstring for why each one matters.
+    await awaitBundle(this.page);
+    await expect(this.inlineStartOverlay).toBeVisible();
+    await expect(this.grid.locator('.ht_master tbody tr').first()).toBeVisible();
+  }
+}

--- a/tests/fixtures/pages/AutoSizeSamplingSettingsPage.ts
+++ b/tests/fixtures/pages/AutoSizeSamplingSettingsPage.ts
@@ -168,7 +168,37 @@ export class AutoSizeSamplingSettingsPage {
     // The bundle first, or the leg would fail pointing at an overlay class instead of the real
     // cause. `awaitBundle()` owns both the `waitForFunction`-over-`expect` choice and the polling
     // interval - see its docstring for why each one matters.
-    await awaitBundle(this.page);
+    //
+    // Then wait for the fixture to have finished building, either way, and rethrow a constructor
+    // throw with its own message. Without this a failed build reads as a `toBeVisible()` timeout
+    // on the overlay below, which points nowhere near the cause.
+    try {
+      await awaitBundle(this.page);
+
+      await this.page.waitForFunction(
+        () => 'hot' in window || 'htBuildError' in window,
+        undefined,
+        { polling: BUNDLE_POLLING_MS }
+      );
+    } catch (timeoutError) {
+      const snapshot = await this.page.evaluate(() => ({
+        readyState: document.readyState,
+        handsontable: typeof (window as { Handsontable?: unknown }).Handsontable,
+        stylesheets: document.styleSheets.length,
+      })).catch(() => 'page unreachable');
+
+      throw new Error(`The fixture never built its grid; page snapshot: ${JSON.stringify(snapshot)}`,
+        { cause: timeoutError });
+    }
+
+    const buildError = await this.page.evaluate(
+      () => (window as { htBuildError?: string }).htBuildError ?? null
+    );
+
+    if (buildError !== null) {
+      throw new Error(`Handsontable constructor threw in the fixture:\n${buildError}`);
+    }
+
     await expect(this.inlineStartOverlay).toBeVisible();
     await expect(this.grid.locator('.ht_master tbody tr').first()).toBeVisible();
   }


### PR DESCRIPTION
### Context

The PR fixes `samplingRatio`, `allowSampleDuplicates` and (for `AutoColumnSize`) `useHeaders` being silently ignored when they arrive through `updateSettings()`. They only ever worked as *initial* settings.

Before this change:

```js
hot.updateSettings({ autoRowSize: { samplingRatio: 6 } });

const plugin = hot.getPlugin('autoRowSize');

plugin.getSetting('samplingRatio');               // 6     <- the setting arrived
plugin.samplesGenerator.getSampleCount();         // 3     <- never applied
```

No error, no warning — the value is stored and readable, but it never reaches the samples generator, so sizes keep using the old sampling.

**Cause.** `enablePlugin()` was the only place reading these settings, and it opens with `if (this.enabled) { return; }`. `BasePlugin#onUpdateSettings` only re-runs the `disablePlugin()` / `enablePlugin()` pair when the plugin's *enabled state* changed, so a plain settings change never reaches those lines. `AutoRowSize` had no `updatePlugin()` override at all; `AutoColumnSize` had one, but it only refreshed changed headers and cleared the samples cache. `AutoRowHeaderSize` re-read them by doing the full `disablePlugin()` / `enablePlugin()` dance, so it was the only one of the three that worked — and it is the in-repo precedent that re-applying is the expected behavior.

**Fix, in three parts.**

1. **Apply the settings in `updatePlugin()`.** Each plugin gets a `#applySamplingSettings()` helper, called from both `enablePlugin()` and `updatePlugin()`. The shared `SamplesGenerator#applySamplingOptions()` applies both sampling options and reports whether either actually changed. On a real change the plugin drops its measured sizes, because those settings decide *which cells get measured at all* — a size measured under the old values describes a different sample. `AutoRowSize` calls `clearCache()` (which sets its full-recalculation flag, honored by its own `beforeRender` listener). `AutoColumnSize` calls `recalculateAllColumnsWidth()` instead: it has no such flag, and only `calculateVisibleColumnsWidth()` runs at render time, so a bare `clearCache()` would leave every off-screen column at the default width.

2. **Restore the stored settings when the payload omits the plugin key.** `SETTING_KEYS` is `true`, so an update that never mentions the plugin still reaches `updatePlugin()` — and by then `BasePlugin` has fed `updatePluginSettings()` the missing key as `undefined`. Neither auto-size plugin declares `SETTINGS_VALIDATORS`, so that assignment falls straight through and **wipes** the stored settings. Reading them in that state returns the defaults. Without the restore, applying them in `updatePlugin()` made things worse than the original bug: an unrelated `updateSettings({ colHeaders: true })` reset the user's `samplingRatio` and dropped every measured size. Each plugin now restores from `hot.getSettings()[PLUGIN_KEY]`, which is untouched — the same repair, for the same base-class reason, that `manualRowResize` makes.

   This is the common path, not an edge case. The Vue wrapper omits every settings key whose value has not changed (`wrappers/vue3/src/helpers.ts`, `simpleEqual`), so a Vue app sends a payload *without* `autoRowSize` on nearly every prop change.

3. **One shared reading of `samplingRatio`.** All three plugins parsed it differently. `SamplesGenerator.resolveSampleCount()` is now the single place: a whole number above zero is used, anything else falls back to the default of 3. That guard is not cosmetic. Parsed raw, `true` and `[]` became `NaN`, and because `NaN !== NaN` the change check reported a change on *every* `updateSettings()` call and never settled; a negative value produced a `needed` count that collected no samples at all; and `'6'` compared as different from `6`.

**Why the change detection matters.** `SETTING_KEYS` is `true`, so `updatePlugin()` runs on every `updateSettings()` call, and React and Angular re-send unchanged settings on every update (React on every commit). An unconditional re-measure would therefore run on each of them. All three plugins re-measure only on a real change, and there are tests pinning the no-change case. `AutoColumnSize` also memoizes `useHeaders`, because it feeds the ghost table rather than the sampler and so is not covered by the generator's own change check.

`AutoRowHeaderSize` keeps its existing unconditional `clearCache()` — deliberately. It measures one column, its `updatePlugin()` already re-read everything through the enable/disable pair, and narrowing it is a separate change with its own risk. It gets the shared ratio reading and the settings restore, nothing more.

**Relationship to DEV-2842.** This is the blocker for that ticket's workaround. DEV-2842 is a separate, long-standing bug (the 3-samples-per-string-length cap drops the 4th equal-length cell from the measurement, so resizing that column desyncs the row headers) and is **not** fixed here. But the recommended mitigation is to raise `samplingRatio`, and a user applying it at runtime saw nothing happen. Verified in Chrome against a local build of this branch: `getSampleCount()` now goes 3 → 6 through `updateSettings()`, and resizing the affected column keeps the master rows and the row-header rows identical (48.99px each, desync 0, nothing clipped) where before the fix the row header stayed at 28.99px with a 20px desync.

### How has this been tested?

Unit tests, a new Playwright E2E spec, three negative controls, and a manual browser check.

**Unit** — 13 plugin tests plus 10 generator tests. Negative control: with the plugin files reverted and the tests kept, **9 of 13 failed** — the "arriving through `updateSettings`", "restore the default" and "drop the measured sizes" cases. The 4 that passed are the initial-settings controls and the re-sent-unchanged guards, which hold both before and after.

**E2E** — `tests/e2e/auto-size-sampling-settings.spec.ts`, with its own fixture and page object. The fixture puts four strings of one length in one row, so the default cap of three leaves the last column unsampled; that column is the only narrow one, so its text is the only text that wraps. The spec reads real geometry: the plugin's measured heights, and the master rows against the row-header overlay. Three tests, all six theme × bundle legs: **18 passed**.

Two negative controls on the E2E, because the assertions are geometric and a geometric assertion can pass on broken code:

- Remove the settings restore → test 3 fails, `sampleCount()` Expected 6 / Received 3. The other two still pass, which is the right shape: only the omitted-key path is broken.
- Remove the sampling re-apply → all three fail, and the row-header drift assertion reports **100px**. That number is the DEV-2842 desync itself, which is what proves the assertion measures the user-visible symptom and not rounding.

```bash
# unit
npm run test:unit --prefix handsontable -- --testPathPattern=samplingSettings
npm run test:unit --prefix handsontable -- --testPathPattern=samplesGenerator

# full core unit suite: 362 suites, 4687 tests, 0 failures
npm run test:unit --prefix handsontable

# new Playwright spec, one leg then all six
cd tests && npx playwright test --project=e2e-main e2e/auto-size-sampling-settings.spec.ts
cd tests && npx playwright test e2e/auto-size-sampling-settings.spec.ts    # 18 passed

# legacy E2E for every plugin that touches SamplesGenerator
npm run test:e2e --prefix handsontable -- --testPathPattern=autoRowSize        # 55 specs, 0 failures
npm run test:e2e --prefix handsontable -- --testPathPattern=autoColumnSize     # 67 specs, 0 failures
npm run test:e2e --prefix handsontable -- --testPathPattern=autoRowHeaderSize  #  5 specs, 0 failures

# lint and types
npm run eslint --prefix handsontable      # 0 errors
npm run stylelint --prefix handsontable   # 0 errors
npm run test:types --prefix handsontable
```

Manual: Chrome, local full build, the fixture from DEV-2842 (`autoRowSize` + `manualColumnResize`, four equal-length strings in one row). Applied `samplingRatio: 6` through `updateSettings()`, then drag-resized the affected column and compared each master row's height against the matching row in the `.ht_clone_inline_start` clone. Also probed the omitted-key path directly: before the restore, `updateSettings({ colHeaders: true })` reset `samplingRatio` from 6 to 3 and `allowSampleDuplicates` from `true` to `false`, and dropped the cache.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2850
2. DEV-2842 — the ticket this was found under. Not fixed by this PR; its workaround is what this unblocks.

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

The documented behavior of these options is unchanged — the docs never said "initial settings only", so this makes the code match what is already published. The class JSDoc of all three plugins now states that the sampling options apply through `updateSettings()` and what `samplingRatio` accepts. All three plugins' `AGENTS.md` are updated too: `autoRowSize`'s already carried a "`updateSettings` does not recalculate — it is the contract, not a bug" section, and this adds the narrow exception for the plugin's own sampling settings, the settings-wipe restore, and the reason the re-measure has to be conditional.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2850

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes run on every `updateSettings()` for enabled auto-size plugins and affect row/column measurement caching, though behavior is gated on real setting changes and covered by new unit and E2E tests.
> 
> **Overview**
> Fixes **AutoRowSize**, **AutoColumnSize**, and **AutoRowHeaderSize** so `samplingRatio`, `allowSampleDuplicates`, and (for columns) `useHeaders` actually apply when changed through `updateSettings()`, not only at init. Sampling options are applied in `updatePlugin()` via shared `#applySamplingSettings()` / `SamplesGenerator.applySamplingOptions()`, and measured sizes are refreshed only when a value really changes (`clearCache()` for rows, `recalculateAllColumnsWidth()` for columns).
> 
> When `updateSettings()` omits the plugin key (typical for Vue), plugins **restore** their options from `hot.getSettings()` before re-applying, so unrelated updates no longer wipe custom sampling or trigger bogus full re-measures. **`samplingRatio`** is normalized in one place (`resolveSampleCount`: positive integers only, default 3).
> 
> Adds unit tests for the three plugins and `SamplesGenerator`, plus Playwright coverage for runtime ratio changes and row-header alignment; changelog and `AGENTS.md` / JSDoc updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60e2c364e9c3e063e06100d180082cff443cfb71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

