### PR TITLE
DEV-1780: Docs-sync classifier temperature, log scrubbing, and workflow rename

### DIFF
--- a/.github/scripts/__tests__/docs-sync-cli.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-cli.test.mjs
@@ -735,7 +735,7 @@ test('a cached decision under the current prompt hash skips the model; a stale p
   // here, the stale-prompt-hash run (the one that must call the model)
   // reliably took ~185s and exited 1; switching to `spawn` drops it back to
   // the sub-second range and both cache scenarios pass.
-  const runWithoutNoLlm = (extraAnswers) => {
+  const runWithoutNoLlm = (extraAnswers, extraEnv = {}) => {
     writeAnswers(f, extraAnswers);
 
     return new Promise((resolve) => {
@@ -752,6 +752,7 @@ test('a cached decision under the current prompt hash skips the model; a stale p
           LITELLM_BASE_URL: `http://127.0.0.1:${port}`,
           LITELLM_API_KEY: 'test-key',
           DOCS_SYNC_MODEL: 'test-model',
+          ...extraEnv,
         },
       });
       let stdout = '';
@@ -799,10 +800,24 @@ test('a cached decision under the current prompt hash skips the model; a stale p
     assert.equal(second.status, 0, second.stderr);
     assert.equal(requests.length, 1, 'a stale prompt hash must call the model exactly once for the one classifiable candidate');
     assert.equal(requests[0].messages[1].role, 'user');
+    // With DOCS_SYNC_TEMPERATURE unset, the request omits temperature entirely.
+    assert.ok(!('temperature' in requests[0]), 'temperature is omitted when the variable is unset');
 
     const summary2 = readFileSync(path.join(f.root, 'summary.md'), 'utf8');
 
     assert.match(summary2, /## Included\n\n- `[0-9a-f]{7}` Fix a typo in guide a \(#101, @someone\)/);
+
+    // DOCS_SYNC_TEMPERATURE reaches the request body when set.
+    rmSync(path.join(f.root, 'summary.md'), { force: true });
+
+    const third = await runWithoutNoLlm(
+      { openPr: { number: 500, url: 'https://github.com/o/r/pull/500', body: staleBody } },
+      { DOCS_SYNC_TEMPERATURE: '0.2' },
+    );
+
+    assert.equal(third.status, 0, third.stderr);
+    assert.equal(requests.length, 2, 'the third run calls the model again under the stale prompt hash');
+    assert.equal(requests[1].temperature, 0.2, 'a configured temperature is forwarded to the request');
   } finally {
     server.close();
     rmSync(f.root, { recursive: true, force: true });

--- a/.github/scripts/__tests__/docs-sync-cli.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-cli.test.mjs
@@ -800,24 +800,27 @@ test('a cached decision under the current prompt hash skips the model; a stale p
     assert.equal(second.status, 0, second.stderr);
     assert.equal(requests.length, 1, 'a stale prompt hash must call the model exactly once for the one classifiable candidate');
     assert.equal(requests[0].messages[1].role, 'user');
-    // With DOCS_SYNC_TEMPERATURE unset, the request omits temperature entirely.
+    // With DOCS_SYNC_TEMPERATURE unset, the request omits temperature entirely,
+    // and DOCS_SYNC_JSON_MODE defaults on, so response_format is sent.
     assert.ok(!('temperature' in requests[0]), 'temperature is omitted when the variable is unset');
+    assert.deepEqual(requests[0].response_format, { type: 'json_object' }, 'json mode is on by default');
 
     const summary2 = readFileSync(path.join(f.root, 'summary.md'), 'utf8');
 
     assert.match(summary2, /## Included\n\n- `[0-9a-f]{7}` Fix a typo in guide a \(#101, @someone\)/);
 
-    // DOCS_SYNC_TEMPERATURE reaches the request body when set.
+    // DOCS_SYNC_TEMPERATURE and DOCS_SYNC_JSON_MODE reach the request body when set.
     rmSync(path.join(f.root, 'summary.md'), { force: true });
 
     const third = await runWithoutNoLlm(
       { openPr: { number: 500, url: 'https://github.com/o/r/pull/500', body: staleBody } },
-      { DOCS_SYNC_TEMPERATURE: '0.2' },
+      { DOCS_SYNC_TEMPERATURE: '0.2', DOCS_SYNC_JSON_MODE: 'off' },
     );
 
     assert.equal(third.status, 0, third.stderr);
     assert.equal(requests.length, 2, 'the third run calls the model again under the stale prompt hash');
     assert.equal(requests[1].temperature, 0.2, 'a configured temperature is forwarded to the request');
+    assert.ok(!('response_format' in requests[1]), 'json mode off omits response_format');
   } finally {
     server.close();
     rmSync(f.root, { recursive: true, force: true });

--- a/.github/scripts/__tests__/docs-sync-cli.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-cli.test.mjs
@@ -752,6 +752,12 @@ test('a cached decision under the current prompt hash skips the model; a stale p
           LITELLM_BASE_URL: `http://127.0.0.1:${port}`,
           LITELLM_API_KEY: 'test-key',
           DOCS_SYNC_MODEL: 'test-model',
+          // Blanked like GIT_DIR/DRY_RUN/TARGET above so an inherited value from
+          // the developer's own shell (docs/AGENTS.md tells people to export
+          // these) cannot flip the omitted-by-default assertions; a run that
+          // needs them passes them through extraEnv below.
+          DOCS_SYNC_TEMPERATURE: undefined,
+          DOCS_SYNC_JSON_MODE: undefined,
           ...extraEnv,
         },
       });

--- a/.github/scripts/__tests__/docs-sync-llm.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-llm.test.mjs
@@ -30,9 +30,50 @@ test('complete posts an OpenAI-shaped JSON request and returns the content', asy
   const body = JSON.parse(calls[0].init.body);
 
   assert.equal(body.model, 'm');
-  assert.equal(body.temperature, 0);
+  // Omitted entirely, not sent as 0: a reasoning-tier model rejects any
+  // non-default temperature, so the absent key is what lets the call through.
+  assert.ok(!('temperature' in body), 'temperature is absent when not configured');
   assert.deepEqual(body.response_format, { type: 'json_object' });
   assert.deepEqual(body.messages, [{ role: 'system', content: 'S' }, { role: 'user', content: 'U' }]);
+});
+
+test('a configured temperature is sent verbatim, including 0', async() => {
+  for (const temperature of [0, 0.7]) {
+    const calls = [];
+    const fetchImpl = async(url, init) => {
+      calls.push(init);
+
+      return ok('{}');
+    };
+    const client = createClient({
+      baseUrl: 'https://x', apiKey: 'k', model: 'm', temperature, fetchImpl, sleep: noSleep,
+    });
+
+    await client.complete({ system: 's', user: 'u' });
+
+    assert.equal(JSON.parse(calls[0].body).temperature, temperature);
+  }
+});
+
+test('an error body is surfaced past 200 characters and capped at 4096', async() => {
+  const shortTail = `${'x'.repeat(300)}NEEDLE`;
+  const fetchImpl = async() => new Response(shortTail, { status: 400 });
+  const client = createClient({ baseUrl: 'https://x', apiKey: 'k', model: 'm', fetchImpl, sleep: noSleep });
+
+  // The old 200-character cut buried the actual cause; the wider cut keeps it.
+  await assert.rejects(() => client.complete({ system: 's', user: 'u' }), /NEEDLE/);
+
+  const longBody = 'y'.repeat(5000);
+  const fetchLong = async() => new Response(longBody, { status: 400 });
+  const clientLong = createClient({ baseUrl: 'https://x', apiKey: 'k', model: 'm', fetchImpl: fetchLong, sleep: noSleep });
+
+  await assert.rejects(() => clientLong.complete({ system: 's', user: 'u' }), (error) => {
+    const quoted = error.message.slice(error.message.indexOf('400: ') + '400: '.length);
+
+    assert.equal(quoted.length, 4096, 'the body is capped at 4096 characters');
+
+    return true;
+  });
 });
 
 test('5xx and 429 are retried, then the last error surfaces', async() => {

--- a/.github/scripts/__tests__/docs-sync-llm.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-llm.test.mjs
@@ -55,6 +55,23 @@ test('a configured temperature is sent verbatim, including 0', async() => {
   }
 });
 
+test('json mode is on by default and omittable', async() => {
+  const bodies = [];
+  const fetchImpl = async(url, init) => {
+    bodies.push(JSON.parse(init.body));
+
+    return ok('{}');
+  };
+
+  await createClient({ baseUrl: 'https://x', apiKey: 'k', model: 'm', fetchImpl, sleep: noSleep })
+    .complete({ system: 's', user: 'u' });
+  await createClient({ baseUrl: 'https://x', apiKey: 'k', model: 'm', jsonMode: false, fetchImpl, sleep: noSleep })
+    .complete({ system: 's', user: 'u' });
+
+  assert.deepEqual(bodies[0].response_format, { type: 'json_object' }, 'response_format is sent by default');
+  assert.ok(!('response_format' in bodies[1]), 'response_format is omitted when json mode is off');
+});
+
 test('an error body is surfaced past 200 characters and capped at 4096', async() => {
   const shortTail = `${'x'.repeat(300)}NEEDLE`;
   const fetchImpl = async() => new Response(shortTail, { status: 400 });

--- a/.github/scripts/__tests__/docs-sync-log.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-log.test.mjs
@@ -41,3 +41,11 @@ test('empty or undefined secrets are ignored', () => {
 
   assert.equal(scrubSecrets(text, ['', undefined]), text);
 });
+
+test('a pathologically short secret is left alone so it cannot shred the log', () => {
+  // A one-character GH_TOKEN (as the CLI test uses) would otherwise replace
+  // every occurrence of that character in every line.
+  const text = 'Target prod-docs/18.1, sync branch docs-sync/prod-docs-18.1.';
+
+  assert.equal(scrubSecrets(text, ['x']), text);
+});

--- a/.github/scripts/__tests__/docs-sync-log.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-log.test.mjs
@@ -16,3 +16,28 @@ test('text without a token is returned unchanged', () => {
 
   assert.equal(scrubSecrets(text), text);
 });
+
+test('a Bearer credential echoed in an error body is redacted', () => {
+  const text = 'LiteLLM responded 401: {"error":"invalid api key","request":{"Authorization":"Bearer sk-litellm-abc123"}}';
+
+  assert.equal(
+    scrubSecrets(text),
+    'LiteLLM responded 401: {"error":"invalid api key","request":{"Authorization":"Bearer ***"}}',
+  );
+});
+
+test('a literal secret is redacted wherever it appears, even without a Bearer prefix', () => {
+  const key = 'sk-litellm-abc123';
+  const text = `LiteLLM responded 403: <title>Blocked</title> key=${key} for ${key}`;
+
+  assert.equal(
+    scrubSecrets(text, [key]),
+    'LiteLLM responded 403: <title>Blocked</title> key=*** for ***',
+  );
+});
+
+test('empty or undefined secrets are ignored', () => {
+  const text = 'nothing to scrub here';
+
+  assert.equal(scrubSecrets(text, ['', undefined]), text);
+});

--- a/.github/scripts/__tests__/docs-sync-workflow.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-workflow.test.mjs
@@ -22,6 +22,13 @@ test('the weekday schedule is landed disabled, pending rollout step 1, with manu
   );
 });
 
+test('is named distinctly from the examples sync and the production deploy', () => {
+  // "Docs Sync" read as a sibling of "Docs Examples Sync" despite doing an
+  // unrelated job; the verb-first name says what this one does and where, and
+  // sets it apart from "Docs Production Deployment", which actually deploys.
+  assert.match(source, /^name: Sync Docs Content to Production$/m);
+});
+
 test('uses the release GitHub App token and never GITHUB_TOKEN', () => {
   assert.match(source, /actions\/create-github-app-token@/);
   assert.match(source, /client-id: \$\{\{ secrets\.RELEASE_APP_CLIENT_ID \}\}/);
@@ -41,6 +48,7 @@ test('passes the LiteLLM secrets and the model variable to the script', () => {
   assert.match(source, /LITELLM_BASE_URL: \$\{\{ secrets\.LITELLM_BASE_URL \}\}/);
   assert.match(source, /LITELLM_API_KEY: \$\{\{ secrets\.LITELLM_API_KEY \}\}/);
   assert.match(source, /DOCS_SYNC_MODEL: \$\{\{ vars\.DOCS_SYNC_MODEL \}\}/);
+  assert.match(source, /DOCS_SYNC_TEMPERATURE: \$\{\{ vars\.DOCS_SYNC_TEMPERATURE \}\}/);
   assert.match(source, /DOCS_SYNC_REVIEWERS: \$\{\{ vars\.DOCS_SYNC_REVIEWERS \}\}/);
   assert.match(source, /run: node \.github\/scripts\/docs-sync\.mjs/);
 });

--- a/.github/scripts/__tests__/docs-sync-workflow.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-workflow.test.mjs
@@ -49,6 +49,7 @@ test('passes the LiteLLM secrets and the model variable to the script', () => {
   assert.match(source, /LITELLM_API_KEY: \$\{\{ secrets\.LITELLM_API_KEY \}\}/);
   assert.match(source, /DOCS_SYNC_MODEL: \$\{\{ vars\.DOCS_SYNC_MODEL \}\}/);
   assert.match(source, /DOCS_SYNC_TEMPERATURE: \$\{\{ vars\.DOCS_SYNC_TEMPERATURE \}\}/);
+  assert.match(source, /DOCS_SYNC_JSON_MODE: \$\{\{ vars\.DOCS_SYNC_JSON_MODE \}\}/);
   assert.match(source, /DOCS_SYNC_REVIEWERS: \$\{\{ vars\.DOCS_SYNC_REVIEWERS \}\}/);
   assert.match(source, /run: node \.github\/scripts\/docs-sync\.mjs/);
 });

--- a/.github/scripts/docs-sync.mjs
+++ b/.github/scripts/docs-sync.mjs
@@ -17,8 +17,8 @@
  *                                      [--repo-dir <path>] [--gh-bin <path>]
  *
  * Env: GH_TOKEN, GH_REPO, LITELLM_BASE_URL, LITELLM_API_KEY, DOCS_SYNC_MODEL,
- *      DOCS_SYNC_TEMPERATURE, DOCS_SYNC_REVIEWERS, DRY_RUN, TARGET,
- *      GITHUB_STEP_SUMMARY.
+ *      DOCS_SYNC_TEMPERATURE, DOCS_SYNC_JSON_MODE, DOCS_SYNC_REVIEWERS, DRY_RUN,
+ *      TARGET, GITHUB_STEP_SUMMARY.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -117,7 +117,7 @@ async function makeClassifier({ prompt, hash, cache, target, releasedVersion, un
 
   const {
     LITELLM_BASE_URL: baseUrl, LITELLM_API_KEY: apiKey, DOCS_SYNC_MODEL: model,
-    DOCS_SYNC_TEMPERATURE: temperatureText,
+    DOCS_SYNC_TEMPERATURE: temperatureText, DOCS_SYNC_JSON_MODE: jsonModeText,
   } = process.env;
 
   if (!baseUrl || !apiKey || !model) {
@@ -139,7 +139,23 @@ async function makeClassifier({ prompt, hash, cache, target, releasedVersion, un
     }
   }
 
-  const client = createClient({ baseUrl, apiKey, model, temperature });
+  // On by default, so an unset variable keeps the `response_format` request
+  // every provider that supports it benefits from. Turn it off only for a model
+  // that rejects `response_format`. A present-but-unrecognized value is a
+  // configuration error, not a silent fallback.
+  let jsonMode = true;
+
+  if (jsonModeText !== undefined && jsonModeText !== '') {
+    if (/^(1|true|on|yes)$/i.test(jsonModeText)) {
+      jsonMode = true;
+    } else if (/^(0|false|off|no)$/i.test(jsonModeText)) {
+      jsonMode = false;
+    } else {
+      throw new Error(`DOCS_SYNC_JSON_MODE must be a boolean (on/off), got "${jsonModeText}".`);
+    }
+  }
+
+  const client = createClient({ baseUrl, apiKey, model, temperature, jsonMode });
 
   return async(candidate) => {
     const key = cacheKey(candidate.sha, hash);

--- a/.github/scripts/docs-sync.mjs
+++ b/.github/scripts/docs-sync.mjs
@@ -72,13 +72,18 @@ const summaryLines = [];
 /**
  * Log to stdout and to the step summary buffer, with secrets scrubbed out of
  * every line -- a failed push echoes the tokenized remote URL through
- * `error.message`, and a LiteLLM error body can quote the `Authorization`
- * header or the key. This is the one place all such messages pass through.
+ * `error.message`, and a LiteLLM error body can quote the request, including
+ * the `Authorization` header, the proxy URL, or the key. The step summary is
+ * not secret-masked by GitHub, so all three of the script's secrets are passed
+ * as literals to be redacted wherever they appear, in whatever shape. This is
+ * the one place all such messages pass through.
  *
  * @param {string} line
  */
 function log(line) {
-  const scrubbed = scrubSecrets(line, [process.env.LITELLM_API_KEY]);
+  const scrubbed = scrubSecrets(line, [
+    process.env.LITELLM_API_KEY, process.env.GH_TOKEN, process.env.LITELLM_BASE_URL,
+  ]);
 
   console.log(scrubbed);
   summaryLines.push(scrubbed);
@@ -131,8 +136,13 @@ async function makeClassifier({ prompt, hash, cache, target, releasedVersion, un
   // serialize to `"temperature": null` and 400 every call.
   let temperature;
 
-  if (temperatureText !== undefined && temperatureText !== '') {
-    temperature = Number.parseFloat(temperatureText);
+  // `Number`, not `Number.parseFloat`: parseFloat stops at the first character
+  // it cannot read and keeps what it has, so a comma typo (`0,7`) or a stray
+  // suffix (`0.7x`) would silently pin a wrong value instead of throwing. The
+  // `.trim()` on the empty check is what keeps `Number(' ') === 0` from reading
+  // a whitespace-only value as a real temperature.
+  if (temperatureText !== undefined && temperatureText.trim() !== '') {
+    temperature = Number(temperatureText);
 
     if (!Number.isFinite(temperature)) {
       throw new Error(`DOCS_SYNC_TEMPERATURE must be a number, got "${temperatureText}".`);

--- a/.github/scripts/docs-sync.mjs
+++ b/.github/scripts/docs-sync.mjs
@@ -17,7 +17,8 @@
  *                                      [--repo-dir <path>] [--gh-bin <path>]
  *
  * Env: GH_TOKEN, GH_REPO, LITELLM_BASE_URL, LITELLM_API_KEY, DOCS_SYNC_MODEL,
- *      DOCS_SYNC_REVIEWERS, DRY_RUN, TARGET, GITHUB_STEP_SUMMARY.
+ *      DOCS_SYNC_TEMPERATURE, DOCS_SYNC_REVIEWERS, DRY_RUN, TARGET,
+ *      GITHUB_STEP_SUMMARY.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -69,14 +70,15 @@ const gh = createGitHub({
 const summaryLines = [];
 
 /**
- * Log to stdout and to the step summary buffer, with the push token scrubbed
- * out of every line -- a failed push echoes the tokenized remote URL through
- * `error.message`, and this is the one place all such messages pass through.
+ * Log to stdout and to the step summary buffer, with secrets scrubbed out of
+ * every line -- a failed push echoes the tokenized remote URL through
+ * `error.message`, and a LiteLLM error body can quote the `Authorization`
+ * header or the key. This is the one place all such messages pass through.
  *
  * @param {string} line
  */
 function log(line) {
-  const scrubbed = scrubSecrets(line);
+  const scrubbed = scrubSecrets(line, [process.env.LITELLM_API_KEY]);
 
   console.log(scrubbed);
   summaryLines.push(scrubbed);
@@ -113,13 +115,31 @@ async function makeClassifier({ prompt, hash, cache, target, releasedVersion, un
     return async() => ({ decision: 'unsure', reason: 'Classifier disabled with --no-llm.' });
   }
 
-  const { LITELLM_BASE_URL: baseUrl, LITELLM_API_KEY: apiKey, DOCS_SYNC_MODEL: model } = process.env;
+  const {
+    LITELLM_BASE_URL: baseUrl, LITELLM_API_KEY: apiKey, DOCS_SYNC_MODEL: model,
+    DOCS_SYNC_TEMPERATURE: temperatureText,
+  } = process.env;
 
   if (!baseUrl || !apiKey || !model) {
     throw new Error('LITELLM_BASE_URL, LITELLM_API_KEY and DOCS_SYNC_MODEL are required unless --no-llm is passed.');
   }
 
-  const client = createClient({ baseUrl, apiKey, model });
+  // Unset repository variables expand to an empty string in the workflow, not
+  // an absent env var, so treat `''` and `undefined` alike: both mean "omit
+  // the temperature and let the model's own default apply". A present but
+  // unparseable value is a configuration error, not a silent `NaN` that would
+  // serialize to `"temperature": null` and 400 every call.
+  let temperature;
+
+  if (temperatureText !== undefined && temperatureText !== '') {
+    temperature = Number.parseFloat(temperatureText);
+
+    if (!Number.isFinite(temperature)) {
+      throw new Error(`DOCS_SYNC_TEMPERATURE must be a number, got "${temperatureText}".`);
+    }
+  }
+
+  const client = createClient({ baseUrl, apiKey, model, temperature });
 
   return async(candidate) => {
     const key = cacheKey(candidate.sha, hash);

--- a/.github/scripts/lib/docs-sync/llm.mjs
+++ b/.github/scripts/lib/docs-sync/llm.mjs
@@ -6,6 +6,14 @@
  * without a network or a wait.
  */
 
+// An upstream error body (a proxy 4xx, an HTML block page) is the one string in
+// this module that a diagnostic needs in full, so it is cut generously rather
+// than at a token-frugal 200: 4096 matches the classifier's own body budget in
+// `classify.mjs`. Every such message passes through `docs-sync.mjs`'s
+// `scrubSecrets` before it reaches a log line or the public step summary, so a
+// key echoed back in the body is redacted regardless of this cap.
+const MAX_ERROR_CHARS = 4096;
+
 /**
  * The chat completions endpoint for a proxy base URL.
  *
@@ -25,6 +33,11 @@ export function completionsUrl(baseUrl) {
  * @param {string} options.baseUrl
  * @param {string} options.apiKey
  * @param {string} options.model
+ * @param {number} [options.temperature] Sampling temperature. Omitted from the
+ *   request body entirely when undefined, so the provider's own default
+ *   applies -- a reasoning-tier model that rejects any non-default temperature
+ *   then accepts the call, while a model that honours it can be pinned (e.g. to
+ *   `0`) for repeatable classifications.
  * @param {typeof fetch} [options.fetchImpl]
  * @param {(ms: number) => Promise<void>} [options.sleep]
  * @param {number} [options.attempts] Total attempts, including the first.
@@ -35,6 +48,7 @@ export function createClient({
   baseUrl,
   apiKey,
   model,
+  temperature,
   fetchImpl = fetch,
   sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); }),
   attempts = 3,
@@ -58,7 +72,7 @@ export function createClient({
       },
       body: JSON.stringify({
         model,
-        temperature: 0,
+        ...(temperature === undefined ? {} : { temperature }),
         response_format: { type: 'json_object' },
         messages: [
           { role: 'system', content: system },
@@ -68,7 +82,7 @@ export function createClient({
     });
 
     if (!response.ok) {
-      const error = new Error(`LiteLLM responded ${response.status}: ${(await response.text()).slice(0, 200)}`);
+      const error = new Error(`LiteLLM responded ${response.status}: ${(await response.text()).slice(0, MAX_ERROR_CHARS)}`);
 
       error.status = response.status;
       throw error;
@@ -78,7 +92,7 @@ export function createClient({
     const content = payload?.choices?.[0]?.message?.content;
 
     if (typeof content !== 'string') {
-      throw new Error(`LiteLLM response carried no message content: ${JSON.stringify(payload).slice(0, 200)}`);
+      throw new Error(`LiteLLM response carried no message content: ${JSON.stringify(payload).slice(0, MAX_ERROR_CHARS)}`);
     }
 
     return content;

--- a/.github/scripts/lib/docs-sync/llm.mjs
+++ b/.github/scripts/lib/docs-sync/llm.mjs
@@ -36,7 +36,7 @@ export function completionsUrl(baseUrl) {
  * @param {number} [options.temperature] Sampling temperature. Omitted from the
  *   request body entirely when undefined, so the provider's own default
  *   applies -- a reasoning-tier model that rejects any non-default temperature
- *   then accepts the call, while a model that honours it can be pinned (e.g. to
+ *   then accepts the call, while a model that honors it can be pinned (e.g. to
  *   `0`) for repeatable classifications.
  * @param {boolean} [options.jsonMode] Whether to ask for a JSON object via
  *   `response_format`. On by default. Turn it off for a model that rejects

--- a/.github/scripts/lib/docs-sync/llm.mjs
+++ b/.github/scripts/lib/docs-sync/llm.mjs
@@ -38,6 +38,10 @@ export function completionsUrl(baseUrl) {
  *   applies -- a reasoning-tier model that rejects any non-default temperature
  *   then accepts the call, while a model that honours it can be pinned (e.g. to
  *   `0`) for repeatable classifications.
+ * @param {boolean} [options.jsonMode] Whether to ask for a JSON object via
+ *   `response_format`. On by default. Turn it off for a model that rejects
+ *   `response_format`; `parseDecision` extracts the JSON object out of prose
+ *   either way, so this only trades a reliability aid, not correctness.
  * @param {typeof fetch} [options.fetchImpl]
  * @param {(ms: number) => Promise<void>} [options.sleep]
  * @param {number} [options.attempts] Total attempts, including the first.
@@ -49,6 +53,7 @@ export function createClient({
   apiKey,
   model,
   temperature,
+  jsonMode = true,
   fetchImpl = fetch,
   sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); }),
   attempts = 3,
@@ -73,7 +78,7 @@ export function createClient({
       body: JSON.stringify({
         model,
         ...(temperature === undefined ? {} : { temperature }),
-        response_format: { type: 'json_object' },
+        ...(jsonMode ? { response_format: { type: 'json_object' } } : {}),
         messages: [
           { role: 'system', content: system },
           { role: 'user', content: user },

--- a/.github/scripts/lib/docs-sync/log.mjs
+++ b/.github/scripts/lib/docs-sync/log.mjs
@@ -19,14 +19,20 @@
  * run's public step summary.
  */
 
+// A literal secret shorter than this is not redacted: every real credential
+// here (a GitHub App token, a LiteLLM key, the proxy URL) is far longer, and
+// redacting a one- or two-character value would replace that substring
+// everywhere in the log and shred otherwise-legible output.
+const MIN_SECRET_CHARS = 8;
+
 /**
  * Redact the tokenized GitHub remote URL, any `Bearer` credential, and every
  * literal secret passed in.
  *
  * @param {string} text
  * @param {string[]} [secrets] Literal secret values to redact wherever they
- *   appear, such as `[process.env.LITELLM_API_KEY]`. Empty and undefined
- *   entries are ignored.
+ *   appear, such as `[process.env.LITELLM_API_KEY]`. Empty, undefined, and
+ *   pathologically short (< 8 characters) entries are ignored.
  * @returns {string}
  */
 export function scrubSecrets(text, secrets = []) {
@@ -38,7 +44,7 @@ export function scrubSecrets(text, secrets = []) {
     .replace(/Bearer\s+[^\s"']+/g, 'Bearer ***');
 
   for (const secret of secrets) {
-    if (secret) {
+    if (secret && secret.length >= MIN_SECRET_CHARS) {
       scrubbed = scrubbed.split(secret).join('***');
     }
   }

--- a/.github/scripts/lib/docs-sync/log.mjs
+++ b/.github/scripts/lib/docs-sync/log.mjs
@@ -1,22 +1,47 @@
 /**
  * Scrub secrets out of text before it reaches a log line or the step summary.
  *
- * The workflow points the push remote at
- * `https://x-access-token:<token>@github.com/...` so the script can push with
- * the GitHub App token. A failed `git push` (a lease mismatch, a rejected
- * ref, a network error) echoes that tokenized remote URL to stderr, and
- * `execFileSync` folds stderr into the thrown error's `message`. Any code
- * path that logs a caught error's message -- including the script's own
- * top-level catch -- must scrub it first, or the token ends up in the run's
- * public step summary.
+ * Two kinds of secret can reach a logged string here:
+ *
+ * - The workflow points the push remote at
+ *   `https://x-access-token:<token>@github.com/...` so the script can push with
+ *   the GitHub App token. A failed `git push` (a lease mismatch, a rejected
+ *   ref, a network error) echoes that tokenized remote URL to stderr, and
+ *   `execFileSync` folds stderr into the thrown error's `message`.
+ * - A LiteLLM error body can quote the request that failed, including its
+ *   `Authorization: Bearer <key>` header, or name the key in its own prose.
+ *   The classifier surfaces that body verbatim (see `llm.mjs`), so the
+ *   `LITELLM_API_KEY` must be redacted too -- especially now the body is cut at
+ *   4096 characters rather than 200.
+ *
+ * Any code path that logs a caught error's message -- including the script's
+ * own top-level catch -- must scrub it first, or the secret ends up in the
+ * run's public step summary.
  */
 
 /**
- * Replace the token in a tokenized GitHub remote URL with a placeholder.
+ * Redact the tokenized GitHub remote URL, any `Bearer` credential, and every
+ * literal secret passed in.
  *
  * @param {string} text
+ * @param {string[]} [secrets] Literal secret values to redact wherever they
+ *   appear, such as `[process.env.LITELLM_API_KEY]`. Empty and undefined
+ *   entries are ignored.
  * @returns {string}
  */
-export function scrubSecrets(text) {
-  return String(text).replace(/x-access-token:[^@]*@/g, 'x-access-token:***@');
+export function scrubSecrets(text, secrets = []) {
+  let scrubbed = String(text)
+    .replace(/x-access-token:[^@]*@/g, 'x-access-token:***@')
+    // Stop the token at whitespace or a quote so a `"Bearer <key>"` echoed
+    // inside a JSON error body is redacted without swallowing the closing quote
+    // and braces that follow it.
+    .replace(/Bearer\s+[^\s"']+/g, 'Bearer ***');
+
+  for (const secret of secrets) {
+    if (secret) {
+      scrubbed = scrubbed.split(secret).join('***');
+    }
+  }
+
+  return scrubbed;
 }

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,4 +1,4 @@
-name: Docs Sync
+name: Sync Docs Content to Production
 
 # Ports content-only documentation commits from develop to the live
 # prod-docs/<major>.<minor> branch through one bot-owned pull request.
@@ -83,6 +83,12 @@ jobs:
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
           # Repository variable, so the model can change without a pull request.
           DOCS_SYNC_MODEL: ${{ vars.DOCS_SYNC_MODEL }}
+          # Optional repository variable. Unset (empty) omits temperature from
+          # the request, so the provider's own default applies -- required for a
+          # reasoning-tier model that rejects any non-default temperature. Set
+          # it to 0 to keep classifications deterministic on a model that
+          # honours temperature (e.g. Anthropic).
+          DOCS_SYNC_TEMPERATURE: ${{ vars.DOCS_SYNC_TEMPERATURE }}
           DOCS_SYNC_REVIEWERS: ${{ vars.DOCS_SYNC_REVIEWERS }}
           # A scheduled run is never a dry run; a manual dispatch defaults to one.
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -87,7 +87,7 @@ jobs:
           # the request, so the provider's own default applies -- required for a
           # reasoning-tier model that rejects any non-default temperature. Set
           # it to 0 to keep classifications deterministic on a model that
-          # honours temperature (e.g. Anthropic).
+          # honors temperature (e.g. Anthropic).
           DOCS_SYNC_TEMPERATURE: ${{ vars.DOCS_SYNC_TEMPERATURE }}
           # Optional repository variable, on by default. Set it to off for a
           # model that rejects `response_format`; the classifier parses the JSON

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -89,6 +89,10 @@ jobs:
           # it to 0 to keep classifications deterministic on a model that
           # honours temperature (e.g. Anthropic).
           DOCS_SYNC_TEMPERATURE: ${{ vars.DOCS_SYNC_TEMPERATURE }}
+          # Optional repository variable, on by default. Set it to off for a
+          # model that rejects `response_format`; the classifier parses the JSON
+          # object out of prose either way.
+          DOCS_SYNC_JSON_MODE: ${{ vars.DOCS_SYNC_JSON_MODE }}
           DOCS_SYNC_REVIEWERS: ${{ vars.DOCS_SYNC_REVIEWERS }}
           # A scheduled run is never a dry run; a manual dispatch defaults to one.
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -593,7 +593,10 @@ pull request body lists every decision with its reason. Merge it and
   squash subject; that is how the sync recognizes the change as already ported.
 - Run it locally: `node .github/scripts/docs-sync.mjs --dry-run --no-llm` needs only
   `gh auth`; drop `--no-llm` with `LITELLM_BASE_URL`, `LITELLM_API_KEY`,
-  `DOCS_SYNC_MODEL` set to exercise the classifier. Add `--skip-lint` on a machine
+  `DOCS_SYNC_MODEL` set to exercise the classifier. Set the optional
+  `DOCS_SYNC_TEMPERATURE` (repository variable) to pin the sampling temperature;
+  leave it unset to use the model's own default -- required for a reasoning-tier
+  model that rejects any non-default temperature. Add `--skip-lint` on a machine
   without the docs toolchain installed. The script checks out the sync branch in
   the checkout it runs in and restores your branch afterwards, so run it from a
   clean checkout or a worktree, never with uncommitted changes.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -593,10 +593,12 @@ pull request body lists every decision with its reason. Merge it and
   squash subject; that is how the sync recognizes the change as already ported.
 - Run it locally: `node .github/scripts/docs-sync.mjs --dry-run --no-llm` needs only
   `gh auth`; drop `--no-llm` with `LITELLM_BASE_URL`, `LITELLM_API_KEY`,
-  `DOCS_SYNC_MODEL` set to exercise the classifier. Set the optional
-  `DOCS_SYNC_TEMPERATURE` (repository variable) to pin the sampling temperature;
-  leave it unset to use the model's own default -- required for a reasoning-tier
-  model that rejects any non-default temperature. Add `--skip-lint` on a machine
+  `DOCS_SYNC_MODEL` set to exercise the classifier. Two optional repository
+  variables tune it per provider: `DOCS_SYNC_TEMPERATURE` pins the sampling
+  temperature (leave it unset to use the model's own default -- required for a
+  reasoning-tier model that rejects any non-default temperature), and
+  `DOCS_SYNC_JSON_MODE` (on by default) can be set to off for a model that
+  rejects `response_format`. Add `--skip-lint` on a machine
   without the docs toolchain installed. The script checks out the sync branch in
   the checkout it runs in and restores your branch afterwards, so run it from a
   clean checkout or a worktree, never with uncommitted changes.


### PR DESCRIPTION
### Context

The PR is a follow-up to the docs-sync automation (DEV-1780). It makes the classifier work across providers (Anthropic and a reasoning-tier OpenAI model), improves its failure diagnostics, and renames the workflow.

**1. Provider-agnostic request, two optional repository variables.** `llm.mjs` hardcoded both `temperature: 0` and `response_format: { type: 'json_object' }`, and a reasoning-tier OpenAI model rejects the first outright (`Unsupported value: 'temperature' does not support 0`). The client stays a single dumb POST with no provider sniffing; instead two knobs are wired from repo variables:

- `DOCS_SYNC_TEMPERATURE` — omitted from the request when unset, so the provider's own default applies; set it to `0` on a model that honours temperature to keep classifications repeatable.
- `DOCS_SYNC_JSON_MODE` — on by default (keeps today's `response_format` request); set it to off for a model that rejects `response_format`. `parseDecision` extracts the JSON object out of prose either way, so this trades a reliability aid, not correctness.

Each is validated: a present-but-unparseable value throws a clear configuration error rather than silently serializing to `"temperature": null` or falling back.

Per-provider setup:

| Model | `DOCS_SYNC_TEMPERATURE` | `DOCS_SYNC_JSON_MODE` |
|---|---|---|
| Anthropic | `0` | on (default) |
| OpenAI reasoning (o1/o3/gpt-5) | unset | set per what that model accepts |

**Operational note before merge:** omit-by-default flips the live Anthropic classifier from `temperature: 0` to the provider default. Set the `DOCS_SYNC_TEMPERATURE` repository variable to `0` when merging to keep deterministic classifications.

**2. Error bodies are widened and scrubbed.** The two `.slice(0, 200)` truncations that buried the real cause of a failed call (an HTML block page, a full provider error) now cut at 4096, matching the classifier's own body budget. Because a LiteLLM error body can echo the `Authorization` header or name the key, `scrubSecrets` now also redacts `Bearer <token>` and the literal `LITELLM_API_KEY` before any message reaches the public step summary — the precondition for widening that exposure.

**3. Workflow renamed** from `Docs Sync` to `Sync Docs Content to Production`, so it is not mistaken for the unrelated `Docs Examples Sync`.

`docs-sync.mjs`'s header comment ("keeps every decision deterministic except one") is unchanged on purpose: it describes the git plumbing, not the sampling temperature, and stays accurate.

The widened logs are also an enabler for diagnosing an unresolved 403 block page from the proxy, not a fix for it — a dispatch after merge should capture the full body.

### How has this been tested?

- `node --test .github/scripts/__tests__/docs-sync-*.test.mjs` — all pass. New/updated coverage: temperature omitted when unset and forwarded when set; `response_format` sent by default and omitted when json mode is off (both `docs-sync-llm` unit and `docs-sync-cli` end-to-end env wiring); an error body surfaced past 200 characters and capped at 4096; `Bearer` and literal-key redaction in `docs-sync-log`; the new workflow name and the `DOCS_SYNC_TEMPERATURE` / `DOCS_SYNC_JSON_MODE` env lines in `docs-sync-workflow`.
- `npm run test:tooling` — all pass.
- `npm run eslint` (root — the only lint config that covers `.github/scripts/`) — clean.
- Not runnable from a checkout: one real `workflow_dispatch` with `DOCS_SYNC_JSON_MODE` off, to confirm the current Anthropic model's answers still parse without `response_format`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1780

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

CI tooling and docs only — no shipped package is changed.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1780

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes classifier request defaults (temperature omission) and widens error text in CI logs; mitigated by expanded secret scrubbing but operators should set DOCS_SYNC_TEMPERATURE=0 if deterministic Anthropic behavior is required.
> 
> **Overview**
> Makes the docs-sync **LLM classifier** work across providers by stopping the hardcoded `temperature: 0` and always-on `response_format`. **`DOCS_SYNC_TEMPERATURE`** and **`DOCS_SYNC_JSON_MODE`** are optional repository variables (parsed in `docs-sync.mjs`, passed through the workflow): unset/empty temperature is **omitted** from the LiteLLM request; JSON mode stays **on by default** and can be turned off for models that reject `response_format`, with clear errors on bad config.
> 
> **Diagnostics and safety:** LiteLLM error bodies are truncated at **4096** characters instead of 200, and **`scrubSecrets`** now redacts `Bearer` credentials and configured literal secrets (GH token, LiteLLM key, base URL) before logs hit the public step summary.
> 
> The GitHub workflow is renamed to **Sync Docs Content to Production**, and **`docs/AGENTS.md`** documents the new knobs. Tests cover env wiring end-to-end, LLM request shape, log scrubbing, and the workflow name/env lines.
> 
> **Note for merge:** live Anthropic runs will no longer send `temperature: 0` unless **`DOCS_SYNC_TEMPERATURE`** is set to `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311fb85ab4adbf118662ee88a476ed763560751e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->