### PR TITLE
DEV-2874: Measure the table only during a live fill-handle drag

### DIFF
--- a/.changelogs/13453.json
+++ b/.changelogs/13453.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the Autofill plugin throwing an error on every pointer move across the page after a grid failed to initialize.",
+  "type": "fixed",
+  "issueOrPR": 13453,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/autofill/AGENTS.md
+++ b/handsontable/src/plugins/autofill/AGENTS.md
@@ -91,6 +91,60 @@ fills anyway. So `updatePlugin()` compares the **resolved** configuration (`dire
 drag. `tests/e2e/fill-handle-disable-mid-drag.spec.ts` pins all three outcomes: the disable ends the
 gesture, the same-value re-send does not, the direction change does.
 
+## The `documentElement` listeners outlive a failed init (DEV-2874)
+
+`enablePlugin()` runs on `afterPluginsInitialized`, which fires **while `Core#init`'s
+`runHooks('beforeInit')` executes**. `hot.table` is assigned later and exactly once, by
+`TableView#createElements()`, reached from the `this.view = new TableView(this)` that follows in the
+same function. So between those two statements this plugin already holds live `mousemove`/`mouseup`
+listeners on `rootDocument.documentElement` while `hot.table` is still `undefined`. (Cited by symbol,
+not by line: `core.ts` moves constantly and a stale line number is worse than none. Grep the calls.)
+
+An init that aborts inside that window leaves those listeners bound forever. The constructor threw, so
+the caller holds no instance and can never `destroy()` it, and the leak is cumulative – one live
+listener per aborted attempt. The `this.updateSettings(mergedUserSettings, true)` between those two
+statements sits right in the gap: the deprecated `rows`/`cols`/`ganttChart` settings throw there
+unconditionally (the three `'is no longer supported'` `throwWithCause` calls at the top of
+`Core#updateSettings`), an unresolvable string cell type in `columns` throws during meta resolution, and
+a user `beforeInit` hook that throws does it even earlier (settings-declared `beforeInit` is registered
+after the plugin constructors, so the plugins are enabled first). The set of throw sites is not
+enumerable, which is why the **consumer** is guarded and not the producer.
+
+`#onMouseMove` therefore must not touch `this.hot.table` unless a gesture is armed. It used to call
+`getIfMouseWasDraggedOutside()` outside the `mouseDownOnCellCorner` block, so every pointer move
+anywhere on the page threw `Cannot read properties of undefined (reading 'ownerDocument')` out of
+`offset()` – Sentry DEMOS-6J, reproduced from a demo runner where a live-typed config aborted the init
+once per keystroke. The guard now short-circuits on `handleDraggedCells > 0`, which is the same
+conjunction the branch already carried, so nothing changed except when the measurement is evaluated.
+The result is named `shouldMarkDragOutside`, not for the row insertion: that is gated separately on
+`autoInsertRow`, which the `fillHandle` schema default (`metaSchema.ts`) leaves `false`.
+
+Two things not to get wrong here:
+
+- **This guard uses the step counter, and the flag rule above does not apply.** Not because the flag
+  would be unsafe – `#resetDragState()` clears `mouseDragOutside` on every teardown path, so there is
+  no stale-true state for `addRow()` to fire from. The reason is narrower and stronger: `handleDraggedCells > 0`
+  was **already** the second conjunct of this predicate, so hoisting it changes nothing but *when* the
+  read-only measurement is evaluated. Gating on `mouseDownOnCellCorner` instead would also skip the
+  `else` write, which is a different change needing its own equivalence argument for no gain. The
+  counter is only ever raised together with the flag (`#onAfterCellCornerMouseDown`), so it implies a
+  live gesture either way.
+- **`undefined` and `null` are different bugs.** Every teardown path – `disablePlugin()`,
+  `BasePlugin#destroy()`, `hot.destroy()` – clears this plugin's `EventManager` and so removes the
+  document listeners, and `hot.destroy()` runs its plugin `destroy()` loop *before* the `objectEach`
+  sweep that nulls instance properties. A future stack reading `ownerDocument` of **null** is a
+  teardown-ordering regression; **undefined** is this pre-view window. Read the message before assuming
+  a stale-reference-after-unmount story.
+
+`tests/e2e/fill-handle-aborted-init.spec.ts` pins both halves: no page error on a pointer move after an
+aborted init, and zero drag-outside measurements while nothing is held (with a real drag as the
+positive control for the counter).
+
+Do **not** guard `offset()` itself. Its parameter is a non-nullable `HTMLElement` and it has many call
+sites; tolerating `undefined` there would hide unrelated bugs. A `return false` fallback inside
+`getIfMouseWasDraggedOutside()` is no better – it is a silent wrong answer, and after the hoist it is
+unreachable from its only caller.
+
 ## Auto-inserting rows
 
 With `autoInsertRow: true`, dragging past the last row inserts rows (`insert_row_below`) on a 200 ms

--- a/handsontable/src/plugins/autofill/autofill.ts
+++ b/handsontable/src/plugins/autofill/autofill.ts
@@ -963,9 +963,14 @@ export class Autofill extends BasePlugin {
       this.redrawBorders(cellCoords);
     }
 
-    const mouseWasDraggedOutside = this.getIfMouseWasDraggedOutside(event);
+    // Short-circuited on purpose: the measurement reads `this.hot.table`, which is `undefined` on
+    // an instance whose init aborted before the view existed. See this plugin's AGENTS.md
+    // ("The `documentElement` listeners outlive a failed init").
+    const shouldMarkDragOutside = this.addingStarted === false &&
+      this.handleDraggedCells > 0 &&
+      this.getIfMouseWasDraggedOutside(event);
 
-    if (this.addingStarted === false && this.handleDraggedCells > 0 && mouseWasDraggedOutside) {
+    if (shouldMarkDragOutside) {
       this.mouseDragOutside = true;
       this.addingStarted = true;
 

--- a/tests/e2e/fill-handle-aborted-init.spec.ts
+++ b/tests/e2e/fill-handle-aborted-init.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '../fixtures/test';
+import { AutofillAbortedInitPage } from '../fixtures/pages/AutofillAbortedInitPage';
+
+/**
+ * The Autofill plugin measured the table on every document `mousemove`, whether or not a fill
+ * gesture was in progress. Its `documentElement` listeners are registered while `beforeInit` runs,
+ * before the grid's `TableView` assigns `hot.table`, so an init that aborts in between leaves live
+ * global listeners on an instance whose `hot.table` stays `undefined` forever - and the constructor
+ * threw, so nothing can `destroy()` it. Every later pointer move on the page then threw
+ * `Cannot read properties of undefined (reading 'ownerDocument')` out of `offset()`, once per
+ * leaked instance (DEV-2874, Sentry DEMOS-6J).
+ */
+test.describe('autofill after an aborted grid init', () => {
+  let grid: AutofillAbortedInitPage;
+  let pageErrors: string[];
+
+  test.beforeEach(async ({ page, theme, bundle }) => {
+    pageErrors = [];
+    page.on('pageerror', error => pageErrors.push(error.message));
+
+    grid = new AutofillAbortedInitPage(page, theme, bundle);
+    await grid.goto();
+  });
+
+  test('does not throw on a pointer move after an init aborted before the view existed', async () => {
+    // Positive control: without it the assertion below would pass on a fixture that quietly
+    // stopped aborting, and the spec would be green forever.
+    expect(await grid.abortGridInit()).toContain('The "rows" setting is no longer supported');
+
+    await grid.movePointerAcrossPage();
+
+    // The healthy grid is untouched by the leak, so it is the pointer move that has to stay silent.
+    await expect(grid.cell(0, 0)).toHaveText('A1');
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('measures the table only while the fill handle is actually held', async () => {
+    // The invariant behind the fix, stated directly: the drag-outside measurement reads
+    // `hot.table`, so it belongs to a live corner gesture and nothing else.
+    await grid.instrumentDragOutsideCheck();
+
+    await grid.movePointerAcrossPage();
+
+    expect(await grid.dragOutsideCheckCount()).toBe(0);
+
+    // Positive control for the counter itself: a real drag still takes the measurement, so a zero
+    // above means "not called", not "instrumentation missed it".
+    await grid.selectCell(0, 0);
+    await grid.dragFillHandleTo(2, 0);
+
+    expect(await grid.dragOutsideCheckCount()).toBeGreaterThan(0);
+    await expect(grid.cell(2, 0)).toHaveText('A1');
+    expect(pageErrors).toEqual([]);
+  });
+});

--- a/tests/fixtures/demo/autofill-aborted-init.html
+++ b/tests/fixtures/demo/autofill-aborted-init.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Autofill aborted-init e2e fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back.
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+  </style>
+</head>
+<body>
+  <!--
+    DEV-2874. The Autofill plugin registers its `documentElement` listeners from `enablePlugin()`,
+    which runs on `afterPluginsInitialized` - fired while `runHooks('beforeInit')` executes, i.e.
+    BEFORE the grid's `TableView` is constructed and `hot.table` is assigned. An init that aborts
+    between those two points therefore leaves live global listeners behind on an instance whose
+    `hot.table` is permanently `undefined`, and the constructor threw, so the caller holds no
+    reference and can never `destroy()` it.
+
+    `#onMouseMove` used to measure the table on EVERY document `mousemove` - the
+    `getIfMouseWasDraggedOutside()` call sat outside the `mouseDownOnCellCorner` guard - so from
+    then on every pointer move anywhere on the page threw
+    `Cannot read properties of undefined (reading 'ownerDocument')` out of the `offset()` helper,
+    once per leaked instance, for the lifetime of the document (Sentry DEMOS-6J).
+
+    `abortGridInit()` uses the deprecated `rows` setting because that is the shallowest guaranteed
+    abort inside the window: an unconditional `throwWithCause` at the top of `updateSettings()`,
+    with no cell-type or meta-manager resolution in the way. Production hit the same window through
+    an unresolvable string cell type while a demo was being live-typed, one abort per keystroke.
+
+    None of this is observable in the frozen Jasmine suite: the leaked listener cannot be cleaned
+    up, so it would keep firing into every later spec sharing the page.
+  -->
+  <h2>Autofill aborted init</h2>
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    // The bundle under test, selected above from the sanitized allowlist. The
+    // closing tag is split so the HTML parser does not end THIS script block.
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    container.className = `ht-theme-${window.htTheme}`;
+
+    /**
+     * Stamps every cell with a stable test id so the specs hook by `data-testid` rather than by
+     * structural CSS.
+     *
+     * @param {object} instance The Handsontable instance.
+     * @param {HTMLTableCellElement} td The cell element.
+     * @param {number} row The visual row index.
+     * @param {number} col The visual column index.
+     */
+    function testIdRenderer(instance, td, row, col) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    }
+
+    window.hot = new Handsontable(container, {
+      data: Array.from({ length: 8 }, (_, row) => [`A${row + 1}`, null, null, null]),
+      colHeaders: true,
+      rowHeaders: true,
+      renderer: testIdRenderer,
+      fillHandle: true,
+      width: 500,
+      height: 300,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    /**
+     * Builds a second grid whose init aborts inside `updateSettings()`, in its own throwaway
+     * container, and reports the message it threw with.
+     *
+     * The caller gets the message back so a test can prove the abort really happened before it
+     * asserts on the absence of a page error - without that positive control the assertion would
+     * pass on a fixture that quietly stopped aborting.
+     *
+     * @returns {string|null} The thrown message, or `null` when the init unexpectedly succeeded.
+     */
+    window.abortGridInit = function() {
+      const doomed = document.createElement('div');
+
+      document.body.appendChild(doomed);
+
+      try {
+        // `rows` was removed years ago and `updateSettings()` throws on it unconditionally, after
+        // `beforeInit` has already enabled every plugin.
+        new Handsontable(doomed, {
+          data: [['a', 'b']],
+          rows: 5,
+          licenseKey: 'non-commercial-and-evaluation',
+        });
+      } catch (error) {
+        return error.message;
+      }
+
+      return null;
+    };
+
+    // Initialised here, not inside the instrumentation, so the counter is a number from the moment
+    // the fixture loads - the page-object type declares it as one.
+    window.dragOutsideCheckCount = 0;
+
+    /**
+     * Counts the calls the healthy grid's Autofill plugin makes to `getIfMouseWasDraggedOutside()`,
+     * the method that reads `hot.table`. This is the invariant the fix establishes: the measurement
+     * belongs to a live corner gesture, so a pointer move with nothing pressed must not take it.
+     *
+     * @returns {boolean}
+     */
+    window.instrumentDragOutsideCheck = function() {
+      const plugin = window.hot.getPlugin('autofill');
+      const original = plugin.getIfMouseWasDraggedOutside.bind(plugin);
+
+
+      plugin.getIfMouseWasDraggedOutside = function(event) {
+        window.dragOutsideCheckCount += 1;
+
+        return original(event);
+      };
+
+      return true;
+    };
+  </script>
+</body>
+</html>

--- a/tests/fixtures/gestures.ts
+++ b/tests/fixtures/gestures.ts
@@ -41,3 +41,27 @@ export async function dragResizeHandle(
   await page.mouse.move(startX + deltaX, startY + deltaY);
   await page.mouse.up();
 }
+
+/**
+ * Drags the autofill fill handle onto a target cell and releases, the way a user drag-fills. The
+ * caller selects the range first (that is what draws the handle) and passes both elements in,
+ * because how a grid is addressed differs per fixture while the gesture does not.
+ *
+ * @param {Page} page The page the handle lives on.
+ * @param {Locator} handle The fill handle to drag.
+ * @param {Locator} target The cell to drag onto.
+ */
+export async function dragFillHandle(page: Page, handle: Locator, target: Locator): Promise<void> {
+  const handleBox = await handle.boundingBox();
+  const targetBox = await target.boundingBox();
+
+  if (!handleBox || !targetBox) {
+    throw new Error('The fill handle or the target cell is not rendered.');
+  }
+
+  await page.mouse.move(handleBox.x + (handleBox.width / 2), handleBox.y + (handleBox.height / 2));
+  await page.mouse.down();
+  // Several moves, because the plugin counts drag steps through `mousemove` and `beforeOnCellMouseOver`.
+  await page.mouse.move(targetBox.x + (targetBox.width / 2), targetBox.y + (targetBox.height / 2), { steps: 8 });
+  await page.mouse.up();
+}

--- a/tests/fixtures/pages/AutofillAbortedInitPage.ts
+++ b/tests/fixtures/pages/AutofillAbortedInitPage.ts
@@ -1,0 +1,90 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+import { awaitBundle } from '../bundle';
+import { dragFillHandle } from '../gestures';
+
+/**
+ * Page Object for the autofill aborted-init fixture
+ * (tests/fixtures/demo/autofill-aborted-init.html).
+ *
+ * The fixture holds one healthy grid plus a helper that builds a second grid whose init aborts
+ * inside `updateSettings()`. Tests express intent (`abortGridInit`, `movePointerAcrossPage`); the
+ * selectors and the `window.hot` driving mechanics live here.
+ */
+export class AutofillAbortedInitPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly grid: Locator;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    this.grid = page.getByTestId('grid');
+  }
+
+  /**
+   * Navigate to the fixture and wait for the grid to have rendered - a real DOM condition, never
+   * a sleep.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(
+      `/tests/fixtures/demo/autofill-aborted-init.html?theme=${this.theme}&bundle=${this.bundle}`
+    );
+
+    await awaitBundle(this.page);
+
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /** A single data cell, by visual row/column, via its stable test id. */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /** The autofill fill handle of the focus selection, scoped to the master overlay. */
+  fillHandle(): Locator {
+    return this.page.locator('.ht_master .wtBorder.current.corner:visible');
+  }
+
+  /**
+   * Build a grid whose init aborts inside `updateSettings()`, leaving the Autofill plugin's
+   * `documentElement` listeners bound to an instance that has no `hot.table`.
+   *
+   * @returns {Promise<string | null>} The message the aborted init threw with, or `null` when it
+   * unexpectedly succeeded.
+   */
+  async abortGridInit(): Promise<string | null> {
+    return this.page.evaluate(() => window.abortGridInit());
+  }
+
+  /**
+   * Move the pointer across the page with no button held. Several moves, so a single swallowed
+   * event cannot make the assertion vacuous.
+   */
+  async movePointerAcrossPage(): Promise<void> {
+    await this.page.mouse.move(10, 10);
+    await this.page.mouse.move(200, 220, { steps: 6 });
+    await this.page.mouse.move(420, 40, { steps: 6 });
+  }
+
+  /** Start counting the healthy grid's `getIfMouseWasDraggedOutside()` calls. */
+  async instrumentDragOutsideCheck(): Promise<void> {
+    await this.page.evaluate(() => window.instrumentDragOutsideCheck());
+  }
+
+  /** How many times the healthy grid measured the table for a drag-outside test. */
+  async dragOutsideCheckCount(): Promise<number> {
+    return this.page.evaluate(() => window.dragOutsideCheckCount);
+  }
+
+  /** Click a cell to select it, which is what draws the fill handle. */
+  async selectCell(row: number, col: number): Promise<void> {
+    await this.cell(row, col).click();
+  }
+
+  /** Drag the fill handle with the real pointer onto the given cell and release. */
+  async dragFillHandleTo(row: number, col: number): Promise<void> {
+    await dragFillHandle(this.page, this.fillHandle(), this.cell(row, col));
+  }
+}

--- a/tests/fixtures/pages/SelectionFeaturesPage.ts
+++ b/tests/fixtures/pages/SelectionFeaturesPage.ts
@@ -1,5 +1,6 @@
 import { type Page, type Locator, expect } from '@playwright/test';
 import type { CellValue, MoveCellsHookRecord } from './windowTypes';
+import { dragFillHandle } from '../gestures';
 
 /**
  * Page Object for the selection features fixture
@@ -887,17 +888,7 @@ export class SelectionFeaturesPage {
 
   /** Drag the fill handle with the real pointer onto the given cell and release. */
   async dragFillHandleTo(row: number, col: number): Promise<void> {
-    const handleBox = await this.fillHandle().boundingBox();
-    const targetBox = await this.cell(row, col).boundingBox();
-
-    if (!handleBox || !targetBox) {
-      throw new Error('The fill handle or the target cell is not rendered.');
-    }
-
-    await this.page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
-    await this.page.mouse.down();
-    await this.page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, { steps: 8 });
-    await this.page.mouse.up();
+    await dragFillHandle(this.page, this.fillHandle(), this.cell(row, col));
   }
 
   /** Whether the Autofill plugin still believes the fill handle is pressed. */

--- a/tests/fixtures/pages/windowTypes.ts
+++ b/tests/fixtures/pages/windowTypes.ts
@@ -218,6 +218,15 @@ declare global {
     /** Per-hook invocation counters of the touch tap-to-edit fixture (DEV-2687). */
     hookCounts: Record<HookCounterName, number>;
     /**
+     * Builds a grid whose init aborts inside `updateSettings()` and returns the message it threw
+     * with, or `null` when it unexpectedly succeeded (DEV-2874 fixture).
+     */
+    abortGridInit(): string | null;
+    /** Starts counting the healthy grid's `getIfMouseWasDraggedOutside()` calls (DEV-2874 fixture). */
+    instrumentDragOutsideCheck(): boolean;
+    /** How many drag-outside measurements the healthy grid has taken since instrumentation. */
+    dragOutsideCheckCount: number;
+    /**
      * Chromium-only InputDeviceCapabilities constructor, used to stamp synthetic mouse events
      * with their origin (DEV-2687).
      */


### PR DESCRIPTION
### Context

The PR fixes the Autofill plugin throwing `Cannot read properties of undefined (reading 'ownerDocument')` out of the `offset()` helper on every pointer move across the page, once per affected grid, for the lifetime of the document. It was reported from the demo runner via Sentry, but the stack sits entirely inside our own library.

The cause is a lifecycle window, not a drag bug:

- `hot.table` is assigned exactly once, by `TableView#createElements()`.
- Autofill registers its `mousemove`/`mouseup` listeners on `rootDocument.documentElement` from `enablePlugin()`, which runs on `afterPluginsInitialized` — fired while `Core#init`'s `runHooks('beforeInit')` executes, i.e. **before** the `TableView` is constructed.

So any grid initialization that aborts between those two statements leaves live document-level listeners bound to an instance whose `hot.table` stays `undefined` forever. The constructor threw, so the caller holds no instance and can never `destroy()` it, and the leak is cumulative — one live listener per aborted attempt. `Core#init` calls `updateSettings()` right in that gap, and the deprecated `rows`/`cols`/`ganttChart` settings throw there unconditionally, an unresolvable string cell type in `columns` throws during meta resolution, and a user `beforeInit` hook that throws does it even earlier.

`#onMouseMove` then made things visible: it called `getIfMouseWasDraggedOutside()` **outside** the `mouseDownOnCellCorner` block, so it measured the table on every document `mousemove` whether or not a fill gesture was in progress.

The fix hoists the guard the branch already carried, so the measurement short-circuits unless a corner gesture is armed:

```js
const shouldMarkDragOutside = this.addingStarted === false &&
  this.handleDraggedCells > 0 &&
  this.getIfMouseWasDraggedOutside(event);
```

This is behavior-identical by construction — `&&` short-circuits and `getIfMouseWasDraggedOutside()` is a read-only predicate (`offset()`, `outerWidth()` and `outerHeight()` are all plain geometry reads), so the only thing that changes is *when* it is evaluated. The `else` branch is untouched. A side benefit, with no number claimed for it: two `offsetParent`-chain walks plus `offsetWidth`/`offsetHeight` reads no longer happen on the hottest event on the page, per enabled grid.

`offset()` itself is deliberately **not** guarded: its parameter is a non-nullable `HTMLElement` and it has many call sites, so tolerating `undefined` there would hide unrelated bugs.

The underlying leak — a half-initialized instance keeping document listeners alive with no way to reach them — is real and out of scope here. It needs its own task; this PR removes the crash, not the leak.

### How has this been tested?

New Playwright spec `tests/e2e/fill-handle-aborted-init.spec.ts`, two cases, each with its own positive control so neither can pass vacuously:

1. **The symptom.** Build a grid whose init aborts, move the pointer, assert no `pageerror`. The abort is asserted first, so a fixture that stopped aborting fails instead of going green.
2. **The invariant.** With a healthy grid and nothing held, a `documentElement` `mousemove` must not call `getIfMouseWasDraggedOutside()` at all. A real fill-handle drag afterwards must call it, which proves the instrumentation works rather than that it missed.

Both were confirmed red before the fix — 13 `ownerDocument` errors, and a call count of 13 instead of 0.

```bash
npm --prefix handsontable run build

# the new spec plus every spec touching either changed page object, all six legs
cd tests && npx playwright test \
  e2e/fill-handle-aborted-init.spec.ts e2e/fill-handle-disable-mid-drag.spec.ts \
  e2e/fill-handle-double-click.spec.ts e2e/fill-handle-formulas.spec.ts \
  e2e/fill-handle-frozen-panes.spec.ts e2e/ctrl-click-highlight.spec.ts \
  e2e/move-cells-api.spec.ts e2e/move-cells-undo.spec.ts e2e/move-zone.spec.ts \
  e2e/row-column-move-undo.spec.ts e2e/selection-handles.spec.ts
# 756 passed

npm --prefix handsontable run test:e2e    # 9949 specs, 0 failures
npm --prefix handsontable run test:unit   # 4686 passed
npm --prefix handsontable run eslint      # 0 errors
npm --prefix handsontable run stylelint   # clean
```

Also reproduced and re-verified outside the suites, in jsdom against the built bundle: nine aborted inits produce nine throws per pointer move before the fix and zero after, while a healthy grid on the same page keeps working.

Two notes for a reviewer:

- `tests/fixtures/gestures.ts` gains a shared `dragFillHandle()`. The fill-handle drag was previously spelled out identically in two page objects, which is exactly what that module exists to prevent; `SelectionFeaturesPage` now calls it too, which is why its specs are in the run above.
- The new `AGENTS.md` section cites `core.ts` by symbol rather than by line. Line numbers there rot within days.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2874

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2874

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving short-circuit on document mousemove with new e2e for aborted init and drag-outside call counts; does not address the underlying leaked-listener lifecycle.
> 
> **Overview**
> Fixes **DEV-2874**: after a grid init aborts between plugin enable and `TableView` creating `hot.table`, leaked Autofill `documentElement` `mousemove` listeners could call `getIfMouseWasDraggedOutside()` on every pointer move and throw on `undefined` table (Sentry DEMOS-6J).
> 
> **Autofill `#onMouseMove`** now evaluates drag-outside measurement only when `addingStarted === false`, `handleDraggedCells > 0`, and the existing predicate would run—via `shouldMarkDragOutside` and `&&` short-circuit so `hot.table` is not read unless a fill-handle drag step is active. Documented in a new **AGENTS.md** section (init window, why the step counter gates this path, why `offset()` stays unguarded).
> 
> **Tests/fixtures:** Playwright spec `fill-handle-aborted-init.spec.ts`, demo `autofill-aborted-init.html`, and `AutofillAbortedInitPage`; shared **`dragFillHandle`** in `gestures.ts` (also used by `SelectionFeaturesPage`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0987725eccb05db0ce2d2f5dfdc27ada525506a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->