### PR TITLE
Fix British spelling in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1694,7 +1694,7 @@ For more information on Handsontable 9.0.2, see:
 
 - Fixed an issue where the validator function was called twice when the Formulas plugin was enabled.
   [#8138](https://github.com/handsontable/handsontable/issues/8138)
-- Introduced a new CSS style for cells of the `checkbox` type to restore previous behaviour.
+- Introduced a new CSS style for cells of the `checkbox` type to restore previous behavior.
   [#8196](https://github.com/handsontable/handsontable/issues/8196)
 
 For more information on Handsontable 9.0.1, see:
@@ -1746,7 +1746,7 @@ For more information on Handsontable 9.0.0, see:
 
 - Introduced a `separated` attribute for the label options (the `label` DOM element may wrap `input`
   or be placed next to it). [#3172](https://github.com/handsontable/handsontable/issues/3172)
-- Introduced the `modifyAutoColumnSizeSeed` hook to let developers overwrite the default behaviour
+- Introduced the `modifyAutoColumnSizeSeed` hook to let developers overwrite the default behavior
   of the AutoColumnSize sampling. [#3339](https://github.com/handsontable/handsontable/issues/3339)
 - Added support for hiding columns for the _NestedHeaders_ plugin.
   [#6879](https://github.com/handsontable/handsontable/issues/6879)

--- a/docs/content/guides/accessibility/accessibility-conformance-report/accessibility-conformance-report.md
+++ b/docs/content/guides/accessibility/accessibility-conformance-report/accessibility-conformance-report.md
@@ -278,7 +278,7 @@ Conformance levels used in this report:
     <tr>
       <td><strong>3.3.2 Labels or Instructions</strong></td>
       <td>Partially Supports</td>
-      <td>The top-left corner button ("Select whole grid") provides an accessible name via <code>aria-label</code> for screen reader users but has no visible label, icon, or text to communicate its purpose to sighted users - particularly those with cognitive impairments (Normal severity). Other controls are generally labelled appropriately.</td>
+      <td>The top-left corner button ("Select whole grid") provides an accessible name via <code>aria-label</code> for screen reader users but has no visible label, icon, or text to communicate its purpose to sighted users - particularly those with cognitive impairments (Normal severity). Other controls are generally labeled appropriately.</td>
     </tr>
     <tr>
       <td><strong>3.3.7 Redundant Entry</strong></td>
@@ -492,7 +492,7 @@ This report targets **WCAG 2.2 Level AA**, published October 2023. WCAG 2.2 remo
 - **Level A (inherited from WCAG 2.1, now formally assessed):** 2.5.1 Pointer Gestures (Partially Supports), 2.5.2 Pointer Cancellation (Supports), 2.5.3 Label in Name (Partially Supports), 2.5.4 Motion Actuation (Not Applicable).
 - **Level AA (new):** 2.4.11 Focus Not Obscured Minimum (Not Evaluated - frozen rows/columns require dedicated testing), 2.5.7 Dragging Movements (Partially Supports - drag alternatives incomplete), 2.5.8 Target Size Minimum (Not Evaluated - formal verification pending), 3.3.8 Accessible Authentication Minimum (Not Applicable).
 
-The Kinaole audit report (December 2025 - January 2026) covered WCAG 2.1 A and AA criteria. The nine WCAG 2.2-specific criteria have been assessed internally and are clearly labelled in the tables above. A future audit cycle will include formal third-party evaluation of all WCAG 2.2 additions.
+The Kinaole audit report (December 2025 - January 2026) covered WCAG 2.1 A and AA criteria. The nine WCAG 2.2-specific criteria have been assessed internally and are clearly labeled in the tables above. A future audit cycle will include formal third-party evaluation of all WCAG 2.2 additions.
 
 ## Legal disclaimer
 

--- a/docs/content/guides/cell-features/autofill-values/autofill-values.md
+++ b/docs/content/guides/cell-features/autofill-values/autofill-values.md
@@ -194,7 +194,7 @@ With the [`Formulas`](@/guides/formulas/formula-calculation/formula-calculation.
 
 - **Relative references adjust per target cell.** Filling `=A1+B1` down from row 1 to row 2 produces `=A2+B2` in the new cell, the same way a spreadsheet application adjusts formulas on fill.
 - **Absolute references stay fixed.** Filling `=$A$1+B1` down keeps `$A$1` unchanged in every filled cell, while the relative `B1` part still adjusts.
-- **The fill is cancelled** if the engine reports that the target cells can't be written to (for example, because they're part of another formula's dependency chain), leaving the target range unchanged.
+- **The fill is canceled** if the engine reports that the target cells can't be written to (for example, because they're part of another formula's dependency chain), leaving the target range unchanged.
 
 ## Result
 

--- a/docs/content/guides/cell-functions/cell-validator/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator/cell-validator.md
@@ -405,7 +405,7 @@ Mind that changes in table are applied after running all validators (both synchr
 
 ## Result
 
-You now have a cell validator that enforces data rules when a user finishes editing. Register it under an alias to reference it by name across your column configuration. Use <code>allowInvalid</code> set to false to keep the editor open until the user enters a valid value, or <code>allowInvalid</code> set to true to accept the value while still visually flagging the cell. Use <code>invalidCellClassName</code> to customise the CSS class applied to cells that fail validation — the default is <code>htInvalid</code>.
+You now have a cell validator that enforces data rules when a user finishes editing. Register it under an alias to reference it by name across your column configuration. Use <code>allowInvalid</code> set to false to keep the editor open until the user enters a valid value, or <code>allowInvalid</code> set to true to accept the value while still visually flagging the cell. Use <code>invalidCellClassName</code> to customize the CSS class applied to cells that fail validation — the default is <code>htInvalid</code>.
 
 ## Related API reference
 

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -96,7 +96,7 @@ This is the same example as above, the difference being that `autocomplete` now 
 - If there is at least one option visible, there always is a selection in HOT-in-HOT
 - When the first row is selected, pressing <kbd>**Arrow Up**</kbd> does not deselect HOT-in-HOT. Instead, it behaves as the <kbd>**Enter**</kbd> key but moves the selection in the main HOT upwards
 
-In strict mode, the [`allowInvalid`](@/api/options.md#allowinvalid) option determines the behaviour in the case of manual user input:
+In strict mode, the [`allowInvalid`](@/api/options.md#allowinvalid) option determines the behavior in the case of manual user input:
 
 - [`allowInvalid: true`](@/api/options.md#allowinvalid) optional - allows manual input of a value that does not exist in the `source`, the field background is highlighted in red, and the selection advances to the next cell
 - [`allowInvalid: false`](@/api/options.md#allowinvalid) - does not allow manual input of a value that does not exist in the `source`, the <kbd>**Enter**</kbd> key is ignored, and the editor field remains open

--- a/docs/content/guides/cell-types/cell-type/cell-type.md
+++ b/docs/content/guides/cell-types/cell-type/cell-type.md
@@ -246,7 +246,7 @@ const hotSettings = ref({
 
 When you create a custom cell type, best practice is to assign it as an alias that will refer to this particular type definition.
 
-This gives users a convenient way of defining which cell type should be used for describing cell properties. The user doesn't need to know which part of the code is responsible for rendering, validating, or editing the cell value. They do not even need to know that there are any functions at all. You can change the cell behaviour associated with an alias without changing the code that defines a cell's properties.
+This gives users a convenient way of defining which cell type should be used for describing cell properties. The user doesn't need to know which part of the code is responsible for rendering, validating, or editing the cell value. They do not even need to know that there are any functions at all. You can change the cell behavior associated with an alias without changing the code that defines a cell's properties.
 
 To register your own alias use `Handsontable.cellTypes.registerCellType()` function. It takes two arguments:
 

--- a/docs/content/guides/columns/column-moving/column-moving.md
+++ b/docs/content/guides/columns/column-moving/column-moving.md
@@ -304,7 +304,7 @@ The [`moveColumns`](@/api/manualColumnMove.md#movecolumns) method has a `finalIn
 
 </span>
 
-The [`moveColumns`](@/api/manualColumnMove.md#movecolumns) function cannot perform some actions, e.g., more than one element can't be moved to the last position. In this scenario, the move will be cancelled. The Plugin's [`isMovePossible`](@/api/manualColumnMove.md#ismovepossible) API method and the `movePossible` parameters [`beforeColumnMove`](@/api/hooks.md#beforecolumnmove) and [`afterColumnMove`](@/api/hooks.md#aftercolumnmove) hooks help in determine such situations.
+The [`moveColumns`](@/api/manualColumnMove.md#movecolumns) function cannot perform some actions, e.g., more than one element can't be moved to the last position. In this scenario, the move will be canceled. The Plugin's [`isMovePossible`](@/api/manualColumnMove.md#ismovepossible) API method and the `movePossible` parameters [`beforeColumnMove`](@/api/hooks.md#beforecolumnmove) and [`afterColumnMove`](@/api/hooks.md#aftercolumnmove) hooks help in determine such situations.
 
 ## Related API reference
 

--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -451,7 +451,7 @@ For live examples of both modes, see the [column stretching](@/guides/columns/co
 
 Handsontable observes window resizing. If the window's dimensions have changed, then we check if Handsontable should resize itself too. Due to the performance issue, we use the debounce method to respond on window resize.
 
-You can easily overwrite this behaviour by returning `false` in the [`beforeRefreshDimensions`](@/api/hooks.md#beforerefreshdimensions) hook.
+You can easily overwrite this behavior by returning `false` in the [`beforeRefreshDimensions`](@/api/hooks.md#beforerefreshdimensions) hook.
 
 ::: only-for javascript
 

--- a/docs/content/guides/rows/row-moving/row-moving.md
+++ b/docs/content/guides/rows/row-moving/row-moving.md
@@ -157,7 +157,7 @@ Return `false` from [`beforeRowMove`](@/api/hooks.md#beforerowmove) to cancel Ha
 
 In this model you also own the order's history. Reverting a move is your code's job, not the grid's.
 
-Cancelling the move changes what the grid does for you, so plan for these:
+Canceling the move changes what the grid does for you, so plan for these:
 
 - [`afterRowMove`](@/api/hooks.md#afterrowmove) never fires. The move stops at [`beforeRowMove`](@/api/hooks.md#beforerowmove), before that hook runs, so the snapshot recipe shown earlier on this page does not apply here. Persist the order from your own update instead.
 - The grid does not re-render or restore the selection, because both wait for a move that actually happened. After the drag, the highlighted row headers stay where they were, and those positions now hold different rows. Re-select the moved rows yourself if that matters.
@@ -319,7 +319,7 @@ The [`moveRows`](@/api/manualRowMove.md#moverows) method has a `finalIndex` para
 
 </span>
 
-The [`moveRows`](@/api/manualRowMove.md#moverows) function cannot perform some actions, e.g., more than one element can't be moved to the last position. In this scenario, the move will be cancelled. The Plugin's [`isMovePossible`](@/api/manualRowMove.md#ismovepossible) API method and the `movePossible` parameters `beforeRowMove` and `afterRowMove` hooks help in determine such situations.
+The [`moveRows`](@/api/manualRowMove.md#moverows) function cannot perform some actions, e.g., more than one element can't be moved to the last position. In this scenario, the move will be canceled. The Plugin's [`isMovePossible`](@/api/manualRowMove.md#ismovepossible) API method and the `movePossible` parameters `beforeRowMove` and `afterRowMove` hooks help in determine such situations.
 
 The [`moveRows`](@/api/manualRowMove.md#moverows) method is also inactive when the [`NestedRows`](@/api/nestedRows.md) plugin is enabled - see [Row parent-child known limitations](@/guides/rows/row-parent-child/row-parent-child.md#known-limitations).
 

--- a/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
+++ b/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
@@ -80,7 +80,7 @@ More generally, [`allowInsertRow: false`](@/api/options.md#allowinsertrow) does 
 
 ## Spare rows with placeholder styling
 
-To hint what to enter in the spare row, add a custom cell renderer that displays greyed-out placeholder text in empty cells. The renderer checks whether the whole row is empty, then shows a template value in a lighter color.
+To hint what to enter in the spare row, add a custom cell renderer that displays grayed-out placeholder text in empty cells. The renderer checks whether the whole row is empty, then shows a template value in a lighter color.
 
 ::: only-for javascript
 
@@ -217,7 +217,7 @@ const hot = new Handsontable(container, {
 
 ## Result
 
-Your grid keeps one or more empty rows at the bottom. Depending on the approach, spare rows show greyed-out placeholder text or auto-fill all cells with template values when the user starts editing.
+Your grid keeps one or more empty rows at the bottom. Depending on the approach, spare rows show grayed-out placeholder text or auto-fill all cells with template values when the user starts editing.
 
 ## Related API reference
 

--- a/docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md
@@ -345,7 +345,7 @@ For more information on this release, see:
 - Fixed a bug where selecting a mixed merged/non-merged section caused improper results. ([#4912](https://github.com/handsontable/handsontable/issues/4912))
 - Fixed a problem where the `Handsontable` class export differed between UMD and other environments. ([#4605](https://github.com/handsontable/handsontable/issues/4605))
 - Fixed a bug where disabling `colHeaders` using `updateSettings` did not work properly. ([#4136](https://github.com/handsontable/handsontable/issues/4136))
-- Fixed a bug where the changes cancelled using the `beforeChange` hook were still validated. ([#3381](https://github.com/handsontable/handsontable/issues/3381))
+- Fixed a bug where the changes canceled using the `beforeChange` hook were still validated. ([#3381](https://github.com/handsontable/handsontable/issues/3381))
 - Updated the documentation for the `setSortConfig` method of the Column Sorting plugin.
 - Fixed a problem where passing an `Array` as a cell value caused the `populateFromArray` method to fail. ([#5675](https://github.com/handsontable/handsontable/issues/5675))
 - Rewrote the TypeScript definition file so it matches the actual structure of the library more precisely. ([#5767](https://github.com/handsontable/handsontable/issues/5767))

--- a/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
@@ -35,7 +35,7 @@ For more information on this release, see:
 
 - Introduced a `separated` attribute for the label options (the `label` DOM element may wrap `input`
   or be placed next to it). ([#3172](https://github.com/handsontable/handsontable/issues/3172))
-- Introduced the `modifyAutoColumnSizeSeed` hook to let developers overwrite the default behaviour
+- Introduced the `modifyAutoColumnSizeSeed` hook to let developers overwrite the default behavior
   of the AutoColumnSize sampling.
   ([#3339](https://github.com/handsontable/handsontable/issues/3339))
 - Added support for hiding columns for the `NestedHeaders` plugin.

--- a/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
@@ -490,7 +490,7 @@ methods and hooks were added and there are few depreciations and removals, too.
   `boolean`. [#6547](https://github.com/handsontable/handsontable/pull/6547)
 - Added additional information available in the cell meta object - the language.
   [#6254](https://github.com/handsontable/handsontable/pull/6254).
-- Added a possibility to allow cancelling of `autofill` in the `beforeAutofill` hook.
+- Added a possibility to allow canceling of `autofill` in the `beforeAutofill` hook.
   [#4441](https://github.com/handsontable/handsontable/issues/4441)
 - Added support for newer versions of moment, numbro and pikaday.
   [#5159](https://github.com/handsontable/handsontable/issues/5159)

--- a/docs/content/guides/upgrade-and-migration/changelog-9/changelog-9.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-9/changelog-9.md
@@ -84,7 +84,7 @@ For more information on this release, see:
 
 - Fixed an issue where the validator function was called twice when the `Formulas` plugin was
   enabled. ([#8138](https://github.com/handsontable/handsontable/issues/8138))
-- Introduced a new CSS style for cells of the `checkbox` type to restore previous behaviour.
+- Introduced a new CSS style for cells of the `checkbox` type to restore previous behavior.
   ([#8196](https://github.com/handsontable/handsontable/issues/8196))
 
 ## 9.0.0

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -1897,7 +1897,7 @@ For more information on this release, see:
 
 - Fixed an issue where the validator function was called twice when the `Formulas` plugin was
   enabled. ([#8138](https://github.com/handsontable/handsontable/issues/8138))
-- Introduced a new CSS style for cells of the `checkbox` type to restore previous behaviour.
+- Introduced a new CSS style for cells of the `checkbox` type to restore previous behavior.
   ([#8196](https://github.com/handsontable/handsontable/issues/8196))
 
 ## 9.0.0
@@ -1963,7 +1963,7 @@ For more information on this release, see:
 
 - Introduced a `separated` attribute for the label options (the `label` DOM element may wrap `input`
   or be placed next to it). ([#3172](https://github.com/handsontable/handsontable/issues/3172))
-- Introduced the `modifyAutoColumnSizeSeed` hook to let developers overwrite the default behaviour
+- Introduced the `modifyAutoColumnSizeSeed` hook to let developers overwrite the default behavior
   of the AutoColumnSize sampling.
   ([#3339](https://github.com/handsontable/handsontable/issues/3339))
 - Added support for hiding columns for the `NestedHeaders` plugin.

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -2388,7 +2388,7 @@ methods and hooks were added and there are few depreciations and removals, too.
   `boolean`. [#6547](https://github.com/handsontable/handsontable/pull/6547)
 - Added additional information available in the cell meta object - the language.
   [#6254](https://github.com/handsontable/handsontable/pull/6254).
-- Added a possibility to allow cancelling of `autofill` in the `beforeAutofill` hook.
+- Added a possibility to allow canceling of `autofill` in the `beforeAutofill` hook.
   [#4441](https://github.com/handsontable/handsontable/issues/4441)
 - Added support for newer versions of moment, numbro and pikaday.
   [#5159](https://github.com/handsontable/handsontable/issues/5159)

--- a/docs/content/recipes/context-menu/custom-context-menu/custom-context-menu.md
+++ b/docs/content/recipes/context-menu/custom-context-menu/custom-context-menu.md
@@ -244,6 +244,6 @@ copy_row_as_json: {
 
 ## Next steps
 
-- Add a `disabled()` function to any item to make it conditionally unavailable. Return `true` to grey out the item and prevent its callback from firing.
+- Add a `disabled()` function to any item to make it conditionally unavailable. Return `true` to gray out the item and prevent its callback from firing.
 - Explore the [Context menu guide](@/guides/accessories-and-menus/context-menu/context-menu.md) for the full list of built-in item keys and advanced configuration.
 - To add the same custom actions to the column dropdown menu, configure `dropdownMenu.items` using the same structure.

--- a/docs/content/recipes/data-management/load-data-rest-api/load-data-rest-api.md
+++ b/docs/content/recipes/data-management/load-data-rest-api/load-data-rest-api.md
@@ -330,7 +330,7 @@ The first two examples manage the fetch lifecycle yourself: you call `loadData()
 - Slicing rows in `fetchRows` using the `page` and `pageSize` query parameters.
 - Enabling `pagination`, `columnSorting`, and `emptyDataState` so the plugin drives navigation and loading overlays.
 - Using `beforeDataProviderFetch`, `afterDataProviderFetch`, and `afterDataProviderFetchError` hooks for status feedback.
-- Passing an `AbortSignal` to `fetch` so superseded requests are cancelled automatically.
+- Passing an `AbortSignal` to `fetch` so superseded requests are canceled automatically.
 
 ## When to use each approach
 
@@ -415,7 +415,7 @@ async fetchRows({ page, pageSize, sort }, { signal }) {
 - `page` -- 1-based page index driven by the Pagination plugin.
 - `pageSize` -- rows per page; matches `pagination: { pageSize: 5 }` in grid options.
 - `sort` -- `{ prop, order }` object when a column header is sorted, or `null` when unsorted.
-- `{ signal }` -- AbortSignal from the plugin. Pass it to your `fetch` call so superseded requests are cancelled.
+- `{ signal }` -- AbortSignal from the plugin. Pass it to your `fetch` call so superseded requests are canceled.
 - Return `{ rows, totalRows }`. `totalRows` is the unsliced count -- the Pagination plugin uses it to calculate the page count and navigation controls.
 
 ## Step 4: Apply sort from query parameters

--- a/docs/content/recipes/data-management/server-side-aspnet/server-side-aspnet.md
+++ b/docs/content/recipes/data-management/server-side-aspnet/server-side-aspnet.md
@@ -105,7 +105,7 @@ Create `DbInitializer.cs`:
 
 **What's happening:**
 
-- The seed script inserts 50 orders across realistic statuses (`pending`, `paid`, `shipped`, `delivered`, `cancelled`). It checks whether data already exists, so restarting the app doesn't duplicate rows.
+- The seed script inserts 50 orders across realistic statuses (`pending`, `paid`, `shipped`, `delivered`, `canceled`). It checks whether data already exists, so restarting the app doesn't duplicate rows.
 - This recipe calls `Database.EnsureCreated()` in `Program.cs` (Step 4) instead of running EF Core migrations. `EnsureCreated()` creates the schema directly from the model, which is enough for a tutorial. For a production app, use `dotnet ef migrations add` and `Database.Migrate()` instead, so schema changes are versioned.
 
 ## Step 4: Wire up `Program.cs`

--- a/docs/content/recipes/data-management/server-side-django/server-side-django.md
+++ b/docs/content/recipes/data-management/server-side-django/server-side-django.md
@@ -308,7 +308,7 @@ With the backend and Vite dev server running (`bash setup.sh`), open `http://loc
 | Option | What it does |
 |---|---|
 | `rowId: 'id'` | Tells `dataProvider` which field identifies a row. Must match the serializer field name. |
-| `{ signal }` in `fetchRows` | Pass the `AbortSignal` to `fetch()` so in-flight requests are cancelled when the user sorts or filters before the previous response arrives. |
+| `{ signal }` in `fetchRows` | Pass the `AbortSignal` to `fetch()` so in-flight requests are canceled when the user sorts or filters before the previous response arrives. |
 | `return res.json()` in `onRowsCreate` | Return the server response so `dataProvider` can update its internal row map with the server-assigned `id` values. |
 | `pagination: { pageSize: 10 }` | Enables the pagination toolbar. `dataProvider` sends the current page and size to `fetchRows` automatically. |
 | `columnSorting: true` | Enables column header click-to-sort. The sort state is passed to `fetchRows` on each change. |

--- a/docs/content/recipes/data-management/server-side-expressjs/server-side-expressjs.md
+++ b/docs/content/recipes/data-management/server-side-expressjs/server-side-expressjs.md
@@ -112,7 +112,7 @@ Express parses this as `filters = { '0': { prop: 'status', ... } }` when only on
 
 ### `ALLOWED_COLUMNS` and `ALLOWED_CONDITIONS` enums
 
-Using `z.enum(ALLOWED_COLUMNS)` on the `prop` field ensures users cannot inject arbitrary column names into the SQL query builder. Any request with an unrecognised column name is rejected with a `400` before reaching the service.
+Using `z.enum(ALLOWED_COLUMNS)` on the `prop` field ensures users cannot inject arbitrary column names into the SQL query builder. Any request with an unrecognized column name is rejected with a `400` before reaching the service.
 
 ## Step 4: Bootstrap the server
 

--- a/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
+++ b/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
@@ -111,7 +111,7 @@ Run it:
 rails db:seed
 ```
 
-The seed script inserts 50 orders across realistic statuses (`pending`, `paid`, `shipped`, `delivered`, `cancelled`). It checks whether data already exists, so running it twice does not duplicate rows.
+The seed script inserts 50 orders across realistic statuses (`pending`, `paid`, `shipped`, `delivered`, `canceled`). It checks whether data already exists, so running it twice does not duplicate rows.
 
 ## Step 4 -- Configure the routes
 
@@ -322,7 +322,7 @@ Start the backend and the Vite dev server with `bash setup.sh` (or `make setup`)
 | Option | What it does |
 |---|---|
 | `rowId: 'id'` | Tells `dataProvider` which field uniquely identifies a row. Must match the Rails primary key name. |
-| `{ signal }` in `fetchRows` | Pass the `AbortSignal` to `fetch()` so in-flight requests are cancelled when the user sorts or filters before the previous response arrives. |
+| `{ signal }` in `fetchRows` | Pass the `AbortSignal` to `fetch()` so in-flight requests are canceled when the user sorts or filters before the previous response arrives. |
 | `{ rowsAmount }` in `onRowsCreate` | `dataProvider` passes the number of rows to add. The frontend builds default objects and sends them as `{ rows: [...] }`. Returning `json.rows` lets `dataProvider` replace client-side placeholder ids with the ids assigned by Rails. |
 | `beforeRowsMutation` | Intercepts mutations before they run. Return `false` to cancel. Used here to show a delete-confirmation notification with **Delete**/**Cancel** actions instead of deleting immediately. |
 | `pagination: { pageSize: 10 }` | Enables the pagination toolbar. `dataProvider` passes the current page and size to `fetchRows` automatically. |


### PR DESCRIPTION
### Context
The docs use American English per `.ai/DOC-STANDARDS.md` (e.g. `behavior`, not `behaviour`). A repo-wide search of `docs/content/` and the root `CHANGELOG.md` found several British spellings still present in guide prose, recipe pages, and changelog entries:

- `behaviour` -> `behavior`
- `grey` -> `gray`
- `customise` -> `customize`
- `unrecognised` -> `unrecognized`
- `labelled` -> `labeled`
- `cancelled` / `cancelling` -> `canceled` / `canceling`

This PR replaces each occurrence found in documentation prose.

Left untouched (out of scope for this PR):
- `theme.palette.grey[...]` in `mui-theme.md` — this is MUI's actual API property name, not a spelling mistake.
- `cancelled` / `Cancelled` occurrences inside embedded example code (sample data values, dropdown option strings) in several recipe/example files — these are code/data content, not prose.
- A handful of source-code comments/JSDoc (`handsontable/src/cellTypes/registry.ts`, `handsontable/src/editors/handsontableEditor/handsontableEditor.ts`, `handsontable/src/utils/licenseBranding/index.ts`, `wrappers/react-wrapper/src/hotEditor.tsx`) and a couple of CI workflow / docs-site component comments — flagged separately, pending approval to edit source code.

### Test evidence (required for source changes)
- Unit tests added/modified (`*.unit.js`): none — docs only
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none — docs only
- Type tests (`*.types.ts`) updated if public API changed: none — docs only
- For a bug fix — the spec that fails without this fix: n/a — not a bug fix
- Demo page / recorded trace (for UI changes): n/a — no UI change

### Commands run
```
grep -rn -iE "behaviour|grey|customise|unrecognised|labelled|cancelled|cancelling" docs/content/ CHANGELOG.md
sed -i '' 's/<british>/<american>/g' <each affected file>
grep -rn -iE "behaviour|grey|customise|unrecognised|labelled|cancelling" docs/content/ CHANGELOG.md   # confirms zero remaining matches (excluding mui-theme.md palette API and embedded example code)
git diff
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://app.clickup.com/t/123kvxea7mq

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [x] My change requires a change to the documentation.

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no runtime, API, or test impact.
> 
> **Overview**
> Aligns **documentation and changelog prose** with the monorepo’s American English standard in `.ai/DOC-STANDARDS.md` by replacing remaining British spellings in `docs/content/` and root `CHANGELOG.md`.
> 
> **Spelling updates** (find-and-replace style, no API or behavior changes): `behaviour` → `behavior`, `grey`/`greyed` → `gray`/`grayed`, `customise` → `customize`, `labelled` → `labeled`, `unrecognised` → `unrecognized`, and `cancelled`/`cancelling` → `canceled`/`canceling` in guides, recipes, accessibility report text, and historical changelog entries.
> 
> **Out of scope** (unchanged in this PR): MUI `theme.palette.grey` API references, British spellings inside embedded example code/data, and source/CI comments noted in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b81597b36e865bc3c9f638b1d7d9d6714f5a8e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->