### PR TITLE
DEV-26: Keep a layered editor's list attached across a scroll round-trip

### DIFF
--- a/.changelogs/13464.json
+++ b/.changelogs/13464.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a bug where a dropdown or autocomplete editor's list disappeared and could no longer be used after the edited cell was scrolled out of view and back in a fixed-height grid.",
+  "type": "fixed",
+  "issueOrPR": 13464,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -463,31 +463,21 @@ export class AutocompleteEditor extends HandsontableEditor {
    * Closes the editor.
    */
   close(): void {
-    // The debounced refocus is armed by the inner grid's `afterScroll` and runs 100 ms later. It
-    // outlives the close by the same route the choices response used to, and `hideEditableElement()`
-    // only sets `opacity: 0`, so its `focus()` puts the caret back into a closed editor. The next
-    // scroll of a reopened list re-arms it, so cancelling here loses nothing.
-    this.#focusDebounced.cancel();
-
-    // Ends the edit session. Closing is the one event that reliably means "no response is wanted
-    // any more": a scroll-out of the rendered range no longer reaches here (see below), and
-    // `afterSetTheme` still closes the editor (`assignHooks`). `_opened` stays false while the cell is
-    // scroll-hidden and after it scrolls back, so the guards elsewhere key on `state`, not `_opened`.
+    // Ends the edit session. Closing means "no response is wanted any more", and so does a scroll-out
+    // of the rendered range (see `hideForScroll()` below, which shares this in-flight cleanup); a late
+    // response must not re-show the list or steal focus in either case (DEV-2653/DEV-2676). `afterSetTheme`
+    // also closes the editor (`assignHooks`). `_opened` stays false while the cell is scroll-hidden and
+    // after it scrolls back, so the guards elsewhere key on `state`, not `_opened`.
     //
     // Queries this editor deferred are cancelled outright; the token below is for the ones already
     // handed to user code, which cannot be.
     //
-    // The two meanings of hiding are now separated in `TextEditor`: a scroll-out of the rendered range
-    // goes through `hideForScroll()` (transient - keeps `beforeKeyDown`, the query timeouts, the edit
-    // session and the loaded list, so the dropdown re-shows populated and re-queries on scroll-back),
-    // while `close()` here is the genuine edit-end teardown. One deliberate consequence: because the
-    // edit session is NOT bumped on a scroll-hide, a function-`source` response that lands while the
-    // cell is scroll-hidden is now accepted and repopulates the list; that is safe because the holder's
-    // `opacity: 0` keeps it invisible until scroll-back re-runs `showEditableElement()`.
-    this.#queryTimeouts.forEach(timeoutId => clearTimeout(timeoutId));
-    this.#queryTimeouts.clear();
-
-    this.#editSession += 1;
+    // The two meanings of hiding are separated in `TextEditor`: a scroll-out goes through
+    // `hideForScroll()` (transient - it runs this same cleanup so late responses are dropped, but keeps
+    // `beforeKeyDown` and the already-loaded choices, so the dropdown re-shows populated and re-queries
+    // on scroll-back), while `close()` here is the genuine edit-end teardown that also unhooks and tears
+    // down the inner grid.
+    this.#dropInFlightQueries();
 
     this.removeHooksByKey('beforeKeyDown');
     super.close();
@@ -497,6 +487,38 @@ export class AutocompleteEditor extends HandsontableEditor {
         A11Y_EXPANDED('false'),
       ]);
     }
+  }
+
+  /**
+   * Cancels the debounced refocus, clears the deferred query timeouts, and bumps the edit-session token
+   * so any `source` response still in flight is dropped. Shared by `close()` and `hideForScroll()`:
+   * both mean "no more responses wanted", and a late one must not re-show the list or steal focus back
+   * through `hot.listen()` (DEV-2653/DEV-2676). The debounced refocus is armed by the inner grid's
+   * `afterScroll` and runs 100 ms later, so it outlives the hide unless cancelled here.
+   *
+   * @private
+   */
+  #dropInFlightQueries(): void {
+    this.#focusDebounced.cancel();
+    this.#queryTimeouts.forEach(timeoutId => clearTimeout(timeoutId));
+    this.#queryTimeouts.clear();
+    this.#editSession += 1;
+  }
+
+  /**
+   * Hides the dropdown because the edited cell scrolled out of the rendered range, without ending the
+   * edit. Drops in-flight responses exactly as `close()` does (a late one must not re-show the list or
+   * steal focus), but the inherited `HandsontableEditor#hideForScroll` only hides the UI — it keeps
+   * `beforeKeyDown` and the already-loaded choices — so the list re-shows populated and typing
+   * re-queries once the cell scrolls back.
+   *
+   * @private
+   * @returns {boolean}
+   */
+  hideForScroll(): boolean {
+    this.#dropInFlightQueries();
+
+    return super.hideForScroll();
   }
 
   /**

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -88,17 +88,19 @@ export class AutocompleteEditor extends HandsontableEditor {
    */
   #queryGeneration = 0;
   /**
-   * Edit-session token. Bumped on every `close()`, so a `source` response can tell that the edit it
-   * belongs to has ended - which neither `state` nor `_opened` reports reliably. Only the response
-   * needs a token: user code holds that callback and there is nothing to cancel, while the editor's
-   * own deferred queries are cancelled outright through `#queryTimeouts`.
+   * Edit-session token. Bumped whenever no further `source` response is wanted - on `close()` and on a
+   * scroll-hide, both through `#dropInFlightQueries()` - so a late response can tell that the query it
+   * belongs to has been abandoned, which neither `state` nor `_opened` reports reliably. Only the
+   * response needs a token: user code holds that callback and there is nothing to cancel, while the
+   * editor's own deferred queries are cancelled outright through `#queryTimeouts`.
    *
    * @type {number}
    */
   #editSession = 0;
   /**
    * Timer ids of the `queryChoices()` calls this editor has deferred and not yet run. Cleared on
-   * `close()`, so a query scheduled during an edit never runs after it.
+   * `close()` and on a scroll-hide (both through `#dropInFlightQueries()`), so a query scheduled during
+   * an edit never runs after the edit ends or while the cell is out of view.
    *
    * @type {Set}
    */
@@ -394,7 +396,8 @@ export class AutocompleteEditor extends HandsontableEditor {
   }
 
   /**
-   * Defers a `queryChoices()` call and keeps its timer id so `close()` can cancel it.
+   * Defers a `queryChoices()` call and keeps its timer id so `close()` and a scroll-hide can cancel it
+   * (both through `#dropInFlightQueries()`).
    *
    * `hot._registerTimeout()` has no cancel path of its own - `_clearTimeouts()` runs only from
    * `Core#destroy()` - so without this a query scheduled during an edit still fires after the
@@ -508,8 +511,9 @@ export class AutocompleteEditor extends HandsontableEditor {
   /**
    * Hides the dropdown because the edited cell scrolled out of the rendered range, without ending the
    * edit. Drops in-flight responses exactly as `close()` does (a late one must not re-show the list or
-   * steal focus), but the inherited `HandsontableEditor#hideForScroll` only hides the UI — it keeps
-   * `beforeKeyDown` and the already-loaded choices — so the list re-shows populated and typing
+   * steal focus), and lowers the combobox `aria-expanded` so a screen reader does not keep announcing
+   * an open listbox while the list is hidden. The inherited `HandsontableEditor#hideForScroll` keeps
+   * `beforeKeyDown` and the already-loaded choices, so the list re-shows populated and typing
    * re-queries once the cell scrolls back.
    *
    * @private
@@ -518,24 +522,52 @@ export class AutocompleteEditor extends HandsontableEditor {
   hideForScroll(): boolean {
     this.#dropInFlightQueries();
 
+    if (this.hot.getSettings().ariaTags) {
+      setAttribute(this.TEXTAREA, [
+        A11Y_EXPANDED('false'),
+      ]);
+    }
+
     return super.hideForScroll();
   }
 
   /**
    * Re-shows the dropdown list after the edited cell scrolled back into the rendered range, keeping the
-   * choices already loaded into the nested grid and re-measuring its size against the cell's new
-   * position. Guarded on there being choices to show, so an empty list stays hidden - matching the
-   * empty branch of {@link AutocompleteEditor#updateChoicesList}.
+   * choices already loaded into the nested grid. Guarded on there being choices to show, so an empty
+   * list stays hidden, matching the empty branch of {@link AutocompleteEditor#updateChoicesList}. The
+   * re-measure is added to the base flip pass through {@link AutocompleteEditor#reflowDropdown}, and the
+   * combobox `aria-expanded` is raised again.
+   *
+   * Known limitation: a `function` `source` whose response was still in flight when the cell scrolled
+   * out was dropped by `hideForScroll()` and is not requested again, so for that one case the list stays
+   * empty until the next keystroke re-queries. Re-querying here would fix it, but at the cost of a source
+   * call on every scroll-back, so it is deliberately left to the keystroke.
    *
    * @private
    */
   showAfterScroll(): void {
     if (this.htEditor && this.strippedChoices.length > 0) {
-      this.htEditor.rootElement.style.display = '';
-      this.updateDropdownDimensions();
-      this.flipDropdownVerticallyIfNeeded();
-      this.flipDropdownHorizontallyIfNeeded();
+      super.showAfterScroll();
+
+      if (this.hot.getSettings().ariaTags) {
+        setAttribute(this.TEXTAREA, [
+          A11Y_EXPANDED('true'),
+        ]);
+      }
     }
+  }
+
+  /**
+   * Re-measures the dropdown to the choices it holds before the base flip pass reads its size, so the
+   * list comes back at the right width and height after a scroll round-trip even if the column was
+   * resized while the cell was out of range.
+   *
+   * @private
+   */
+  reflowDropdown(): void {
+    this.updateDropdownDimensions();
+
+    super.reflowDropdown();
   }
 
   /**
@@ -569,10 +601,12 @@ export class AutocompleteEditor extends HandsontableEditor {
     // editor stays open and returns to `EDITING`. Rejecting them would stop the list refreshing for
     // the length of every validation, which is a behavior change rather than a fix.
     //
-    // `state` rather than `isOpened()`: `_opened` stays false after `refreshDimensions()` closes an
-    // editor whose cell scrolled out of view and then shows it again on the way back, without ever
-    // restoring the flag.
-    if (this.state !== EDITOR_STATE.EDITING && this.state !== EDITOR_STATE.WAITING) {
+    // `_opened` is false while the edited cell is scroll-hidden (`hideForScroll()`) and is restored on
+    // scroll-back. Bailing on it keeps a keystroke made while the cell is out of view - which
+    // `beforeKeyDown` still schedules, since the hide deliberately keeps that hook - from reaching the
+    // source and, once it answered, re-showing the list and calling `hot.listen()` against a cell with
+    // no rendered rect.
+    if ((this.state !== EDITOR_STATE.EDITING && this.state !== EDITOR_STATE.WAITING) || !this._opened) {
       return;
     }
 

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -470,19 +470,20 @@ export class AutocompleteEditor extends HandsontableEditor {
     this.#focusDebounced.cancel();
 
     // Ends the edit session. Closing is the one event that reliably means "no response is wanted
-    // any more": `state` stays `EDITING` when `refreshDimensions()` closes an editor whose cell
-    // scrolled out of the rendered range and when `afterSetTheme` closes one (`assignHooks`), and
-    // `_opened` stays false after that same cell scrolls back and the editor is shown again.
+    // any more": a scroll-out of the rendered range no longer reaches here (see below), and
+    // `afterSetTheme` still closes the editor (`assignHooks`). `_opened` stays false while the cell is
+    // scroll-hidden and after it scrolls back, so the guards elsewhere key on `state`, not `_opened`.
     //
     // Queries this editor deferred are cancelled outright; the token below is for the ones already
     // handed to user code, which cannot be.
     //
-    // Known limitation: `refreshDimensions()` also calls `close()` as "hide for now" when the
-    // edited cell scrolls out of the rendered range, and there is no signal here to tell that apart
-    // from "the edit ended". So after the cell scrolls back the editor is visible again but its
-    // list can no longer populate. That path was already one-way before this change - the
-    // `removeHooksByKey` below means typing could not re-query after a scroll round trip either -
-    // and separating the two meanings belongs in `TextEditor`, not here.
+    // The two meanings of hiding are now separated in `TextEditor`: a scroll-out of the rendered range
+    // goes through `hideForScroll()` (transient - keeps `beforeKeyDown`, the query timeouts, the edit
+    // session and the loaded list, so the dropdown re-shows populated and re-queries on scroll-back),
+    // while `close()` here is the genuine edit-end teardown. One deliberate consequence: because the
+    // edit session is NOT bumped on a scroll-hide, a function-`source` response that lands while the
+    // cell is scroll-hidden is now accepted and repopulates the list; that is safe because the holder's
+    // `opacity: 0` keeps it invisible until scroll-back re-runs `showEditableElement()`.
     this.#queryTimeouts.forEach(timeoutId => clearTimeout(timeoutId));
     this.#queryTimeouts.clear();
 
@@ -495,6 +496,23 @@ export class AutocompleteEditor extends HandsontableEditor {
       setAttribute(this.TEXTAREA, [
         A11Y_EXPANDED('false'),
       ]);
+    }
+  }
+
+  /**
+   * Re-shows the dropdown list after the edited cell scrolled back into the rendered range, keeping the
+   * choices already loaded into the nested grid and re-measuring its size against the cell's new
+   * position. Guarded on there being choices to show, so an empty list stays hidden - matching the
+   * empty branch of {@link AutocompleteEditor#updateChoicesList}.
+   *
+   * @private
+   */
+  showAfterScroll(): void {
+    if (this.htEditor && this.strippedChoices.length > 0) {
+      this.htEditor.rootElement.style.display = '';
+      this.updateDropdownDimensions();
+      this.flipDropdownVerticallyIfNeeded();
+      this.flipDropdownHorizontallyIfNeeded();
     }
   }
 

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.ts
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.ts
@@ -148,17 +148,53 @@ export class HandsontableEditor extends TextEditor {
    * Closes the editor.
    */
   close(): void {
-    // Deliberately NOT clearing `innerSelectionOrigin` here. `TextEditor#refreshDimensions()` calls
-    // `close()` as "hide for now" when the edited cell scrolls out of the rendered range, and
-    // `afterSetTheme` does the same - neither ends the edit, `state` stays `EDITING` and the inner
-    // grid keeps its selection. Clearing here threw away a pick the user could still see and had
-    // not finished with. `open()` sets the origin on every real re-open, which is what resets it.
+    // Deliberately NOT clearing `innerSelectionOrigin` here. `afterSetTheme` calls `close()` without
+    // ending the edit - `state` stays `EDITING` and the inner grid keeps its selection - so clearing
+    // here would throw away a pick the user could still see and had not finished with. (A scroll-out
+    // of the rendered range no longer reaches `close()`; it goes through `hideForScroll()`, which also
+    // preserves the selection.) `open()` sets the origin on every real re-open, which is what resets it.
     if (this.htEditor) {
       this.htEditor.rootElement.style.display = 'none';
     }
 
     this.removeHooksByKey('beforeKeyDown');
     super.close();
+  }
+
+  /**
+   * Hides the nested grid because the edited cell scrolled out of the rendered range, without ending
+   * the edit. Only the display and the `_opened` flag change; the `beforeKeyDown` hook, the shortcut
+   * group, and the nested grid's data and selection are all preserved (unlike {@link HandsontableEditor#close},
+   * which tears them down). This is what lets the list re-show still populated, and typing and arrow
+   * navigation keep working, after a scroll round-trip.
+   *
+   * @private
+   * @returns {boolean} Always `true` - the hide is transient and the layer must be re-shown on scroll-back.
+   */
+  hideForScroll(): boolean {
+    this._opened = false;
+    this.hideEditableElement();
+
+    if (this.htEditor) {
+      this.htEditor.rootElement.style.display = 'none';
+    }
+
+    return true;
+  }
+
+  /**
+   * Re-shows the nested grid after the edited cell scrolled back into the rendered range, re-anchoring
+   * it to the cell. The grid's data and selection were preserved by {@link HandsontableEditor#hideForScroll},
+   * so nothing is reloaded here.
+   *
+   * @private
+   */
+  showAfterScroll(): void {
+    if (this.htEditor) {
+      this.htEditor.rootElement.style.display = '';
+      this.flipDropdownVerticallyIfNeeded();
+      this.flipDropdownHorizontallyIfNeeded();
+    }
   }
 
   /**

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.ts
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.ts
@@ -192,9 +192,20 @@ export class HandsontableEditor extends TextEditor {
   showAfterScroll(): void {
     if (this.htEditor) {
       this.htEditor.rootElement.style.display = '';
-      this.flipDropdownVerticallyIfNeeded();
-      this.flipDropdownHorizontallyIfNeeded();
+      this.reflowDropdown();
     }
+  }
+
+  /**
+   * Re-anchors the re-shown dropdown to the edited cell's new viewport position. Split from
+   * {@link HandsontableEditor#showAfterScroll} so {@link AutocompleteEditor} can re-measure the list to
+   * its choices before the flip pass reads its size.
+   *
+   * @private
+   */
+  reflowDropdown(): void {
+    this.flipDropdownVerticallyIfNeeded();
+    this.flipDropdownHorizontallyIfNeeded();
   }
 
   /**

--- a/handsontable/src/editors/textEditor/textEditor.ts
+++ b/handsontable/src/editors/textEditor/textEditor.ts
@@ -87,6 +87,15 @@ export class TextEditor extends BaseEditor {
    * @type {string}
    */
   declare layerClass: string;
+  /**
+   * Tracks whether the editor was transiently hidden because its edited cell scrolled out of the
+   * rendered range (as opposed to the edit ending). Set from the return value of
+   * {@link TextEditor#hideForScroll}, read in {@link TextEditor#refreshDimensions} to re-show a
+   * layered editor's UI once the cell scrolls back into view.
+   *
+   * @type {boolean}
+   */
+  #hiddenByScroll = false;
 
   /**
    * @param {Core} hotInstance The Handsontable instance.
@@ -124,6 +133,7 @@ export class TextEditor extends BaseEditor {
    */
   open(): void {
     this._opened = true;
+    this.#hiddenByScroll = false;
     this.refreshDimensions(); // need it instantly, to prevent https://github.com/handsontable/handsontable/issues/348
     this.showEditableElement();
     this.hot.getShortcutManager().setActiveContextName('editor');
@@ -135,6 +145,7 @@ export class TextEditor extends BaseEditor {
    */
   close(): void {
     this._opened = false;
+    this.#hiddenByScroll = false;
     this.autoResize.unObserve();
 
     if (isInternalElement(getDeepActiveElement(this.hot.rootDocument) as HTMLElement, this.hot.rootElement)) {
@@ -327,6 +338,30 @@ export class TextEditor extends BaseEditor {
   }
 
   /**
+   * Hides the editor because its edited cell scrolled out of the rendered range. This is a transient,
+   * reversible hide, not the end of the edit. The base editor has no persistent layer of its own, so
+   * it delegates to the destructive {@link TextEditor#close} to preserve the historic inline-editor
+   * behavior, and reports that the hide was not transient. Layered editors (Handsontable, autocomplete,
+   * dropdown) override this to hide only their UI while keeping the edit alive, and return `true`.
+   *
+   * @private
+   * @returns {boolean} `true` when the hide is transient and the layer must be re-shown on scroll-back.
+   */
+  hideForScroll(): boolean {
+    this.close();
+
+    return false;
+  }
+
+  /**
+   * Re-shows the editor's layer after its edited cell scrolled back into the rendered range. No-op for
+   * the base editor, which has no persistent layer. Layered editors override this to restore their UI.
+   *
+   * @private
+   */
+  showAfterScroll(): void {}
+
+  /**
    * Refreshes editor's size and position.
    *
    * @private
@@ -341,7 +376,9 @@ export class TextEditor extends BaseEditor {
     // TD is outside of the viewport.
     if (!this.TD) {
       if (!force) {
-        this.close(); // TODO shouldn't it be this.finishEditing() ?
+        // Hide the editor for now; the edit stays alive. A layered editor keeps its list state so it
+        // can be re-shown, still populated, once the cell scrolls back (see the tail of this method).
+        this.#hiddenByScroll = this.hideForScroll();
       }
 
       return;
@@ -372,6 +409,14 @@ export class TextEditor extends BaseEditor {
       maxWidth,
       maxHeight,
     }, true);
+
+    // The cell scrolled back into the rendered range after a transient scroll-hide. The textarea has
+    // just been restored above; let a layered editor restore and re-anchor its UI too. Gated on
+    // `!force` so `prepare()`/`open()` (which call `refreshDimensions(true)`) never trigger it.
+    if (!force && this.#hiddenByScroll) {
+      this.#hiddenByScroll = false;
+      this.showAfterScroll();
+    }
   }
 
   /**

--- a/handsontable/src/editors/textEditor/textEditor.ts
+++ b/handsontable/src/editors/textEditor/textEditor.ts
@@ -411,11 +411,17 @@ export class TextEditor extends BaseEditor {
     }, true);
 
     // The cell scrolled back into the rendered range after a transient scroll-hide. The textarea has
-    // just been restored above; let a layered editor restore and re-anchor its UI too. `open()` clears
-    // `#hiddenByScroll` up front, so its own `refreshDimensions()` cannot trigger this; the `!force`
-    // gate covers `prepare()`, which calls `refreshDimensions(true)` before any scroll-hide can occur.
+    // just been restored above; restore `_opened` and let a layered editor restore and re-anchor its
+    // UI too. Restoring `_opened` here is required: `hideForScroll()` cleared it, and while it is false
+    // `Core#applyChanges()` treats the live edit as closed - the next data change runs `prepareEditor()`,
+    // which resets the editor to `VIRGIN` and blanks the value the user typed. It must be set on the way
+    // back, not inside the overrides, because `AutocompleteEditor#showAfterScroll()` does not call
+    // `super`. `open()` clears `#hiddenByScroll` up front, so its own `refreshDimensions()` cannot
+    // trigger this; the `!force` gate covers `prepare()`, which calls `refreshDimensions(true)` before
+    // any scroll-hide can occur.
     if (!force && this.#hiddenByScroll) {
       this.#hiddenByScroll = false;
+      this._opened = true;
       this.showAfterScroll();
     }
   }

--- a/handsontable/src/editors/textEditor/textEditor.ts
+++ b/handsontable/src/editors/textEditor/textEditor.ts
@@ -411,8 +411,9 @@ export class TextEditor extends BaseEditor {
     }, true);
 
     // The cell scrolled back into the rendered range after a transient scroll-hide. The textarea has
-    // just been restored above; let a layered editor restore and re-anchor its UI too. Gated on
-    // `!force` so `prepare()`/`open()` (which call `refreshDimensions(true)`) never trigger it.
+    // just been restored above; let a layered editor restore and re-anchor its UI too. `open()` clears
+    // `#hiddenByScroll` up front, so its own `refreshDimensions()` cannot trigger this; the `!force`
+    // gate covers `prepare()`, which calls `refreshDimensions(true)` before any scroll-hide can occur.
     if (!force && this.#hiddenByScroll) {
       this.#hiddenByScroll = false;
       this.showAfterScroll();

--- a/tests/e2e/dropdown-scroll-round-trip.spec.ts
+++ b/tests/e2e/dropdown-scroll-round-trip.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '../fixtures/test';
+import { DropdownScrollRoundTripPage } from '../fixtures/pages/DropdownScrollRoundTripPage';
+
+/**
+ * DEV-26: with a fixed container `height`, opening a layered editor (dropdown / autocomplete) and
+ * scrolling the edited cell out of the rendered range then back left the editor "half open" — the
+ * textarea returned but the dropdown list stayed hidden and could no longer populate, while the cell
+ * was still in edit mode.
+ *
+ * Root cause: `TextEditor#refreshDimensions()` reused the destructive `close()` as "hide for now"
+ * when `getEditedCell()` returned null, and the scroll-back path restored only the textarea. The fix
+ * separates a transient scroll-hide from `close()` and re-shows the list on scroll-back.
+ *
+ * The scroll-out step waits until the edited cell genuinely leaves the rendered range
+ * (`editedCellRendered() === false`); a grid tall enough to keep the cell rendered would fail there
+ * rather than pass a vacuous "list still visible" afterwards.
+ */
+test.describe('layered editor — scroll round-trip (DEV-26)', () => {
+  let grid: DropdownScrollRoundTripPage;
+
+  test.beforeEach(async ({ page, theme, bundle }) => {
+    grid = new DropdownScrollRoundTripPage(page, theme, bundle);
+    await grid.goto();
+  });
+
+  test('dropdown list returns, populated and navigable, after a scroll round-trip', async () => {
+    await grid.openEditor(2, 1);
+    await expect(grid.options().first()).toBeVisible();
+    // The list is virtualized, so the rendered option count is a theme-dependent baseline (some
+    // options may be scrolled out of the short list). Capture it and require it to return in full.
+    const renderedOptions = await grid.options().count();
+
+    expect(renderedOptions).toBeGreaterThan(0);
+    expect(await grid.listDisplayed()).toBe(true);
+
+    // Scroll the edited cell out of the rendered range — the reproduction's precondition. The edit
+    // stays alive (state EDITING); only the UI is hidden.
+    await grid.scrollToBottom();
+    expect(await grid.editedCellRendered()).toBe(false);
+    expect(await grid.editorState()).toBe('STATE_EDITING');
+
+    // Back into view: before the fix the list stayed hidden here.
+    await grid.scrollToTop();
+    expect(await grid.listDisplayed()).toBe(true);
+    await expect(grid.options()).toHaveCount(renderedOptions);
+    await expect(grid.optionByText('Alpha')).toBeVisible();
+
+    // The inner grid and the editor's ArrowDown shortcut group survived the round trip.
+    await grid.pressArrowDown();
+    await expect.poll(() => grid.innerSelectedRow()).toBe(0);
+  });
+
+  test('autocomplete list returns and re-queries on keystroke after a scroll round-trip', async () => {
+    await grid.openEditor(2, 2);
+    await expect(grid.options().first()).toBeVisible();
+    const renderedOptions = await grid.options().count();
+
+    expect(renderedOptions).toBeGreaterThan(0);
+
+    await grid.scrollToBottom();
+    expect(await grid.editedCellRendered()).toBe(false);
+    expect(await grid.editorState()).toBe('STATE_EDITING');
+
+    await grid.scrollToTop();
+    expect(await grid.listDisplayed()).toBe(true);
+    await expect(grid.options()).toHaveCount(renderedOptions);
+
+    // Typing must still filter the list — proof the textarea `input` requery path survived the
+    // round trip (it did not before the fix, because `close()` tore its query state down). `Al`
+    // matches Alpha / Alfa / Alto only.
+    await grid.focusEditor();
+    await grid.type('Al');
+    await expect(grid.options()).toHaveCount(3);
+    await expect(grid.optionByText('Bravo')).toHaveCount(0);
+  });
+
+  test('plain text editor round-trip is unchanged (negative control)', async () => {
+    await grid.openEditor(2, 0);
+    await grid.focusEditor();
+    await grid.type('X');
+    expect(await grid.editorValue()).toBe('Row 2X');
+
+    await grid.scrollToBottom();
+    expect(await grid.editedCellRendered()).toBe(false);
+
+    await grid.scrollToTop();
+    // The inline editor already survived a scroll round trip; assert the seam did not regress it.
+    expect(await grid.editorState()).toBe('STATE_EDITING');
+    expect(await grid.editorValue()).toBe('Row 2X');
+  });
+});

--- a/tests/e2e/dropdown-scroll-round-trip.spec.ts
+++ b/tests/e2e/dropdown-scroll-round-trip.spec.ts
@@ -45,6 +45,13 @@ test.describe('layered editor — scroll round-trip (DEV-26)', () => {
     await expect(grid.options()).toHaveCount(renderedOptions);
     await expect(grid.optionByText('Alpha')).toBeVisible();
 
+    // The whole editor layer must be back, not just the list's `display`. `isOpened()` must read true
+    // again (a false value there makes the next data change reset the live edit via `applyChanges()`),
+    // and the holder must be opaque (a regression that leaves it at `opacity: 0` hides everything while
+    // `listDisplayed()` still passes).
+    expect(await grid.isEditorOpen()).toBe(true);
+    expect(await grid.holderOpacity()).toBe('1');
+
     // The inner grid and the editor's ArrowDown shortcut group survived the round trip.
     await grid.pressArrowDown();
     await expect.poll(() => grid.innerSelectedRow()).toBe(0);
@@ -65,9 +72,9 @@ test.describe('layered editor — scroll round-trip (DEV-26)', () => {
     expect(await grid.listDisplayed()).toBe(true);
     await expect(grid.options()).toHaveCount(renderedOptions);
 
-    // Typing must still filter the list — proof the textarea `input` requery path survived the
-    // round trip (it did not before the fix, because `close()` tore its query state down). `Al`
-    // matches Alpha / Alfa / Alto only.
+    // Typing must still filter the list, proof the `beforeKeyDown` requery hook survived the round
+    // trip (it did not before the fix, because `close()` unhooked it). `Al` matches Alpha / Alfa /
+    // Alto only.
     await grid.focusEditor();
     await grid.type('Al');
     await expect(grid.options()).toHaveCount(3);

--- a/tests/fixtures/demo/dropdown-scroll-round-trip.html
+++ b/tests/fixtures/demo/dropdown-scroll-round-trip.html
@@ -97,8 +97,6 @@
       afterRender: stampTestIds,
       licenseKey: 'non-commercial-and-evaluation',
     });
-
-    window.htOptionCount = OPTIONS.length;
   </script>
 </body>
 </html>

--- a/tests/fixtures/demo/dropdown-scroll-round-trip.html
+++ b/tests/fixtures/demo/dropdown-scroll-round-trip.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable e2e fixture — dropdown scroll round-trip</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    // Theme and bundle come from the ?theme=/?bundle= query params set by the
+    // Playwright projects, mapped through fixed allowlists to LITERALS so a
+    // crafted param can never be reflected into the document — no XSS. An
+    // ABSENT param keeps the default (main / plain UMD) so the fixture stays
+    // browsable by hand; an unknown value THROWS instead of falling back — a
+    // typo in the project config must be one red leg, never a silently
+    // mislabeled green one (nothing else asserts which file actually loaded).
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[htParams.get('bundle') ?? 'umd'];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+  </style>
+</head>
+<body>
+  <!--
+    E2E fixture for DEV-26: a layered (dropdown / autocomplete) editor whose cell
+    scrolls out of the rendered range of a FIXED-HEIGHT grid and then back.
+
+    The grid is short (a fixed `height`) and tall in data (100 rows), so scrolling
+    to the bottom takes any near-top edited cell out of the RENDERED band — the
+    state where `TextEditor#refreshDimensions()` hides the editor because
+    `getEditedCell()` returns null. Scrolling back must restore not only the
+    textarea but the dropdown list, still populated and still interactive.
+
+    Column 1 is a `dropdown` (forces `filter: false`), column 2 an `autocomplete`
+    (filters by the typed value). The source options share the `Al` prefix so that
+    with an empty cell both list the whole set, and typing `Al` into the
+    autocomplete narrows it — the observable proof that keystrokes still re-query
+    after the round trip. Column 0 is a plain `text` editor: the negative control
+    that must survive the same round trip unchanged.
+
+    The list cells start empty so opening the editor lists every option rather than
+    filtering down to the cell's own value.
+
+    TDs are stamped with data-testid in afterRender (re-stamped on every render, so
+    rows revealed by scrolling get ids too) because the list cell types own their
+    renderer (the dropdown arrow), so a custom renderer would break it.
+  -->
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const OPTIONS = ['Alpha', 'Alfa', 'Alto', 'Bravo', 'Charlie'];
+    const ROWS = 100;
+
+    function stampTestIds() {
+      this.getData().forEach((rowData, row) => {
+        rowData.forEach((cellValue, col) => {
+          const td = this.getCell(row, col);
+
+          if (td) {
+            td.setAttribute('data-testid', `cell-${row}-${col}`);
+          }
+        });
+      });
+    }
+
+    const data = Array.from({ length: ROWS }, (_, row) => [`Row ${row}`, '', '']);
+
+    const grid = document.querySelector('[data-testid="grid"]');
+
+    grid.className = `ht-theme-${window.htTheme}`;
+
+    window.hot = new Handsontable(grid, {
+      data,
+      colWidths: [120, 160, 160],
+      colHeaders: ['Text', 'Dropdown', 'Autocomplete'],
+      rowHeaders: true,
+      height: 220,
+      columns: [
+        {},
+        { type: 'dropdown', source: OPTIONS },
+        { type: 'autocomplete', source: OPTIONS },
+      ],
+      afterRender: stampTestIds,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    window.htOptionCount = OPTIONS.length;
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/dropdown-scroll-round-trip.html
+++ b/tests/fixtures/demo/dropdown-scroll-round-trip.html
@@ -85,7 +85,10 @@
       colWidths: [120, 160, 160],
       colHeaders: ['Text', 'Dropdown', 'Autocomplete'],
       rowHeaders: true,
-      height: 220,
+      // Tall enough that the 5-option dropdown opened at row 2 always fits BELOW the cell on every
+      // theme (so it never flips upward — a flipped list changes ArrowDown semantics), while 100 rows
+      // still let a near-top cell scroll fully out of the rendered range.
+      height: 400,
       columns: [
         {},
         { type: 'dropdown', source: OPTIONS },

--- a/tests/fixtures/pages/DropdownScrollRoundTripPage.ts
+++ b/tests/fixtures/pages/DropdownScrollRoundTripPage.ts
@@ -5,15 +5,12 @@ interface EditorHandle {
   isOpened(): boolean;
   state: string;
   getEditedCell(): HTMLElement | null;
-  getValue(): unknown;
   TEXTAREA?: HTMLTextAreaElement;
   htEditor?: { getSelectedActive(): number[] | undefined };
 }
 
 interface HandsontableFixture {
   getActiveEditor(): EditorHandle | undefined;
-  getDataAtCell(row: number, col: number): unknown;
-  selectCell(row: number, col: number): void;
 }
 
 type FixtureWindow = Window & { hot: HandsontableFixture };
@@ -120,6 +117,27 @@ export class DropdownScrollRoundTripPage {
     return this.page.evaluate(() => (
       (window as FixtureWindow).hot.getActiveEditor()?.getEditedCell() != null
     ));
+  }
+
+  /**
+   * Whether `getActiveEditor().isOpened()` reports true. This must be true again after a scroll-back:
+   * `Core#applyChanges()` reads this flag (not `state`), and a false value while the editor is visible
+   * makes the next data change reset the live edit.
+   */
+  async isEditorOpen(): Promise<boolean> {
+    return this.page.evaluate(() => (
+      (window as FixtureWindow).hot.getActiveEditor()?.isOpened() === true
+    ));
+  }
+
+  /**
+   * The computed opacity of the editor holder (`.handsontableInputHolder`). `hideEditableElement()`
+   * drops it to 0 and `showEditableElement()` restores it to 1. Read it directly, since the list's own
+   * `display` (see {@link listDisplayed}) would not catch a holder left transparent.
+   */
+  async holderOpacity(): Promise<string> {
+    return this.page.getByTestId('grid').locator('.handsontableInputHolder')
+      .evaluate((el: HTMLElement) => el.ownerDocument.defaultView!.getComputedStyle(el).opacity);
   }
 
   /**

--- a/tests/fixtures/pages/DropdownScrollRoundTripPage.ts
+++ b/tests/fixtures/pages/DropdownScrollRoundTripPage.ts
@@ -1,0 +1,211 @@
+import { type Locator, type Page, expect } from '@playwright/test';
+import { awaitBundle } from '../bundle';
+
+interface EditorHandle {
+  isOpened(): boolean;
+  state: string;
+  getEditedCell(): HTMLElement | null;
+  getValue(): unknown;
+  TEXTAREA?: HTMLTextAreaElement;
+  htEditor?: { getSelectedActive(): number[] | undefined };
+}
+
+interface HandsontableFixture {
+  getActiveEditor(): EditorHandle | undefined;
+  getDataAtCell(row: number, col: number): unknown;
+  selectCell(row: number, col: number): void;
+}
+
+type FixtureWindow = Window & { hot: HandsontableFixture };
+
+/**
+ * Page Object for the dropdown-scroll-round-trip fixture (DEV-26): a layered editor
+ * (dropdown / autocomplete) opened in a fixed-height grid, whose edited cell is scrolled
+ * out of the rendered range and then back. Encapsulates opening the editor, driving the
+ * viewport scroll to and from the edited cell's band, and reading the list state.
+ *
+ * Column 0 is a plain text editor (the negative control), column 1 a `dropdown`, column 2
+ * an `autocomplete`.
+ */
+export class DropdownScrollRoundTripPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+  }
+
+  /**
+   * Navigate and wait for the bundle and the first data cell to render.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(
+      `/tests/fixtures/demo/dropdown-scroll-round-trip.html?theme=${this.theme}&bundle=${this.bundle}`,
+    );
+    await awaitBundle(this.page);
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /**
+   * A data cell in the grid's master table, addressed by its fixture-owned test id.
+   */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId('grid').locator('.ht_master').getByTestId(`cell-${row}-${col}`);
+  }
+
+  /**
+   * Selects a cell by its leading edge, then opens the editor with Enter.
+   *
+   * A centred click is avoided on purpose: the list cell types right-float a dropdown arrow whose
+   * `mousedown` opens the editor by itself, so a centred press races the deliberate Enter (DEV-2677).
+   * The leading edge is padding in every cell type.
+   */
+  async openEditor(row: number, col: number): Promise<void> {
+    const box = await this.cell(row, col).boundingBox();
+
+    if (!box) {
+      throw new Error(`Cell (${row}, ${col}) is not rendered`);
+    }
+
+    await this.page.mouse.click(box.x + 4, box.y + (box.height / 2));
+    await this.page.keyboard.press('Enter');
+
+    await expect.poll(() => this.editorState()).toBe('STATE_EDITING');
+  }
+
+  /**
+   * The outer grid's master vertical scroll holder, whose `scrollTop` moves the viewport the way a
+   * user's wheel or scrollbar drag does — firing the `afterScrollVertically` hook the editor listens
+   * on. Scoped with `.first()`: the open layered editor is itself a nested Handsontable with its own
+   * `.ht_master .wtHolder`, appended after the grid's tables, so the outer holder is first in the DOM.
+   */
+  #masterHolder(): Locator {
+    return this.page.getByTestId('grid').locator('.ht_master .wtHolder').first();
+  }
+
+  /**
+   * Scrolls the viewport to the bottom, taking a near-top edited cell out of the rendered range.
+   * Ends on the render-state probe that the edited cell is no longer rendered — so if the grid is
+   * ever tall enough to keep the cell in the band, this waits out rather than passing silently.
+   */
+  async scrollToBottom(): Promise<void> {
+    await this.#masterHolder().evaluate((holder: HTMLElement) => {
+      holder.scrollTop = holder.scrollHeight;
+    });
+
+    await expect.poll(() => this.editedCellRendered()).toBe(false);
+  }
+
+  /**
+   * Scrolls the viewport back to the top, bringing the edited cell into the rendered range again.
+   * Ends on the render-state probe that the edited cell is rendered once more.
+   */
+  async scrollToTop(): Promise<void> {
+    await this.#masterHolder().evaluate((holder: HTMLElement) => {
+      holder.scrollTop = 0;
+    });
+
+    await expect.poll(() => this.editedCellRendered()).toBe(true);
+  }
+
+  /**
+   * Whether the edited cell currently has a rendered `TD` (i.e. is inside the rendered range).
+   * `getEditedCell()` returns null once the cell scrolls out of the band — the exact condition that
+   * makes `refreshDimensions()` hide the editor.
+   */
+  async editedCellRendered(): Promise<boolean> {
+    return this.page.evaluate(() => (
+      (window as FixtureWindow).hot.getActiveEditor()?.getEditedCell() != null
+    ));
+  }
+
+  /**
+   * The editor's state-machine value, or null when there is no active editor.
+   */
+  async editorState(): Promise<string | null> {
+    return this.page.evaluate(() => (
+      (window as FixtureWindow).hot.getActiveEditor()?.state ?? null
+    ));
+  }
+
+  /**
+   * The value currently held by the editor (its textarea), whether or not it is shown.
+   */
+  async editorValue(): Promise<string | null> {
+    return this.page.evaluate(() => (
+      (window as FixtureWindow).hot.getActiveEditor()?.TEXTAREA?.value ?? null
+    ));
+  }
+
+  /**
+   * The inner listbox table of the open layered editor. Shared by both the dropdown and the
+   * autocomplete editor (both carry the `autocompleteEditor` container class).
+   */
+  #list(): Locator {
+    return this.page.getByTestId('grid')
+      .locator('.handsontableInputHolder .autocompleteEditor .ht_master .htCore');
+  }
+
+  /**
+   * Every option row cell currently rendered in the open list.
+   */
+  options(): Locator {
+    return this.#list().locator('tbody tr td');
+  }
+
+  /**
+   * One option row addressed by its exact label.
+   */
+  optionByText(label: string): Locator {
+    return this.options().filter({ hasText: label });
+  }
+
+  /**
+   * Whether the inner list root is displayed (not hidden with `display: none`). On the unfixed code
+   * this stays `none` after a scroll round trip; the fix restores it.
+   */
+  async listDisplayed(): Promise<boolean> {
+    return this.page.evaluate(() => {
+      const editor = (window as FixtureWindow).hot.getActiveEditor() as
+        (EditorHandle & { htEditor?: { rootElement: HTMLElement } }) | undefined;
+      const root = editor?.htEditor?.rootElement;
+
+      return root ? root.ownerDocument.defaultView!.getComputedStyle(root).display !== 'none' : false;
+    });
+  }
+
+  /**
+   * Focuses the editor textarea, so a subsequent `type()` reaches it. The autocomplete requery is
+   * driven by the textarea's own `input` event.
+   */
+  async focusEditor(): Promise<void> {
+    await this.page.getByTestId('grid').locator('.handsontableInputHolder textarea.handsontableInput').focus();
+  }
+
+  /**
+   * Types into the focused editor textarea.
+   */
+  async type(text: string): Promise<void> {
+    await this.page.keyboard.type(text);
+  }
+
+  /**
+   * Presses ArrowDown, which the layered editor maps onto its inner grid's selection.
+   */
+  async pressArrowDown(): Promise<void> {
+    await this.page.keyboard.press('ArrowDown');
+  }
+
+  /**
+   * The row selected inside the inner list grid, or null when nothing is selected. Proves the
+   * editor's ArrowUp/ArrowDown shortcut group and the inner grid survived the round trip.
+   */
+  async innerSelectedRow(): Promise<number | null> {
+    return this.page.evaluate(() => (
+      (window as FixtureWindow).hot.getActiveEditor()?.htEditor?.getSelectedActive()?.[0] ?? null
+    ));
+  }
+}


### PR DESCRIPTION
### Context

The PR fixes DEV-26: with a fixed container `height`, opening a layered editor (dropdown or autocomplete) and scrolling the edited cell out of the rendered range then back left the editor "half open" — the textarea returned but the dropdown list stayed hidden and could no longer populate, while the cell was still in edit mode.

Root cause: `TextEditor#refreshDimensions()` (bound to `afterScrollVertically`/`afterScrollHorizontally`) reused the destructive `close()` as a "hide for now" when `getEditedCell()` returned `null` for a cell scrolled out of the rendered band. `close()` tears the layered editor down (hides `htEditor`, removes `beforeKeyDown`, cancels deferred queries) without ending the edit (`state` stays `EDITING`). On scroll-back only the textarea was restored; nothing re-showed or re-populated the list. The in-source comment already flagged this and named the fix location.

The fix separates the two meanings inside `TextEditor`:

- A new `hideForScroll()` / `showAfterScroll()` pair plus a private `#hiddenByScroll` flag. The base `hideForScroll()` delegates to `close()` and returns `false`, so inline editors are byte-identical to before; layered editors override it to hide only their UI (display + `_opened`) while preserving `beforeKeyDown`, the query timeouts, the edit session, and the inner grid's data/selection.
- On scroll-back, `refreshDimensions()` calls `showAfterScroll()` (gated on `!force`) to re-display and re-anchor the list, still populated and still interactive.

This implements the "Pin to Cell" (variant A) behaviour from the DEV-26 UX research, for layered editors. No new option or default is introduced; no breaking change.

### How has this been tested?

New Playwright E2E — `tests/e2e/dropdown-scroll-round-trip.spec.ts` (+ fixture and page object). It scrolls the edited cell fully out of the rendered range (asserting `getEditedCell() === null` mid-scroll, the precondition the pre-existing specs never reached — they scroll 1–3 rows, inside the overscan), scrolls back, and asserts the list returns populated, re-queries on keystroke (autocomplete), and stays keyboard-navigable (arrow keys). A plain-text-editor round trip is the negative control.

```bash
# from tests/ (use a free HOT_TEST_PORT if another checkout owns 8123)
HOT_TEST_PORT=8137 npx playwright test --project=e2e-main e2e/dropdown-scroll-round-trip.spec.ts
```

Verified the spec fails on unfixed `develop` (both layered cases red at `listDisplayed() === false` after scroll-back, negative control green), then passes with the fix. Regression-checked the frozen Jasmine suite for the editors — `editors/(autocompleteEditor|dropdownEditor|handsontableEditor|textEditor)/__tests__`: 370 specs, 0 failures. `npm run test:types` and `eslint` clean.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-26

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core editor scroll/dimension and open-state logic for dropdown and autocomplete; behavior change is scoped to scroll-out-of-view but affects in-flight async `source` callbacks and `_opened` semantics.
> 
> **Overview**
> Fixes **DEV-26**: in a fixed-height grid, scrolling an edited cell out of the rendered range and back no longer leaves dropdown/autocomplete editors half-open (textarea visible, list stuck hidden).
> 
> **`TextEditor#refreshDimensions`** no longer calls **`close()`** when `getEditedCell()` is null. It uses a transient **`hideForScroll()` / `showAfterScroll()`** path with **`#hiddenByScroll`**, restores **`_opened`** on scroll-back, and leaves plain text editors on the old **`close()`** behavior via the base override.
> 
> **`HandsontableEditor`** hides only the nested list UI (preserving hooks, shortcuts, and inner grid state); **`AutocompleteEditor`** adds shared **`#dropInFlightQueries()`** on scroll-hide and real close, **`aria-expanded`** updates, list re-show with **`reflowDropdown()`**, and a **`queryChoices()`** guard when **`!_opened`** so keystrokes while off-screen cannot resurrect the list.
> 
> Adds changelog **#13464** and Playwright coverage for dropdown, autocomplete, and a text-editor negative control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efa7927fea068c79a9cf8597120de86b844aa384. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->