### PR TITLE
DEV-62: Pin large-integer numeric formatting and fix its docs

### DIFF
--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -382,6 +382,38 @@ numericFormat: {
 
 For a complete reference, see the [`numericFormat` API documentation](@/api/options.md#numericformat) or [MDN: Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options).
 
+### Numbers beyond the safe-integer limit
+
+JavaScript holds every number as a double, so an integer above `Number.MAX_SAFE_INTEGER`
+(`9007199254740991`) is rounded before Handsontable ever sees it. Written as a number,
+`9007199254740993` is already `9007199254740992` in your data.
+
+To display such a value exactly, provide it as a string:
+
+```js
+data: [['9007199254740993']],
+columns: [
+  {
+    type: 'numeric',
+    preserveNumericLiteral: true, // keeps the value exact after editing, too
+    numericFormat: {
+      style: 'decimal',
+      useGrouping: true,
+    },
+  }
+],
+```
+
+The cell renders `9,007,199,254,740,993`. Your
+[`numericFormat`](@/api/options.md#numericformat) still applies, and no digit is lost, because
+`Intl.NumberFormat` reads a string as an exact decimal instead of converting it to a number. The
+same value written as a number renders as `9,007,199,254,740,992`.
+
+A string in the source data renders exactly on its own. Set
+[`preserveNumericLiteral`](@/api/options.md#preservenumericliteral) to `true` as well, so the value
+is still a string after someone edits the cell -- without it, editing converts the entry to a
+number and the precision is lost at that point. See [Editor behavior](#editor-behavior).
+
 ### Editor behavior
 
 Mind that the [`numericFormat`](@/api/options.md#numericformat) option doesn't change the way
@@ -403,7 +435,8 @@ you edit a numeric cell:
   [`preserveNumericLiteral`](@/api/options.md#preservenumericliteral) option to `true`. Then, only
   when converting your entry to a JavaScript number would lose information -- a trailing decimal
   zero such as `9.0`, or a value whose magnitude exceeds the safe-integer limit
-  (`9007199254740991`) -- Handsontable keeps the literal you typed, so the editor shows it exactly.
+  (`9007199254740991`) -- Handsontable keeps the literal you typed, so both the editor and the cell
+  show it exactly. See [Numbers beyond the safe-integer limit](#numbers-beyond-the-safe-integer-limit).
   Values that convert without loss (such as `9.5`) are still stored as numbers, so sorting,
   filtering, and formulas are unaffected. A preserved literal still behaves like a number in those
   features: sorting and filter conditions compare it numerically, and the formulas engine parses it

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -5266,9 +5266,11 @@ export default (): Record<string, unknown> => {
      * the value according to [`numericFormat`](@/api/options.md#numericformat), and it keeps every
      * digit of the literal: `Intl.NumberFormat` reads a string operand as an exact decimal instead
      * of converting it to a JavaScript number. That makes `preserveNumericLiteral` the supported
-     * way to display a value beyond the safe-integer limit – the literal `'9007199254740993'`
-     * renders as `9,007,199,254,740,993`, while the same value held as a number renders as
-     * `9,007,199,254,740,992`. One exception: the filter menu's "Filter by value" checkbox
+     * way to display a value beyond the safe-integer limit: the literal `'9007199254740993'`
+     * renders with every digit intact, while the same value held as a number renders as
+     * `9007199254740992`. Grouping and decimals still follow
+     * [`numericFormat`](@/api/options.md#numericformat). One exception: the filter menu's
+     * "Filter by value" checkbox
      * list compares values strictly, so a preserved literal (`'9.0'`) and its plain number (`9`)
      * appear as two separate entries.
      *

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -5211,10 +5211,14 @@ export default (): Record<string, unknown> => {
      *
      * This option affects only the displayed output in the cell renderer.
      * It has no effect on the numeric cell editor. In the source data, numeric values
-     * are stored as JavaScript numbers.
+     * are stored as JavaScript numbers, so a value beyond the safe-integer limit
+     * (`9007199254740991`) loses precision before the formatter ever sees it. To store and display
+     * such a value exactly, set [`preserveNumericLiteral`](@/api/options.md#preservenumericliteral)
+     * to `true` and provide the value as a string.
      *
      * Read more:
      * - [`locale`](@/api/options.md#locale)
+     * - [`preserveNumericLiteral`](@/api/options.md#preservenumericliteral)
      * - [Numeric cell type](@/guides/cell-types/numeric-cell-type/numeric-cell-type.md)
      * - [Cell renderer](@/guides/cell-functions/cell-renderer/cell-renderer.md)
      * - [Third-party licenses](@/guides/technical-specification/third-party-licenses/third-party-licenses.md)
@@ -5259,8 +5263,12 @@ export default (): Record<string, unknown> => {
      * behaving like a number in those features: column sorting and filter conditions compare it
      * numerically, and the [`Formulas`](@/api/formulas.md) engine parses the literal as a number,
      * so functions such as `SUM` still include the cell. The cell renderer still formats
-     * the value according to [`numericFormat`](@/api/options.md#numericformat); only the editor
-     * shows the preserved literal. One exception: the filter menu's "Filter by value" checkbox
+     * the value according to [`numericFormat`](@/api/options.md#numericformat), and it keeps every
+     * digit of the literal: `Intl.NumberFormat` reads a string operand as an exact decimal instead
+     * of converting it to a JavaScript number. That makes `preserveNumericLiteral` the supported
+     * way to display a value beyond the safe-integer limit – the literal `'9007199254740993'`
+     * renders as `9,007,199,254,740,993`, while the same value held as a number renders as
+     * `9,007,199,254,740,992`. One exception: the filter menu's "Filter by value" checkbox
      * list compares values strictly, so a preserved literal (`'9.0'`) and its plain number (`9`)
      * appear as two separate entries.
      *

--- a/handsontable/src/renderers/numericRenderer/__tests__/numericRenderer.unit.ts
+++ b/handsontable/src/renderers/numericRenderer/__tests__/numericRenderer.unit.ts
@@ -65,6 +65,47 @@ describe('numericRenderer', () => {
         expect(cellMeta.className).toBe('htRight htNumeric');
       });
 
+      it('should format integers near Number.MAX_SAFE_INTEGER without losing a digit', () => {
+        const instance = getInstance();
+        const cellMeta = {
+          instance,
+          locale: 'en-US',
+          numericFormat: {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          }
+        };
+
+        // `9007199254740990` is exactly representable as a double, so formatting must not shift
+        // it to `...989`. The removed numbro dependency did, because it rounded through
+        // `value * 100`, which overflows the safe-integer range.
+        expect(numericRenderer.valueFormatter(9007199254740988, cellMeta)).toBe('9,007,199,254,740,988.00');
+        expect(numericRenderer.valueFormatter(9007199254740989, cellMeta)).toBe('9,007,199,254,740,989.00');
+        expect(numericRenderer.valueFormatter(9007199254740990, cellMeta)).toBe('9,007,199,254,740,990.00');
+        expect(numericRenderer.valueFormatter(9007199254740991, cellMeta)).toBe('9,007,199,254,740,991.00');
+      });
+
+      it('should format a numeric string literal above Number.MAX_SAFE_INTEGER exactly', () => {
+        const instance = getInstance();
+        const cellMeta = {
+          instance,
+          locale: 'en-US',
+          numericFormat: {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          }
+        };
+
+        // `Intl.NumberFormat#format` reads a string operand as an exact decimal and never routes
+        // it through a double, so a literal kept by `preserveNumericLiteral` renders every digit.
+        // The same value as a number collapses to `...992` - hence `Number()` here rather than a
+        // literal, which `no-loss-of-precision` rejects.
+        const literal = '9007199254740993';
+
+        expect(numericRenderer.valueFormatter(literal, cellMeta)).toBe('9,007,199,254,740,993.00');
+        expect(numericRenderer.valueFormatter(Number(literal), cellMeta)).toBe('9,007,199,254,740,992.00');
+      });
+
       it('should emit an unsupported-format warning once per instance when numericFormat.pattern is present', () => {
         /* eslint-disable no-console */
         /* eslint-disable no-restricted-globals */


### PR DESCRIPTION
### Context

The PR closes DEV-62, and it changes no runtime behavior.

DEV-62 reported that a `numeric` cell displayed `9007199254740990` (one below `Number.MAX_SAFE_INTEGER`) as `9,007,199,254,740,989.00`. Investigating it produced two findings.

**1. The bug is already fixed, and nothing pinned it.** The wrong digit came from numbro, not from Handsontable. numbro rounds to N decimals by scaling, rounding, then dividing back (`numbro/dist/numbro.js:4861`):

```js
const n = new BigNumber(roundingFunction(+`${value}e+${precision}`) / (Math.pow(10, precision)));
```

At this magnitude the scaled values collide. `9007199254740989 * 100` and `9007199254740990 * 100` both land on the double `900719925474099000`, because the gap between neighbouring doubles near 9e17 is 128. Dividing back always yields the lower one, which is why exactly one value was wrong and its neighbours were not:

| Value | x 100 (as a double) | / 100 back | Result |
| --- | --- | --- | --- |
| `9007199254740988` | `900719925474098800` | `9007199254740988` | correct |
| `9007199254740989` | `900719925474099000` | `9007199254740989` | correct |
| `9007199254740990` | `900719925474099000` | `9007199254740989` | off by one |
| `9007199254740991` | `900719925474099100` | `9007199254740991` | correct |

numbro was removed in 18.0.0 (#12689) and `Intl.NumberFormat` does not scale-and-divide, so the value now formats correctly. No test covered it, so a future rounding step in `intlFormatter` could reintroduce the bug with a green suite. This PR adds that test.

**2. `preserveNumericLiteral` is documented as editor-only, which is wrong.** Both the API JSDoc and the guide state that only the editor shows a preserved literal. `Intl.NumberFormat#format` accepts a string and reads it as an exact decimal rather than converting it to a number, so the **renderer** keeps every digit too:

```
format('9007199254740993')  ->  9,007,199,254,740,993.00   exact
format(9007199254740993)    ->  9,007,199,254,740,992.00   collapsed
```

That is the answer to "how do I display a value above the safe-integer limit", and it was written down nowhere. A reader following the current wording concludes it cannot be done. The support floor is clear: per MDN's compatibility data the string-operand behaviour landed in Chrome 106, Edge 106, Firefox 116 and Safari/iOS 15.4, while `browser-targets.js` pins the compile floor at Chrome 130, Edge 130, Firefox 132 and Safari/iOS 18.2.

### What changed

- `handsontable/src/renderers/numericRenderer/__tests__/numericRenderer.unit.ts` -- two regression tests.
- `handsontable/src/dataMap/metaManager/metaSchema.ts` -- JSDoc only. Corrects the `preserveNumericLiteral` wording, and adds a note plus a `Read more` link to `numericFormat`, which said nothing about large values.
- `docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md` -- adds a `Numbers beyond the safe-integer limit` section under `Format numbers`, so the answer sits where someone with a display problem looks, and corrects the `Editor behavior` bullet.

### How has this been tested?

```bash
# the two new tests, plus the existing numeric and meta suites
npm run test:unit --prefix handsontable -- --testPathPattern=numericRenderer   # 14 passed
npm run test:unit --prefix handsontable -- --testPathPattern=numeric           # 49 passed
npm run test:unit --prefix handsontable -- --testPathPattern=meta              # 317 passed

# full unit suite
npm run test:unit --prefix handsontable                                        # 362 suites, 4688 passed

npx eslint src/dataMap/metaManager/metaSchema.ts \
           src/renderers/numericRenderer/__tests__/numericRenderer.unit.ts     # clean
```

The root cause was reproduced against real numbro 2.5.0 rather than inferred: `numbro(9007199254740990).format('0,0.00')` returns `9,007,199,254,740,989.00`, matching the reporter's screenshot.

**Mutation check on the new tests.** `intlFormatter` was temporarily changed to return `...989.00` the way numbro did. The new `should format integers near Number.MAX_SAFE_INTEGER without losing a digit` test failed and the other 13 stayed green, then the change was reverted. The tests catch this defect rather than only executing the path.

One note for reviewers: writing `9007199254740993` as a plain literal trips the `no-loss-of-precision` ESLint rule, correctly. The second test derives it with `Number(literal)` from the string, which also states the point more clearly.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

Documentation and test coverage only. No runtime behavior changes.

### Related issue(s):

1. DEV-62
2. Fixed in 18.0.0 by #12689 (numbro removal); `preserveNumericLiteral` added in #13170.

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) -- one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation. (It is the documentation.)

[skip changelog]

The only non-test file under `handsontable/src/**` is a JSDoc comment, so the changelog gate fires on a change with no runtime effect. An entry would also misdate the capability: the exact rendering of a preserved literal has worked since `preserveNumericLiteral` shipped in 18.1.0, so listing it now would read as a new feature.

## Docs PR checklist

- [x] `type:` field present in frontmatter (`how-to`, unchanged)
- [x] Page uses the correct Diataxis template for its type
- [x] Title matches the Diataxis naming convention for its type
- [x] No banned placeholder data (foo, bar, A1, Column1, etc.)
- [x] All example data is domain-realistic and internally consistent
- [x] All code blocks have language tags
- [x] No `var` in code examples; uses `const` / `let`
- [x] Heading hierarchy is correct (new `###` sits under the existing `## Format numbers`)
- [x] Headings use sentence case
- [x] Active voice and second person used throughout
- [x] No banned words: simply, just, easy, straightforward, note that, please
- [x] Hyphens / double hyphens as clause separators, no en dashes (docs-site voice)
- [x] `menuTag: updated` already set on the page
- [x] `[skip changelog]` in PR body

Not applicable: no new page, so no `sidebar.js` registration; no Prerequisites / Result / Next steps sections (an added section on an existing how-to); no `new Handsontable(...)` call in the snippet, so no `licenseKey` line; no Excel or Google Sheets mention, so no trademark disclaimer; the snippet is a settings fragment rather than a runnable example, matching the neighbouring `numericFormat` snippet.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-62

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and unit tests only; no production code paths change.
> 
> **Overview**
> **Documentation and regression tests only** — no runtime changes. DEV-62’s display bug was already fixed when numbro was replaced by `Intl.NumberFormat` in 18.0.0; this PR locks that in with tests and fixes misleading docs.
> 
> The numeric cell type guide gains a **Numbers beyond the safe-integer limit** section: store values above `Number.MAX_SAFE_INTEGER` as strings, use `preserveNumericLiteral: true` after edits, and rely on `Intl.NumberFormat` formatting strings as exact decimals. The **Editor behavior** bullet now states preserved literals appear in **both** the editor and the cell, with a cross-link.
> 
> JSDoc in `metaSchema.ts` for `numericFormat` and `preserveNumericLiteral` is updated the same way (large integers, string operands, renderer precision).
> 
> Two unit tests in `numericRenderer.unit.ts` assert correct formatting for integers near `MAX_SAFE_INTEGER` and exact formatting for string literals above the safe limit versus rounded JavaScript numbers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43bb05cb5c1731a7f450d0f3c96aabc8e5a27f50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->