### PR TITLE
DEV-1780: Log upstream headers and full body on a docs-sync classifier failure

### DIFF
--- a/.github/scripts/__tests__/docs-sync-cli.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-cli.test.mjs
@@ -167,6 +167,50 @@ function runCli(f, extra = [], envOverrides = {}) {
   });
 }
 
+/**
+ * Spawn the CLI against an in-process fake LiteLLM server on `port`, with the
+ * classifier live (no `--no-llm`). Async on purpose: `spawnSync` would block
+ * this process's event loop so the in-process server could never answer.
+ *
+ * @param {object} f A `fixture()`.
+ * @param {{ port: number, extraEnv?: object }} options
+ * @returns {Promise<{ status: number, stdout: string, stderr: string }>}
+ */
+function spawnCli(f, { port, extraEnv = {} }) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI, '--repo-dir', f.work, '--gh-bin', f.fakeGh, '--skip-lint'], {
+      env: {
+        ...process.env,
+        GIT_DIR: undefined,
+        GH_REPO: 'o/r',
+        GH_TOKEN: 'x',
+        DRY_RUN: '',
+        TARGET: '',
+        GITHUB_STEP_SUMMARY: path.join(f.root, 'summary.md'),
+        FAKE_GH_ANSWERS: f.answersPath,
+        LITELLM_BASE_URL: `http://127.0.0.1:${port}`,
+        LITELLM_API_KEY: 'test-key',
+        DOCS_SYNC_MODEL: 'test-model',
+        // Blanked like GIT_DIR/DRY_RUN/TARGET so an inherited value from the
+        // developer's own shell (docs/AGENTS.md tells people to export these)
+        // cannot flip the omitted-by-default assertions; a run that needs them
+        // passes them through extraEnv.
+        DOCS_SYNC_TEMPERATURE: undefined,
+        DOCS_SYNC_JSON_MODE: undefined,
+        ...extraEnv,
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (status) => { resolve({ status, stdout, stderr }); });
+  });
+}
+
 test('the CLI classifies deterministically, pushes the sync branch, and opens one pull request', () => {
   const f = fixture();
 
@@ -738,38 +782,7 @@ test('a cached decision under the current prompt hash skips the model; a stale p
   const runWithoutNoLlm = (extraAnswers, extraEnv = {}) => {
     writeAnswers(f, extraAnswers);
 
-    return new Promise((resolve) => {
-      const child = spawn(process.execPath, [CLI, '--repo-dir', f.work, '--gh-bin', f.fakeGh, '--skip-lint'], {
-        env: {
-          ...process.env,
-          GIT_DIR: undefined,
-          GH_REPO: 'o/r',
-          GH_TOKEN: 'x',
-          DRY_RUN: '',
-          TARGET: '',
-          GITHUB_STEP_SUMMARY: path.join(f.root, 'summary.md'),
-          FAKE_GH_ANSWERS: f.answersPath,
-          LITELLM_BASE_URL: `http://127.0.0.1:${port}`,
-          LITELLM_API_KEY: 'test-key',
-          DOCS_SYNC_MODEL: 'test-model',
-          // Blanked like GIT_DIR/DRY_RUN/TARGET above so an inherited value from
-          // the developer's own shell (docs/AGENTS.md tells people to export
-          // these) cannot flip the omitted-by-default assertions; a run that
-          // needs them passes them through extraEnv below.
-          DOCS_SYNC_TEMPERATURE: undefined,
-          DOCS_SYNC_JSON_MODE: undefined,
-          ...extraEnv,
-        },
-      });
-      let stdout = '';
-      let stderr = '';
-
-      child.stdout.setEncoding('utf8');
-      child.stderr.setEncoding('utf8');
-      child.stdout.on('data', (chunk) => { stdout += chunk; });
-      child.stderr.on('data', (chunk) => { stderr += chunk; });
-      child.on('close', (status) => { resolve({ status, stdout, stderr }); });
-    });
+    return spawnCli(f, { port, extraEnv });
   };
 
   try {
@@ -833,13 +846,13 @@ test('a cached decision under the current prompt hash skips the model; a stale p
   }
 });
 
-test('a failed classifier call logs the whole body but caps the step summary', async() => {
+test('a failed classifier call logs the whole body but bounds the step summary', async() => {
   const f = fixture();
   const bigBody = `<!DOCTYPE html><html><head><title>Blocked</title></head><body>${'Z'.repeat(20_000)}</body></html>`;
   const server = createServer((req, res) => {
-    let body = '';
+    // Drain the request so the response goes out; the body itself is not needed.
+    req.resume();
 
-    req.on('data', (chunk) => { body += chunk; });
     req.on('end', () => {
       res.writeHead(403, {
         'Content-Type': 'text/html', 'cf-ray': 'testray-WAW', 'cf-mitigated': 'challenge', server: 'cloudflare',
@@ -852,40 +865,10 @@ test('a failed classifier call logs the whole body but caps the step summary', a
 
   const { port } = server.address();
 
-  // `spawn`, not `spawnSync`: the fake server lives in this process, so a
-  // blocking child would deadlock (see the cache test above for the full note).
-  const run = () => new Promise((resolve) => {
-    const child = spawn(process.execPath, [CLI, '--repo-dir', f.work, '--gh-bin', f.fakeGh, '--skip-lint'], {
-      env: {
-        ...process.env,
-        GIT_DIR: undefined,
-        GH_REPO: 'o/r',
-        GH_TOKEN: 'x',
-        DRY_RUN: '',
-        TARGET: '',
-        GITHUB_STEP_SUMMARY: path.join(f.root, 'summary.md'),
-        FAKE_GH_ANSWERS: f.answersPath,
-        LITELLM_BASE_URL: `http://127.0.0.1:${port}`,
-        LITELLM_API_KEY: 'test-key-well-over-eight-chars',
-        DOCS_SYNC_MODEL: 'test-model',
-        DOCS_SYNC_TEMPERATURE: undefined,
-        DOCS_SYNC_JSON_MODE: undefined,
-      },
-    });
-    let stdout = '';
-    let stderr = '';
-
-    child.stdout.setEncoding('utf8');
-    child.stderr.setEncoding('utf8');
-    child.stdout.on('data', (chunk) => { stdout += chunk; });
-    child.stderr.on('data', (chunk) => { stderr += chunk; });
-    child.on('close', (status) => { resolve({ status, stdout, stderr }); });
-  });
-
   try {
     writeAnswers(f, {});
 
-    const result = await run();
+    const result = await spawnCli(f, { port });
 
     assert.notEqual(result.status, 0, 'the 403 aborts the run');
     // The job log (stdout) carries the response whole, including the far end of
@@ -893,12 +876,13 @@ test('a failed classifier call logs the whole body but caps the step summary', a
     assert.ok(result.stdout.includes('Z'.repeat(20_000)), 'the full block-page body reaches the job log');
     assert.match(result.stdout, /Looks like a Cloudflare edge block/);
     assert.match(result.stdout, /cf-ray=testray-WAW/);
-    assert.doesNotMatch(result.stdout, /\[truncated/, 'the job log is never truncated');
+    assert.doesNotMatch(result.stdout, /cut for the step summary/, 'the job log is never cut');
 
-    // The step summary is bounded, with a pointer to the uncut log.
+    // The step summary is bounded and fenced, with a pointer to the uncut log.
     const summary = readFileSync(path.join(f.root, 'summary.md'), 'utf8');
 
-    assert.match(summary, /\[truncated: \d+ more characters; see the full job log\]/);
+    assert.match(summary, /\[cut for the step summary; full text in the job log\]/);
+    assert.match(summary, /````/, 'the summary body is fenced so GitHub renders it literally');
     assert.ok(!summary.includes('Z'.repeat(20_000)), 'the summary does not carry the whole body');
   } finally {
     server.close();

--- a/.github/scripts/__tests__/docs-sync-cli.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-cli.test.mjs
@@ -832,3 +832,76 @@ test('a cached decision under the current prompt hash skips the model; a stale p
     rmSync(f.root, { recursive: true, force: true });
   }
 });
+
+test('a failed classifier call logs the whole body but caps the step summary', async() => {
+  const f = fixture();
+  const bigBody = `<!DOCTYPE html><html><head><title>Blocked</title></head><body>${'Z'.repeat(20_000)}</body></html>`;
+  const server = createServer((req, res) => {
+    let body = '';
+
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => {
+      res.writeHead(403, {
+        'Content-Type': 'text/html', 'cf-ray': 'testray-WAW', 'cf-mitigated': 'challenge', server: 'cloudflare',
+      });
+      res.end(bigBody);
+    });
+  });
+
+  await new Promise((resolve) => { server.listen(0, '127.0.0.1', resolve); });
+
+  const { port } = server.address();
+
+  // `spawn`, not `spawnSync`: the fake server lives in this process, so a
+  // blocking child would deadlock (see the cache test above for the full note).
+  const run = () => new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI, '--repo-dir', f.work, '--gh-bin', f.fakeGh, '--skip-lint'], {
+      env: {
+        ...process.env,
+        GIT_DIR: undefined,
+        GH_REPO: 'o/r',
+        GH_TOKEN: 'x',
+        DRY_RUN: '',
+        TARGET: '',
+        GITHUB_STEP_SUMMARY: path.join(f.root, 'summary.md'),
+        FAKE_GH_ANSWERS: f.answersPath,
+        LITELLM_BASE_URL: `http://127.0.0.1:${port}`,
+        LITELLM_API_KEY: 'test-key-well-over-eight-chars',
+        DOCS_SYNC_MODEL: 'test-model',
+        DOCS_SYNC_TEMPERATURE: undefined,
+        DOCS_SYNC_JSON_MODE: undefined,
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (status) => { resolve({ status, stdout, stderr }); });
+  });
+
+  try {
+    writeAnswers(f, {});
+
+    const result = await run();
+
+    assert.notEqual(result.status, 0, 'the 403 aborts the run');
+    // The job log (stdout) carries the response whole, including the far end of
+    // the body and the Cloudflare-block hint from the headers.
+    assert.ok(result.stdout.includes('Z'.repeat(20_000)), 'the full block-page body reaches the job log');
+    assert.match(result.stdout, /Looks like a Cloudflare edge block/);
+    assert.match(result.stdout, /cf-ray=testray-WAW/);
+    assert.doesNotMatch(result.stdout, /\[truncated/, 'the job log is never truncated');
+
+    // The step summary is bounded, with a pointer to the uncut log.
+    const summary = readFileSync(path.join(f.root, 'summary.md'), 'utf8');
+
+    assert.match(summary, /\[truncated: \d+ more characters; see the full job log\]/);
+    assert.ok(!summary.includes('Z'.repeat(20_000)), 'the summary does not carry the whole body');
+  } finally {
+    server.close();
+    rmSync(f.root, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/__tests__/docs-sync-llm.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-llm.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { completionsUrl, createClient } from '../lib/docs-sync/llm.mjs';
+import { completionsUrl, createClient, describeErrorResponse } from '../lib/docs-sync/llm.mjs';
 
 const ok = (content) => new Response(JSON.stringify({ choices: [{ message: { content } }] }), { status: 200 });
 const noSleep = async() => {};
@@ -72,7 +72,7 @@ test('json mode is on by default and omittable', async() => {
   assert.ok(!('response_format' in bodies[1]), 'response_format is omitted when json mode is off');
 });
 
-test('an error body is surfaced past 200 characters and capped at 4096', async() => {
+test('an error body is surfaced past 200 characters and capped at 16 KiB', async() => {
   const shortTail = `${'x'.repeat(300)}NEEDLE`;
   const fetchImpl = async() => new Response(shortTail, { status: 400 });
   const client = createClient({ baseUrl: 'https://x', apiKey: 'k', model: 'm', fetchImpl, sleep: noSleep });
@@ -80,17 +80,58 @@ test('an error body is surfaced past 200 characters and capped at 4096', async()
   // The old 200-character cut buried the actual cause; the wider cut keeps it.
   await assert.rejects(() => client.complete({ system: 's', user: 'u' }), /NEEDLE/);
 
-  const longBody = 'y'.repeat(5000);
-  const fetchLong = async() => new Response(longBody, { status: 400 });
+  const overCap = 20_000;
+  const fetchLong = async() => new Response('y'.repeat(overCap), { status: 400 });
   const clientLong = createClient({ baseUrl: 'https://x', apiKey: 'k', model: 'm', fetchImpl: fetchLong, sleep: noSleep });
 
+  // Assert around the truncation notice, not a byte offset -- the message now
+  // carries a status line and a headers block before the body.
   await assert.rejects(() => clientLong.complete({ system: 's', user: 'u' }), (error) => {
-    const quoted = error.message.slice(error.message.indexOf('400: ') + '400: '.length);
-
-    assert.equal(quoted.length, 4096, 'the body is capped at 4096 characters');
+    assert.match(error.message, new RegExp(`\\[truncated: ${overCap - 16_384} more characters\\]`));
 
     return true;
   });
+});
+
+test('describeErrorResponse flags a Cloudflare edge block and surfaces its cf-ray', () => {
+  const blockPage = `<!DOCTYPE html><html><head><title>Blocked</title></head><body>${'@'.repeat(500)}</body></html>`;
+  const response = new Response(blockPage, {
+    status: 403,
+    statusText: 'Forbidden',
+    headers: {
+      server: 'cloudflare',
+      'cf-ray': 'a39683217aeeb5f7-WAW',
+      'cf-mitigated': 'challenge',
+      'content-type': 'text/html; charset=UTF-8',
+      'x-ratelimit-remaining-requests': '4999',
+      'set-cookie': 'secret-cf-clearance=should-not-appear',
+    },
+  });
+
+  const message = describeErrorResponse(response, blockPage);
+
+  assert.match(message, /LiteLLM responded 403 Forbidden/);
+  assert.match(message, /Looks like a Cloudflare edge block/);
+  assert.match(message, /cf-ray=a39683217aeeb5f7-WAW/);
+  // Allowlisted diagnostic headers appear...
+  assert.match(message, /^ {2}cf-mitigated: challenge$/m);
+  assert.match(message, /^ {2}x-ratelimit-remaining-requests: 4999$/m);
+  // ...but a non-diagnostic header (a cookie) is counted, never printed.
+  assert.doesNotMatch(message, /should-not-appear/);
+  assert.match(message, /\(1 other header omitted\)/);
+  assert.match(message, /Blocked/);
+});
+
+test('describeErrorResponse stays quiet about Cloudflare for an ordinary JSON API error', () => {
+  const body = '{"error":{"message":"model not found"}}';
+  const response = new Response(body, {
+    status: 404, statusText: 'Not Found', headers: { 'content-type': 'application/json' },
+  });
+
+  const message = describeErrorResponse(response, body);
+
+  assert.doesNotMatch(message, /Cloudflare/);
+  assert.match(message, /model not found/);
 });
 
 test('5xx and 429 are retried, then the last error surfaces', async() => {

--- a/.github/scripts/__tests__/docs-sync-llm.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-llm.test.mjs
@@ -135,6 +135,55 @@ test('describeErrorResponse stays quiet about Cloudflare for an ordinary JSON AP
   assert.match(message, /model not found/);
 });
 
+test('describeErrorResponse softens the claim for a Cloudflare-fronted HTML error with no cf-mitigated', () => {
+  // A Cloudflare-fronted origin's own 5xx HTML page: server=cloudflare + HTML,
+  // but no cf-mitigated -- so it must not be called an edge block.
+  const body = '<!DOCTYPE html><html><body>502 Bad Gateway</body></html>';
+  const response = new Response(body, {
+    status: 502,
+    statusText: 'Bad Gateway',
+    headers: { server: 'cloudflare', 'cf-ray': 'deadbeef-WAW', 'content-type': 'text/html' },
+  });
+
+  const message = describeErrorResponse(response, body);
+
+  assert.doesNotMatch(message, /edge block/);
+  assert.match(message, /Cloudflare served this HTML, not the model API; cf-ray=deadbeef-WAW/);
+});
+
+test('describeErrorResponse drops the Headers label when nothing matches the allowlist', () => {
+  const body = 'gateway timeout';
+  // A hand-built headers object, not a Response: the Response constructor adds a
+  // content-type for a string body, which is itself a diagnostic header.
+  const response = {
+    status: 504,
+    statusText: 'Gateway Timeout',
+    headers: new Headers({ 'x-lb-node': 'edge-7' }),
+  };
+
+  const message = describeErrorResponse(response, body);
+
+  // No empty "Headers:" section; just the omitted count.
+  assert.doesNotMatch(message, /^Headers:$/m);
+  assert.match(message, /\(1 other header omitted\)/);
+});
+
+test('a fetchImpl that omits headers degrades instead of throwing, and the status still governs the retry', async() => {
+  let n = 0;
+  // A hand-rolled response with no `headers` property at all.
+  const fetchImpl = async() => {
+    n += 1;
+
+    return { ok: false, status: 400, statusText: 'Bad Request', text: async() => 'no headers here' };
+  };
+  const client = createClient({ baseUrl: 'https://x', apiKey: 'k', model: 'm', fetchImpl, sleep: noSleep });
+
+  // 400 is a non-retryable status, so it must surface as a 400 -- not get
+  // mistaken for a network error (undefined status) and retried three times.
+  await assert.rejects(() => client.complete({ system: 's', user: 'u' }), /LiteLLM responded 400/);
+  assert.equal(n, 1);
+});
+
 test('5xx and 429 are retried, then the last error surfaces', async() => {
   let n = 0;
   const fetchImpl = async() => {

--- a/.github/scripts/__tests__/docs-sync-llm.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-llm.test.mjs
@@ -72,22 +72,23 @@ test('json mode is on by default and omittable', async() => {
   assert.ok(!('response_format' in bodies[1]), 'response_format is omitted when json mode is off');
 });
 
-test('an error body is surfaced past 200 characters and capped at 16 KiB', async() => {
+test('the error body is surfaced in full, uncut at the client', async() => {
   const shortTail = `${'x'.repeat(300)}NEEDLE`;
   const fetchImpl = async() => new Response(shortTail, { status: 400 });
   const client = createClient({ baseUrl: 'https://x', apiKey: 'k', model: 'm', fetchImpl, sleep: noSleep });
 
-  // The old 200-character cut buried the actual cause; the wider cut keeps it.
+  // The old 200-character cut buried the actual cause.
   await assert.rejects(() => client.complete({ system: 's', user: 'u' }), /NEEDLE/);
 
-  const overCap = 20_000;
-  const fetchLong = async() => new Response('y'.repeat(overCap), { status: 400 });
+  // A large body is kept whole here; only the step-summary sink caps it, so the
+  // job log carries the full response.
+  const big = 'y'.repeat(20_000);
+  const fetchLong = async() => new Response(big, { status: 400 });
   const clientLong = createClient({ baseUrl: 'https://x', apiKey: 'k', model: 'm', fetchImpl: fetchLong, sleep: noSleep });
 
-  // Assert around the truncation notice, not a byte offset -- the message now
-  // carries a status line and a headers block before the body.
   await assert.rejects(() => clientLong.complete({ system: 's', user: 'u' }), (error) => {
-    assert.match(error.message, new RegExp(`\\[truncated: ${overCap - 16_384} more characters\\]`));
+    assert.ok(error.message.includes(big), 'the whole body is present in the error message');
+    assert.doesNotMatch(error.message, /\[truncated/, 'the client does not truncate the body');
 
     return true;
   });

--- a/.github/scripts/__tests__/docs-sync-log.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-log.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { capForSummary, scrubSecrets } from '../lib/docs-sync/log.mjs';
+import { fenceForSummary, scrubSecrets } from '../lib/docs-sync/log.mjs';
 
 test('a tokenized remote URL is scrubbed', () => {
   const text = "Command failed: git push --quiet origin HEAD:refs/heads/docs-sync/prod-docs-18.1\nfatal: unable to access 'https://x-access-token:ghs_abc123DEF456@github.com/handsontable/handsontable.git/': stale lease";
@@ -50,13 +50,21 @@ test('a pathologically short secret is left alone so it cannot shred the log', (
   assert.equal(scrubSecrets(text, ['x']), text);
 });
 
-test('capForSummary passes short text through and bounds long text with a pointer to the log', () => {
-  assert.equal(capForSummary('short and fine', 100), 'short and fine');
+test('fenceForSummary fences short text whole and bounds long text with a distinct pointer', () => {
+  const short = fenceForSummary('short and fine', 100);
 
-  const capped = capForSummary('z'.repeat(50), 20);
+  assert.equal(short, '````\nshort and fine\n````');
 
-  assert.ok(capped.startsWith('z'.repeat(20)));
-  assert.match(capped, /\[truncated: 30 more characters; see the full job log\]/);
-  // The cap is on the summary copy only, so the pointer is what leads a reader
-  // from the summary to the uncut job log.
+  // Distinguishable content, so a slice that kept too much (a `max + 10` bug)
+  // would fail the exact-length check on the fenced line.
+  const capped = fenceForSummary('ab'.repeat(25), 20);
+  const lines = capped.split('\n');
+
+  assert.equal(lines[0], '````', 'opens with the four-backtick fence');
+  assert.equal(lines[1], 'ab'.repeat(10), 'exactly the first 20 characters are kept');
+  assert.match(capped, /\[cut for the step summary; full text in the job log\]/);
+  assert.equal(lines.at(-1), '````', 'the closing fence survives the cut');
+  // The marker deliberately avoids the `[truncated:` prefix classify.mjs uses,
+  // so a log-scanning assertion never confuses the two.
+  assert.doesNotMatch(capped, /\[truncated:/);
 });

--- a/.github/scripts/__tests__/docs-sync-log.test.mjs
+++ b/.github/scripts/__tests__/docs-sync-log.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { scrubSecrets } from '../lib/docs-sync/log.mjs';
+import { capForSummary, scrubSecrets } from '../lib/docs-sync/log.mjs';
 
 test('a tokenized remote URL is scrubbed', () => {
   const text = "Command failed: git push --quiet origin HEAD:refs/heads/docs-sync/prod-docs-18.1\nfatal: unable to access 'https://x-access-token:ghs_abc123DEF456@github.com/handsontable/handsontable.git/': stale lease";
@@ -48,4 +48,15 @@ test('a pathologically short secret is left alone so it cannot shred the log', (
   const text = 'Target prod-docs/18.1, sync branch docs-sync/prod-docs-18.1.';
 
   assert.equal(scrubSecrets(text, ['x']), text);
+});
+
+test('capForSummary passes short text through and bounds long text with a pointer to the log', () => {
+  assert.equal(capForSummary('short and fine', 100), 'short and fine');
+
+  const capped = capForSummary('z'.repeat(50), 20);
+
+  assert.ok(capped.startsWith('z'.repeat(20)));
+  assert.match(capped, /\[truncated: 30 more characters; see the full job log\]/);
+  // The cap is on the summary copy only, so the pointer is what leads a reader
+  // from the summary to the uncut job log.
 });

--- a/.github/scripts/docs-sync.mjs
+++ b/.github/scripts/docs-sync.mjs
@@ -43,7 +43,7 @@ import {
   applyCommits, git, hasForeignCommits, resetSyncBranch,
 } from './lib/docs-sync/git-apply.mjs';
 import { createGitHub } from './lib/docs-sync/github.mjs';
-import { capForSummary, scrubSecrets } from './lib/docs-sync/log.mjs';
+import { fenceForSummary, scrubSecrets } from './lib/docs-sync/log.mjs';
 
 const HOLD_MARKER = '<!-- docs-sync-hold -->';
 const CONTENT_PATHSPECS = CONTENT_PREFIXES.map((prefix) => prefix.replace(/\/$/, ''));
@@ -68,6 +68,11 @@ const gh = createGitHub({
   run: (args) => execFileSync(flags['gh-bin'], args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim(),
 });
 const summaryLines = [];
+// GitHub drops the entire step summary if a step writes more than ~1 MiB to it,
+// so the buffer is bounded well under that; the job log is never bounded.
+const SUMMARY_BUDGET_CHARS = 900_000;
+let summaryUsedChars = 0;
+let summaryTruncated = false;
 
 /**
  * Log to stdout and to the step summary buffer, with secrets scrubbed out of
@@ -78,19 +83,37 @@ const summaryLines = [];
  * as literals to be redacted wherever they appear, in whatever shape. This is
  * the one place all such messages pass through.
  *
- * The job log gets the full scrubbed line; the step summary gets a size-bounded
- * copy (`capForSummary`), so a huge failure body stays whole in the log while
- * the summary does not run away.
+ * The job log always gets the full scrubbed line. The step summary gets `line`
+ * too, unless the caller passes a `summary` override (the failure path passes a
+ * bounded, fenced copy) -- and once the summary buffer nears GitHub's size
+ * limit, one marker is written and further summary appends stop, so a large run
+ * never costs the whole summary.
  *
  * @param {string} line
+ * @param {{ summary?: string }} [options] `summary` replaces `line` in the step
+ *   summary only (already bounded by the caller); the job log still gets `line`.
  */
-function log(line) {
-  const scrubbed = scrubSecrets(line, [
-    process.env.LITELLM_API_KEY, process.env.GH_TOKEN, process.env.LITELLM_BASE_URL,
-  ]);
+function log(line, { summary } = {}) {
+  const secrets = [process.env.LITELLM_API_KEY, process.env.GH_TOKEN, process.env.LITELLM_BASE_URL];
+  const forLog = scrubSecrets(line, secrets);
 
-  console.log(scrubbed);
-  summaryLines.push(capForSummary(scrubbed));
+  console.log(forLog);
+
+  if (summaryTruncated) {
+    return;
+  }
+
+  const forSummary = summary === undefined ? forLog : scrubSecrets(summary, secrets);
+
+  if (summaryUsedChars + forSummary.length + 1 > SUMMARY_BUDGET_CHARS) {
+    summaryLines.push('[step summary truncated to stay within GitHub\'s size limit; see the full job log]');
+    summaryTruncated = true;
+
+    return;
+  }
+
+  summaryLines.push(forSummary);
+  summaryUsedChars += forSummary.length + 1;
 }
 
 /**
@@ -539,7 +562,10 @@ try {
 
   await flushSummary();
 } catch (error) {
-  log(`Failed: ${error.message}`);
+  // The job log gets the whole error (a failed classifier call carries the full
+  // upstream response); the summary gets a bounded, fenced copy so a block page
+  // renders literally and cannot run the summary away.
+  log(`Failed: ${error.message}`, { summary: `Failed:\n${fenceForSummary(error.message)}` });
   await flushSummary();
   process.exitCode = 1;
 }

--- a/.github/scripts/docs-sync.mjs
+++ b/.github/scripts/docs-sync.mjs
@@ -43,7 +43,7 @@ import {
   applyCommits, git, hasForeignCommits, resetSyncBranch,
 } from './lib/docs-sync/git-apply.mjs';
 import { createGitHub } from './lib/docs-sync/github.mjs';
-import { scrubSecrets } from './lib/docs-sync/log.mjs';
+import { capForSummary, scrubSecrets } from './lib/docs-sync/log.mjs';
 
 const HOLD_MARKER = '<!-- docs-sync-hold -->';
 const CONTENT_PATHSPECS = CONTENT_PREFIXES.map((prefix) => prefix.replace(/\/$/, ''));
@@ -78,6 +78,10 @@ const summaryLines = [];
  * as literals to be redacted wherever they appear, in whatever shape. This is
  * the one place all such messages pass through.
  *
+ * The job log gets the full scrubbed line; the step summary gets a size-bounded
+ * copy (`capForSummary`), so a huge failure body stays whole in the log while
+ * the summary does not run away.
+ *
  * @param {string} line
  */
 function log(line) {
@@ -86,7 +90,7 @@ function log(line) {
   ]);
 
   console.log(scrubbed);
-  summaryLines.push(scrubbed);
+  summaryLines.push(capForSummary(scrubbed));
 }
 
 /**

--- a/.github/scripts/lib/docs-sync/llm.mjs
+++ b/.github/scripts/lib/docs-sync/llm.mjs
@@ -6,13 +6,27 @@
  * without a network or a wait.
  */
 
-// An upstream error body (a proxy 4xx, an HTML block page) is the one string in
-// this module that a diagnostic needs in full, so it is cut generously rather
-// than at a token-frugal 200: 4096 matches the classifier's own body budget in
-// `classify.mjs`. Every such message passes through `docs-sync.mjs`'s
-// `scrubSecrets` before it reaches a log line or the public step summary, so a
-// key echoed back in the body is redacted regardless of this cap.
-const MAX_ERROR_CHARS = 4096;
+// The classifier's own malformed-response payload (our JSON) is cut here; it is
+// small and self-authored, so a modest cap is enough.
+const MAX_PAYLOAD_CHARS = 4096;
+
+// A failed upstream call's body is cut much more generously: a Cloudflare block
+// page is mostly a base64 font blob, but its signal (`<title>Blocked</title>`,
+// the visible message) sits in the first few hundred bytes, so 16 KiB captures
+// every real error whole while staying well under `$GITHUB_STEP_SUMMARY`'s size
+// limit -- it is not unbounded because that summary has a cap and is not
+// secret-masked.
+const MAX_ERROR_BODY_CHARS = 16_384;
+
+// The response headers worth surfacing on a failed call -- the set the probe
+// proved discriminates a Cloudflare edge block from a real API error. Every
+// `x-ratelimit-*` header is kept too (rate-limit state is diagnostic and the
+// exact names vary by provider). Allowlisted, not dumped: this string reaches
+// the un-masked step summary, so an unanticipated header must never ride along.
+const DIAGNOSTIC_HEADERS = [
+  'server', 'cf-ray', 'cf-mitigated', 'cf-cache-status', 'retry-after',
+  'x-litellm-model-id', 'content-type', 'date',
+];
 
 /**
  * The chat completions endpoint for a proxy base URL.
@@ -24,6 +38,59 @@ export function completionsUrl(baseUrl) {
   const base = baseUrl.replace(/\/+$/, '');
 
   return base.endsWith('/v1') ? `${base}/chat/completions` : `${base}/v1/chat/completions`;
+}
+
+/**
+ * A diagnostic message for a non-2xx response: the status, the headers that
+ * tell an edge block apart from an API error, and the body.
+ *
+ * The trimming is deliberate, not laziness: the whole string is thrown, logged,
+ * and appended to `$GITHUB_STEP_SUMMARY`, which has a size limit and is not
+ * secret-masked. So headers are allowlisted (never dumped whole) and the body is
+ * capped -- see the constants above.
+ *
+ * @param {Response} response
+ * @param {string} bodyText The already-read response body.
+ * @returns {string}
+ */
+export function describeErrorResponse(response, bodyText) {
+  const lines = [`LiteLLM responded ${response.status} ${response.statusText}`.trimEnd()];
+
+  // A Cloudflare edge block returns HTML with cf-ray/cf-mitigated, not the JSON
+  // an API error carries. Flag that from the headers alone -- do not assert
+  // which hop or whose zone Cloudflare fronts; the headers cannot support that,
+  // and a wrong guess here misleads the next reader.
+  const server = response.headers.get('server') ?? '';
+  const cfMitigated = response.headers.get('cf-mitigated');
+  const contentType = response.headers.get('content-type') ?? '';
+
+  if (/cloudflare/i.test(server) && (cfMitigated != null || /text\/html/i.test(contentType))) {
+    lines.push(`Looks like a Cloudflare edge block, not the model API; cf-ray=${response.headers.get('cf-ray') ?? '?'}, cf-mitigated=${cfMitigated ?? 'n/a'}.`);
+  }
+
+  const shown = [];
+  let omitted = 0;
+
+  for (const [name, value] of response.headers) {
+    if (DIAGNOSTIC_HEADERS.includes(name) || name.startsWith('x-ratelimit-')) {
+      shown.push(`  ${name}: ${value}`);
+    } else {
+      omitted += 1;
+    }
+  }
+
+  lines.push('Headers:', ...shown);
+  if (omitted > 0) {
+    lines.push(`  (${omitted} other header${omitted === 1 ? '' : 's'} omitted)`);
+  }
+
+  const body = bodyText.length > MAX_ERROR_BODY_CHARS
+    ? `${bodyText.slice(0, MAX_ERROR_BODY_CHARS)}\n[truncated: ${bodyText.length - MAX_ERROR_BODY_CHARS} more characters]`
+    : bodyText;
+
+  lines.push('Body:', body);
+
+  return lines.join('\n');
 }
 
 /**
@@ -87,7 +154,7 @@ export function createClient({
     });
 
     if (!response.ok) {
-      const error = new Error(`LiteLLM responded ${response.status}: ${(await response.text()).slice(0, MAX_ERROR_CHARS)}`);
+      const error = new Error(describeErrorResponse(response, await response.text()));
 
       error.status = response.status;
       throw error;
@@ -97,7 +164,7 @@ export function createClient({
     const content = payload?.choices?.[0]?.message?.content;
 
     if (typeof content !== 'string') {
-      throw new Error(`LiteLLM response carried no message content: ${JSON.stringify(payload).slice(0, MAX_ERROR_CHARS)}`);
+      throw new Error(`LiteLLM response carried no message content: ${JSON.stringify(payload).slice(0, MAX_PAYLOAD_CHARS)}`);
     }
 
     return content;

--- a/.github/scripts/lib/docs-sync/llm.mjs
+++ b/.github/scripts/lib/docs-sync/llm.mjs
@@ -10,13 +10,10 @@
 // small and self-authored, so a modest cap is enough.
 const MAX_PAYLOAD_CHARS = 4096;
 
-// A failed upstream call's body is cut much more generously: a Cloudflare block
-// page is mostly a base64 font blob, but its signal (`<title>Blocked</title>`,
-// the visible message) sits in the first few hundred bytes, so 16 KiB captures
-// every real error whole while staying well under `$GITHUB_STEP_SUMMARY`'s size
-// limit -- it is not unbounded because that summary has a cap and is not
-// secret-masked.
-const MAX_ERROR_BODY_CHARS = 16_384;
+// A failed upstream call's body is NOT cut here -- the whole response goes to
+// the diagnostic message so the run log carries it in full. The size-limited,
+// un-masked step summary is capped downstream at the summary sink
+// (`log.mjs`'s `capForSummary`), not here, so the two sinks can differ.
 
 // The response headers worth surfacing on a failed call -- the set the probe
 // proved discriminates a Cloudflare edge block from a real API error. Every
@@ -84,11 +81,7 @@ export function describeErrorResponse(response, bodyText) {
     lines.push(`  (${omitted} other header${omitted === 1 ? '' : 's'} omitted)`);
   }
 
-  const body = bodyText.length > MAX_ERROR_BODY_CHARS
-    ? `${bodyText.slice(0, MAX_ERROR_BODY_CHARS)}\n[truncated: ${bodyText.length - MAX_ERROR_BODY_CHARS} more characters]`
-    : bodyText;
-
-  lines.push('Body:', body);
+  lines.push('Body:', bodyText);
 
   return lines.join('\n');
 }

--- a/.github/scripts/lib/docs-sync/llm.mjs
+++ b/.github/scripts/lib/docs-sync/llm.mjs
@@ -11,9 +11,9 @@
 const MAX_PAYLOAD_CHARS = 4096;
 
 // A failed upstream call's body is NOT cut here -- the whole response goes to
-// the diagnostic message so the run log carries it in full. The size-limited,
-// un-masked step summary is capped downstream at the summary sink
-// (`log.mjs`'s `capForSummary`), not here, so the two sinks can differ.
+// the diagnostic message so the job log carries it in full. The size-limited,
+// un-masked step summary is bounded and fenced downstream at the summary sink
+// (`log.mjs`'s `fenceForSummary`), not here, so the two sinks can differ.
 
 // The response headers worth surfacing on a failed call -- the set the probe
 // proved discriminates a Cloudflare edge block from a real API error. Every
@@ -39,36 +39,41 @@ export function completionsUrl(baseUrl) {
 
 /**
  * A diagnostic message for a non-2xx response: the status, the headers that
- * tell an edge block apart from an API error, and the body.
+ * tell an edge block apart from an API error, and the full body. This is the
+ * job-log/exception text; the summary sink bounds and fences it downstream.
  *
- * The trimming is deliberate, not laziness: the whole string is thrown, logged,
- * and appended to `$GITHUB_STEP_SUMMARY`, which has a size limit and is not
- * secret-masked. So headers are allowlisted (never dumped whole) and the body is
- * capped -- see the constants above.
+ * Headers are allowlisted, never dumped: this string can reach the un-masked
+ * step summary, so an unanticipated header must never ride along. It reads
+ * `response.headers` defensively so a hand-rolled `fetchImpl` that omits it
+ * degrades to "no headers" instead of throwing.
  *
  * @param {Response} response
  * @param {string} bodyText The already-read response body.
  * @returns {string}
  */
 export function describeErrorResponse(response, bodyText) {
-  const lines = [`LiteLLM responded ${response.status} ${response.statusText}`.trimEnd()];
+  const headers = response.headers ?? new Headers();
+  const lines = [`LiteLLM responded ${response.status} ${response.statusText ?? ''}`.trimEnd()];
 
-  // A Cloudflare edge block returns HTML with cf-ray/cf-mitigated, not the JSON
-  // an API error carries. Flag that from the headers alone -- do not assert
-  // which hop or whose zone Cloudflare fronts; the headers cannot support that,
-  // and a wrong guess here misleads the next reader.
-  const server = response.headers.get('server') ?? '';
-  const cfMitigated = response.headers.get('cf-mitigated');
-  const contentType = response.headers.get('content-type') ?? '';
+  // Do not assert which hop or whose zone Cloudflare fronts; the headers cannot
+  // support that. `cf-mitigated` is set only when Cloudflare actually mitigates,
+  // so it is the confident signal and holds even if a later proxy rewrote the
+  // Server header. Server: cloudflare plus an HTML body is weaker -- it can be a
+  // Cloudflare-fronted origin's own error page -- so word that case without
+  // calling it an edge block.
+  const cfMitigated = headers.get('cf-mitigated');
+  const cfRay = headers.get('cf-ray') ?? '?';
 
-  if (/cloudflare/i.test(server) && (cfMitigated != null || /text\/html/i.test(contentType))) {
-    lines.push(`Looks like a Cloudflare edge block, not the model API; cf-ray=${response.headers.get('cf-ray') ?? '?'}, cf-mitigated=${cfMitigated ?? 'n/a'}.`);
+  if (cfMitigated != null) {
+    lines.push(`Looks like a Cloudflare edge block, not the model API; cf-ray=${cfRay}, cf-mitigated=${cfMitigated}.`);
+  } else if (/cloudflare/i.test(headers.get('server') ?? '') && /text\/html/i.test(headers.get('content-type') ?? '')) {
+    lines.push(`Cloudflare served this HTML, not the model API; cf-ray=${cfRay}.`);
   }
 
   const shown = [];
   let omitted = 0;
 
-  for (const [name, value] of response.headers) {
+  for (const [name, value] of headers) {
     if (DIAGNOSTIC_HEADERS.includes(name) || name.startsWith('x-ratelimit-')) {
       shown.push(`  ${name}: ${value}`);
     } else {
@@ -76,7 +81,9 @@ export function describeErrorResponse(response, bodyText) {
     }
   }
 
-  lines.push('Headers:', ...shown);
+  if (shown.length > 0) {
+    lines.push('Headers:', ...shown);
+  }
   if (omitted > 0) {
     lines.push(`  (${omitted} other header${omitted === 1 ? '' : 's'} omitted)`);
   }

--- a/.github/scripts/lib/docs-sync/log.mjs
+++ b/.github/scripts/lib/docs-sync/log.mjs
@@ -10,14 +10,19 @@
  *   `execFileSync` folds stderr into the thrown error's `message`.
  * - A LiteLLM error body can quote the request that failed, including its
  *   `Authorization: Bearer <key>` header, or name the key in its own prose.
- *   The classifier surfaces that body verbatim (see `llm.mjs`), so the
- *   `LITELLM_API_KEY` must be redacted too -- especially now the body is cut at
- *   4096 characters rather than 200.
+ *   The classifier surfaces that body verbatim and in full (see `llm.mjs`), so
+ *   the `LITELLM_API_KEY` must be redacted too.
  *
  * Any code path that logs a caught error's message -- including the script's
  * own top-level catch -- must scrub it first, or the secret ends up in the
  * run's public step summary.
  */
+
+// The GitHub step summary has a size limit and, unlike a job log, is rendered
+// markdown, so one huge failure body (a Cloudflare block page, say) must not run
+// away in it. `capForSummary` bounds the summary copy; the job log keeps the
+// full string.
+const MAX_SUMMARY_CHARS = 16_384;
 
 // A literal secret shorter than this is not redacted: every real credential
 // here (a GitHub App token, a LiteLLM key, the proxy URL) is far longer, and
@@ -50,4 +55,22 @@ export function scrubSecrets(text, secrets = []) {
   }
 
   return scrubbed;
+}
+
+/**
+ * Bound a string for the step summary, pointing the reader at the full job log
+ * when it had to cut. The job log is written uncapped, so nothing is lost.
+ *
+ * @param {string} text
+ * @param {number} [max]
+ * @returns {string}
+ */
+export function capForSummary(text, max = MAX_SUMMARY_CHARS) {
+  const string = String(text);
+
+  if (string.length <= max) {
+    return string;
+  }
+
+  return `${string.slice(0, max)}\n[truncated: ${string.length - max} more characters; see the full job log]`;
 }

--- a/.github/scripts/lib/docs-sync/log.mjs
+++ b/.github/scripts/lib/docs-sync/log.mjs
@@ -18,11 +18,13 @@
  * run's public step summary.
  */
 
-// The GitHub step summary has a size limit and, unlike a job log, is rendered
-// markdown, so one huge failure body (a Cloudflare block page, say) must not run
-// away in it. `capForSummary` bounds the summary copy; the job log keeps the
-// full string.
+// The step summary has a size limit and, unlike a job log, is rendered markdown
+// -- GitHub parses a raw `<!DOCTYPE html>` block page and strips the tags. So a
+// failure body destined for the summary is both bounded and wrapped in a code
+// fence; the job log keeps the full, unfenced string. Four backticks so a stray
+// ``` inside the page cannot close the fence early.
 const MAX_SUMMARY_CHARS = 16_384;
+const FENCE = '````';
 
 // A literal secret shorter than this is not redacted: every real credential
 // here (a GitHub App token, a LiteLLM key, the proxy URL) is far longer, and
@@ -58,19 +60,21 @@ export function scrubSecrets(text, secrets = []) {
 }
 
 /**
- * Bound a string for the step summary, pointing the reader at the full job log
- * when it had to cut. The job log is written uncapped, so nothing is lost.
+ * Bound a string for the step summary and wrap it in a code fence so GitHub
+ * renders it literally instead of parsing any HTML in it. The cut notice is
+ * worded distinctly (no `[truncated:` prefix) so it never collides with
+ * `classify.mjs`'s prompt truncation in a log-scanning assertion. The job log
+ * is written uncapped and unfenced, so nothing is lost there.
  *
  * @param {string} text
  * @param {number} [max]
  * @returns {string}
  */
-export function capForSummary(text, max = MAX_SUMMARY_CHARS) {
+export function fenceForSummary(text, max = MAX_SUMMARY_CHARS) {
   const string = String(text);
+  const shown = string.length > max
+    ? `${string.slice(0, max)}\n[cut for the step summary; full text in the job log]`
+    : string;
 
-  if (string.length <= max) {
-    return string;
-  }
-
-  return `${string.slice(0, max)}\n[truncated: ${string.length - max} more characters; see the full job log]`;
+  return `${FENCE}\n${shown}\n${FENCE}`;
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -603,6 +603,25 @@ pull request body lists every decision with its reason. Merge it and
   the checkout it runs in and restores your branch afterwards, so run it from a
   clean checkout or a worktree, never with uncommitted changes.
 
+#### A `Blocked` HTML 403 from the classifier is a Cloudflare block on the runner IP
+
+The classifier calls the gateway at `litellm.handsontable.com`, which sits
+behind Cloudflare. A CI run can get an HTML `Blocked` 403 after a handful of
+successful calls, while the same calls from a developer machine never block.
+This is **caller-IP dependent** - measured 42/42 successes from a non-datacenter
+IP against roughly six-then-block from the GitHub Actions runner - so the block
+is on the runner -> gateway leg at Cloudflare (bot management on the runner's
+datacenter IP), not the model API, the gateway's own rate limit (its
+`x-ratelimit-remaining-requests` stayed near its ceiling), or the gateway ->
+provider egress (that leg is identical from a machine that never blocks). The
+fix is to allowlist the runner IP at that Cloudflare zone, or turn off Bot Fight
+Mode for the host - not a client change. Whether that zone is Handsontable's own
+or the host's is unconfirmed until someone reads Cloudflare -> Security -> Events
+for `litellm.handsontable.com`; that view also names the exact rule that fired.
+On a failed call the classifier now logs the upstream response headers (`cf-ray`,
+`cf-mitigated`, `server`, rate-limit headers) so the block is identifiable
+straight from the run summary.
+
 ---
 
 ## 2.12 Content Pipeline and Dev-Server Memory (DEV-1991)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -603,25 +603,6 @@ pull request body lists every decision with its reason. Merge it and
   the checkout it runs in and restores your branch afterwards, so run it from a
   clean checkout or a worktree, never with uncommitted changes.
 
-#### A `Blocked` HTML 403 from the classifier is a Cloudflare block on the runner IP
-
-The classifier calls the gateway at `litellm.handsontable.com`, which sits
-behind Cloudflare. A CI run can get an HTML `Blocked` 403 after a handful of
-successful calls, while the same calls from a developer machine never block.
-This is **caller-IP dependent** - measured 42/42 successes from a non-datacenter
-IP against roughly six-then-block from the GitHub Actions runner - so the block
-is on the runner -> gateway leg at Cloudflare (bot management on the runner's
-datacenter IP), not the model API, the gateway's own rate limit (its
-`x-ratelimit-remaining-requests` stayed near its ceiling), or the gateway ->
-provider egress (that leg is identical from a machine that never blocks). The
-fix is to allowlist the runner IP at that Cloudflare zone, or turn off Bot Fight
-Mode for the host - not a client change. Whether that zone is Handsontable's own
-or the host's is unconfirmed until someone reads Cloudflare -> Security -> Events
-for `litellm.handsontable.com`; that view also names the exact rule that fired.
-On a failed call the classifier now logs the upstream response headers (`cf-ray`,
-`cf-mitigated`, `server`, rate-limit headers) so the block is identifiable
-straight from the run summary.
-
 ---
 
 ## 2.12 Content Pipeline and Dev-Server Memory (DEV-1991)


### PR DESCRIPTION
### Context

Follow-up to the docs-sync classifier work (DEV-1780). When a classifier call fails, the thrown error carried only the response body, cut at a small cap, and no headers. That hid the actual cause of a live incident: a `Blocked` HTML 403 whose real signal was in the response **headers** (`cf-ray`, `cf-mitigated`, `server`), not the body - and the body's useful part (`<title>Blocked</title>`) was being truncated away.

This makes a failed upstream call self-explanatory from the run:

- **Response headers are captured** on any non-2xx, via a new `describeErrorResponse()` in `llm.mjs`. Headers are **allowlisted**, not dumped - the diagnostic set a live probe proved discriminating (`server`, `cf-ray`, `cf-mitigated`, `cf-cache-status`, `retry-after`, every `x-ratelimit-*`, `x-litellm-model-id`, `content-type`, `date`), plus an "N other headers omitted" count. The message lands in `$GITHUB_STEP_SUMMARY`, which GitHub does not secret-mask, so an unanticipated header must never ride along; the allowlist is that guarantee.
- **The full response body reaches the job log.** The client no longer truncates it at all. The size-limited, un-masked step summary is the only place it is bounded: `log()` now writes the full scrubbed line to the job log and a capped copy (`capForSummary`, 16 KiB) to the summary, with a `[truncated: N more characters; see the full job log]` pointer. So the whole block page is one click away in the log, and the summary stays legible. (That split answers the "why trim at all" question directly: only the summary sink needs a bound.)
- **A Cloudflare edge block is flagged** when the headers show it (`server: cloudflare` plus `cf-mitigated` or an HTML content-type), with the `cf-ray`. The hint is deliberately hop-agnostic - it says "looks like a Cloudflare edge block, not the model API" and nothing about which hop or whose zone, because the headers cannot support more and a wrong guess misleads the next reader.

Everything still flows through `docs-sync.mjs`'s `log()` -> `scrubSecrets()`, so the three known secrets stay redacted on top of the header allowlist.

Out of scope (kept separate on purpose): the resilience change - checkpointing decisions and not aborting the whole batch on one failed call - and the infra fix for the block itself, which is not a client change.

### How has this been tested?

- `node --test .github/scripts/__tests__/docs-sync-*.test.mjs` - all pass. New coverage: `describeErrorResponse` flags a Cloudflare 403 and surfaces its `cf-ray`, counts but never prints a non-diagnostic header (a cookie), and stays quiet about Cloudflare for an ordinary JSON API error; the body is surfaced in full, uncut at the client; `capForSummary` bounds the summary copy and points to the log; and an end-to-end CLI test drives a 403 with a 20 KB body through a fake gateway and asserts the whole body reaches stdout while the summary is capped.
- `npm run test:tooling` - all pass.
- `npm run eslint` (root - the only lint config covering `.github/scripts/`) - clean.
- Verified live against the gateway with a standalone probe (42/42 calls succeeded from a non-datacenter IP), which is how the failing case was isolated to the CI runner's IP.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1780

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

CI tooling only - no shipped package is changed.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1780

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only docs-sync scripting and tests; no shipped packages. Slightly more data in job logs on failure, with secret scrubbing and header allowlisting preserved for the public step summary.
> 
> **Overview**
> When the docs-sync classifier’s LiteLLM call fails, failures are easier to diagnose: **`describeErrorResponse`** builds the error from status, an **allowlisted** set of headers (plus `x-ratelimit-*`), the **full** response body, and hints when headers look like a **Cloudflare edge block** vs a normal API error.
> 
> **Logging is split by sink:** the job log keeps the entire scrubbed message; the GitHub step summary gets a **16 KiB capped, four-backtick fenced** copy via **`fenceForSummary`**, with a pointer to the log. **`log()`** can pass a `summary` override on failure and stops appending once a ~900k summary budget is hit. The LLM client no longer truncates upstream error bodies (only malformed JSON payloads stay capped).
> 
> Tests add **`spawnCli`** for async LLM runs, unit coverage for **`describeErrorResponse`** / **`fenceForSummary`**, and an end-to-end case where a 403 HTML block page fills stdout but not the summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 781ff1d91c59e128f43f51806b122756781ad0aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->