### PR TITLE
DEV-30: Restore nested parent rows and their children on undo

### DIFF
--- a/.changelogs/13471.json
+++ b/.changelogs/13471.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed undoing the removal of a nested parent row.",
+  "type": "fixed",
+  "issueOrPR": 13471,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/dataMap/metaManager/index.ts
+++ b/handsontable/src/dataMap/metaManager/index.ts
@@ -1,7 +1,7 @@
 import GlobalMeta from './metaLayers/globalMeta';
 import TableMeta from './metaLayers/tableMeta';
 import ColumnMeta from './metaLayers/columnMeta';
-import CellMeta from './metaLayers/cellMeta';
+import CellMeta, { type CellMetaAtRowEntry } from './metaLayers/cellMeta';
 import localHooks from '../../mixins/localHooks';
 import { mixin } from '../../helpers/object';
 import { throwWithCause } from '../../helpers/errors';
@@ -378,6 +378,17 @@ export default class MetaManager {
    */
   getCellsMetaAtRow(physicalRow: number) {
     return this.cellMeta.getMetasAtRow(physicalRow);
+  }
+
+  /**
+   * Returns all materialized cell meta objects for a physical row together with their physical
+   * column keys.
+   *
+   * @param {number} physicalRow The physical row index.
+   * @returns {{physicalColumn: number, meta: object}[]}
+   */
+  getCellsMetaAtRowWithPhysicalColumns(physicalRow: number): CellMetaAtRowEntry[] {
+    return this.cellMeta.getMetasAtRowWithPhysicalColumns(physicalRow);
   }
 
   /**

--- a/handsontable/src/dataMap/metaManager/metaLayers/__tests__/cellMeta.unit.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/__tests__/cellMeta.unit.ts
@@ -241,6 +241,23 @@ describe('ColumnMeta', () => {
       expect(meta.getMetasAtRow(2).map(metaObject => metaObject._test)).toEqual(['zero', 'one', 'three', 'four']);
     });
 
+    it('should return physical column keys with metas', () => {
+      const globalMeta = new GlobalMeta();
+      const columnMeta = new ColumnMeta(globalMeta);
+      const meta = new CellMeta(columnMeta);
+
+      meta.getMeta(2, 4)._test = 'four';
+      meta.getMeta(2, 1)._test = 'one';
+
+      expect(meta.getMetasAtRowWithPhysicalColumns(2).map(({ physicalColumn, meta: cellMeta }) => ({
+        physicalColumn,
+        value: cellMeta._test,
+      }))).toEqual([
+        { physicalColumn: 1, value: 'one' },
+        { physicalColumn: 4, value: 'four' },
+      ]);
+    });
+
     it('should change cell meta by reference', () => {
       const globalMeta = new GlobalMeta();
       const columnMeta = new ColumnMeta(globalMeta);

--- a/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
@@ -41,6 +41,11 @@ export interface CellMetaSnapshotEntry {
   value: unknown;
 }
 
+export interface CellMetaAtRowEntry {
+  physicalColumn: number;
+  meta: CellProperties;
+}
+
 /**
  * @class CellMeta
  *
@@ -478,6 +483,28 @@ export default class CellMeta {
     return Array.from(rowMeta)
       .sort(([a], [b]) => a - b)
       .map(([, meta]) => meta);
+  }
+
+  /**
+   * Returns the materialized cell metas for a physical row together with the physical column keys
+   * that own them. The coordinate fields on a meta object are render-time values and can be stale
+   * after a row or column map changes.
+   *
+   * @param {number} physicalRow The physical row index.
+   * @returns {{physicalColumn: number, meta: object}[]}
+   */
+  getMetasAtRowWithPhysicalColumns(physicalRow: number): CellMetaAtRowEntry[] {
+    assert(() => isUnsignedNumber(physicalRow), 'Expecting an unsigned number.');
+
+    const rowMeta = this.metas.getIfExists(physicalRow);
+
+    if (rowMeta === undefined) {
+      return [];
+    }
+
+    return Array.from(rowMeta)
+      .sort(([a], [b]) => a - b)
+      .map(([physicalColumn, meta]) => ({ physicalColumn, meta }));
   }
 
   /**

--- a/handsontable/src/helpers/__tests__/object.unit.ts
+++ b/handsontable/src/helpers/__tests__/object.unit.ts
@@ -12,6 +12,7 @@ import {
   assignObjectDefaults,
   deepMerge,
   deepClone,
+  stripFunctionValues,
 } from 'handsontable/helpers/object';
 
 describe('Object helper', () => {
@@ -710,6 +711,26 @@ describe('Object helper', () => {
 
     it('should return false if the object is undefined', () => {
       expect(isKeyValueObject(undefined)).toBe(false);
+    });
+  });
+
+  describe('stripFunctionValues', () => {
+    it('should delete function-valued object keys and null function-valued array entries', () => {
+      const callback = () => {};
+      const value = {
+        name: 'A',
+        run: callback,
+        nested: { run: callback },
+        list: [callback, 'keep'],
+      };
+
+      stripFunctionValues(value);
+
+      expect(value).toEqual({
+        name: 'A',
+        nested: {},
+        list: [null, 'keep'],
+      });
     });
   });
 });

--- a/handsontable/src/helpers/object.ts
+++ b/handsontable/src/helpers/object.ts
@@ -304,6 +304,36 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
 }
 
 /**
+ * Recursively deletes function-valued keys from a cloned value. `deepClone` keeps functions by
+ * reference at every depth, so a top-level-only sweep would still alias a nested closure onto the
+ * object created on undo.
+ *
+ * Array entries that hold a function become `null`. Object keys that hold a function are deleted.
+ *
+ * @param {unknown} value The cloned value to sweep.
+ */
+export function stripFunctionValues(value: unknown): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => {
+      if (typeof entry === 'function') {
+        value[index] = null;
+      } else {
+        stripFunctionValues(entry);
+      }
+    });
+
+  } else if (isPlainObject(value)) {
+    Object.keys(value).forEach((key) => {
+      if (typeof value[key] === 'function') {
+        delete value[key];
+      } else {
+        stripFunctionValues(value[key]);
+      }
+    });
+  }
+}
+
+/**
  * @param {object} object The object on which to define the property.
  * @param {string} property The name of the property to be defined or modified.
  * @param {*} value The value associated with the property.

--- a/handsontable/src/plugins/formulas/AGENTS.md
+++ b/handsontable/src/plugins/formulas/AGENTS.md
@@ -63,6 +63,11 @@ instead of replaying the move, so `afterMoveCells` — where the forward directi
 has to cover it here. Redo *does* replay the move, so it must **not** be listed, or the sheet is scanned
 twice.
 
+**A nested `remove_row` undo can refuse to land.** `RemoveRowAction.canUndo()` runs the enabled and
+`beforeCreateRow` checks **before** `beforeUndo`, because this plugin always calls `engine.undo()`
+there. A late `{ wasUndone: false }` would leave HyperFormula restored and Handsontable empty.
+`UndoRedo.undo()` also skips `afterUndo` when the action reports that failure.
+
 ## Sequence syncing
 
 The row/column sequence is mirrored into HF as a **permutation**, and two hooks matter:

--- a/handsontable/src/plugins/formulas/__tests__/plugins/nestedRows.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/plugins/nestedRows.spec.js
@@ -420,6 +420,85 @@ describe('Formulas', () => {
       expect(reloaded[0][1]).toBe('=SUM(A1:A4)');
     });
 
+    it('should keep HyperFormula in step when undoing a nested parent removal', async() => {
+      handsontable({
+        data: [{
+          col1: 'A1',
+          __children: [{ col1: 'A1.1' }],
+        }],
+        formulas: {
+          engine: HyperFormula,
+          sheetName: 'Sheet1'
+        },
+        nestedRows: true,
+      });
+
+      await alter('remove_row', 0);
+      getPlugin('undoRedo').undo();
+
+      const formulasPlugin = getPlugin('formulas');
+
+      expect(countRows()).toBe(2);
+      expect(getPlugin('nestedRows').dataManager.getRawSourceData()).toEqual([{
+        col1: 'A1',
+        __children: [{ col1: 'A1.1' }],
+      }]);
+      expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual([
+        ['A1'],
+        ['A1.1'],
+      ]);
+    });
+
+    it('should not undo HyperFormula when a nested parent undo is vetoed', async() => {
+      handsontable({
+        data: [{
+          col1: 'A1',
+          __children: [{ col1: '=A1' }],
+        }],
+        formulas: {
+          engine: HyperFormula,
+          sheetName: 'Sheet1'
+        },
+        beforeCreateRow: () => false,
+        nestedRows: true,
+      });
+
+      await alter('remove_row', 0);
+
+      const formulasPlugin = getPlugin('formulas');
+      const sheetAfterRemove = formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId);
+
+      getPlugin('undoRedo').undo();
+
+      expect(countRows()).toBe(0);
+      expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual(sheetAfterRemove);
+    });
+
+    it('should not undo HyperFormula when NestedRows is disabled before undo', async() => {
+      handsontable({
+        data: [{
+          col1: 'A1',
+          __children: [{ col1: '=A1' }],
+        }],
+        formulas: {
+          engine: HyperFormula,
+          sheetName: 'Sheet1'
+        },
+        nestedRows: true,
+      });
+
+      await alter('remove_row', 0);
+      getPlugin('nestedRows').disablePlugin();
+
+      const formulasPlugin = getPlugin('formulas');
+      const sheetAfterRemove = formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId);
+
+      getPlugin('undoRedo').undo();
+
+      expect(countRows()).toBe(0);
+      expect(formulasPlugin.engine.getSheetSerialized(formulasPlugin.sheetId)).toEqual(sheetAfterRemove);
+    });
+
     it('should clear the detach guard when the plugin is re-enabled', async() => {
       const data = [
         [10, '=SUM(A1:A3)'],

--- a/handsontable/src/plugins/mergeCells/AGENTS.md
+++ b/handsontable/src/plugins/mergeCells/AGENTS.md
@@ -37,6 +37,11 @@ trimming and reordering. The merge's own `row`/`col`/`rowspan` are re-derived fr
 `rowIndexMapper` `cacheUpdated`, so treat them as a snapshot of how the merge currently *draws*, not as
 what it owns.
 
+`restorePhysicalRowSpansAfterRemoval` must match a snapshot to a merge by **that merge's own
+anchor** (`merge.row === snapshot.row && merge.col === snapshot.col`). `mergedCellsCollection.get()`
+answers for every covered cell, so after a removal has slid another merge onto those coords the
+lookup hands back the wrong object and the snapshot's `physicalRows` are written onto it.
+
 The rows are an explicit list, not a `{ start, length }` range: merging on a sorted grid, or over a row a
 filter has hidden, gives a merge whose physical rows are not consecutive.
 

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -40,6 +40,10 @@ interface MergeAnchor {
   physicalColumn: number;
 }
 
+export interface PhysicalRowMergeSnapshot extends MergeAreaGeometry {
+  physicalRows: number[];
+}
+
 /**
  * What a row move does to one merge, decided before the move's fragments exist.
  *
@@ -863,6 +867,65 @@ export class MergeCells extends BasePlugin {
    */
   getPasteUnmergeSnapshot(): MergeAreaGeometry[] {
     return [...this.#pasteUnmergeSnapshot];
+  }
+
+  /**
+   * Captures merge geometry and its physical row anchor before a nested-row removal.
+   *
+   * @private
+   * @returns {Array} Merge snapshots keyed by their physical rows.
+   */
+  getPhysicalRowSpansForRemoval(): PhysicalRowMergeSnapshot[] {
+    if (!this.enabled || !this.mergedCellsCollection) {
+      return [];
+    }
+
+    this.#captureMissingMergeAnchors();
+
+    return this.mergedCellsCollection.mergedCells.map(merge => ({
+      row: merge.row,
+      col: merge.col,
+      rowspan: merge.rowspan,
+      colspan: merge.colspan,
+      physicalRows: this.#mergeAnchors.get(merge)?.physicalRows.slice() ?? [],
+    }));
+  }
+
+  /**
+   * Restores the physical anchor on merge objects recreated by UndoRedo after a nested-row removal.
+   *
+   * @private
+   * @param {PhysicalRowMergeSnapshot[]} snapshots Merge snapshots captured before removal.
+   */
+  restorePhysicalRowSpansAfterRemoval(snapshots: PhysicalRowMergeSnapshot[]) {
+    if (!this.enabled || !this.mergedCellsCollection) {
+      return;
+    }
+
+    snapshots.forEach((snapshot) => {
+      let merge = this.mergedCellsCollection.get(snapshot.row, snapshot.col);
+      const physicalColumn = merge ? this.hot.toPhysicalColumn(merge.col) : null;
+
+      if (!merge && snapshot.physicalRows.length > 0) {
+        merge = this.mergedCellsCollection.add({
+          row: snapshot.row,
+          col: snapshot.col,
+          rowspan: snapshot.rowspan,
+          colspan: snapshot.colspan,
+        }, true);
+      }
+
+      const restoredPhysicalColumn = merge ? this.hot.toPhysicalColumn(merge.col) : null;
+
+      if (merge && (physicalColumn ?? restoredPhysicalColumn) !== null && snapshot.physicalRows.length > 0) {
+        this.#mergeAnchors.set(merge, {
+          physicalRows: snapshot.physicalRows.slice(),
+          physicalColumn: physicalColumn ?? restoredPhysicalColumn!,
+        });
+      }
+    });
+
+    this.#reanchorMergesToVisibleRows();
   }
 
   /**

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -903,7 +903,12 @@ export class MergeCells extends BasePlugin {
     }
 
     snapshots.forEach((snapshot) => {
-      let merge = this.mergedCellsCollection.get(snapshot.row, snapshot.col);
+      const candidate = this.mergedCellsCollection.get(snapshot.row, snapshot.col);
+      // `get()` maps every covered cell, not just the top-left anchor. After a removal has
+      // slid surviving merges up, those coords can belong to a different merge.
+      let merge = candidate && candidate.row === snapshot.row && candidate.col === snapshot.col
+        ? candidate
+        : false;
       const physicalColumn = merge ? this.hot.toPhysicalColumn(merge.col) : null;
 
       if (!merge && snapshot.physicalRows.length > 0) {

--- a/handsontable/src/plugins/nestedRows/AGENTS.md
+++ b/handsontable/src/plugins/nestedRows/AGENTS.md
@@ -327,6 +327,14 @@ They are written in different places and can drift. Keep this in mind:
   `UndoRedo.undo` as the source. Do not fix this by widening `amount` while still dropping
   `__children`. Tests that assert the nested source tree must use `dataManager.getRawSourceData()`,
   because the public `getSourceData()` path is intentionally flattened by `modifyRowData`.
+  Sibling roots go back in **ascending** `index` order: the live array is already compacted, and
+  inserting high indexes first writes past the remaining siblings (`A,B,C` minus `A` and `B`
+  becomes `A,C,B`). `row.index` is the position inside the parent – never use it as a visual-row
+  fallback for the probe hooks; a trimmed root would hand Formulas `0`. Context-menu removal
+  (`ContextMenu.removeRow`) never calls `selection.shiftRows`, so that undo path must not either
+  or the highlight lands below the restored subtree. The create-row probe asks **every** root
+  before deciding, otherwise a later veto leaves the earlier roots' `beforeCreateRow` unpaired
+  and the later root unasked.
 - **AutoRowHeaderSize already subsumes `HeadersUI#updateRowHeaderWidth()` — never measure labels
   here.** That method derives a width from the nesting depth alone
   (`Math.max(50, padding * 2 + 10 * levelCount + 25)`, exactly 61px on a two-level tree in

--- a/handsontable/src/plugins/nestedRows/AGENTS.md
+++ b/handsontable/src/plugins/nestedRows/AGENTS.md
@@ -268,6 +268,21 @@ They are written in different places and can drift. Keep this in mind:
   physical order never diverge because of a move. Only trimming makes them diverge.
 - **UndoRedo** deletes `__children` before storing undo data, because this plugin restores the tree
   itself.
+- **Nested parent undo is a two-phase operation.** The `beforeRemoveRow` list must contain every
+  cached descendant, while `RemoveRowAction` captures the complete subtree before `filterData`
+  mutates the source. Undo restores the tree and physical row/meta slots first, then replays the
+  generic cell values and accessors. The snapshot must also carry every row-index-map value and the
+  collapsed-parent list – restoring only `IndexesSequence` moves trimming and hiding state onto the
+  wrong physical rows. MergeCells needs its physical row anchors restored after its visual geometry.
+  Do not send that geometry through `restoreMergedCells`: `merge()` populates non-corner cells with
+  `null`, and the generic `data` snapshot only holds the parent row. Skip the visual remesh and
+  reattach physical anchors only. A nested undo that cannot land (plugin disabled,
+  `beforeCreateRow` veto) must be refused before `beforeUndo`. Formulas always calls `engine.undo()`
+  there, so a late `{ wasUndone: false }` leaves HyperFormula restored and Handsontable empty.
+  The nested restore emits the normal `beforeCreateRow`/`afterCreateRow` pair with
+  `UndoRedo.undo` as the source. Do not fix this by widening `amount` while still dropping
+  `__children`. Tests that assert the nested source tree must use `dataManager.getRawSourceData()`,
+  because the public `getSourceData()` path is intentionally flattened by `modifyRowData`.
 - **AutoRowHeaderSize already subsumes `HeadersUI#updateRowHeaderWidth()` — never measure labels
   here.** That method derives a width from the nesting depth alone
   (`Math.max(50, padding * 2 + 10 * levelCount + 25)`, exactly 61px on a two-level tree in

--- a/handsontable/src/plugins/nestedRows/__tests__/integration/undoRedo.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/integration/undoRedo.spec.js
@@ -228,18 +228,84 @@ describe('NestedRows', () => {
         }],
         beforeUndo,
         afterUndo,
+        fixedRowsTop: 2,
         nestedRows: true,
       });
 
       await alter('remove_row', 0);
+
+      const fixedRowsTopAfterRemove = getSettings().fixedRowsTop;
+
       getPlugin('nestedRows').disablePlugin();
       getPlugin('undoRedo').undo();
 
       expect(getPlugin('undoRedo').doneActions.length).toBe(1);
       expect(getPlugin('undoRedo').undoneActions.length).toBe(0);
       expect(countRows()).toBe(0);
+      expect(getSettings().fixedRowsTop).toBe(fixedRowsTopAfterRemove);
       expect(beforeUndo).not.toHaveBeenCalled();
       expect(afterUndo).not.toHaveBeenCalled();
+    });
+
+    it('should restore two sibling parents in their original order', async() => {
+      handsontable({
+        data: [
+          { col1: 'A' },
+          { col1: 'B' },
+          { col1: 'C' },
+        ],
+        nestedRows: true,
+      });
+
+      await alter('remove_row', 0, 2);
+      getPlugin('undoRedo').undo();
+
+      expect(getPlugin('nestedRows').dataManager.getRawSourceData()).toEqual([
+        { col1: 'A' },
+        { col1: 'B' },
+        { col1: 'C' },
+      ]);
+    });
+
+    it('should ask every removed root before refusing a later create-row veto', async() => {
+      const beforeCreateRow = jasmine.createSpy('beforeCreateRow').and.callFake(index => index !== 1);
+
+      handsontable({
+        data: [
+          { col1: 'A' },
+          { col1: 'B' },
+          { col1: 'C' },
+        ],
+        beforeCreateRow,
+        nestedRows: true,
+      });
+
+      await alter('remove_row', 0, 2);
+      beforeCreateRow.calls.reset();
+      getPlugin('undoRedo').undo();
+
+      expect(beforeCreateRow.calls.allArgs().map(args => args[0])).toEqual([0, 1]);
+      expect(countRows()).toBe(1);
+      expect(getPlugin('undoRedo').doneActions.length).toBe(1);
+    });
+
+    it('should keep restored cell-option meta out of the user-defined bucket', async() => {
+      handsontable({
+        data: [{
+          col1: 'A1',
+          __children: [{ col1: 'A1.1' }],
+        }],
+        cell: [{ row: 0, col: 0, className: 'from-cell-option' }],
+        nestedRows: true,
+      });
+
+      await alter('remove_row', 0);
+      getPlugin('undoRedo').undo();
+      await updateSettings({
+        cell: [{ row: 0, col: 0, className: 'replaced' }],
+      });
+
+      expect(getCellMeta(0, 0).className).toBe('replaced');
     });
 
     it('should not throw an error when removing a parent row', async() => {

--- a/handsontable/src/plugins/nestedRows/__tests__/integration/undoRedo.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/integration/undoRedo.spec.js
@@ -30,6 +30,218 @@ describe('NestedRows', () => {
       expect(getDataAtCell(1, 0)).toBe('A1.1');
     });
 
+    it('should restore collapsed row state when undoing a removed parent', async() => {
+      handsontable({
+        data: [
+          {
+            col1: 'A1',
+            __children: [{
+              col1: 'A1.1',
+              __children: [{ col1: 'A1.1.1' }],
+            }],
+          },
+          { col1: 'A2' },
+        ],
+        nestedRows: true,
+      });
+
+      getPlugin('nestedRows').collapseParent(0);
+      await alter('remove_row', 0);
+      getPlugin('undoRedo').undo();
+
+      expect(getPlugin('nestedRows').getCollapsedParents()).toEqual([0]);
+      expect(getPlugin('nestedRows').dataManager.getRawSourceData()).toEqual([
+        {
+          col1: 'A1',
+          __children: [{
+            col1: 'A1.1',
+            __children: [{ col1: 'A1.1.1' }],
+          }],
+        },
+        { col1: 'A2' },
+      ]);
+      expect(getPlugin('nestedRows').dataManager.hot.rowIndexMapper.isTrimmed(1)).toBe(true);
+      expect(getPlugin('nestedRows').dataManager.hot.rowIndexMapper.isTrimmed(2)).toBe(true);
+    });
+
+    it('should restore named linked row maps by physical index and order', async() => {
+      handsontable({
+        data: [{
+          col1: 'A1',
+          __children: [{ col1: 'A1.1' }, { col1: 'A1.2' }],
+        }],
+        nestedRows: true,
+      });
+
+      const rowIndexMapper = getPlugin('nestedRows').dataManager.hot.rowIndexMapper;
+      const linkedMap = rowIndexMapper.createAndRegisterIndexMap(
+        'nestedRowsUndoLinkedMap', 'linkedPhysicalIndexToValue'
+      );
+
+      linkedMap.setValueAtIndex(2, 'child-2');
+      linkedMap.setValueAtIndex(1, 'child-1', 0);
+
+      await alter('remove_row', 0);
+      getPlugin('undoRedo').undo();
+
+      expect(linkedMap.getEntries()).toEqual([
+        [1, 'child-1'],
+        [2, 'child-2'],
+      ]);
+    });
+
+    it('should restore merges spanning a removed nested subtree', async() => {
+      handsontable({
+        data: [
+          {
+            col1: 'A1',
+            __children: [{ col1: 'A1.1' }, { col1: 'A1.2' }],
+          },
+          { col1: 'A2' },
+        ],
+        mergeCells: [{ row: 0, col: 0, rowspan: 3, colspan: 1 }],
+        nestedRows: true,
+      });
+
+      getPlugin('nestedRows').collapseParent(0);
+      await alter('remove_row', 0);
+      getPlugin('undoRedo').undo();
+
+      const restoredMerge = getPlugin('mergeCells').mergedCellsCollection.mergedCells[0];
+
+      expect(restoredMerge).toEqual(jasmine.objectContaining({
+        row: 0,
+        col: 0,
+        rowspan: 1,
+        colspan: 1,
+      }));
+
+      getPlugin('nestedRows').expandParent(0);
+
+      expect(getPlugin('mergeCells').mergedCellsCollection.mergedCells[0].rowspan).toBe(3);
+    });
+
+    it('should keep descendant values when undoing a parent under an expanded merge', async() => {
+      handsontable({
+        data: [
+          {
+            col1: 'A1',
+            __children: [{ col1: 'A1.1' }, { col1: 'A1.2' }],
+          },
+          { col1: 'A2' },
+        ],
+        mergeCells: true,
+        nestedRows: true,
+      });
+
+      const mergeCells = getPlugin('mergeCells');
+      const range = mergeCells.hot._createCellRange(
+        mergeCells.hot._createCellCoords(0, 0),
+        mergeCells.hot._createCellCoords(0, 0),
+        mergeCells.hot._createCellCoords(2, 0)
+      );
+
+      // Geometry only: `merge()` would `populateFromArray` nulls into the children before we
+      // remove them, so the undo snapshot would already lack `A1.1` / `A1.2`.
+      mergeCells.mergeRange(range, true, true);
+
+      expect(getPlugin('nestedRows').dataManager.getRawSourceData()).toEqual([
+        {
+          col1: 'A1',
+          __children: [{ col1: 'A1.1' }, { col1: 'A1.2' }],
+        },
+        { col1: 'A2' },
+      ]);
+
+      await alter('remove_row', 0);
+      getPlugin('undoRedo').undo();
+
+      expect(getPlugin('nestedRows').dataManager.getRawSourceData()).toEqual([
+        {
+          col1: 'A1',
+          __children: [{ col1: 'A1.1' }, { col1: 'A1.2' }],
+        },
+        { col1: 'A2' },
+      ]);
+      expect(getPlugin('mergeCells').mergedCellsCollection.mergedCells[0]).toEqual(jasmine.objectContaining({
+        row: 0,
+        col: 0,
+        rowspan: 3,
+        colspan: 1,
+      }));
+    });
+
+    it('should fire row creation hooks when undo restores a nested parent', async() => {
+      const beforeCreateRow = jasmine.createSpy('beforeCreateRow');
+      const afterCreateRow = jasmine.createSpy('afterCreateRow');
+
+      handsontable({
+        data: [{
+          col1: 'A1',
+          __children: [{ col1: 'A1.1' }],
+        }],
+        beforeCreateRow,
+        afterCreateRow,
+        nestedRows: true,
+      });
+
+      await alter('remove_row', 0);
+      getPlugin('undoRedo').undo();
+
+      expect(beforeCreateRow).toHaveBeenCalledWith(0, 2, 'UndoRedo.undo');
+      expect(afterCreateRow).toHaveBeenCalledWith(0, 2, 'UndoRedo.undo');
+    });
+
+    it('should keep the removal action when a create-row hook vetoes undo', async() => {
+      const beforeUndo = jasmine.createSpy('beforeUndo');
+      const afterUndo = jasmine.createSpy('afterUndo');
+
+      handsontable({
+        data: [{
+          col1: 'A1',
+          __children: [{ col1: 'A1.1' }],
+        }],
+        beforeCreateRow: () => false,
+        beforeUndo,
+        afterUndo,
+        nestedRows: true,
+      });
+
+      await alter('remove_row', 0);
+      getPlugin('undoRedo').undo();
+
+      expect(countRows()).toBe(0);
+      expect(getPlugin('undoRedo').doneActions.length).toBe(1);
+      expect(getPlugin('undoRedo').undoneActions.length).toBe(0);
+      expect(beforeUndo).not.toHaveBeenCalled();
+      expect(afterUndo).not.toHaveBeenCalled();
+    });
+
+    it('should keep the nested removal action when the plugin is disabled before undo', async() => {
+      const beforeUndo = jasmine.createSpy('beforeUndo');
+      const afterUndo = jasmine.createSpy('afterUndo');
+
+      handsontable({
+        data: [{
+          col1: 'A1',
+          __children: [{ col1: 'A1.1' }],
+        }],
+        beforeUndo,
+        afterUndo,
+        nestedRows: true,
+      });
+
+      await alter('remove_row', 0);
+      getPlugin('nestedRows').disablePlugin();
+      getPlugin('undoRedo').undo();
+
+      expect(getPlugin('undoRedo').doneActions.length).toBe(1);
+      expect(getPlugin('undoRedo').undoneActions.length).toBe(0);
+      expect(countRows()).toBe(0);
+      expect(beforeUndo).not.toHaveBeenCalled();
+      expect(afterUndo).not.toHaveBeenCalled();
+    });
+
     it('should not throw an error when removing a parent row', async() => {
       const onErrorSpy = spyOn(window, 'onerror').and.returnValue(true);
 
@@ -53,6 +265,19 @@ describe('NestedRows', () => {
       await waitForNextAnimationFrames(2);
 
       expect(onErrorSpy).not.toHaveBeenCalled();
+      expect(countRows()).toBe(2);
+      expect(getDataAtCell(0, 0)).toBe('A1');
+      expect(getDataAtCell(1, 0)).toBe('A1.1');
+      expect(getPlugin('nestedRows').dataManager.getRawSourceData()).toEqual([
+        {
+          col1: 'A1',
+          __children: [{ col1: 'A1.1' }],
+        },
+      ]);
+
+      getPlugin('undoRedo').redo();
+
+      expect(countRows()).toBe(0);
     });
   });
 });

--- a/handsontable/src/plugins/nestedRows/data/dataManager.ts
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.ts
@@ -1,6 +1,6 @@
 import type { HotInstance } from '../../../core/types';
 import { rangeEach } from '../../../helpers/number';
-import { objectEach } from '../../../helpers/object';
+import { deepClone, isPlainObject, objectEach } from '../../../helpers/object';
 import { arrayEach } from '../../../helpers/array';
 import type { NestedRows } from '../nestedRows';
 
@@ -17,11 +17,82 @@ interface NodeInfo {
   level: number;
 }
 
+interface RemovedRowSnapshot {
+  data: RowObject;
+  index: number;
+  path: number[];
+  parentPath: number[] | null;
+  parent: RowObject | null;
+  physicalRows: number[];
+  visualIndex: number | null;
+}
+
+interface IndexMapSnapshot {
+  name: string;
+  values: unknown[];
+  orderOfIndexes?: number[];
+}
+
+interface RowIndexMapsSnapshot {
+  indexesSequence: number[];
+  trimmingMaps: IndexMapSnapshot[];
+  hidingMaps: IndexMapSnapshot[];
+  variousMaps: IndexMapSnapshot[];
+}
+
+export interface NestedRowsRemovalSnapshot {
+  rows: RemovedRowSnapshot[];
+  rowIndexMaps: RowIndexMapsSnapshot;
+  collapsedRows: number[];
+}
+
 interface CacheStructure {
   levels: RowObject[][];
   levelCount: number;
   rows: RowObject[];
   nodeInfo: WeakMap<object, NodeInfo>;
+}
+
+/**
+ * Removes function-valued properties from a cloned row.
+ *
+ * Function values are not cell data and retaining them would alias a callback from the removed
+ * source row onto the row restored by UndoRedo.
+ *
+ * @param {unknown} value The cloned value to clean.
+ */
+function stripFunctionValues(value: unknown): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => {
+      if (typeof entry === 'function') {
+        value[index] = null;
+      } else {
+        stripFunctionValues(entry);
+      }
+    });
+  } else if (isPlainObject(value)) {
+    Object.keys(value).forEach((key) => {
+      if (typeof value[key] === 'function') {
+        delete value[key];
+      } else {
+        stripFunctionValues(value[key]);
+      }
+    });
+  }
+}
+
+/**
+ * Creates a detached copy of a nested row, retaining its complete subtree.
+ *
+ * @param {RowObject} row The row to clone.
+ * @returns {RowObject} The detached row tree.
+ */
+function cloneRowData(row: RowObject): RowObject {
+  const clonedRow = deepClone(row);
+
+  stripFunctionValues(clonedRow);
+
+  return clonedRow;
 }
 
 /**
@@ -115,6 +186,308 @@ class DataManager {
   updateWithData(data: RowObject[]) {
     this.setData(data);
     this.rewriteCache();
+  }
+
+  /**
+   * Captures the top-level roots represented by a physical removal list, including each root's
+   * complete nested subtree and its original parent position.
+   *
+   * Descendants are omitted when an ancestor is also being removed. The parent object reference
+   * lets restoration find a surviving parent even when another removed top-level row shifted its
+   * tree path.
+   *
+   * @param {number[]} physicalRows Physical rows being removed.
+   * @returns {NestedRowsRemovalSnapshot} Detached nested-row removal snapshot.
+   */
+  captureRemovedRows(physicalRows: number[]): NestedRowsRemovalSnapshot {
+    const rowsToRemove = new Set(physicalRows);
+    const rows: RemovedRowSnapshot[] = [];
+
+    physicalRows.forEach((physicalRow) => {
+      const rowObject = this.getDataObject(physicalRow);
+
+      if (!rowObject) {
+        return;
+      }
+
+      const parent = this.getRowParent(rowObject);
+      const parentRow = parent === null ? null : this.getRowIndex(parent);
+
+      if (parentRow !== null && rowsToRemove.has(parentRow)) {
+        return;
+      }
+
+      const path = this.getRowTreePath(physicalRow);
+
+      if (path === null) {
+        return;
+      }
+
+      const subtreePhysicalRows = [physicalRow];
+
+      this.#collectSubtreePhysicalRows(rowObject, subtreePhysicalRows);
+
+      rows.push({
+        data: cloneRowData(rowObject),
+        index: this.getRowIndexWithinParent(rowObject),
+        path,
+        parentPath: parentRow === null ? null : this.getRowTreePath(parentRow),
+        parent,
+        physicalRows: subtreePhysicalRows,
+        visualIndex: this.hot.toVisualRow(physicalRow),
+      });
+    });
+
+    return {
+      rows,
+      rowIndexMaps: this.#captureRowIndexMaps(),
+      collapsedRows: this.plugin.collapsingUI?.getCollapsedParents() ?? [],
+    };
+  }
+
+  /**
+   * Returns every physical row represented by a nested removal snapshot.
+   *
+   * @param {NestedRowsRemovalSnapshot} snapshot Detached nested-row removal snapshot.
+   * @returns {number[]} Physical rows in the removed subtrees.
+   */
+  getRemovedPhysicalRows(snapshot: NestedRowsRemovalSnapshot): number[] {
+    const physicalRows = new Set<number>();
+
+    snapshot.rows.forEach((row) => {
+      row.physicalRows.forEach((physicalRow) => {
+        physicalRows.add(physicalRow);
+      });
+    });
+
+    return Array.from(physicalRows);
+  }
+
+  /**
+   * Runs the create-row lifecycle hooks for a nested undo without mutating the tree.
+   *
+   * UndoRedo must call this before `beforeUndo`. Formulas always calls `engine.undo()` in
+   * `beforeUndo`, so a veto discovered only while applying the snapshot would leave HyperFormula
+   * restored and Handsontable empty.
+   *
+   * @param {NestedRowsRemovalSnapshot} snapshot Detached nested-row removal snapshot.
+   * @returns {boolean} `true` when every restore hook allows the operation.
+   */
+  canRestoreRemovedRows(snapshot: NestedRowsRemovalSnapshot): boolean {
+    return snapshot.rows.every((row) => {
+      const visualIndex = row.visualIndex ?? row.index;
+      const subtreeLength = row.physicalRows.length;
+
+      if (this.hot.runHooks('beforeAlter', 'insert_row_above', visualIndex, subtreeLength, 'UndoRedo.undo') === false ||
+        this.hot.runHooks('beforeCreateRow', visualIndex, subtreeLength, 'UndoRedo.undo') === false) {
+        return false;
+      }
+
+      this.plugin.disableCoreAPIModifiers();
+
+      try {
+        return this.hot.runHooks('beforeDataSplice', row.physicalRows[0], 0, [row.data]) !== false;
+      } finally {
+        this.plugin.enableCoreAPIModifiers();
+      }
+    });
+  }
+
+  /**
+   * Restores nested removal roots at their original parent positions and repairs the row index
+   * mapper to the sequence that existed before the removal.
+   *
+   * Call {@link DataManager#canRestoreRemovedRows} first. This method applies the snapshot and
+   * does not re-run the veto hooks.
+   *
+   * @param {NestedRowsRemovalSnapshot} snapshot Detached nested-row removal snapshot.
+   * @param {number[]} rowIndexesSequence Physical row sequence from before the removal.
+   * @returns {boolean} `true` when the operation was restored.
+   */
+  restoreRemovedRows(snapshot: NestedRowsRemovalSnapshot, rowIndexesSequence: number[]): boolean {
+    if (!this.plugin.enabled || this.plugin.dataManager !== this) {
+      return false;
+    }
+
+    const rowsByParent = new Map<RowObject | null, RemovedRowSnapshot[]>();
+
+    snapshot.rows.forEach((row) => {
+      const parent = row.parent !== null && this.getRowIndex(row.parent) !== null
+        ? row.parent
+        : this.#getRowObjectByTreePath(row.parentPath);
+      const rows = rowsByParent.get(parent) ?? [];
+
+      rows.push({ ...row, parent });
+      rowsByParent.set(parent, rows);
+    });
+
+    rowsByParent.forEach((rows, parent) => {
+      rows.sort((first, second) => second.index - first.index);
+
+      rows.forEach((row) => {
+        if (parent === null) {
+          this.data!.splice(row.index, 0, row.data);
+        } else {
+          if (!Array.isArray(parent.__children)) {
+            parent.__children = [];
+          }
+
+          parent.__children.splice(row.index, 0, row.data);
+        }
+      });
+    });
+
+    this.rewriteCache();
+
+    const restoredPhysicalRows: number[] = [];
+    const restoredRowBlocks: Array<{ physicalRow: number, amount: number, visualIndex: number | null }> = [];
+
+    snapshot.rows.forEach((row) => {
+      const physicalRow = this.getRowIndex(row.data);
+
+      if (physicalRow === null) {
+        return;
+      }
+
+      const subtreeLength = this.countChildren(row.data) + 1;
+
+      restoredRowBlocks.push({ physicalRow, amount: subtreeLength, visualIndex: row.visualIndex });
+
+      for (let offset = 0; offset < subtreeLength; offset++) {
+        restoredPhysicalRows.push(physicalRow + offset);
+      }
+    });
+
+    Array.from(new Set(restoredPhysicalRows))
+      .sort((first, second) => first - second)
+      .forEach((physicalRow) => {
+        this.hot._getMetaManager().createRow(physicalRow, 1);
+      });
+
+    this.#restoreRowIndexMaps(snapshot.rowIndexMaps, rowIndexesSequence);
+
+    if (this.plugin.collapsingUI) {
+      this.plugin.collapsingUI.collapsedRows = snapshot.collapsedRows.slice();
+    }
+
+    restoredRowBlocks.forEach(({ physicalRow, amount, visualIndex }) => {
+      this.hot.runHooks(
+        'afterCreateRow',
+        visualIndex ?? this.hot.toVisualRow(physicalRow) ?? physicalRow,
+        amount,
+        'UndoRedo.undo'
+      );
+    });
+
+    restoredRowBlocks.forEach(({ physicalRow, amount }) => {
+      const visualRow = this.hot.toVisualRow(physicalRow);
+      let visibleAmount = 0;
+
+      for (let offset = 0; offset < amount; offset++) {
+        if (this.hot.toVisualRow(physicalRow + offset) !== null) {
+          visibleAmount += 1;
+        }
+      }
+
+      if (visualRow !== null && visibleAmount > 0) {
+        this.hot.selection.shiftRows(visualRow, visibleAmount);
+      }
+    });
+
+    return true;
+  }
+
+  /**
+   * Captures every row index map by physical index. Row removal compacts the map arrays, so restoring
+   * only the physical order leaves trimming, hiding, and plugin-owned values attached to the wrong
+   * rows.
+   *
+   * @returns {RowIndexMapsSnapshot} Row index-map values from before the removal.
+   */
+  #captureRowIndexMaps(): RowIndexMapsSnapshot {
+    const rowIndexMapper = this.hot.rowIndexMapper;
+
+    return {
+      indexesSequence: rowIndexMapper.getIndexesSequence().slice(),
+      trimmingMaps: this.#captureIndexMapCollection(rowIndexMapper.trimmingMapsCollection),
+      hidingMaps: this.#captureIndexMapCollection(rowIndexMapper.hidingMapsCollection),
+      variousMaps: this.#captureIndexMapCollection(rowIndexMapper.variousMapsCollection),
+    };
+  }
+
+  /**
+   * Restores every row index map after the source tree has been put back.
+   *
+   * @param {RowIndexMapsSnapshot} snapshot Row index-map values from before the removal.
+   * @param {number[]} fallbackSequence The legacy sequence captured by the generic action.
+   */
+  #restoreRowIndexMaps(snapshot: RowIndexMapsSnapshot | undefined, fallbackSequence: number[]) {
+    const rowIndexMapper = this.hot.rowIndexMapper;
+    const indexesSequence = snapshot?.indexesSequence ?? fallbackSequence;
+
+    rowIndexMapper.fitToLength(indexesSequence.length);
+    rowIndexMapper.suspendOperations();
+
+    try {
+      rowIndexMapper.setIndexesSequence(indexesSequence);
+
+      const restoreMaps = (
+        collection: { collection: Map<string, {
+          getValues: () => unknown[];
+          setValues: (values: unknown[]) => void;
+          indexedValues: unknown[];
+          orderOfIndexes?: number[];
+        }> },
+        maps: IndexMapSnapshot[] = []
+      ) => {
+        maps.forEach(({ name, values, orderOfIndexes }) => {
+          const indexMap = collection.collection.get(name);
+
+          if (!indexMap) {
+            return;
+          }
+
+          indexMap.setValues(values);
+
+          if (orderOfIndexes !== undefined && 'orderOfIndexes' in indexMap) {
+            indexMap.orderOfIndexes = orderOfIndexes.slice();
+          }
+        });
+      };
+
+      restoreMaps(rowIndexMapper.trimmingMapsCollection, snapshot?.trimmingMaps);
+      restoreMaps(rowIndexMapper.hidingMapsCollection, snapshot?.hidingMaps);
+      restoreMaps(rowIndexMapper.variousMapsCollection, snapshot?.variousMaps);
+    } finally {
+      rowIndexMapper.resumeOperations();
+    }
+  }
+
+  /**
+   * Captures map values by registration name. Linked maps expose their values in link order, so the
+   * physical backing array and its order are both retained.
+   *
+   * @param {{collection: Map<string, object>}} collection Registered row index maps.
+   * @returns {IndexMapSnapshot[]} Named map snapshots.
+   */
+  #captureIndexMapCollection(collection: {
+    collection: Map<string, {
+      getValues: () => unknown[];
+      indexedValues: unknown[];
+      orderOfIndexes?: number[];
+    }>
+  }): IndexMapSnapshot[] {
+    return Array.from(collection.collection.entries()).map(([name, indexMap]) => {
+      const isLinkedMap = indexMap.orderOfIndexes !== undefined;
+
+      return {
+        name,
+        values: (isLinkedMap ? indexMap.indexedValues : indexMap.getValues()).slice(),
+        ...(isLinkedMap ? {
+          orderOfIndexes: indexMap.orderOfIndexes!.slice(),
+        } : {}),
+      };
+    });
   }
 
   /**
@@ -375,6 +748,57 @@ class DataManager {
     }
 
     return this.getRowIndex(node);
+  }
+
+  /**
+   * Returns the row object at a tree path.
+   *
+   * @param {number[]|null} path Chain of child indexes.
+   * @returns {RowObject|null} The row object, or `null` when the path is invalid.
+   */
+  #getRowObjectByTreePath(path: number[] | null): RowObject | null {
+    if (!Array.isArray(path) || path.length === 0) {
+      return null;
+    }
+
+    let siblings: RowObject[] | null | undefined = this.data;
+    let row: RowObject | null = null;
+
+    for (let i = 0; i < path.length; i++) {
+      row = siblings?.[path[i]] ?? null;
+
+      if (row === null) {
+        return null;
+      }
+
+      siblings = row.__children;
+    }
+
+    return row;
+  }
+
+  /**
+   * Collects the physical rows currently known for a subtree.
+   *
+   * @param {RowObject} row The current subtree node.
+   * @param {number[]} physicalRows Accumulator of known physical rows.
+   */
+  #collectSubtreePhysicalRows(row: RowObject, physicalRows: number[]): void {
+    const children = row.__children;
+
+    if (!Array.isArray(children)) {
+      return;
+    }
+
+    children.forEach((child) => {
+      const childPhysicalRow = this.getRowIndex(child);
+
+      if (childPhysicalRow !== null) {
+        physicalRows.push(childPhysicalRow);
+      }
+
+      this.#collectSubtreePhysicalRows(child, physicalRows);
+    });
   }
 
   /**

--- a/handsontable/src/plugins/nestedRows/data/dataManager.ts
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.ts
@@ -1,6 +1,6 @@
 import type { HotInstance } from '../../../core/types';
 import { rangeEach } from '../../../helpers/number';
-import { deepClone, isPlainObject, objectEach } from '../../../helpers/object';
+import { deepClone, objectEach, stripFunctionValues } from '../../../helpers/object';
 import { arrayEach } from '../../../helpers/array';
 import type { NestedRows } from '../nestedRows';
 
@@ -51,34 +51,6 @@ interface CacheStructure {
   levelCount: number;
   rows: RowObject[];
   nodeInfo: WeakMap<object, NodeInfo>;
-}
-
-/**
- * Removes function-valued properties from a cloned row.
- *
- * Function values are not cell data and retaining them would alias a callback from the removed
- * source row onto the row restored by UndoRedo.
- *
- * @param {unknown} value The cloned value to clean.
- */
-function stripFunctionValues(value: unknown): void {
-  if (Array.isArray(value)) {
-    value.forEach((entry, index) => {
-      if (typeof entry === 'function') {
-        value[index] = null;
-      } else {
-        stripFunctionValues(entry);
-      }
-    });
-  } else if (isPlainObject(value)) {
-    Object.keys(value).forEach((key) => {
-      if (typeof value[key] === 'function') {
-        delete value[key];
-      } else {
-        stripFunctionValues(value[key]);
-      }
-    });
-  }
 }
 
 /**
@@ -264,6 +236,18 @@ class DataManager {
   }
 
   /**
+   * Visual insert index for a captured nested root. `row.index` is the position inside the parent,
+   * so it must not stand in for a missing visual row – a trimmed root would hand the hooks `0`
+   * instead of the physical slot Formulas uses for its veto check.
+   *
+   * @param {RemovedRowSnapshot} row A captured nested removal root.
+   * @returns {number} A visual row, or the physical row when the root was trimmed.
+   */
+  #visualIndexForRemovedRow(row: RemovedRowSnapshot): number {
+    return row.visualIndex ?? this.hot.toVisualRow(row.physicalRows[0]) ?? row.physicalRows[0];
+  }
+
+  /**
    * Runs the create-row lifecycle hooks for a nested undo without mutating the tree.
    *
    * UndoRedo must call this before `beforeUndo`. Formulas always calls `engine.undo()` in
@@ -274,23 +258,44 @@ class DataManager {
    * @returns {boolean} `true` when every restore hook allows the operation.
    */
   canRestoreRemovedRows(snapshot: NestedRowsRemovalSnapshot): boolean {
-    return snapshot.rows.every((row) => {
-      const visualIndex = row.visualIndex ?? row.index;
-      const subtreeLength = row.physicalRows.length;
+    const roots = snapshot.rows.map(row => ({
+      row,
+      visualIndex: this.#visualIndexForRemovedRow(row),
+      subtreeLength: row.physicalRows.length,
+    }));
 
-      if (this.hot.runHooks('beforeAlter', 'insert_row_above', visualIndex, subtreeLength, 'UndoRedo.undo') === false ||
-        this.hot.runHooks('beforeCreateRow', visualIndex, subtreeLength, 'UndoRedo.undo') === false) {
-        return false;
+    // Ask every root before deciding. Stopping at the first `false` would fire the insert
+    // hooks for earlier roots and skip later ones, so a listener pairing before/after on the
+    // first root is left holding state and a veto on the second root is never heard.
+    let allowed = true;
+
+    roots.forEach(({ visualIndex, subtreeLength }) => {
+      if (this.hot.runHooks('beforeAlter', 'insert_row_above', visualIndex, subtreeLength, 'UndoRedo.undo') === false) {
+        allowed = false;
       }
 
+      if (this.hot.runHooks('beforeCreateRow', visualIndex, subtreeLength, 'UndoRedo.undo') === false) {
+        allowed = false;
+      }
+    });
+
+    if (!allowed) {
+      return false;
+    }
+
+    roots.forEach(({ row }) => {
       this.plugin.disableCoreAPIModifiers();
 
       try {
-        return this.hot.runHooks('beforeDataSplice', row.physicalRows[0], 0, [row.data]) !== false;
+        if (this.hot.runHooks('beforeDataSplice', row.physicalRows[0], 0, [row.data]) === false) {
+          allowed = false;
+        }
       } finally {
         this.plugin.enableCoreAPIModifiers();
       }
     });
+
+    return allowed;
   }
 
   /**
@@ -302,9 +307,15 @@ class DataManager {
    *
    * @param {NestedRowsRemovalSnapshot} snapshot Detached nested-row removal snapshot.
    * @param {number[]} rowIndexesSequence Physical row sequence from before the removal.
+   * @param {boolean} [shiftSelection=true] When `false`, skip `selection.shiftRows`. Context-menu
+   *   removal never shifted the highlight, so undoing that path must not push it down by the subtree.
    * @returns {boolean} `true` when the operation was restored.
    */
-  restoreRemovedRows(snapshot: NestedRowsRemovalSnapshot, rowIndexesSequence: number[]): boolean {
+  restoreRemovedRows(
+    snapshot: NestedRowsRemovalSnapshot,
+    rowIndexesSequence: number[],
+    shiftSelection = true
+  ): boolean {
     if (!this.plugin.enabled || this.plugin.dataManager !== this) {
       return false;
     }
@@ -322,7 +333,11 @@ class DataManager {
     });
 
     rowsByParent.forEach((rows, parent) => {
-      rows.sort((first, second) => second.index - first.index);
+      // The live array is already compacted. Inserting high indexes first writes past the
+      // remaining siblings and lands them in the wrong order (A,B,C minus A and B becomes A,C,B).
+      // Ascending original-index order pushes that compacted tail to the right as each root
+      // goes back, which rebuilds the pre-removal layout.
+      rows.sort((first, second) => first.index - second.index);
 
       rows.forEach((row) => {
         if (parent === null) {
@@ -379,20 +394,22 @@ class DataManager {
       );
     });
 
-    restoredRowBlocks.forEach(({ physicalRow, amount }) => {
-      const visualRow = this.hot.toVisualRow(physicalRow);
-      let visibleAmount = 0;
+    if (shiftSelection) {
+      restoredRowBlocks.forEach(({ physicalRow, amount }) => {
+        const visualRow = this.hot.toVisualRow(physicalRow);
+        let visibleAmount = 0;
 
-      for (let offset = 0; offset < amount; offset++) {
-        if (this.hot.toVisualRow(physicalRow + offset) !== null) {
-          visibleAmount += 1;
+        for (let offset = 0; offset < amount; offset++) {
+          if (this.hot.toVisualRow(physicalRow + offset) !== null) {
+            visibleAmount += 1;
+          }
         }
-      }
 
-      if (visualRow !== null && visibleAmount > 0) {
-        this.hot.selection.shiftRows(visualRow, visibleAmount);
-      }
-    });
+        if (visualRow !== null && visibleAmount > 0) {
+          this.hot.selection.shiftRows(visualRow, visibleAmount);
+        }
+      });
+    }
 
     return true;
   }

--- a/handsontable/src/plugins/nestedRows/nestedRows.ts
+++ b/handsontable/src/plugins/nestedRows/nestedRows.ts
@@ -766,13 +766,15 @@ export class NestedRows extends BasePlugin {
    * @private
    * @param {unknown} snapshot An internal nested-row snapshot.
    * @param {number[]} rowIndexesSequence Physical row sequence from before removal.
+   * @param {boolean} [shiftSelection=true] When `false`, skip shifting the highlight. Context-menu
+   *   removal never called `shiftRows`, so undoing that path must not push the selection down.
    */
-  restoreRemovedRows(snapshot: unknown, rowIndexesSequence: number[]): boolean {
+  restoreRemovedRows(snapshot: unknown, rowIndexesSequence: number[], shiftSelection = true): boolean {
     if (!this.#isOperational() || !this.#isNestedRowsRemovalSnapshot(snapshot)) {
       return false;
     }
 
-    const wasRestored = this.dataManager!.restoreRemovedRows(snapshot, rowIndexesSequence);
+    const wasRestored = this.dataManager!.restoreRemovedRows(snapshot, rowIndexesSequence, shiftSelection);
 
     this.hot.selection.refresh();
 

--- a/handsontable/src/plugins/nestedRows/nestedRows.ts
+++ b/handsontable/src/plugins/nestedRows/nestedRows.ts
@@ -1,6 +1,6 @@
 import type { default as CellCoords } from '../../3rdparty/walkontable/src/cell/coords';
 import { BasePlugin } from '../base';
-import DataManager, { type RowObject } from './data/dataManager';
+import DataManager, { type NestedRowsRemovalSnapshot, type RowObject } from './data/dataManager';
 import CollapsingUI from './ui/collapsing';
 import HeadersUI from './ui/headers';
 import ContextMenuUI from './ui/contextMenu';
@@ -716,6 +716,84 @@ export class NestedRows extends BasePlugin {
   }
 
   /**
+   * Captures the nested roots represented by a row removal for UndoRedo.
+   *
+   * @private
+   * @param {number[]} physicalRows Physical rows expanded by the removal hook.
+   * @returns {unknown} An internal nested-row snapshot.
+   */
+  captureRemovedRows(physicalRows: number[]): unknown {
+    if (!this.#isOperational()) {
+      return null;
+    }
+
+    return this.dataManager!.captureRemovedRows(physicalRows);
+  }
+
+  /**
+   * Returns the physical rows represented by an internal nested-row snapshot.
+   *
+   * @private
+   * @param {unknown} snapshot An internal nested-row snapshot.
+   * @returns {number[]} Physical rows in the removed subtrees.
+   */
+  getRemovedPhysicalRows(snapshot: unknown): number[] {
+    if (!this.#isOperational() || !this.#isNestedRowsRemovalSnapshot(snapshot)) {
+      return [];
+    }
+
+    return this.dataManager!.getRemovedPhysicalRows(snapshot);
+  }
+
+  /**
+   * Reports whether a nested-row snapshot can be restored without mutating the tree.
+   *
+   * @private
+   * @param {unknown} snapshot An internal nested-row snapshot.
+   * @returns {boolean} `true` when the plugin is active and the restore hooks allow the operation.
+   */
+  canRestoreRemovedRows(snapshot: unknown): boolean {
+    if (!this.#isOperational() || !this.#isNestedRowsRemovalSnapshot(snapshot)) {
+      return false;
+    }
+
+    return this.dataManager!.canRestoreRemovedRows(snapshot);
+  }
+
+  /**
+   * Restores an internal nested-row snapshot and the physical row sequence it belonged to.
+   *
+   * @private
+   * @param {unknown} snapshot An internal nested-row snapshot.
+   * @param {number[]} rowIndexesSequence Physical row sequence from before removal.
+   */
+  restoreRemovedRows(snapshot: unknown, rowIndexesSequence: number[]): boolean {
+    if (!this.#isOperational() || !this.#isNestedRowsRemovalSnapshot(snapshot)) {
+      return false;
+    }
+
+    const wasRestored = this.dataManager!.restoreRemovedRows(snapshot, rowIndexesSequence);
+
+    this.hot.selection.refresh();
+
+    return wasRestored;
+  }
+
+  /**
+   * Checks whether a value has the shape produced by `captureRemovedRows`.
+   *
+   * @param {unknown} snapshot The value to check.
+   * @returns {boolean}
+   */
+  #isNestedRowsRemovalSnapshot(snapshot: unknown): snapshot is NestedRowsRemovalSnapshot {
+    return typeof snapshot === 'object' && snapshot !== null &&
+      'rows' in snapshot && Array.isArray(snapshot.rows) &&
+      'rowIndexMaps' in snapshot && typeof snapshot.rowIndexMaps === 'object' &&
+      snapshot.rowIndexMaps !== null &&
+      'collapsedRows' in snapshot && Array.isArray(snapshot.collapsedRows);
+  }
+
+  /**
    * @private
    * @param {number} index The index where the data was spliced.
    * @param {number} amount An amount of items to remove.
@@ -820,8 +898,38 @@ export class NestedRows extends BasePlugin {
   };
 
   /**
+   * Adds every descendant of the given node, at every depth, to the set of rows to remove.
+   *
+   * The list is bounded by the flatten cache. A live `__children` tree can be ahead of that cache
+   * when application code mutates source data directly, so a descendant is included only when its
+   * physical index is still known.
+   *
+   * @param {object} node The parent node whose descendants are collected.
+   * @param {Set} removedRows Accumulator of physical indexes to remove.
+   */
+  #collectDescendants = (node: RowObject | null | undefined, removedRows: Set<number>) => {
+    const children = node?.__children;
+
+    if (!Array.isArray(children)) {
+      return;
+    }
+
+    children.forEach((child) => {
+      const childRowIndex = this.dataManager!.getRowIndex(child);
+
+      if (childRowIndex !== null) {
+        removedRows.add(childRowIndex);
+      }
+
+      this.#collectDescendants(child, removedRows);
+    });
+  };
+
+  /**
    * Callback for the `beforeRemoveRow` change list of removed physical indexes by reference. Removing parent node
-   * has effect in removing children nodes.
+   * has the effect of removing its whole subtree, at every depth – removing the parent object from the
+   * source array takes every descendant with it, so a descendant left out of this list would survive in the
+   * index maps as a row with no data behind it.
    *
    * @param {number} index Visual index of starter row.
    * @param {number} amount Amount of rows to be removed.
@@ -829,33 +937,25 @@ export class NestedRows extends BasePlugin {
    */
   #onBeforeRemoveRow = (index: number, amount: number, physicalRows: number[]) => {
     const modifiedPhysicalRows = Array.from(physicalRows.reduce((removedRows: Set<number>, physicalIndex: number) => {
-      if (this.dataManager!.isParent(physicalIndex)) {
-        const children = this.dataManager!.getDataObject(physicalIndex)?.__children;
-
-        // Preserve a parent in the list of removed rows.
-        removedRows.add(physicalIndex);
-
-        if (Array.isArray(children)) {
-          // Add a children to the list of removed rows.
-          children.forEach((child) => {
-            const childRowIndex = this.dataManager!.getRowIndex(child);
-
-            if (childRowIndex !== null) {
-              removedRows.add(childRowIndex);
-            }
-          });
-        }
-
+      if (removedRows.has(physicalIndex)) {
         return removedRows;
       }
 
-      // Don't modify list of removed rows when already checked element isn't a parent.
-      return removedRows.add(physicalIndex);
+      removedRows.add(physicalIndex);
+
+      if (this.dataManager!.isParent(physicalIndex)) {
+        this.#collectDescendants(this.dataManager!.getDataObject(physicalIndex), removedRows);
+      }
+
+      return removedRows;
     }, new Set()));
 
     // Modifying hook's argument by the reference.
     physicalRows.length = 0;
-    physicalRows.push(...modifiedPhysicalRows);
+
+    modifiedPhysicalRows.forEach((physicalIndex) => {
+      physicalRows.push(physicalIndex);
+    });
   };
 
   /**

--- a/handsontable/src/plugins/undoRedo/AGENTS.md
+++ b/handsontable/src/plugins/undoRedo/AGENTS.md
@@ -40,6 +40,13 @@ snapshot** — exposes `canUndo(hot)`. `UndoRedo.undo()` calls it **before** `be
 always calls `engine.undo()` in `beforeUndo`, so a veto or a disabled NestedRows plugin discovered
 only while applying the snapshot would leave HyperFormula restored and Handsontable empty. A late
 `{ wasUndone: false }` still puts the action back on the done stack and must **not** emit `afterUndo`.
+Write `settings.fixedRowsTop` / `fixedRowsBottom` **after** that restore lands: those two assignments
+mutate the settings object by reference, and a refused nested undo would otherwise leave the
+frozen-row counts of a state that never came back. Nested cell-meta restore must reopen the origin
+that filed each key (`startCellOptionMetaRecording`, a plain `setCellMeta`, or
+`disableUserDefinedMetaRecording`); a bare write files everything as user-defined and #5661
+returns. The merge snapshot type is `import type { PhysicalRowMergeSnapshot }` from MergeCells —
+type-only, so registering UndoRedo still does not pull that plugin into the bundle.
 
 ## `MoveCellsAction` is the asymmetric one, in three ways
 

--- a/handsontable/src/plugins/undoRedo/AGENTS.md
+++ b/handsontable/src/plugins/undoRedo/AGENTS.md
@@ -35,6 +35,12 @@ Most actions settle the redo by calling back with **no argument**. An action tha
 redo — **currently only `MoveCellsAction`** — reports `{ wasRedone: false }`, which pushes the action back
 onto the **undone** stack instead of the done stack.
 
+An action that can legitimately fail to undo — **currently only `RemoveRowAction` with a nested
+snapshot** — exposes `canUndo(hot)`. `UndoRedo.undo()` calls it **before** `beforeUndo`. Formulas
+always calls `engine.undo()` in `beforeUndo`, so a veto or a disabled NestedRows plugin discovered
+only while applying the snapshot would leave HyperFormula restored and Handsontable empty. A late
+`{ wasUndone: false }` still puts the action back on the done stack and must **not** emit `afterUndo`.
+
 ## `MoveCellsAction` is the asymmetric one, in three ways
 
 1. **Its `undo` restores both regions with `restoreRegion` instead of replaying the move**, so

--- a/handsontable/src/plugins/undoRedo/actions/removeRow.ts
+++ b/handsontable/src/plugins/undoRedo/actions/removeRow.ts
@@ -3,45 +3,10 @@ import type { HotInstance } from '../../../core/types';
 import type { UndoRedoActionResult } from '../undoRedo';
 import { BaseAction } from './_base';
 import { getCellMetas, collectAffectedMergedCells, restoreMergedCells } from '../utils';
-import { deepClone, isPlainObject } from '../../../helpers/object';
+import { deepClone, isPlainObject, stripFunctionValues } from '../../../helpers/object';
 import { isDataAccessorFn } from '../../../dataMap/dataSource';
 import type { DataAccessorFn } from '../../../dataMap/dataSource';
-
-type NestedRemovedMergedCell = {
-  row: number;
-  col: number;
-  rowspan: number;
-  colspan: number;
-  physicalRows: number[];
-};
-
-/**
- * Recursively deletes function-valued keys from a cloned row. `deepClone` keeps functions by
- * reference at every depth, so a top-level-only sweep would still alias a nested closure of the
- * removed row onto the row the `dataSchema` creates on undo.
- *
- * @param {unknown} value The cloned value to sweep.
- */
-function stripFunctionValues(value: unknown): void {
-  if (Array.isArray(value)) {
-    value.forEach((entry, index) => {
-      if (typeof entry === 'function') {
-        value[index] = null;
-      } else {
-        stripFunctionValues(entry);
-      }
-    });
-
-  } else if (isPlainObject(value)) {
-    Object.keys(value).forEach((key) => {
-      if (typeof value[key] === 'function') {
-        delete value[key];
-      } else {
-        stripFunctionValues(value[key]);
-      }
-    });
-  }
-}
+import type { PhysicalRowMergeSnapshot } from '../../mergeCells/mergeCells';
 
 /**
  * Snapshots one source row for later restoration. Function-valued keys are dropped (at every
@@ -135,10 +100,10 @@ function capturePhysicalCellMetas(
  * @param {number[]} physicalRows Physical rows being removed.
  * @returns {Array<object>} A de-duplicated list of affected merged ranges.
  */
-function collectNestedRemovedMergedCells(hot: HotInstance, physicalRows: number[]): NestedRemovedMergedCell[] {
+function collectNestedRemovedMergedCells(hot: HotInstance, physicalRows: number[]): PhysicalRowMergeSnapshot[] {
   type MergeCellsPlugin = {
     enabled?: boolean;
-    getPhysicalRowSpansForRemoval?: () => NestedRemovedMergedCell[];
+    getPhysicalRowSpansForRemoval?: () => PhysicalRowMergeSnapshot[];
   };
   const mergeCellsPlugin = hot.getPlugin('mergeCells') as MergeCellsPlugin | undefined;
 
@@ -217,7 +182,14 @@ export class RemoveRowAction extends BaseAction {
    *
    * @type {Array}
    */
-  declare nestedRemovedMergedCells?: NestedRemovedMergedCell[];
+  declare nestedRemovedMergedCells?: PhysicalRowMergeSnapshot[];
+  /**
+   * Source of the nested removal (`ContextMenu.removeRow`, `UndoRedo.redo`, and so on). Context-menu
+   * removal does not call `selection.shiftRows`, so undo must not either.
+   *
+   * @type {string}
+   */
+  declare nestedRemovalSource?: string;
 
   /**
    * Initializes the remove row action with the removed data, captured accessor-column values, row index
@@ -236,6 +208,7 @@ export class RemoveRowAction extends BaseAction {
     nestedRemovedCellMetas,
     nestedAccessorValues,
     nestedRemovedMergedCells,
+    nestedRemovalSource,
   }: {
     index: number, indexes?: number[], data: unknown[][], accessorValues: Array<Array<[number, unknown]>>,
     fixedRowsBottom: number, fixedRowsTop: number,
@@ -244,7 +217,8 @@ export class RemoveRowAction extends BaseAction {
     nestedRowsSnapshot?: unknown,
     nestedRemovedCellMetas?: Array<[number, number, Record<string, unknown>]>,
     nestedAccessorValues?: Array<{ row: number, values: Array<[number, unknown]> }>,
-    nestedRemovedMergedCells?: NestedRemovedMergedCell[],
+    nestedRemovedMergedCells?: PhysicalRowMergeSnapshot[],
+    nestedRemovalSource?: string,
   }) {
     super('remove_row');
     this.index = index;
@@ -261,6 +235,7 @@ export class RemoveRowAction extends BaseAction {
       this.nestedRemovedCellMetas = nestedRemovedCellMetas;
       this.nestedAccessorValues = nestedAccessorValues;
       this.nestedRemovedMergedCells = nestedRemovedMergedCells;
+      this.nestedRemovalSource = nestedRemovalSource;
     }
   }
 
@@ -320,6 +295,7 @@ export class RemoveRowAction extends BaseAction {
           nestedRemovedCellMetas,
           nestedAccessorValues,
           nestedRemovedMergedCells,
+          nestedRemovalSource: source,
         });
       };
 
@@ -356,10 +332,6 @@ export class RemoveRowAction extends BaseAction {
   undo(hot: HotInstance, undoneCallback: (result?: UndoRedoActionResult) => void) {
     const settings = hot.getSettings();
     const changes: unknown[][] = [];
-
-    // Changing by the reference as `updateSettings` doesn't work the best.
-    settings.fixedRowsBottom = this.fixedRowsBottom;
-    settings.fixedRowsTop = this.fixedRowsTop;
 
     // Prepare the change list to fill the source data.
     this.data.forEach((row, rowIndexDelta) => {
@@ -410,7 +382,11 @@ export class RemoveRowAction extends BaseAction {
     }
 
     if (this.nestedRowsSnapshot !== undefined && nestedRows.enabled) {
-      const wasRestored = nestedRows.restoreRemovedRows(this.nestedRowsSnapshot, this.rowIndexesSequence);
+      const wasRestored = nestedRows.restoreRemovedRows(
+        this.nestedRowsSnapshot,
+        this.rowIndexesSequence,
+        this.nestedRemovalSource !== 'ContextMenu.removeRow'
+      );
 
       if (!wasRestored) {
         undoneCallback({ wasUndone: false });
@@ -428,6 +404,10 @@ export class RemoveRowAction extends BaseAction {
       hot.alter('insert_row_above', hot.toVisualRow(this.index), this.data.length, 'UndoRedo.undo');
       hot.rowIndexMapper.setIndexesSequence(this.rowIndexesSequence);
     }
+
+    // Changing by the reference as `updateSettings` doesn't work the best.
+    settings.fixedRowsBottom = this.fixedRowsBottom;
+    settings.fixedRowsTop = this.fixedRowsTop;
 
     if (this.nestedRowsSnapshot !== undefined && this.nestedRemovedCellMetas) {
       const metaManager = hot._getMetaManager();
@@ -447,7 +427,30 @@ export class RemoveRowAction extends BaseAction {
             }
           }
 
-          metaManager.setCellMeta(physicalRow, physicalColumn, key, cellMeta[key]);
+          // Re-open the origin that filed the write. A bare `setCellMeta` would put every
+          // key in `_userDefinedMetaProps` and drop it from `_cellOptionMetaProps`, so a
+          // later `updateSettings({ cell: [...] })` would replay the stale value (#5661).
+          // Plugin-declarative keys (ColumnSummary `readOnly`) belong to no bucket.
+          const cellOptionKeys = cellMeta._cellOptionMetaProps;
+          const userDefinedKeys = cellMeta._userDefinedMetaProps;
+          const isCellOption = cellOptionKeys instanceof Set && cellOptionKeys.has(key);
+          const isUserDefined = userDefinedKeys instanceof Set && userDefinedKeys.has(key);
+
+          if (isCellOption) {
+            metaManager.startCellOptionMetaRecording();
+          } else if (!isUserDefined) {
+            metaManager.disableUserDefinedMetaRecording();
+          }
+
+          try {
+            metaManager.setCellMeta(physicalRow, physicalColumn, key, cellMeta[key]);
+          } finally {
+            if (isCellOption) {
+              metaManager.endCellOptionMetaRecording();
+            } else if (!isUserDefined) {
+              metaManager.enableUserDefinedMetaRecording();
+            }
+          }
 
           if (canUsePublicMetaHooks) {
             hot.runHooks('afterSetCellMeta', visualRow, visualColumn, key, cellMeta[key]);
@@ -482,7 +485,7 @@ export class RemoveRowAction extends BaseAction {
 
     if (this.nestedRemovedMergedCells?.length) {
       type MergeCellsPlugin = {
-        restorePhysicalRowSpansAfterRemoval?: (snapshots: NestedRemovedMergedCell[]) => void;
+        restorePhysicalRowSpansAfterRemoval?: (snapshots: PhysicalRowMergeSnapshot[]) => void;
       };
       const mergeCellsPlugin = hot.getPlugin('mergeCells') as MergeCellsPlugin | undefined;
 

--- a/handsontable/src/plugins/undoRedo/actions/removeRow.ts
+++ b/handsontable/src/plugins/undoRedo/actions/removeRow.ts
@@ -1,10 +1,19 @@
 import type { HookCallback } from '../../../core/hooks/bucket';
 import type { HotInstance } from '../../../core/types';
+import type { UndoRedoActionResult } from '../undoRedo';
 import { BaseAction } from './_base';
 import { getCellMetas, collectAffectedMergedCells, restoreMergedCells } from '../utils';
 import { deepClone, isPlainObject } from '../../../helpers/object';
 import { isDataAccessorFn } from '../../../dataMap/dataSource';
 import type { DataAccessorFn } from '../../../dataMap/dataSource';
+
+type NestedRemovedMergedCell = {
+  row: number;
+  col: number;
+  rowspan: number;
+  colspan: number;
+  physicalRows: number[];
+};
 
 /**
  * Recursively deletes function-valued keys from a cloned row. `deepClone` keeps functions by
@@ -98,6 +107,52 @@ function captureAccessorValues(
 }
 
 /**
+ * Captures cell metadata by physical row so nested rows can restore metadata for every descendant.
+ *
+ * @param {HotInstance} hot The Handsontable instance.
+ * @param {number[]} physicalRows Physical rows being removed.
+ * @returns {Array<[number, number, object]>} Physical row/column metadata entries.
+ */
+function capturePhysicalCellMetas(
+  hot: HotInstance, physicalRows: number[]
+): Array<[number, number, Record<string, unknown>]> {
+  const cellMetas: Array<[number, number, Record<string, unknown>]> = [];
+  const metaManager = hot._getMetaManager();
+
+  physicalRows.forEach((physicalRow) => {
+    metaManager.getCellsMetaAtRowWithPhysicalColumns(physicalRow).forEach(({ physicalColumn, meta }) => {
+      cellMetas.push([physicalRow, physicalColumn, meta as Record<string, unknown>]);
+    });
+  });
+
+  return cellMetas;
+}
+
+/**
+ * Captures merged ranges intersecting every visible row in a nested removal.
+ *
+ * @param {HotInstance} hot The Handsontable instance.
+ * @param {number[]} physicalRows Physical rows being removed.
+ * @returns {Array<object>} A de-duplicated list of affected merged ranges.
+ */
+function collectNestedRemovedMergedCells(hot: HotInstance, physicalRows: number[]): NestedRemovedMergedCell[] {
+  type MergeCellsPlugin = {
+    enabled?: boolean;
+    getPhysicalRowSpansForRemoval?: () => NestedRemovedMergedCell[];
+  };
+  const mergeCellsPlugin = hot.getPlugin('mergeCells') as MergeCellsPlugin | undefined;
+
+  if (!mergeCellsPlugin?.enabled || !mergeCellsPlugin.getPhysicalRowSpansForRemoval) {
+    return [];
+  }
+
+  const removedPhysicalRows = new Set(physicalRows);
+
+  return mergeCellsPlugin.getPhysicalRowSpansForRemoval()
+    .filter(mergedCell => mergedCell.physicalRows.some(physicalRow => removedPhysicalRows.has(physicalRow)));
+}
+
+/**
  * Action that tracks changes in row removal.
  *
  * @class RemoveRowAction
@@ -139,10 +194,34 @@ export class RemoveRowAction extends BaseAction {
    *   the removed rows. Stored as plain `{ row, col, rowspan, colspan }` objects in visual coords.
    */
   removedMergedCells;
+  /**
+   * Internal snapshot supplied by the NestedRows plugin when a removed row owns a nested subtree.
+   *
+   * @type {unknown}
+   */
+  declare nestedRowsSnapshot?: unknown;
+  /**
+   * Cell metadata captured in physical coordinates for nested rows.
+   *
+   * @type {Array}
+   */
+  declare nestedRemovedCellMetas?: Array<[number, number, Record<string, unknown>]>;
+  /**
+   * Accessor-column values captured for every physical row in a nested subtree.
+   *
+   * @type {Array}
+   */
+  declare nestedAccessorValues?: Array<{ row: number, values: Array<[number, unknown]> }>;
+  /**
+   * Merge geometry and physical anchors captured for nested rows.
+   *
+   * @type {Array}
+   */
+  declare nestedRemovedMergedCells?: NestedRemovedMergedCell[];
 
   /**
    * Initializes the remove row action with the removed data, captured accessor-column values, row index
-   * sequence, fixed-row counts, cell meta backup, and affected merged cells.
+   * sequence, fixed-row counts, cell meta backup, affected merged cells, and an optional nested-row snapshot.
    */
   constructor({
     index,
@@ -153,11 +232,19 @@ export class RemoveRowAction extends BaseAction {
     rowIndexesSequence,
     removedCellMetas,
     removedMergedCells,
+    nestedRowsSnapshot,
+    nestedRemovedCellMetas,
+    nestedAccessorValues,
+    nestedRemovedMergedCells,
   }: {
     index: number, indexes?: number[], data: unknown[][], accessorValues: Array<Array<[number, unknown]>>,
     fixedRowsBottom: number, fixedRowsTop: number,
     rowIndexesSequence: number[], removedCellMetas: unknown[],
-    removedMergedCells: Array<{ row: number, col: number, rowspan: number, colspan: number }>
+    removedMergedCells: Array<{ row: number, col: number, rowspan: number, colspan: number }>,
+    nestedRowsSnapshot?: unknown,
+    nestedRemovedCellMetas?: Array<[number, number, Record<string, unknown>]>,
+    nestedAccessorValues?: Array<{ row: number, values: Array<[number, unknown]> }>,
+    nestedRemovedMergedCells?: NestedRemovedMergedCell[],
   }) {
     super('remove_row');
     this.index = index;
@@ -168,6 +255,13 @@ export class RemoveRowAction extends BaseAction {
     this.rowIndexesSequence = rowIndexesSequence;
     this.removedCellMetas = removedCellMetas;
     this.removedMergedCells = removedMergedCells;
+
+    if (nestedRowsSnapshot !== null && nestedRowsSnapshot !== undefined) {
+      this.nestedRowsSnapshot = nestedRowsSnapshot;
+      this.nestedRemovedCellMetas = nestedRemovedCellMetas;
+      this.nestedAccessorValues = nestedAccessorValues;
+      this.nestedRemovedMergedCells = nestedRemovedMergedCells;
+    }
   }
 
   /**
@@ -181,6 +275,32 @@ export class RemoveRowAction extends BaseAction {
         const removedData: unknown[] = [];
         const removedAccessorValues: Array<Array<[number, unknown]>> = [];
         const accessorColumns = collectAccessorColumns(hot);
+        const removedPhysicalRows = Array.isArray(logicRows)
+          ? logicRows.filter((row): row is number => typeof row === 'number')
+          : [];
+        const nestedRows = hot.getPlugin('nestedRows');
+        const nestedRowsSnapshot = nestedRows?.enabled
+          ? nestedRows.captureRemovedRows(removedPhysicalRows)
+          : null;
+        const hasNestedRowsSnapshot = nestedRowsSnapshot !== null && nestedRowsSnapshot !== undefined;
+        const nestedRemovedPhysicalRows = hasNestedRowsSnapshot && nestedRows
+          ? nestedRows.getRemovedPhysicalRows(nestedRowsSnapshot)
+          : [];
+        const nestedRemovedCellMetas = hasNestedRowsSnapshot
+          ? capturePhysicalCellMetas(hot, nestedRemovedPhysicalRows)
+          : undefined;
+        const nestedAccessorValues = hasNestedRowsSnapshot
+          ? nestedRemovedPhysicalRows.map(row => ({
+            row,
+            values: captureAccessorValues(hot, row, accessorColumns),
+          }))
+          : undefined;
+        const nestedRemovedMergedCells = hasNestedRowsSnapshot
+          ? collectNestedRemovedMergedCells(hot, nestedRemovedPhysicalRows)
+          : undefined;
+        const removedMergedCells = nestedRemovedMergedCells
+          ? nestedRemovedMergedCells.map(({ physicalRows: _physicalRows, ...mergedCell }) => mergedCell)
+          : collectAffectedMergedCells(hot, 'row', index, amount);
 
         for (let i = 0; i < amount; i++) {
           removedData.push(captureRowData(hot, physicalRowIndex + i));
@@ -195,7 +315,11 @@ export class RemoveRowAction extends BaseAction {
           fixedRowsTop: hot.getSettings().fixedRowsTop ?? 0,
           rowIndexesSequence: hot.rowIndexMapper.getIndexesSequence(),
           removedCellMetas: getCellMetas(hot, physicalRowIndex, lastRowIndex, 0, hot.countCols() - 1),
-          removedMergedCells: collectAffectedMergedCells(hot, 'row', index, amount),
+          removedMergedCells,
+          nestedRowsSnapshot,
+          nestedRemovedCellMetas,
+          nestedAccessorValues,
+          nestedRemovedMergedCells,
         });
       };
 
@@ -206,10 +330,30 @@ export class RemoveRowAction extends BaseAction {
   }
 
   /**
+   * Reports whether this nested removal can be undone without mutating the grid.
+   *
+   * UndoRedo must call this before `beforeUndo`. Formulas always calls `engine.undo()` in
+   * `beforeUndo`, so a disabled plugin or a create-row veto discovered only while applying
+   * the snapshot would leave HyperFormula restored and Handsontable empty.
+   *
+   * @param {Core} hot The Handsontable instance.
+   * @returns {boolean} `true` when undo can proceed.
+   */
+  canUndo(hot: HotInstance): boolean {
+    if (this.nestedRowsSnapshot === undefined) {
+      return true;
+    }
+
+    const nestedRows = hot.getPlugin('nestedRows');
+
+    return !!nestedRows?.enabled && nestedRows.canRestoreRemovedRows(this.nestedRowsSnapshot);
+  }
+
+  /**
    * @param {Core} hot The Handsontable instance.
    * @param {function(): void} undoneCallback The callback to be called after the action is undone.
    */
-  undo(hot: HotInstance, undoneCallback: HookCallback) {
+  undo(hot: HotInstance, undoneCallback: (result?: UndoRedoActionResult) => void) {
     const settings = hot.getSettings();
     const changes: unknown[][] = [];
 
@@ -235,33 +379,115 @@ export class RemoveRowAction extends BaseAction {
     // an accessor. A hidden column keeps its visual index, so it restores like any other. A column
     // trimmed at removal time is never captured either, because `captureAccessorValues` iterates
     // `countCols()`, which does not count trimmed columns.
-    this.accessorValues.forEach((rowValues, rowIndexDelta) => {
-      rowValues.forEach(([physicalColumn, value]) => {
-        const prop: unknown = hot.colToProp(hot.toVisualColumn(physicalColumn));
+    if (this.nestedRowsSnapshot !== undefined) {
+      this.nestedAccessorValues?.forEach(({ row, values }) => {
+        values.forEach(([physicalColumn, value]) => {
+          const prop: unknown = hot.colToProp(hot.toVisualColumn(physicalColumn));
 
-        if (isDataAccessorFn(prop)) {
-          changes.push([this.index + rowIndexDelta, prop, value]);
+          if (isDataAccessorFn(prop)) {
+            changes.push([row, prop, value]);
+          }
+        });
+      });
+    } else {
+      this.accessorValues.forEach((rowValues, rowIndexDelta) => {
+        rowValues.forEach(([physicalColumn, value]) => {
+          const prop: unknown = hot.colToProp(hot.toVisualColumn(physicalColumn));
+
+          if (isDataAccessorFn(prop)) {
+            changes.push([this.index + rowIndexDelta, prop, value]);
+          }
+        });
+      });
+    }
+
+    const nestedRows = hot.getPlugin('nestedRows');
+
+    if (this.nestedRowsSnapshot !== undefined && !nestedRows?.enabled) {
+      undoneCallback({ wasUndone: false });
+
+      return;
+    }
+
+    if (this.nestedRowsSnapshot !== undefined && nestedRows.enabled) {
+      const wasRestored = nestedRows.restoreRemovedRows(this.nestedRowsSnapshot, this.rowIndexesSequence);
+
+      if (!wasRestored) {
+        undoneCallback({ wasUndone: false });
+
+        return;
+      }
+    } else {
+      // The indexes sequence have to be applied twice.
+      //  * First for proper index translation. The alter method accepts a visual index
+      //    and we are able to retrieve the correct index indicating where to add a new row based
+      //    only on the previous order state of the rows;
+      //  * The alter method shifts the indexes (a side-effect), so we need to reapply the indexes sequence
+      //    the same as it was in the previous state;
+      hot.rowIndexMapper.setIndexesSequence(this.rowIndexesSequence);
+      hot.alter('insert_row_above', hot.toVisualRow(this.index), this.data.length, 'UndoRedo.undo');
+      hot.rowIndexMapper.setIndexesSequence(this.rowIndexesSequence);
+    }
+
+    if (this.nestedRowsSnapshot !== undefined && this.nestedRemovedCellMetas) {
+      const metaManager = hot._getMetaManager();
+
+      this.nestedRemovedCellMetas.forEach(([physicalRow, physicalColumn, cellMeta]) => {
+        const visualRow = hot.toVisualRow(physicalRow);
+        const visualColumn = hot.toVisualColumn(physicalColumn);
+        const canUsePublicMetaHooks = visualRow !== null && visualColumn !== null;
+        const restoreMeta = (key: string) => {
+          if (canUsePublicMetaHooks) {
+            const allowSetCellMeta = hot.runHooks(
+              'beforeSetCellMeta', visualRow, visualColumn, key, cellMeta[key]
+            );
+
+            if (allowSetCellMeta === false) {
+              return;
+            }
+          }
+
+          metaManager.setCellMeta(physicalRow, physicalColumn, key, cellMeta[key]);
+
+          if (canUsePublicMetaHooks) {
+            hot.runHooks('afterSetCellMeta', visualRow, visualColumn, key, cellMeta[key]);
+          }
+        };
+        const persistedMetaProps = cellMeta._persistedMetaProps;
+
+        if (persistedMetaProps instanceof Set) {
+          persistedMetaProps.forEach((key) => {
+            if (Object.prototype.hasOwnProperty.call(cellMeta, key)) {
+              restoreMeta(key);
+            }
+          });
+
+        } else {
+          Object.keys(cellMeta)
+            .filter(key => !['row', 'col', 'prop', 'visualRow', 'visualCol', '_isBaseRendererCalled'].includes(key))
+            .forEach(restoreMeta);
         }
       });
-    });
+    } else {
+      this.removedCellMetas.forEach((entry: unknown) => {
+        const [rowIndex, columnIndex, cellMeta] = entry as [number, number, Record<string, unknown>];
 
-    // The indexes sequence have to be applied twice.
-    //  * First for proper index translation. The alter method accepts a visual index
-    //    and we are able to retrieve the correct index indicating where to add a new row based
-    //    only on the previous order state of the rows;
-    //  * The alter method shifts the indexes (a side-effect), so we need to reapply the indexes sequence
-    //    the same as it was in the previous state;
-    hot.rowIndexMapper.setIndexesSequence(this.rowIndexesSequence);
-    hot.alter('insert_row_above', hot.toVisualRow(this.index), this.data.length, 'UndoRedo.undo');
-    hot.rowIndexMapper.setIndexesSequence(this.rowIndexesSequence);
+        hot.setCellMetaObject(rowIndex, columnIndex, cellMeta);
+      });
+    }
 
-    this.removedCellMetas.forEach((entry: unknown) => {
-      const [rowIndex, columnIndex, cellMeta] = entry as [number, number, Record<string, unknown>];
+    if (this.nestedRowsSnapshot === undefined) {
+      restoreMergedCells(hot, this.removedMergedCells);
+    }
 
-      hot.setCellMetaObject(rowIndex, columnIndex, cellMeta);
-    });
+    if (this.nestedRemovedMergedCells?.length) {
+      type MergeCellsPlugin = {
+        restorePhysicalRowSpansAfterRemoval?: (snapshots: NestedRemovedMergedCell[]) => void;
+      };
+      const mergeCellsPlugin = hot.getPlugin('mergeCells') as MergeCellsPlugin | undefined;
 
-    restoreMergedCells(hot, this.removedMergedCells);
+      mergeCellsPlugin?.restorePhysicalRowSpansAfterRemoval?.(this.nestedRemovedMergedCells);
+    }
 
     hot.addHookOnce('afterViewRender', undoneCallback);
 

--- a/handsontable/src/plugins/undoRedo/undoRedo.ts
+++ b/handsontable/src/plugins/undoRedo/undoRedo.ts
@@ -11,6 +11,10 @@ export interface UndoRedoAction {
   [key: string]: unknown;
 }
 
+export interface UndoRedoActionResult {
+  wasUndone?: boolean;
+}
+
 export const PLUGIN_KEY = 'undoRedo';
 export const PLUGIN_PRIORITY = 1000;
 
@@ -245,6 +249,18 @@ export class UndoRedo extends BasePlugin {
       return;
     }
 
+    type UndoableAction = {
+      canUndo?: (hot: HotInstance) => boolean
+      undo: (hot: HotInstance, callback: (result?: UndoRedoActionResult) => void) => void
+    };
+    const pendingAction = this.doneActions[this.doneActions.length - 1] as UndoableAction;
+
+    // A nested remove-row undo can still fail (plugin disabled, create-row veto). Formulas
+    // always calls `engine.undo()` in `beforeUndo`, so that check has to win first.
+    if (pendingAction.canUndo?.(this.hot) === false) {
+      return;
+    }
+
     const doneActionsCopy = this.doneActions.slice();
 
     this.hot.runHooks('beforeUndoStackChange', doneActionsCopy);
@@ -266,10 +282,18 @@ export class UndoRedo extends BasePlugin {
 
     this.hot.runHooks('beforeRedoStackChange', undoneActionsCopy);
 
+    let wasUndone = true;
+
     try {
-      (action as { undo: (hot: HotInstance, callback: () => void) => void }).undo(this.hot, () => {
+      (action as UndoableAction).undo(this.hot, (result) => {
         this.ignoreNewActions = false;
-        this.undoneActions.push(action);
+        wasUndone = result?.wasUndone !== false;
+
+        if (wasUndone) {
+          this.undoneActions.push(action);
+        } else {
+          this.doneActions.push(action);
+        }
       });
 
     } catch (error) {
@@ -282,7 +306,10 @@ export class UndoRedo extends BasePlugin {
     }
 
     this.hot.runHooks('afterRedoStackChange', undoneActionsCopy, this.undoneActions.slice());
-    this.hot.runHooks('afterUndo', actionClone);
+
+    if (wasUndone) {
+      this.hot.runHooks('afterUndo', actionClone);
+    }
   }
 
   /**

--- a/tests/e2e/nested-rows-undo.spec.ts
+++ b/tests/e2e/nested-rows-undo.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '../fixtures/test';
+import { NestedRowsUndoPage } from '../fixtures/pages/NestedRowsUndoPage';
+
+const EXPECTED_NAMES = [
+  'Leaf 0',
+  'Leaf 1',
+  'Leaf 2',
+  'Leaf 3',
+  'Leaf 4',
+  'Leaf 5',
+  'Leaf 6',
+  'Leaf 7',
+  'Leaf 8',
+  'Leaf 9',
+  'Leaf 10',
+  'Leaf 11',
+  'Leaf 12',
+  'Parent 13',
+  'Child 13',
+  'Grandchild 13',
+  'After 13',
+];
+
+/**
+ * DEV-30: removing a nested parent through the context menu and undoing with Cmd/Ctrl+Z must
+ * restore the complete source subtree, not only the flat parent row.
+ */
+test('undo restores a removed nested parent and its descendants', async({ page, theme, bundle }) => {
+  const nestedRows = new NestedRowsUndoPage(page, theme, bundle);
+
+  await nestedRows.goto();
+  expect(await nestedRows.visibleNames()).toEqual(EXPECTED_NAMES);
+
+  await nestedRows.removeRowViaContextMenu(13);
+
+  const removedState = await nestedRows.state();
+  expect(removedState.sourceData).toEqual([
+    { name: 'Leaf 0' },
+    { name: 'Leaf 1' },
+    { name: 'Leaf 2' },
+    { name: 'Leaf 3' },
+    { name: 'Leaf 4' },
+    { name: 'Leaf 5' },
+    { name: 'Leaf 6' },
+    { name: 'Leaf 7' },
+    { name: 'Leaf 8' },
+    { name: 'Leaf 9' },
+    { name: 'Leaf 10' },
+    { name: 'Leaf 11' },
+    { name: 'Leaf 12' },
+    { name: 'After 13' },
+  ]);
+
+  await nestedRows.undoWithKeyboard();
+
+  const restoredState = await nestedRows.state();
+
+  // The assertions below cover the complete restoration contract, including the raw nested tree
+  // and the physical row index sequence.
+  expect(restoredState.error).toBeUndefined();
+  expect(restoredState.countRows).toBe(EXPECTED_NAMES.length);
+  expect(restoredState.visibleNames).toEqual(EXPECTED_NAMES);
+  expect(restoredState.cellMeta).toEqual(['parent-meta', 'child-meta', 'grandchild-meta']);
+  expect(restoredState.sourceData).toEqual([
+    ...Array.from({ length: 13 }, (_, index) => ({ name: `Leaf ${index}` })),
+    {
+      name: 'Parent 13',
+      __children: [{
+        name: 'Child 13',
+        __children: [{ name: 'Grandchild 13' }],
+      }],
+    },
+    { name: 'After 13' },
+  ]);
+  expect(restoredState.rowIndexesSequence).toEqual(EXPECTED_NAMES.map((_, index) => index));
+  expect(await nestedRows.removeLog()).toEqual([
+    {
+      hook: 'beforeRemoveRow',
+      index: 13,
+      amount: 1,
+      physicalRows: [13, 14, 15],
+      source: 'ContextMenu.removeRow',
+    },
+    {
+      hook: 'afterRemoveRow',
+      index: 13,
+      amount: 3,
+      physicalRows: [13, 14, 15],
+      source: 'ContextMenu.removeRow',
+    },
+  ]);
+  expect(nestedRows.pageErrors).toEqual([]);
+
+  await nestedRows.redo();
+
+  const redoneState = await nestedRows.state();
+
+  expect(redoneState.countRows).toBe(14);
+  expect(redoneState.visibleNames).toEqual(EXPECTED_NAMES.filter((_, index) => index !== 13 &&
+    index !== 14 && index !== 15));
+  expect(redoneState.sourceData).toEqual([
+    ...Array.from({ length: 13 }, (_, index) => ({ name: `Leaf ${index}` })),
+    { name: 'After 13' },
+  ]);
+});

--- a/tests/e2e/nested-rows-undo.spec.ts
+++ b/tests/e2e/nested-rows-undo.spec.ts
@@ -103,3 +103,16 @@ test('undo restores a removed nested parent and its descendants', async({ page, 
     { name: 'After 13' },
   ]);
 });
+
+test('undo after a context-menu removal keeps the highlight on the restored parent', async({
+  page, theme, bundle,
+}) => {
+  const nestedRows = new NestedRowsUndoPage(page, theme, bundle);
+
+  await nestedRows.goto();
+  await nestedRows.removeRowViaContextMenu(13);
+  await nestedRows.undoViaPlugin();
+
+  expect(await nestedRows.selectedRow()).toBe(13);
+  expect(await nestedRows.visibleNames()).toEqual(EXPECTED_NAMES);
+});

--- a/tests/fixtures/demo/nested-rows-undo.html
+++ b/tests/fixtures/demo/nested-rows-undo.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable e2e fixture - nested row undo</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <script>
+    const htParams = new URLSearchParams(location.search);
+
+    window.htTheme = ({ main: 'main', horizon: 'horizon', classic: 'classic' })[htParams.get('theme') ?? 'main'];
+    if (!window.htTheme) {
+      throw new Error('Unknown ?theme= value: ' + JSON.stringify(htParams.get('theme')));
+    }
+
+    document.write('<link rel="stylesheet" href="/handsontable/styles/ht-theme-' + window.htTheme + '.min.css">');
+    window.htBundle = ({ umd: 'handsontable.js', 'full-min': 'handsontable.full.min.js' })[
+      htParams.get('bundle') ?? 'umd'
+    ];
+    if (!window.htBundle) {
+      throw new Error('Unknown ?bundle= value: ' + JSON.stringify(htParams.get('bundle')));
+    }
+  </script>
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+  </style>
+</head>
+<body>
+  <div id="grid" data-testid="grid"></div>
+
+  <script>
+    document.write('<scr' + 'ipt src="/handsontable/dist/' + window.htBundle + '"></scr' + 'ipt>');
+  </script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+    container.className = `ht-theme-${window.htTheme}`;
+
+    const testIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    };
+
+    window.removeLog = [];
+
+    window.hot = new Handsontable(container, {
+      data: [
+        { name: 'Leaf 0' },
+        { name: 'Leaf 1' },
+        { name: 'Leaf 2' },
+        { name: 'Leaf 3' },
+        { name: 'Leaf 4' },
+        { name: 'Leaf 5' },
+        { name: 'Leaf 6' },
+        { name: 'Leaf 7' },
+        { name: 'Leaf 8' },
+        { name: 'Leaf 9' },
+        { name: 'Leaf 10' },
+        { name: 'Leaf 11' },
+        { name: 'Leaf 12' },
+        {
+          name: 'Parent 13',
+          __children: [{
+            name: 'Child 13',
+            __children: [{ name: 'Grandchild 13' }],
+          }],
+        },
+        { name: 'After 13' },
+      ],
+      columns: [{ data: 'name' }],
+      colHeaders: ['Name'],
+      rowHeaders: true,
+      nestedRows: true,
+      contextMenu: true,
+      undo: true,
+      renderer: testIdRenderer,
+      height: 'auto',
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    window.hot.setCellMeta(13, 0, 'className', 'parent-meta');
+    window.hot.setCellMeta(14, 0, 'className', 'child-meta');
+    window.hot.setCellMeta(15, 0, 'className', 'grandchild-meta');
+
+    const recordRemove = (hook) => (index, amount, physicalRows, source) => {
+      window.removeLog.push({
+        hook,
+        index,
+        amount,
+        physicalRows: physicalRows.slice(),
+        source,
+      });
+    };
+
+    window.hot.addHook('beforeRemoveRow', recordRemove('beforeRemoveRow'));
+    window.hot.addHook('afterRemoveRow', recordRemove('afterRemoveRow'));
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/NestedRowsUndoPage.ts
+++ b/tests/fixtures/pages/NestedRowsUndoPage.ts
@@ -1,0 +1,125 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+import { awaitBundle } from '../bundle';
+
+export interface NestedRowsRemoveLogEntry {
+  hook: 'beforeRemoveRow' | 'afterRemoveRow';
+  index: number;
+  amount: number;
+  physicalRows: number[];
+  source?: string;
+}
+
+export interface NestedRowsUndoState {
+  countRows?: number;
+  visibleNames?: string[];
+  sourceData?: unknown[];
+  rowIndexesSequence?: number[];
+  cellMeta?: Array<string | undefined>;
+  error?: string;
+}
+
+/**
+ * Page object for the DEV-30 nested parent removal and undo reproduction.
+ *
+ * The fixture keeps the parent at visual row 13, matching the reported gesture, and gives that
+ * parent a nested parent descendant so the removal list and the source tree can diverge.
+ */
+export class NestedRowsUndoPage {
+  readonly page: Page;
+  readonly theme: string;
+  readonly bundle: string;
+  readonly pageErrors: string[] = [];
+
+  constructor(page: Page, theme = 'main', bundle = 'umd') {
+    this.page = page;
+    this.theme = theme;
+    this.bundle = bundle;
+    page.on('pageerror', (error) => { this.pageErrors.push(error.message); });
+  }
+
+  /** Navigate to the reproduction fixture and wait for the bundle and first cell. */
+  async goto(): Promise<void> {
+    await this.page.goto(
+      `/tests/fixtures/demo/nested-rows-undo.html?theme=${this.theme}&bundle=${this.bundle}`
+    );
+    await awaitBundle(this.page);
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /** A single data cell addressed by its current visual row and column. */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /** Remove one row through the context-menu gesture reported in DEV-30. */
+  async removeRowViaContextMenu(row: number): Promise<void> {
+    await this.cell(row, 0).click({ button: 'right' });
+    const menu = this.page.locator('.htContextMenu.handsontable').locator('visible=true');
+
+    await expect(menu).toBeVisible();
+    await menu.locator('.ht_master td').filter({ hasText: /^Remove row$/ }).click();
+    await expect(menu).toBeHidden();
+  }
+
+  /** Undo the removal through the platform-specific Cmd/Ctrl+Z shortcut. */
+  async undoWithKeyboard(): Promise<void> {
+    await this.cell(0, 0).click();
+    await this.page.keyboard.press('ControlOrMeta+z');
+  }
+
+  /** Redo the removal through the UndoRedo plugin API. */
+  async redo(): Promise<void> {
+    await this.page.evaluate(() => window.hot.getPlugin('undoRedo').redo());
+  }
+
+  /** Read the names currently visible through the public visual-row API. */
+  visibleNames(): Promise<string[]> {
+    return this.page.evaluate(() => {
+      const names: string[] = [];
+
+      for (let row = 0; row < window.hot.countRows(); row++) {
+        names.push(String(window.hot.getDataAtCell(row, 0)));
+      }
+
+      return names;
+    });
+  }
+
+  /** Capture the source tree, visual row count, and index-map sequence in one browser round trip. */
+  state(): Promise<NestedRowsUndoState> {
+    return this.page.evaluate(() => {
+      try {
+        const hot = window.hot;
+        const countRows = hot.countRows();
+
+        return {
+          countRows,
+          visibleNames: Array.from({ length: countRows }, (_, row) => String(hot.getDataAtCell(row, 0))),
+          sourceData: hot.getPlugin('nestedRows').dataManager.getRawSourceData(),
+          rowIndexesSequence: hot.rowIndexMapper.getIndexesSequence(),
+          cellMeta: countRows > 15
+            ? [13, 14, 15].map(row => hot.getCellMeta(row, 0).className)
+            : [],
+        };
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    });
+  }
+
+  /** Return the last captured before/after remove hook arguments. */
+  removeLog(): Promise<NestedRowsRemoveLogEntry[]> {
+    return this.page.evaluate(() => window.removeLog);
+  }
+
+  /** Return the latest serialized UndoRedo action after the removal. */
+  undoAction(): Promise<unknown> {
+    return this.page.evaluate(() => {
+      const actions = window.hot.getPlugin('undoRedo').doneActions;
+
+      return actions[actions.length - 1];
+    });
+  }
+}

--- a/tests/fixtures/pages/NestedRowsUndoPage.ts
+++ b/tests/fixtures/pages/NestedRowsUndoPage.ts
@@ -72,6 +72,16 @@ export class NestedRowsUndoPage {
     await this.page.evaluate(() => window.hot.getPlugin('undoRedo').redo());
   }
 
+  /** Undo through the plugin API without moving the highlight first. */
+  async undoViaPlugin(): Promise<void> {
+    await this.page.evaluate(() => window.hot.getPlugin('undoRedo').undo());
+  }
+
+  /** Visual row of the current highlight, or `null` when nothing is selected. */
+  selectedRow(): Promise<number | null> {
+    return this.page.evaluate(() => window.hot.getSelectedLast()?.[0] ?? null);
+  }
+
   /** Read the names currently visible through the public visual-row API. */
   visibleNames(): Promise<string[]> {
     return this.page.evaluate(() => {

--- a/tests/fixtures/pages/windowTypes.ts
+++ b/tests/fixtures/pages/windowTypes.ts
@@ -35,6 +35,7 @@ export interface FixtureHotInstance {
   getSourceDataAtCell(row: number, col: number): CellValue;
   getSourceData(): unknown[];
   setDataAtCell(row: number, col: number, value: CellValue): void;
+  setCellMeta(row: number, col: number, key: string, value: unknown): void;
   getCellMeta(row: number, col: number): { className?: string, readOnly?: boolean };
   getPlugin(name: 'formulas'): {
     getCellType(row: number, col: number): string,
@@ -106,6 +107,7 @@ export interface FixtureHotInstance {
     },
     dataManager: {
       getDataObject(row: number): object | null,
+      getRawSourceData(): unknown[],
       addChild(parent: object): void,
     },
   };
@@ -231,6 +233,14 @@ declare global {
     moveCellsHookLog: MoveCellsHookRecord[];
     /** Recorded NestedRows collapse/expand hook calls, in firing order. */
     hookLog: { name: string, args: unknown[] }[];
+    /** Recorded remove-row hook arguments from the DEV-30 nested undo fixture. */
+    removeLog: {
+      hook: 'beforeRemoveRow' | 'afterRemoveRow';
+      index: number;
+      amount: number;
+      physicalRows: number[];
+      source?: string;
+    }[];
     /** Makes the fixture's `beforeMoveCells` listener return `false`. */
     setBeforeMoveCellsVeto(shouldVeto: boolean): boolean;
     /** Makes the fixture's `beforeRowMove` listener return `false`. */


### PR DESCRIPTION
### Context

The PR fixes undo after removing a nested parent row. `RemoveRowAction` stored only the parent object and dropped `__children`, so Cmd/Ctrl+Z restored a flat row and left the grid and source tree out of step. Nested undo now captures the complete subtree, physical row maps, collapsed-parent state, metadata, and merge anchors, then restores them through NestedRows.

A nested undo that cannot land (NestedRows disabled, or a `beforeCreateRow` veto) is refused before `beforeUndo`, so Formulas does not call `engine.undo()` against a grid that stayed empty. Expanded merges skip `restoreMergedCells()` on that path, because `merge()` would populate `null` into descendant cells the parent-only `data` snapshot cannot put back.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-30

### Test evidence (required for source changes)

- Unit tests added/modified (`*.unit.js`): `handsontable/src/dataMap/metaManager/metaLayers/__tests__/cellMeta.unit.ts`
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): `tests/e2e/nested-rows-undo.spec.ts`
- Legacy Jasmine specs edited (frozen suite): `handsontable/src/plugins/nestedRows/__tests__/integration/undoRedo.spec.js`, `handsontable/src/plugins/formulas/__tests__/plugins/nestedRows.spec.js`. These extend existing plugin-integration files (map restore, merge geometry, hook veto, Formulas pairing) rather than adding a new Jasmine spec. The user-visible remove-and-Cmd/Z path is in Playwright.
- Type tests (`*.types.ts`) updated if public API changed: none
- For a bug fix — the spec that fails without this fix: `undo restores a removed nested parent and its descendants` in `tests/e2e/nested-rows-undo.spec.ts`
- Demo page / recorded trace (for UI changes): `tests/fixtures/demo/nested-rows-undo.html`

### Commands run

```text
npm run test:unit --prefix handsontable -- --testPathPattern=undoRedo
# 31 passed

npm run test:e2e --prefix handsontable -- --testPathPattern=nestedRows/__tests__/integration/undoRedo
# 14 specs, 0 failures

npm run test:e2e --prefix handsontable -- --testPathPattern=formulas/__tests__/plugins/nestedRows
# 17 specs, 0 failures

HOT_TEST_PORT=8133 npx playwright test e2e/nested-rows-undo.spec.ts
# PASS (6) FAIL (0)
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-30

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.
- [ ] MANUAL QA NEEDED — <!-- one line: WHAT to check and why automation can't judge it. Also add the red `Requires Manual QA` label (that exact name — it already exists; `QA needed` and `Verified by QA` are different labels). Ticking holds the Tests run for a manual-qa environment approval by a designated reviewer (never whoever triggered the run). The box is read once per run, so if you change it after the pipeline ran, press "Re-run all jobs". This line is machine-read — keep its wording. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches UndoRedo, NestedRows, MergeCells, and Formulas ordering around row removal/undo—core grid state and plugin coordination.
> 
> **Overview**
> **Fixes undo after removing a nested parent row** so Ctrl/Cmd+Z brings back the full subtree, row index maps, collapsed state, cell meta, and merge physical anchors—not a single flat row with blank descendants.
> 
> **NestedRows** now captures a removal snapshot (`captureRemovedRows` / `restoreRemovedRows`) and probes create-row hooks via `canRestoreRemovedRows` before any undo side effects run.
> 
> **UndoRedo** calls `RemoveRowAction.canUndo()` before `beforeUndo` (so Formulas does not `engine.undo()` into an empty grid), supports `{ wasUndone: false }`, and defers `fixedRowsTop`/`fixedRowsBottom` until a nested restore actually lands. Nested undo restores meta through the correct recording buckets and reattaches merge anchors via **MergeCells** instead of `restoreMergedCells()`.
> 
> Supporting changes: shared **`stripFunctionValues`**, and **`getCellsMetaAtRowWithPhysicalColumns`** for per-descendant meta capture. Docs/changelog note 18.2 behavior; Playwright and integration coverage added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc7d33250cc85e1b7a098a53990ea57893128100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->