### PR TITLE
DEV-2076: Clarify that dropdownMenu and contextMenu are independent plugins

### DIFF
--- a/docs/content/guides/accessories-and-menus/column-menu/column-menu.md
+++ b/docs/content/guides/accessories-and-menus/column-menu/column-menu.md
@@ -24,7 +24,11 @@ Display a configurable dropdown menu, triggered by clicking on a button in a col
 ## Overview
 
 The [`DropdownMenu`](@/api/dropdownMenu.md) plugin enables you to add a configurable dropdown menu to the table's column headers.
-The dropdown menu acts like the [context menu](@/guides/accessories-and-menus/context-menu/context-menu.md) but is triggered by clicking the button in the header.
+The dropdown menu and the [context menu](@/guides/accessories-and-menus/context-menu/context-menu.md) are two independent plugins, each with its own configuration key (`dropdownMenu` and `contextMenu`). The dropdown menu is triggered by clicking the button in the column header, instead of right-clicking.
+
+::: warning `dropdownMenu` and `contextMenu` are configured separately
+Setting one option does not affect the other, even though both accept items in the same format.
+:::
 
 ## Quick setup
 


### PR DESCRIPTION
### Context
The Column menu guide's Overview said the dropdown menu "acts like" the context menu. An LLM eval test (MENU-CUST-003) showed a model reading this as "same configuration structure and API" for both, even though the two use separate config keys (`dropdownMenu` vs `contextMenu`) and different triggers. This PR states plainly that they are two independent plugins and adds a warning callout naming both keys, so the docs page itself corrects that assumption.

This is the first of several planned edits for this task (edit-1 of 6); the rest (Quick Setup prerequisite tip, a "Differences from contextMenu" comparison section, etc.) will follow separately.

### Test evidence (required for source changes)
- Unit tests added/modified (`*.unit.js`): none — docs only
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none — docs only
- Type tests (`*.types.ts`) updated if public API changed: none — docs only
- For a bug fix — the spec that fails without this fix: n/a
- Demo page / recorded trace (for UI changes): n/a

### Commands run
none — docs-only wording change, no build/test commands run

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://app.clickup.com/t/86car2gku

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.
- [ ] MANUAL QA NEEDED

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording in the column menu guide; no runtime or API behavior changes.
> 
> **Overview**
> Updates the **Column menu** guide Overview so it no longer describes the dropdown as merely “acting like” the context menu. It now states that **`dropdownMenu` and `contextMenu` are separate plugins** with distinct config keys and triggers (header button vs right-click).
> 
> Adds a **warning callout** that configuring one option does not affect the other, even when menu items use the same format—aimed at readers (and doc-driven tooling) that might treat them as a single API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 869fd8c1c6e1fb85fc12492b8069503200cda111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->