### PR TITLE
DEV-2879: Document the nested rows row header width limit

### DIFF
--- a/docs/content/guides/rows/row-parent-child/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child/row-parent-child.md
@@ -423,6 +423,22 @@ When you use the parent-child row structure, the following Handsontable features
 
 When the `NestedRows` plugin is enabled, the `ManualRowMove` plugin's [`moveRows()`](@/api/manualRowMove.md#moverows) method has no effect and logs a console warning. To move rows programmatically, use [`dragRows()`](@/api/manualRowMove.md#dragrows) instead.
 
+### Row header width with custom labels
+
+The `NestedRows` plugin sizes the row header column from the depth of your data, not from the text in
+the headers. It then spends part of that width on the indentation and on the collapse or expand
+button. If you pass your own labels through [`rowHeaders`](@/api/options.md#rowheaders), they can be
+cut off, and the indentation that separates parents from children gets squeezed.
+
+You have two ways to give the labels room:
+
+- Set [`rowHeaderWidth`](@/api/options.md#rowheaderwidth) to a fixed number of pixels. The plugin
+  treats the width it computes as a minimum, so a larger value of your own wins.
+- Enable the [`AutoRowHeaderSize`](@/api/autoRowHeaderSize.md) plugin by setting
+  [`autoRowHeaderSize`](@/api/options.md#autorowheadersize) to `true`. It measures the headers as they
+  are rendered, so the indentation and the button are counted, and it sizes the column to the longest
+  label.
+
 ### Keyboard shortcuts
 
 This header-focused shortcut works only when a row header is focused. Enable [`navigableHeaders: true`](@/api/options.md#navigableheaders) to move focus onto headers with the arrow keys. For more details, see [Keyboard navigation](@/guides/accessibility/accessibility/accessibility.md#keyboard-navigation).

--- a/handsontable/src/plugins/nestedRows/AGENTS.md
+++ b/handsontable/src/plugins/nestedRows/AGENTS.md
@@ -268,6 +268,22 @@ They are written in different places and can drift. Keep this in mind:
   physical order never diverge because of a move. Only trimming makes them diverge.
 - **UndoRedo** deletes `__children` before storing undo data, because this plugin restores the tree
   itself.
+- **AutoRowHeaderSize already subsumes `HeadersUI#updateRowHeaderWidth()` — never measure labels
+  here.** That method derives a width from the nesting depth alone
+  (`Math.max(50, padding * 2 + 10 * levelCount + 25)`, exactly 61px on a two-level tree in
+  `ht-theme-main`) and never looks at the label, so a ~40px custom `rowHeaders` label is clipped
+  (DEV-64). AutoRowHeaderSize measures the header **as rendered**, decoration included: it runs the
+  renderers from `afterGetRowHeaderRenderers` into a `GhostTable`, and the grid's own one
+  (`appendRowHeader`, `tableView.ts:2196`) fires `afterGetRowHeader`, which is where
+  `appendLevelIndicators` adds the spacers and the button. Measured: toggling nesting alone moves it
+  66px -> 104px, and 133px -> 170px with longer labels — a constant ~38px, this plugin's decoration.
+  The 61px floor therefore never wins once that plugin is on. So the formula is a deliberately crude
+  **fallback for the no-AutoRowHeaderSize case**; teaching it to measure text would duplicate a whole
+  sampler and would still disagree with a plain grid, which is fixed-width by default too. If it is
+  ever changed to *add* decoration room on top of the incoming width instead of `Math.max`-ing a
+  floor, gate that on `this.hot.getPlugin('autoRowHeaderSize')?.isEnabled()` (the pattern
+  `manualRowResize.ts:876` uses for `autoRowSize`) or the 38px is counted twice. Users escape with
+  `rowHeaderWidth` (works back to 16.2, because the floor is a `Math.max`) or `autoRowHeaderSize: true`.
 
 ## Tests
 


### PR DESCRIPTION
### Context

The PR documents a limitation of the `NestedRows` plugin: with custom `rowHeaders` labels, the row header column is too narrow and the labels are cut off.

[DEV-64](https://app.clickup.com/t/9015210959/DEV-64) (migrated from dev-handsontable#3038) reported this against 16.2, and a comment on it from February asked for a documented known limitation. That was never written. The behavior still reproduces on develop, and it is worse than in the reported version: on 16.2 the four parent rows were still readable, and now all 24 row headers render as just `Row`.

**Cause.** `HeadersUI#updateRowHeaderWidth()` sizes the row header column from the nesting depth alone — `Math.max(50, cellHorizontalPadding * 2 + 10 * levelCount + 25)`, which is exactly 61px on a two-level tree in `ht-theme-main`. The label is never measured. The indent spacers, the collapse button and the label span padding then take 32–35px of that 61px, leaving about 26px for a 40px label.

**Why this is documentation and not a code fix.** There is no duplicated measurement to remove. `AutoRowHeaderSize` already measures the header as rendered, decoration included — toggling nesting with the labels held constant moves the measured width from 66px to 104px, and from 133px to 170px with longer labels. That is a constant ~38px, which is exactly the plugin's decoration. It works because `AutoRowHeaderSize` runs the renderers collected from `afterGetRowHeaderRenderers` into a `GhostTable`, and the grid's own renderer (`appendRowHeader`, `tableView.ts:2196`) fires `afterGetRowHeader`, which is where `appendLevelIndicators` adds the spacers and the button.

So the depth formula is a deliberately crude fallback for the case where nothing measures at all, not a second sampler. Two alternatives were rejected:

- Teaching the nested-rows floor to measure text. It would duplicate `AutoRowHeaderSize`, and it would still disagree with a plain grid, which is fixed-width by default too.
- Having `NestedRows` enable `AutoRowHeaderSize` under the hood. It would silently widen the row headers of every existing nested-rows grid, and it would add a hidden dependency on a plugin that a modular build may not register.

**Both documented workarounds are verified, and one works on every released version:**

| Config | Header width | Labels clipped |
| --- | --- | --- |
| 18.1.0, nesting, no `rowHeaderWidth` | 61px | 24 / 24 |
| 16.2.0, nesting, `rowHeaderWidth: 100` | 100px | 0 / 24 |
| 18.1.0, nesting, `rowHeaderWidth: 100` | 100px | 0 / 24 |
| develop, nesting, `rowHeaderWidth: 100` | 100px | 0 / 24 |
| develop, nesting, `autoRowHeaderSize: true` | 104px | 0 / 24 |

`rowHeaderWidth` works because the nested-rows width is applied as a `Math.max` floor, so a larger value wins. A value below the floor is ignored, which is correct.

**Release timing.** The guide names `autoRowHeaderSize`, which is not in the 18.1.0 tag and ships with the next release. A cherry-pick to the live 18.1.0 docs would need a `rowHeaderWidth`-only variant.

### Test evidence (required for source changes)

This PR changes no source. Both files are Markdown: a documentation guide and an `AGENTS.md`. The presence gate agrees — its `SOURCE` pattern is `^handsontable/src/.*\.(ts|js|tsx)$`, so an `AGENTS.md` under `handsontable/src/` is not source, and the pre-push gate passed.

- Unit tests added/modified (`*.unit.js`): none — no source change
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none — no source change
- Type tests (`*.types.ts`) updated if public API changed: none — no public API change
- For a bug fix — the spec that fails without this fix: not applicable
- Demo page / recorded trace (for UI changes): not applicable

The existing test that covers the changed guide is `handsontable/test/__tests__/jsdocLinkSyntax.unit.js`, which scans `docs/content`. It passes.

The numbers quoted above were measured in headless Chrome against three builds — 16.2.0 and 18.1.0 from the CDN and a local develop build — using the reproduction from the reported fiddle.

### Commands run

```
npm run test:unit --prefix handsontable -- --testPathPattern='jsdocLinkSyntax'
  Test Suites: 1 passed, 1 total
  Tests:       2 passed, 2 total
```

```
git push  (lefthook pre-push)
  ## Test-presence gate
  ✅ Pass.
  Test-weakening gate: no weakened specs detected.
  pre-push: ok
```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

None of the four apply. This is a documentation-only change; no shipped code is touched.

### Related issue(s):
1. DEV-2879
2. DEV-64

### Affected project(s):
- [x] `handsontable` — documentation only (`src/plugins/nestedRows/AGENTS.md`); no shipped code changes
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation. — this PR is that change.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2879
Reported issue: https://app.clickup.com/t/9015210959/DEV-64

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime or API behavior is modified.
> 
> **Overview**
> Documents a **known limitation** of nested rows: the row header column is sized from tree **depth** (via `HeadersUI#updateRowHeaderWidth()`), not from custom [`rowHeaders`](@/api/options.md#rowheaders) text, so labels and indentation can be clipped.
> 
> The **row parent-child guide** gains a subsection *Row header width with custom labels* with two workarounds: set a larger [`rowHeaderWidth`](@/api/options.md#rowheaderwidth) (the nested-rows minimum is a `Math.max` floor) or enable [`autoRowHeaderSize`](@/api/options.md#autorowheadersize) so headers are measured as rendered, including nesting decoration.
> 
> **`nestedRows/AGENTS.md`** adds maintainer guidance: do not add label measurement in NestedRows (duplicates `AutoRowHeaderSize`); the depth formula is an intentional fallback; any future change that stacks decoration on top of width must gate on whether `autoRowHeaderSize` is enabled to avoid double-counting ~38px decoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24c195ff12e8be2a1c7b0c3da673435eb83b3934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->