### PR TITLE
docs: clarify when afterSetDataAtCell and afterSetDataAtRowProp fire

### DIFF
--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -1313,6 +1313,11 @@ export const REGISTERED_HOOKS = [
    * before they are validated and applied to the data source.
    * Use [`afterChange`](@/api/hooks.md#afterchange) if you need to react after the data has been written.
    *
+   * This hook fires whenever a change is written through `setDataAtCell()` — not only when you call
+   * it directly, but also for regular cell edits, paste, and cut, since those are applied internally
+   * via `setDataAtCell()` too. Changes made through `setDataAtRowProp()` fire
+   * [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop) instead — never both for the same change.
+   *
    * @event Hooks#afterSetDataAtCell
    * @param {Array} changes An array of changes in format `[[row, column, oldValue, value], ...]`.
    * @param {string} [source] String that identifies source of hook call
@@ -1324,6 +1329,11 @@ export const REGISTERED_HOOKS = [
    * Fired after [`setDataAtRowProp`](@/api/core.md#setdataatrowprop) is called and changes are processed,
    * before they are validated and applied to the data source.
    * Use [`afterChange`](@/api/hooks.md#afterchange) if you need to react after the data has been written.
+   *
+   * This hook fires only for changes made through a direct `setDataAtRowProp()` call. Changes made
+   * through `setDataAtCell()` — including regular cell edits, paste, and cut, which apply internally
+   * via `setDataAtCell()` — fire [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell) instead —
+   * never both for the same change.
    *
    * @event Hooks#afterSetDataAtRowProp
    * @param {Array} changes An array of changes in format `[[row, prop, oldValue, value], ...]`.

--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -1313,10 +1313,12 @@ export const REGISTERED_HOOKS = [
    * before they are validated and applied to the data source.
    * Use [`afterChange`](@/api/hooks.md#afterchange) if you need to react after the data has been written.
    *
-   * This hook fires whenever a change is written through `setDataAtCell()` — not only when you call
-   * it directly, but also for regular cell edits, paste, and cut, since those are applied internally
-   * via `setDataAtCell()` too. Changes made through `setDataAtRowProp()` fire
-   * [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop) instead — never both for the same change.
+   * This hook fires for every `setDataAtCell()` call – not only when you call it directly, but also
+   * for regular cell edits, paste, cut, Delete/Backspace, the fill handle, Ctrl+Enter, a checkbox
+   * click, and undo/redo, since those are applied internally via `setDataAtCell()` too. It also fires
+   * when a `beforeChange` handler cancels the change, with an empty `changes` array. Changes made
+   * through `setDataAtRowProp()` fire [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop)
+   * instead – never both for the same change.
    *
    * @event Hooks#afterSetDataAtCell
    * @param {Array} changes An array of changes in format `[[row, prop, oldValue, value], ...]`.
@@ -1330,10 +1332,12 @@ export const REGISTERED_HOOKS = [
    * before they are validated and applied to the data source.
    * Use [`afterChange`](@/api/hooks.md#afterchange) if you need to react after the data has been written.
    *
-   * This hook fires only for changes made through a direct `setDataAtRowProp()` call. Changes made
-   * through `setDataAtCell()` — including regular cell edits, paste, and cut, which apply internally
-   * via `setDataAtCell()` — fire [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell) instead —
-   * never both for the same change.
+   * This hook fires for every `setDataAtRowProp()` call, yours or a plugin's – for example, the
+   * DataProvider plugin calls it internally (with `source` set to `'DataProvider.revert'`) to roll
+   * back an optimistic edit after a failed server update. Changes made through `setDataAtCell()` –
+   * including regular cell edits, paste, cut, Delete/Backspace, the fill handle, Ctrl+Enter, a
+   * checkbox click, and undo/redo, which apply internally via `setDataAtCell()` – fire
+   * [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell) instead – never both for the same change.
    *
    * @event Hooks#afterSetDataAtRowProp
    * @param {Array} changes An array of changes in format `[[row, prop, oldValue, value], ...]`.

--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -1319,7 +1319,7 @@ export const REGISTERED_HOOKS = [
    * [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop) instead — never both for the same change.
    *
    * @event Hooks#afterSetDataAtCell
-   * @param {Array} changes An array of changes in format `[[row, column, oldValue, value], ...]`.
+   * @param {Array} changes An array of changes in format `[[row, prop, oldValue, value], ...]`.
    * @param {string} [source] String that identifies source of hook call
    *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    */


### PR DESCRIPTION
### Context
The JSDoc for `afterSetDataAtCell` and `afterSetDataAtRowProp` (source of the generated `/api/hooks/` reference page) did not state when each hook fires relative to the other, or that `afterSetDataAtCell` also fires for regular cell edits, paste, and cut (not only a direct `setDataAtCell()` call), since those apply internally via `setDataAtCell()`. 

Then `afterSetDataAtRowProp` only fires for a direct `setDataAtRowProp()` call. The two hooks never fire together for the same change. This gap was surfaced by an internal docs eval where a model incorrectly claimed neither hook exists.


Action | Hooks fired
-- | --
Manual cell edit | afterChange + afterSetDataAtCell
Paste | afterChange + afterSetDataAtCell
Cut | afterChange + afterSetDataAtCell
setDataAtCell() (direct call) | afterChange + afterSetDataAtCell
setDataAtRowProp() (direct call) | afterChange + afterSetDataAtRowProp (never afterSetDataAtCell)

Demo for test: https://demos.handsontable.com/d/5g175j425t/


### Test evidence (required for source changes)
- Unit tests added/modified (`*.unit.js`): none — comment-only JSDoc change, no behavior modified
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none
- Type tests (`*.types.ts`) updated if public API changed: not applicable — no API change
- For a bug fix — the spec that fails without this fix: not applicable — documentation clarification only
- Demo page / recorded trace (for UI changes): not applicable

[skip changelog]

### Commands run
```
$ npm run test:unit -- --testPathPattern=jsdocLinkSyntax
PASS test/__tests__/jsdocLinkSyntax.unit.js
  cross-reference link syntax
    ✓ should not use TypeDoc `[[Target]]` links in core JSDoc comments (160 ms)
    ✓ should not use TypeDoc `[[Target]]` links in documentation pages (146 ms)
Tests:       2 passed, 2 total

$ npm run eslint -- --no-eslintrc --config .eslintrc.js src/core/hooks/constants.ts
ESLint: 1 errors, 0 warnings in 1 files
  handsontable/require-tracked-hook-in-enable (1x)
# confirmed pre-existing on develop (unrelated to this change) by running the same
# lint command against the file before this edit — same single error
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://app.clickup.com/t/9015210959/DEV-2037

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.
- [ ] MANUAL QA NEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only JSDoc in hook constants; no code paths or types changed.
> 
> **Overview**
> **Documentation-only** updates to the JSDoc for **`afterSetDataAtCell`** and **`afterSetDataAtRowProp`** in `constants.ts` (feeds the generated `/api/hooks/` reference).
> 
> For **`afterSetDataAtCell`**, the docs now state that the hook runs on every internal `setDataAtCell()` path—not only direct API calls—including normal edits, paste/cut, Delete/Backspace, fill handle, Ctrl+Enter, checkbox toggles, and undo/redo; that it can run with an **empty `changes` array** when `beforeChange` cancels; and that **`setDataAtRowProp()` changes use `afterSetDataAtRowProp` instead**, with the two hooks never firing together for one change. The **`changes`** `@param` description is corrected from `column` to **`prop`**.
> 
> For **`afterSetDataAtRowProp`**, parallel wording explains plugin/internal use (e.g. DataProvider revert with source `'DataProvider.revert'`) and the same **mutual exclusivity** with `afterSetDataAtCell`.
> 
> No runtime or public API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 608a11700cf9f369df8c9a7798176f4290b2743b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->