### PR TITLE
DEV-2894: Americanize British spelling in source comments, JSDoc, and CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,7 @@ name: E2E
 # End-to-end tests, build-dependent (consume the UMD artifact). Two matrices,
 # 1:1 with each other: the frozen Puppeteer suite and the new Playwright suite,
 # both over theme × bundle (UMD / UMD.min). Per-leg gating keeps the exact old
-# scope behaviour (UMD legs on the e2e scope, UMD.min on the e2e-min scope).
+# scope behavior (UMD legs on the e2e scope, UMD.min on the e2e-min scope).
 # The UMD.min legs load handsontable.full.min.js — the exact file Puppeteer's
 # test:production runs. The bundles Puppeteer does not test either
 # (handsontable.full.js and handsontable.min.js) are deliberately not covered

--- a/.github/workflows/test-health.yml
+++ b/.github/workflows/test-health.yml
@@ -52,7 +52,7 @@ jobs:
   collect:
     name: Collect
     runs-on: ubuntu-latest
-    # A cancelled run's artifacts are incomplete by definition. Every other run
+    # A canceled run's artifacts are incomplete by definition. Every other run
     # is worth a look: a red one for its failures, a green one for a flaky test
     # under quarantine, which keeps its leg green but still uploads its report.
     # A run with no test artifacts costs one API call and changes nothing.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,7 +189,7 @@ jobs:
     # Gated on the ES+CJS build (the visual examples consume it) OR the visual
     # scope — NOT on the build module merely succeeding. A tests/**-only PR
     # builds UMD (for Playwright) but not ES+CJS, and must not pay for the full
-    # visual suite (matches the pre-split behaviour).
+    # visual suite (matches the pre-split behavior).
     if: ${{ !failure() && !cancelled() && (needs.build.outputs.es-cjs-built == 'true' || needs.checks.outputs.test-visual == 'true') }}
     uses: ./.github/workflows/visual.yml
     secrets: inherit
@@ -218,7 +218,7 @@ jobs:
   # then sit as "Expected — waiting for status to be reported" and block the PR
   # forever. This job instead ALWAYS runs (so it always reports one stable name)
   # and derives a single verdict from every other job's result: it fails if any
-  # job that actually ran failed or was cancelled, and passes when everything
+  # job that actually ran failed or was canceled, and passes when everything
   # else succeeded or was legitimately scope-skipped. Branch protection should
   # require ONLY "CI Gate" and unpin every individual/matrix check name. The
   # manual-QA gate blocks through its needs edge here: a ticked PR's pending

--- a/.github/workflows/visual-approval-rerun.yml
+++ b/.github/workflows/visual-approval-rerun.yml
@@ -4,7 +4,7 @@ name: Visual approval rerun
 # is the whole action rather than step one of two.
 #
 # The gate in `visual.yml` reads the label live, but only a NEW attempt runs it,
-# and nothing started one — so a labelled pull request kept its red
+# and nothing started one — so a labeled pull request kept its red
 # `Visual / Compare`, and with it a red `CI Gate`, until someone pressed
 # "Re-run jobs" by hand.
 #

--- a/docs/src/components/PageTitle.astro
+++ b/docs/src/components/PageTitle.astro
@@ -5,7 +5,7 @@
  * Renders:
  *  1. A top bar with breadcrumbs.
  *  2. The page <h1> (id="_top" preserved — required by Starlight's skip-link
- *     and on-page TOC behaviour).
+ *     and on-page TOC behavior).
  *
  * Page-action buttons (Copy Markdown, Open in…) are rendered by the
  * PageSidebar override below the table of contents.

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -128,7 +128,7 @@ if (isRecipePage) {
     const entries: any[] = (matchingGroup as any).entries;
 
     if (pathname.includes('/api/')) {
-      // On API pages: show only the API reference items (the last group, labelled
+      // On API pages: show only the API reference items (the last group, labeled
       // 'API reference'). The items inside it are the flat API nav list.
       const apiGroup = entries.findLast((e: any) => e.type === 'group' && e.label === 'API reference');
       (Astro.locals.starlightRoute as any).sidebar = apiGroup ? apiGroup.entries : entries;

--- a/docs/src/llms.mjs
+++ b/docs/src/llms.mjs
@@ -166,7 +166,7 @@ export function buildLlmsIndex(pageMeta, sections) {
     for (const { label, slug, prefix } of section.items) {
       const meta = pageMeta.get(slug);
       // Prefer the page's own title: sidebar labels lean on their group for
-      // context (every recipe group's overview page is labelled 'Overview'),
+      // context (every recipe group's overview page is labeled 'Overview'),
       // which a flat index does not have.
       const desc = meta?.description ? `: ${meta.description}` : '';
 

--- a/docs/src/scripts/option-levels.ts
+++ b/docs/src/scripts/option-levels.ts
@@ -109,7 +109,7 @@ function mount(): void {
 
     const qs = next.toString();
     // Keep the fragment. Rebuilding the URL from the path alone drops it, and because
-    // this runs on mount too, that cancelled the browser's jump to a section link.
+    // this runs on mount too, that canceled the browser's jump to a section link.
     const { pathname, hash } = window.location;
     const url = `${pathname}${qs ? `?${qs}` : ''}${hash}`;
 

--- a/docs/src/styles/base/variables.css
+++ b/docs/src/styles/base/variables.css
@@ -9,7 +9,7 @@
  */
 
 /* -------------------------------------------------------------------------
- * Handsontable brand colours (matches the Stylus theme variables)
+ * Handsontable brand colors (matches the Stylus theme variables)
  * Starlight CSS custom properties:
  * https://starlight.astro.build/guides/css-and-tailwind/#theming
  *
@@ -17,10 +17,10 @@
  * Unlayered rules always win over layered ones, so we must NOT override
  * the gray-scale / white / black variables here — those need to invert
  * between light and dark mode via Starlight's own layered rules.
- * Only set accent colours (with separate dark/light values) and typography.
+ * Only set accent colors (with separate dark/light values) and typography.
  * ------------------------------------------------------------------------- */
 
-/* Dark mode accent colours + pure neutral gray palette */
+/* Dark mode accent colors + pure neutral gray palette */
 :root {
   --sl-color-accent-low:  #1a3a6b;
   --sl-color-accent:      #2856ea;
@@ -68,7 +68,7 @@
   --sl-color-block-bg: #121212;
 }
 
-/* Light mode accent colours + pure neutral gray palette */
+/* Light mode accent colors + pure neutral gray palette */
 :root[data-theme='light'] {
   --sl-color-accent-low:  #e6f3ff;
   --sl-color-accent:      #1A42E8;

--- a/docs/src/styles/layout/sidebar.css
+++ b/docs/src/styles/layout/sidebar.css
@@ -2,7 +2,7 @@
  * Sidebar menu-tag badges  (menuTag: new | updated in frontmatter)
  *
  * Starlight renders these as .sl-badge.success / .sl-badge.caution.
- * Badge colours are handled by starlight-theme-rapide. Only size and
+ * Badge colors are handled by starlight-theme-rapide. Only size and
  * layout adjustments for the sidebar context are applied here.
  * ------------------------------------------------------------------------- */
 

--- a/handsontable/src/3rdparty/walkontable/src/event.ts
+++ b/handsontable/src/3rdparty/walkontable/src/event.ts
@@ -755,7 +755,7 @@ class Event {
    * It also releases the mouse-down flag: a long-press fires `onMouseDown` from its timer, and
    * after a cancel no `mouseup` ever follows, which would leave mouse-move selection dragging
    * armed until the next click. The pending synthesized-pair flag is cleared for the same reason
-   * the scroll branch of `onTouchEnd` clears it: a cancelled gesture armed nothing, so a
+   * the scroll branch of `onTouchEnd` clears it: a canceled gesture armed nothing, so a
    * still-pending flag belongs to an earlier gesture whose pair never came, and left in place it
    * would drop the next real mouse pair inside the ceiling on engines that do not report the
    * input origin.

--- a/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
@@ -315,7 +315,7 @@ class Overlays {
 
   /**
    * Whether the press being handled started as a touch, so the compatibility `mousedown`/`click`/
-   * `contextmenu` that follow the same tap can be recognised and let through - only `pointerdown`
+   * `contextmenu` that follow the same tap can be recognized and let through - only `pointerdown`
    * carries a `pointerType`.
    */
   #pressIsTouch = false;
@@ -664,7 +664,7 @@ class Overlays {
    *
    * Driving the axis owner rather than the single `scrollableElement` matters in split mode, where
    * that element is the holder while the window owns the vertical axis: a wheel that moved the
-   * holder's `scrollLeft` was cancelled, and the window-owned vertical part went with it — the
+   * holder's `scrollLeft` was canceled, and the window-owned vertical part went with it — the
    * columns moved, the page did not. Scrolling the window from here consumes both axes at once.
    *
    * @param {number} delta Relative value to scroll.
@@ -909,7 +909,7 @@ class Overlays {
     const scrollbarWidth = geometryReader.getScrollbarWidth(rootDocument);
     // Only where an overlay is actually clipped out of the strip. The band exists to fill in for the
     // frozen content that stops short of the scrollbar; along an edge no overlay reaches, there is
-    // nothing to fill in for, and drawing one paints a grey strip over live cells and swallows the
+    // nothing to fill in for, and drawing one paints a gray strip over live cells and swallows the
     // presses there - which is what a grid with no frozen rows or columns used to get.
     const covers = (edge: 'bottom' | 'inlineEnd') =>
       this.#overlays.some(overlay => overlay.coversScrollbarEdge(edge));

--- a/handsontable/src/3rdparty/walkontable/src/overlay/regions/_base.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/regions/_base.ts
@@ -182,7 +182,7 @@ export abstract class Overlay {
    * viewport predicates (`isVerticallyScrollableByWindow()` / `isHorizontallyScrollableByWindow()`),
    * never through this field. The corner overlays, which have no axis of their own, hold the
    * single-answer trimming container of `getTrimmingContainer()` resolved at construction only – it
-   * is never refreshed – and position themselves from their two neighbours' owners, which
+   * is never refreshed – and position themselves from their two neighbors' owners, which
    * `Overlays#beforeDraw` re-resolves on every full draw.
    *
    * @type {HTMLElement | Window}
@@ -365,7 +365,7 @@ export abstract class Overlay {
    * Whether this overlay is currently keeping a strip clear along one of the scrollbar edges.
    *
    * The track band is drawn only where the answer is yes for at least one overlay. A band with nothing
-   * clipped behind it is a grey strip painted over live cells, and it swallows presses there.
+   * clipped behind it is a gray strip painted over live cells, and it swallows presses there.
    *
    * The strips are the single source of truth here, and an overlay publishes one only while its clone
    * is rendered - so this asks nothing else. Two gates for one decision is how this feature drifted: a

--- a/handsontable/src/3rdparty/walkontable/src/overlay/regions/bottomInlineStartCornerOverlay.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/regions/bottomInlineStartCornerOverlay.ts
@@ -75,8 +75,8 @@ export class BottomInlineStartCornerOverlay extends Overlay {
 
     overlayRoot.style.top = '';
 
-    // Same rule as the top corner: the positioned form whenever either neighbour's axis is owned by
-    // the window; each neighbour reports a 0 offset on an element-owned axis.
+    // Same rule as the top corner: the positioned form whenever either neighbor's axis is owned by
+    // the window; each neighbor reports a 0 offset on an element-owned axis.
     const anyAxisOnWindow = this.bottomOverlay.trimmingContainer === rootWindow ||
       this.inlineStartOverlay.trimmingContainer === rootWindow;
 

--- a/handsontable/src/3rdparty/walkontable/src/overlay/regions/topInlineStartCornerOverlay.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/regions/topInlineStartCornerOverlay.ts
@@ -133,7 +133,7 @@ export class TopInlineStartCornerOverlay extends Overlay {
     const overlayRoot = this.clone.wtTable.holder.parentNode as HTMLElement;
     const { rootWindow } = this.deps;
 
-    // The corner follows the window on whichever axis the window owns; a neighbour whose axis is
+    // The corner follows the window on whichever axis the window owns; a neighbor whose axis is
     // owned by an element reports a 0 offset on that axis, so the positioned form is right whenever
     // at least one axis scrolls with the window.
     if (this.topOverlay.trimmingContainer === rootWindow || this.inlineStartOverlay.trimmingContainer === rootWindow) {

--- a/handsontable/src/3rdparty/walkontable/src/overlay/resizeMonitor.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/resizeMonitor.ts
@@ -127,7 +127,7 @@ export class ResizeMonitor {
 
   /**
    * Whether the monitor was destroyed. Every callback that outlives a task boundary opens with this,
-   * because cancelling a handle cannot undo a callback the engine already dispatched.
+   * because canceling a handle cannot undo a callback the engine already dispatched.
    *
    * @type {boolean}
    */
@@ -183,7 +183,7 @@ export class ResizeMonitor {
    * listeners whenever the scrollable element changes, so an explicit re-observe can land in the middle
    * of a cooldown and must not leave a timer behind to observe a second time.
    *
-   * Cancelling that timer is only safe while this call can replace it. When the wrapper is detached
+   * Canceling that timer is only safe while this call can replace it. When the wrapper is detached
    * there is nothing to attach to, so a call landing mid-cooldown has to put the reconnect back or it
    * would consume the retry and leave the container watched by nobody - the permanent disconnect
    * again, one call further along. A failed attach OUTSIDE a cooldown arms nothing, which is the

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -1547,7 +1547,7 @@ class Border {
     // to move onto it. A cell in the first body row of a table that renders a head row draws no top
     // border - the column header owns that gridline (DEV-2786) - and the shared pixel is then the
     // last pixel of the top overlay, which paints at z-index 160 against this layer's 10. An edge
-    // left centred on it loses half its thickness behind the column header, so both cases put the
+    // left centered on it loses half its thickness behind the column header, so both cases put the
     // visible edge at the cell's own top boundary. The row axis's twin of the inline-start case
     // below; `standsBelowColumnHeader` explains why it is read from the DOM.
     if (parseInt(style.borderTopWidth, 10) > 0 || standsBelowColumnHeader(fromTDEl)) {
@@ -1557,7 +1557,7 @@ class Border {
     // The inline-start gridline sits INSIDE the cell when the cell draws its own start border, so the
     // edge has to move onto it. A cell standing behind a row header draws no start border - the row
     // header owns that gridline (#6673) - and the shared pixel is then the last pixel of the
-    // inline-start overlay, which paints at z-index 120 against this layer's 10. An edge left centred
+    // inline-start overlay, which paints at z-index 120 against this layer's 10. An edge left centered
     // on it would be hidden behind the row header, so both cases put the visible edge at the cell's
     // own inline-start boundary. Read from the DOM, not from a column index: with row headers no cell
     // owns that border, and `htFirstDatasetColumnNotRendered` takes it off the first rendered column
@@ -1586,7 +1586,7 @@ class Border {
     // A corner is only filled when the perpendicular edge is actually drawn there. A horizontal edge
     // extends toward the end corner only if this cell has a visible end edge, and toward the bottom
     // only if it has a visible bottom edge. Without this, a per-cell custom border whose end/bottom
-    // side is hidden (an interior or split-range edge) would still extend into the empty neighbour and
+    // side is hidden (an interior or split-range edge) would still extend into the empty neighbor and
     // stick out. For regular selections the side settings are absent, so `!undefined?.hide` is `true`
     // and the extension behaves exactly as before.
     const extendToEnd = !this.settings.end?.hide;

--- a/handsontable/src/3rdparty/walkontable/src/selection/manager.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/manager.ts
@@ -345,7 +345,7 @@ export class SelectionManager {
         headerAttributesMap.set(element, attributes);
       }
 
-      // Tag the active-header neighbour classes in this same pass, so the scanned element set is
+      // Tag the active-header neighbor classes in this same pass, so the scanned element set is
       // walked once. Order into `classNamesMap` does not matter — it is applied after the loop.
       if (isActiveHeader) {
         this.#markActiveHeaderNeighbor(element, className as string, classNamesMap);
@@ -468,7 +468,7 @@ export class SelectionManager {
   }
 
   /**
-   * Tags the neighbours of a single active-header cell: the TH directly BEFORE an active header gets
+   * Tags the neighbors of a single active-header cell: the TH directly BEFORE an active header gets
    * `<className>-prev` (the theme colors its inline-end border, giving the active header its
    * inline-start accent), and every TH of the TBODY row directly ABOVE an active row header gets
    * `<className>-prev-row` (the theme colors its bottom border, giving the active row header its top
@@ -481,7 +481,7 @@ export class SelectionManager {
    * active-header element, from the class-applying pass in `render`.
    *
    * @param {HTMLElement} element A scanned active-header element.
-   * @param {string} activeHeaderClassName The active header class name (the neighbour classes derive from it).
+   * @param {string} activeHeaderClassName The active header class name (the neighbor classes derive from it).
    * @param {Map} classNamesMap The render cycle's element→classNames map (applied and cleaned up later).
    */
   #markActiveHeaderNeighbor(
@@ -507,7 +507,7 @@ export class SelectionManager {
    * half of {@link SelectionManager#markActiveHeaderNeighbor}.
    *
    * @param {HTMLElement} element The active row-header cell.
-   * @param {string} activeHeaderClassName The active header class name (the neighbour class derives from it).
+   * @param {string} activeHeaderClassName The active header class name (the neighbor class derives from it).
    * @param {Map} classNamesMap The render cycle's element→classNames map (applied and cleaned up later).
    */
   #markPreviousRowHeaders(
@@ -562,7 +562,7 @@ export class SelectionManager {
   /**
    * Tags the last frozen column header with a seam class when the first non-frozen column is the
    * active header. That header's inline-start edge lands on the frozen-pane seam, which is drawn by
-   * the frozen overlay (a separate table) and is therefore out of reach of the neighbour `:has()`
+   * the frozen overlay (a separate table) and is therefore out of reach of the neighbor `:has()`
    * rule that gives every other active header its inline-start accent. The class lets the theme color
    * that seam to match. No-op unless `fixedColumnsStart` is used and this is the frozen overlay.
    *

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -343,7 +343,7 @@ function captureRenderedState(table: Table, wtViewport: Viewport): RenderedState
 
 /**
  * Puts the pre-draw rendered state back, undoing the band and filter advance of a draw whose render
- * the `beforeDraw` hook cancelled — but only when the rollback is provably safe. When any guard
+ * the `beforeDraw` hook canceled — but only when the rollback is provably safe. When any guard
  * fails, the this-draw state is kept, which is exactly the pre-rollback behavior of the engine, so
  * a blocked rollback is never worse than what shipped before the rollback existed.
  *

--- a/handsontable/src/3rdparty/walkontable/src/table/regions/masterTable.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/regions/masterTable.ts
@@ -186,7 +186,7 @@ class MasterTable extends Table {
     // throws; the brand check detects the pre-init call so the caching block
     // can be skipped. The non-caching branches (window-trimming overflow
     // reset and the trailing isVisible check) still run, matching the
-    // pre-DEV-1777 behaviour and the side effects callers depend on.
+    // pre-DEV-1777 behavior and the side effects callers depend on.
     const fieldsInitialized = #trimmingCache in this;
     const preventOverflow = this.wtSettings.getSetting('preventOverflow');
     // Each axis has its own owner (see `overlay/axisOwner.ts`). The overlays read the same two

--- a/handsontable/src/cellTypes/registry.ts
+++ b/handsontable/src/cellTypes/registry.ts
@@ -54,7 +54,7 @@ function _getItem(name: string): CellTypeObject {
  * Register cell type under specified name.
  *
  * @param {string} name Cell type identification.
- * @param {object} type An object with contains keys (eq: `editor`, `renderer`, `validator`) which describes specified behaviour of the cell.
+ * @param {object} type An object with contains keys (eq: `editor`, `renderer`, `validator`) which describes specified behavior of the cell.
  */
 function _register(name: string | CellTypeObject, type?: CellTypeObject): void {
   if (typeof name !== 'string') {

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -2403,7 +2403,7 @@ export default function Core(
               shouldBeCanceled = false;
               // cancel the change
               changes.splice(index, 1);
-              // we cancelled the change, so cell value is still valid
+              // we canceled the change, so cell value is still valid
               cellPropertiesReference.valid = true;
               // ...and the stored meta has to hear about it too, or a cache clear that landed while
               // the validator was running leaves the kept value wearing the rejected edit's mark.
@@ -2760,7 +2760,7 @@ export default function Core(
    */
   function processChanges(changes: Array<CellChange | null>, source: string | undefined): CellChange[] {
     const beforeChangeResult = instance.runHooks('beforeChange', changes, source || 'edit');
-    // The `beforeChange` hook could add a `null` for purpose of cancelling some dataset's change.
+    // The `beforeChange` hook could add a `null` for purpose of canceling some dataset's change.
     const filteredChanges = changes.filter((change): change is CellChange => change !== null);
 
     if (beforeChangeResult === false || filteredChanges.length === 0) {

--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -284,7 +284,7 @@ export const REGISTERED_HOOKS = [
    * @param {number} amount Number of newly created columns in the data source array.
    * @param {string} [source] String that identifies source of hook call
    *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
-   * @returns {*} If `false` then creating columns is cancelled.
+   * @returns {*} If `false` then creating columns is canceled.
    * @example
    * ::: only-for javascript
    * ```js
@@ -1421,7 +1421,7 @@ export const REGISTERED_HOOKS = [
    * @param {CellRange} targetRange The range new values will be filled into.
    * @param {string} direction Declares the direction of the autofill. Possible values: `up`, `down`, `left`, `right`.
    *
-   * @returns {boolean|Array[]} If false, the operation is cancelled. If array of arrays, the returned data
+   * @returns {boolean|Array[]} If false, the operation is canceled. If array of arrays, the returned data
    *                              will be passed into [`populateFromArray`](@/api/core.md#populatefromarray) instead of the default autofill
    *                              algorithm's result.
    */
@@ -1478,7 +1478,7 @@ export const REGISTERED_HOOKS = [
    *                          [Binding to data: Identify changed columns in hooks](@/guides/getting-started/binding-to-data/binding-to-data.md#identify-changed-columns-in-hooks).
    * @param {string} [source] String that identifies source of hook call
    *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
-   * @returns {undefined | boolean} If `false` all changes were cancelled, `true` otherwise.
+   * @returns {undefined | boolean} If `false` all changes were canceled, `true` otherwise.
    * @example
    * ::: only-for javascript
    * ```js

--- a/handsontable/src/dataMap/dataMap.ts
+++ b/handsontable/src/dataMap/dataMap.ts
@@ -595,7 +595,7 @@ class DataMap {
    * @param {number} [index] Visual index of the row to be removed. If not provided, the last row will be removed.
    * @param {number} [amount=1] Amount of the rows to be removed. If not provided, one row will be removed.
    * @param {string} [source] Source of method call.
-   * @returns {boolean} Returns `false` when action was cancelled, otherwise `true`.
+   * @returns {boolean} Returns `false` when action was canceled, otherwise `true`.
    */
   removeRow(index: number, amount = 1, source: string) {
     let rowIndex = Number.isInteger(index) ? index : -amount; // -amount = taking indexes from the end.
@@ -648,7 +648,7 @@ class DataMap {
    * @param {number} [index] Visual index of the column to be removed. If not provided, the last column will be removed.
    * @param {number} [amount=1] Amount of the columns to be removed. If not provided, one column will be removed.
    * @param {string} [source] Source of method call.
-   * @returns {boolean} Returns `false` when action was cancelled, otherwise `true`.
+   * @returns {boolean} Returns `false` when action was canceled, otherwise `true`.
    */
   removeCol(index: number, amount = 1, source: string) {
     if (this.hot!.dataType === 'object' || this.tableMeta.columns) {

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -731,7 +731,7 @@ class EditorManager {
    * visual index space instead of preserving it, so `isHidden()` reads `false` for a trimmed row and
    * this method never fires for one.
    *
-   * The edit is finished rather than cancelled, which for most editors means it is COMMITTED - the
+   * The edit is finished rather than canceled, which for most editors means it is COMMITTED - the
    * same outcome clicking the pager already produces, since that is an outside click and therefore
    * deselects. The final say still belongs to the editor: `DropdownEditor#finishEditing()` rewrites
    * the flag to a discard when the active range no longer contains the edited cell. On THIS path it

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -92,7 +92,7 @@ export class AutocompleteEditor extends HandsontableEditor {
    * scroll-hide, both through `#dropInFlightQueries()` - so a late response can tell that the query it
    * belongs to has been abandoned, which neither `state` nor `_opened` reports reliably. Only the
    * response needs a token: user code holds that callback and there is nothing to cancel, while the
-   * editor's own deferred queries are cancelled outright through `#queryTimeouts`.
+   * editor's own deferred queries are canceled outright through `#queryTimeouts`.
    *
    * @type {number}
    */
@@ -480,7 +480,7 @@ export class AutocompleteEditor extends HandsontableEditor {
     // also closes the editor (`assignHooks`). `_opened` stays false while the cell is scroll-hidden and
     // after it scrolls back, so the guards elsewhere key on `state`, not `_opened`.
     //
-    // Queries this editor deferred are cancelled outright; the token below is for the ones already
+    // Queries this editor deferred are canceled outright; the token below is for the ones already
     // handed to user code, which cannot be.
     //
     // The two meanings of hiding are separated in `TextEditor`: a scroll-out goes through
@@ -505,7 +505,7 @@ export class AutocompleteEditor extends HandsontableEditor {
    * so any `source` response still in flight is dropped. Shared by `close()` and `hideForScroll()`:
    * both mean "no more responses wanted", and a late one must not re-show the list or steal focus back
    * through `hot.listen()` (DEV-2653/DEV-2676). The debounced refocus is armed by the inner grid's
-   * `afterScroll` and runs 100 ms later, so it outlives the hide unless cancelled here.
+   * `afterScroll` and runs 100 ms later, so it outlives the hide unless canceled here.
    *
    * @private
    */
@@ -579,7 +579,7 @@ export class AutocompleteEditor extends HandsontableEditor {
   }
 
   /**
-   * Verifies result of validation or closes editor if user's cancelled changes.
+   * Verifies result of validation or closes editor if user's canceled changes.
    *
    * @param {boolean|undefined} result If `false` and the cell using allowInvalid option,
    *                                   then an editor won't be closed until validation is passed.

--- a/handsontable/src/editors/baseEditor/baseEditor.ts
+++ b/handsontable/src/editors/baseEditor/baseEditor.ts
@@ -519,7 +519,7 @@ export class BaseEditor {
   }
 
   /**
-   * Verifies result of validation or closes editor if user's cancelled changes.
+   * Verifies result of validation or closes editor if user's canceled changes.
    *
    * @param {boolean|undefined} result If `false` and the cell using allowInvalid option,
    *                                   then an editor won't be closed until validation is passed.
@@ -683,7 +683,7 @@ export class BaseEditor {
     // The position above shifted the editor 1px towards the inline start so that it covers the
     // gridline the previous cell draws on its inline-end side. A cell that draws its OWN
     // inline-start border keeps that gridline inside its box, so there is nothing to cover and the
-    // shift is cancelled here. Which cells those are is not a fixed index: with row headers the
+    // shift is canceled here. Which cells those are is not a fixed index: with row headers the
     // header owns the gridline and column 0 draws none (#6673), and `htFirstDatasetColumnNotRendered`
     // takes it off the first rendered column too - so read the border rather than the index, and
     // key it off the same value that sizes the editor below, or the two disagree by a pixel.

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.ts
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.ts
@@ -585,7 +585,7 @@ export class HandsontableEditor extends TextEditor {
 
         return action(rowToSelect, event);
       },
-      preventDefault: false, // Doesn't block default behaviour (navigation) for a `textArea` HTMLElement.
+      preventDefault: false, // Doesn't block default behavior (navigation) for a `textArea` HTMLElement.
     }, {
       keys: [['ArrowDown']],
       callback: (event: KeyboardEvent) => {
@@ -612,7 +612,7 @@ export class HandsontableEditor extends TextEditor {
 
         return action(rowToSelect, event);
       },
-      preventDefault: false, // Doesn't block default behaviour (navigation) for a `textArea` HTMLElement.
+      preventDefault: false, // Doesn't block default behavior (navigation) for a `textArea` HTMLElement.
     }], contextConfig);
   }
 

--- a/handsontable/src/helpers/dom/event.ts
+++ b/handsontable/src/helpers/dom/event.ts
@@ -74,7 +74,7 @@ export interface TouchPoint {
  *
  * `touches` is every finger currently on the screen, in the order they were placed. `changedTouches`
  * is only the fingers this particular event is about - the ones that landed, moved, lifted or were
- * cancelled.
+ * canceled.
  */
 export interface TouchListEvent extends Event {
   touches: ArrayLike<TouchPoint>;

--- a/handsontable/src/plugins/autoRowHeaderSize/autoRowHeaderSize.ts
+++ b/handsontable/src/plugins/autoRowHeaderSize/autoRowHeaderSize.ts
@@ -668,7 +668,7 @@ export class AutoRowHeaderSize extends BasePlugin {
   ): void {
     // Each level is bucketed by the labels IT draws. Sampling every level by another's labels would
     // skip the row carrying this one's longest label, leaving the level narrow. The grid's own
-    // renderer is recognised by reference: it is the only one whose text `getRowHeader` can be
+    // renderer is recognized by reference: it is the only one whose text `getRowHeader` can be
     // trusted for, and it is not necessarily the first in the array.
     this.#readLabel = isGridRenderer
       ? visualRow => this.hot.getRowHeader(visualRow)

--- a/handsontable/src/plugins/comments/comments.ts
+++ b/handsontable/src/plugins/comments/comments.ts
@@ -1020,7 +1020,7 @@ export class Comments extends BasePlugin {
     // `#cellBelowCursor === target` one: the drag lands an event on the element underneath the
     // pointer (the browser hit-tests each "mousemove" against the textarea's pre-resize box) and
     // `elementFromPoint` already resolves to the resized textarea, so the next event - the one
-    // over the textarea - matches and would return before cancelling anything.
+    // over the textarea - matches and would return before canceling anything.
     if (this.targetIsCommentTextArea(event)) {
       this.#displaySwitch?.keepVisible();
       // Returning early skips the `#cellBelowCursor` write below, so the field would keep naming

--- a/handsontable/src/plugins/comments/displaySwitch.ts
+++ b/handsontable/src/plugins/comments/displaySwitch.ts
@@ -111,7 +111,7 @@ class DisplaySwitch {
    *
    * Dropping the show is what separates this from `cancelHiding()`, and it is required rather than
    * tidy. `cancelHiding()` also sets `wasLastActionShow` back to `true`, which is the only thing
-   * suppressing a show that a `hide()` had already overruled - so cancelling a hide on its own
+   * suppressing a show that a `hide()` had already overruled - so canceling a hide on its own
    * revives that show, and the comment on screen is replaced by another cell's a moment later.
    * The caller here is reacting to the pointer resting ON the editor, where the comment already
    * displayed is the one that belongs there.
@@ -139,7 +139,7 @@ class DisplaySwitch {
     // A rebuild has to both cancel and carry over. The replaced function keeps its timer in its own
     // closure, and that timer closes over this instance, so leaving it running would show a comment
     // with nothing holding a reference to stop it - `keepVisible()` can only reach the CURRENT
-    // function, so one orphan defeats it. Cancelling alone is not enough either: it would drop a
+    // function, so one orphan defeats it. Canceling alone is not enough either: it would drop a
     // hover the user already started, and the comment would never appear until the pointer moved.
     const pendingRange = this.#pendingShowRange;
 

--- a/handsontable/src/plugins/contextMenu/menu/menu.ts
+++ b/handsontable/src/plugins/contextMenu/menu/menu.ts
@@ -220,7 +220,7 @@ export class Menu {
    */
   #subMenuSwitchTimer: ReturnType<typeof setTimeout> | null = null;
   /**
-   * The debounced hover-driven sub-menu open, kept as a field so it can be cancelled when
+   * The debounced hover-driven sub-menu open, kept as a field so it can be canceled when
    * the pointer leaves the menu. Assigned in `open()`.
    *
    * @type {Function|null}
@@ -713,7 +713,7 @@ export class Menu {
     this.#clearHoverSubMenuTimers();
 
     // `_registerTimeout` so the handle is cleared if the grid is destroyed with the menu open.
-    // It is the convention here, and the cost is known: `hot.timeouts` only grows, so cancelling
+    // It is the convention here, and the cost is known: `hot.timeouts` only grows, so canceling
     // leaves a dead handle behind and hovering across menu rows adds one each time. They are
     // integers on an array freed with the instance. The alternative — a generation token and a
     // timer that fires and no-ops — trades that for more state and a callback that still runs.

--- a/handsontable/src/plugins/copyPaste/copyPaste.ts
+++ b/handsontable/src/plugins/copyPaste/copyPaste.ts
@@ -84,7 +84,7 @@ function padRowsToWidest(data: unknown[][]) {
 const CLIPBOARD_PARSE_WARN_KEY = 'copyPaste.clipboardParse';
 
 /**
- * Reads the `text/plain` clipboard flavour.
+ * Reads the `text/plain` clipboard flavor.
  *
  * Shared by the no-table branch and by the fallback taken when the HTML parse throws, so the two
  * cannot drift on the trailing-newline rule below.
@@ -1040,7 +1040,7 @@ export class CopyPaste extends BasePlugin {
         // Every HTML parse entry point is a Trusted Types sink, so `parseFromString` throws under
         // `require-trusted-types-for 'script'` unless the value came from a policy - which it did
         // not when no `sanitizer` is configured, or when one is configured and returns a plain
-        // string. Losing the source-data flavour costs object-key fidelity on an internal paste;
+        // string. Losing the source-data flavor costs object-key fidelity on an internal paste;
         // letting the throw escape would kill the paste outright.
         try {
           const parsedSourceConfig = htmlToGridSettings(
@@ -1060,8 +1060,8 @@ export class CopyPaste extends BasePlugin {
       if (textHTML && /(<table)|(<TABLE)/g.test(String(textHTML))) {
         // Same sink as the source-data parse above. Falling back to `text/plain` is what the
         // no-table branch below already does, so a page enforcing Trusted Types with no policy of
-        // its own still pastes - it pastes the plain-text flavour, losing only the cell types and
-        // styling the HTML flavour carried.
+        // its own still pastes - it pastes the plain-text flavor, losing only the cell types and
+        // styling the HTML flavor carried.
         try {
           const parsedConfig = htmlToGridSettings(textHTML, this.hot.rootDocument, {
             normalize: typeof textHTML === 'string',
@@ -1073,7 +1073,7 @@ export class CopyPaste extends BasePlugin {
 
           const plainText = readPlainText(clipboardData);
 
-          // Only when there is something to fall back TO. An empty `text/plain` flavour parses
+          // Only when there is something to fall back TO. An empty `text/plain` flavor parses
           // into `[['']]`, which the guard in `onPaste` does not stop, so assigning it would blank
           // the target cell - a worse outcome than the no-op that `undefined` produces, and this
           // payload was valid markup the parser simply would not accept.
@@ -1096,7 +1096,7 @@ export class CopyPaste extends BasePlugin {
   /**
    * Warns once that a clipboard payload could not be parsed, and why that is usually Trusted Types.
    *
-   * Deliberately says nothing about which flavour landed. Both parse sites share this message and
+   * Deliberately says nothing about which flavor landed. Both parse sites share this message and
    * one `warnOnce` key, and their consequences differ: a refused `text/html` payload falls back to
    * `text/plain`, while a refused source-data payload costs only object-key fidelity and leaves the
    * paste itself intact. Naming one outcome would print a false statement whenever the other site
@@ -1124,7 +1124,7 @@ export class CopyPaste extends BasePlugin {
    * values it writes, so an unprojected header reaches a rich-text target as the visible characters
    * `<b>Total</b>` rather than as bold text - the same mismatch the option exists to remove.
    *
-   * The source-data flavour is left alone. It carries the values behind the cells so that a copy
+   * The source-data flavor is left alone. It carries the values behind the cells so that a copy
    * between grids restores them exactly, and a projection would corrupt that round trip.
    *
    * The rows are mapped rather than mutated, so the array handed to `beforeCopy` and `afterCopy`

--- a/handsontable/src/plugins/customBorders/customBorders.ts
+++ b/handsontable/src/plugins/customBorders/customBorders.ts
@@ -1301,7 +1301,7 @@ export class CustomBorders extends BasePlugin {
 
   /**
    * Applies one progressive batch, renders so the newly in-viewport borders appear, then schedules
-   * the next batch or finishes. Aborts if the load was cancelled/superseded (token mismatch).
+   * the next batch or finishes. Aborts if the load was canceled/superseded (token mismatch).
    *
    * @param {number} token The generation token captured when the load started.
    */

--- a/handsontable/src/plugins/dataProvider/query/crud.ts
+++ b/handsontable/src/plugins/dataProvider/query/crud.ts
@@ -31,7 +31,7 @@ type InternalRowUpdatePayload = Partial<RowUpdatePayload>;
  * @param {Core} hot Handsontable instance.
  * @param {string} operation Mutation kind (`create`, `update`, or `remove`).
  * @param {object} payload Hook payload (`RowMutationPayload` in `types/plugins/dataProvider/dataProvider.d.ts`).
- * @returns {boolean|undefined} `false` when cancelled.
+ * @returns {boolean|undefined} `false` when canceled.
  */
 export function runBeforeRowsMutation(hot: HotInstance, operation: string, payload: object): false | undefined {
   if (hot.runHooks('beforeRowsMutation', operation, payload) === false) {

--- a/handsontable/src/plugins/exportFile/types/xlsx.ts
+++ b/handsontable/src/plugins/exportFile/types/xlsx.ts
@@ -414,7 +414,7 @@ class Xlsx extends BaseType {
     //    suppressed whenever ColumnSummary is present.
     //
     // 2. Setting protection on every cell — even { locked: false } — causes ExcelJS to
-    //    initialise font/fill/border to sentinel values, which adds noise to the file
+    //    initialize font/fill/border to sentinel values, which adds noise to the file
     //    and breaks styling assertions in tests.
     const hasColumnSummary = summaryMap.size > 0;
     const hasReadOnlyCells = !hasColumnSummary &&

--- a/handsontable/src/plugins/exportFile/types/xlsx/cell-style.ts
+++ b/handsontable/src/plugins/exportFile/types/xlsx/cell-style.ts
@@ -365,7 +365,7 @@ export function getAlignmentFromClassName(className: string | undefined): object
 /**
  * Derives an ExcelJS `alignment` object from the cell meta `className`.
  *
- * Recognised Handsontable alignment classes:
+ * Recognized Handsontable alignment classes:
  * - Horizontal: `htLeft`, `htCenter`, `htRight`, `htJustify`
  * - Vertical: `htTop`, `htMiddle`, `htBottom`
  *

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -772,7 +772,7 @@ export class Formulas extends BasePlugin {
       // `actionType` the engine step cannot be dispatched safely (`engine.redo()` vs the
       // `move_cells` replay path — the wrong branch runs the engine operation twice), so cancel
       // the redo instead of desyncing HyperFormula. The guard runs BEFORE `setPerformRedo(true)`
-      // — a cancelled redo never fires `afterRedo`, so a flag set here would leak.
+      // — a canceled redo never fires `afterRedo`, so a flag set here would leak.
       if (typeof action !== 'object' || action === null || !('actionType' in action)) {
         return false;
       }
@@ -790,7 +790,7 @@ export class Formulas extends BasePlugin {
 
     this.addHook('afterUndo', (action: unknown) => {
       this.indexSyncer!.setPerformUndo(false);
-      // Also clears the redo flags: a redo cancelled by a `beforeRedo` listener never fires
+      // Also clears the redo flags: a redo canceled by a `beforeRedo` listener never fires
       // `afterRedo`, so without these resets the flags set in `beforeRedo` would leak until the
       // next successful redo.
       this.indexSyncer!.setPerformRedo(false);
@@ -3294,7 +3294,7 @@ export class Formulas extends BasePlugin {
    * Formula cells are already served correctly through `modifyData` via `getCellValue`.
    * Plain VALUE / EMPTY cells, however, fall back to the raw HOT data, so after HF
    * moves the data the old raw values must be cleared from the source cells and the
-   * serialised HF content must be written to the target cells.
+   * serialized HF content must be written to the target cells.
    *
    * The write is fenced with `#moveCellsSyncPending` to prevent the `afterSetDataAtCell`
    * hook from re-syncing the same data back into HyperFormula.
@@ -3362,7 +3362,7 @@ export class Formulas extends BasePlugin {
         );
       }
 
-      // Write target cells with HF-serialised content (formula strings preserved).
+      // Write target cells with HF-serialized content (formula strings preserved).
       // Use 'auto' source so UndoRedo does not record these writes as separate DataChangeActions
       // — they are part of the move and are covered by the MoveCellsAction in the undo stack.
       this.hot.populateFromArray(

--- a/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
+++ b/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
@@ -84,7 +84,7 @@ export class ManualColumnMove extends BasePlugin {
    */
   #pressed = false;
   /**
-   * Whether the pointer travelled far enough since the header was pressed to count as a drag. A
+   * Whether the pointer traveled far enough since the header was pressed to count as a drag. A
    * press that stayed put is a click to sort, so no columns move and the move hooks stay quiet.
    */
   #dragged = false;
@@ -270,7 +270,7 @@ export class ManualColumnMove extends BasePlugin {
 
   /**
    * Checks whether a column drag is in progress - the header is held down and the pointer has
-   * travelled far enough to count as a drag rather than a click.
+   * traveled far enough to count as a drag rather than a click.
    *
    * `ColumnSorting` asks this on release to tell a click apart from a drag, so the two plugins
    * cannot disagree about where that line is.
@@ -790,7 +790,7 @@ export class ManualColumnMove extends BasePlugin {
       addClass(this.hot.rootElement, CSS_AFTER_SELECTION);
     }
 
-    // A press that never travelled is a click, not a move. Bailing out here also keeps
+    // A press that never traveled is a click, not a move. Bailing out here also keeps
     // `beforeColumnMove` / `afterColumnMove` from firing on every header click.
     if (!wasDragged || columnsLen < 1 || target === undefined) {
       this.#columnsToMove.length = 0;

--- a/handsontable/src/plugins/multipleSelectionHandles/multipleSelectionHandles.ts
+++ b/handsontable/src/plugins/multipleSelectionHandles/multipleSelectionHandles.ts
@@ -230,7 +230,7 @@ export class MultipleSelectionHandles extends BasePlugin {
       }
     });
 
-    // A cancelled gesture never reaches `touchend`, and browsers cancel often on a real phone - a
+    // A canceled gesture never reaches `touchend`, and browsers cancel often on a real phone - a
     // system gesture, an incoming call, the browser claiming the touch for scrolling. Both events are
     // handled the same way, because both answer the same question: which fingers are gone?
     for (const eventName of ['touchend', 'touchcancel']) {

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
@@ -473,7 +473,7 @@ export class NestedHeaders extends BasePlugin {
 
     if (this.enabled) {
       // Derive tree colspan / isHidden state from the current hiding map. This covers columns
-      // that were already hidden before the plugin initialised (e.g. HiddenColumns configured
+      // that were already hidden before the plugin initialized (e.g. HiddenColumns configured
       // together with nestedHeaders). Future changes are handled by #onColumnIndexMapperCacheUpdated.
       this.#stateManager.syncVisibility(createColumnVisibilityAdapter(this.hot));
     }

--- a/handsontable/src/plugins/sheetsBar/ui/dropIndex.ts
+++ b/handsontable/src/plugins/sheetsBar/ui/dropIndex.ts
@@ -1,15 +1,15 @@
 /**
  * Decides which slot a dragged tab belongs in.
  *
- * The tab takes a neighbour's slot once the pointer crosses that neighbour's centre, which is
+ * The tab takes a neighbor's slot once the pointer crosses that neighbor's center, which is
  * what makes the strip settle rather than oscillate: the swap point and the point that would
  * swap it back are the same coordinate, so a pointer resting on a boundary does not flicker.
  *
- * The centres array reflects the layout direction: ascending under LTR, descending under RTL.
+ * The centers array reflects the layout direction: ascending under LTR, descending under RTL.
  * The function works on both by detecting the orientation and comparing accordingly, so the
  * caller does not need an RTL branch.
  *
- * @param {number[]} centers The centre coordinate of every tab, in DOM order (ascending LTR, descending RTL).
+ * @param {number[]} centers The center coordinate of every tab, in DOM order (ascending LTR, descending RTL).
  * @param {number} pointer The pointer coordinate along the same axis.
  * @param {number} from The dragged tab's current index.
  * @returns {number} The index the dragged tab should occupy.

--- a/handsontable/src/plugins/sheetsBar/ui/overflow.ts
+++ b/handsontable/src/plugins/sheetsBar/ui/overflow.ts
@@ -156,7 +156,7 @@ export class OverflowController {
 
     this.#pagingSection.hidden = !(this.#pagingEnabled && overflows);
 
-    // Distance travelled from the first tab. Under RTL the strip scrolls into negative
+    // Distance traveled from the first tab. Under RTL the strip scrolls into negative
     // `scrollLeft`, so the magnitude is what both ends have in common.
     const travelled = Math.abs(this.#strip.scrollLeft);
     const total = this.#strip.scrollWidth - this.#strip.clientWidth;

--- a/handsontable/src/plugins/sheetsBar/ui/tabDrag.ts
+++ b/handsontable/src/plugins/sheetsBar/ui/tabDrag.ts
@@ -122,7 +122,7 @@ export class TabDrag {
    */
   #grabOffset = 0;
   /**
-   * The dragged tab's index when the gesture started, restored when the drag is cancelled.
+   * The dragged tab's index when the gesture started, restored when the drag is canceled.
    */
   #originIndex = 0;
   /**
@@ -278,8 +278,8 @@ export class TabDrag {
       lefts.set(element, rect.left);
 
       // The drop decision reads the slot a tab has settled in, not the point its slide
-      // animation happens to be passing through. Right after a swap the displaced neighbour is
-      // still travelling, its centre still near the pointer, and a pointer that wobbles a pixel
+      // animation happens to be passing through. Right after a swap the displaced neighbor is
+      // still traveling, its center still near the pointer, and a pointer that wobbles a pixel
       // would swap it straight back — the strip then flickers between the two orders for as
       // long as the hand is unsteady. The in-flight translation is subtracted, so the swap
       // boundary stands still while the tabs animate around it.
@@ -465,7 +465,7 @@ export class TabDrag {
    * Moving the tab to another slot re-inserts it into the strip, and a re-inserted element
    * loses its pointer capture — so the capture is taken again, and the gesture goes on. When
    * the pointer itself is no longer active — released over another document, say — taking it
-   * again fails, and no release will ever reach the strip: the gesture is cancelled instead.
+   * again fails, and no release will ever reach the strip: the gesture is canceled instead.
    *
    * @param {PointerEvent} event The lostpointercapture event.
    */

--- a/handsontable/src/plugins/undoRedo/actions/columnMove.ts
+++ b/handsontable/src/plugins/undoRedo/actions/columnMove.ts
@@ -36,7 +36,7 @@ export class ColumnMoveAction extends BaseAction {
    * attached later still, so this is always the first instance listener on the hook. `Hooks.run` threads
    * a listener's return value into the next listener's first argument, so every veto is raised after this
    * listener has already run: the old `columns === false` guard caught no plugin or settings veto at all,
-   * and a cancelled move always reached the stack. `afterColumnMove` never fires for a vetoed move, and its
+   * and a canceled move always reached the stack. `afterColumnMove` never fires for a vetoed move, and its
    * `orderChanged` argument is `false` when the move was impossible or left the order intact, so gating on
    * it also keeps no-op moves off the stack.
    */

--- a/handsontable/src/plugins/undoRedo/actions/rowMove.ts
+++ b/handsontable/src/plugins/undoRedo/actions/rowMove.ts
@@ -36,7 +36,7 @@ export class RowMoveAction extends BaseAction {
    * attached later still, so this is always the first instance listener on the hook. `Hooks.run` threads
    * a listener's return value into the next listener's first argument, so every veto is raised after this
    * listener has already run: the old `rows === false` guard caught no plugin or settings veto at all, and
-   * a cancelled move always reached the stack. `afterRowMove` never fires for a vetoed move, and its
+   * a canceled move always reached the stack. `afterRowMove` never fires for a vetoed move, and its
    * `orderChanged` argument is `false` when the move was impossible or left the order intact, so gating on
    * it also keeps no-op moves off the stack.
    */

--- a/handsontable/src/shortcuts/manager.ts
+++ b/handsontable/src/shortcuts/manager.ts
@@ -208,7 +208,7 @@ export const createShortcutManager = ({ ownerWindow, handleEvent, beforeKeyDown,
    *
    * @param {KeyboardEvent} event The keyboard event.
    * @param {string[]} keys Normalized pressed keys.
-   * @returns {boolean} Whether a shortcut cancelled further handling.
+   * @returns {boolean} Whether a shortcut canceled further handling.
    */
   const runGlobalScopedShortcuts = (event: KeyboardEvent, keys: string[]) => {
     const items = CONTEXTS.getItems();

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -357,9 +357,9 @@
 
       // An active header's inline-start edge has width 0 (only `:first-child` reserves
       // it), so its accent went missing there while the inline-end side kept it — most visible on
-      // frozen columns. Color the shared gridline on the inline-start neighbour instead, so every
+      // frozen columns. Color the shared gridline on the inline-start neighbor instead, so every
       // active column header shows a matching inline-start accent. `SelectionManager` stamps the
-      // neighbour with this class; selecting on `:has(+ th.ht__active_highlight)` instead makes every
+      // neighbor with this class; selecting on `:has(+ th.ht__active_highlight)` instead makes every
       // toggle of the active class (it moves between recycled header nodes on scroll) trigger a style
       // invalidation scaled to the whole host page.
       &.ht__active_highlight-prev {
@@ -368,7 +368,7 @@
 
       // Boundary seam: when the first non-frozen column is the active header, its inline-start edge
       // falls on the frozen-pane seam drawn by the frozen overlay (a separate table), out of reach of
-      // the neighbour class above (stamped within one table). `SelectionManager` tags the last frozen
+      // the neighbor class above (stamped within one table). `SelectionManager` tags the last frozen
       // header with this class so the seam gets the same accent.
       &.ht__active_highlight-seam {
         border-inline-end-color: var(--ht-header-active-border-color);
@@ -466,7 +466,7 @@
         }
       }
 
-      // An active row header's top edge sits on the bottom gridline of the row above. Colour that
+      // An active row header's top edge sits on the bottom gridline of the row above. Color that
       // real border instead of drawing a box-shadow on the active header itself, so the accent rides
       // the layout gridline and never drifts a pixel (the box-shadow rounded independently and, on
       // the first row of each overlay table, doubled with the `tr:first-child` border-top below).

--- a/handsontable/src/styles/components/plugins/_column-sorting.scss
+++ b/handsontable/src/styles/components/plugins/_column-sorting.scss
@@ -12,7 +12,7 @@
     .colHeader.columnSorting.sortAction {
       box-sizing: border-box;
       flex-grow: 0;
-      // Centres the label; `htLeft`/`htRight` move the box instead, below.
+      // Centers the label; `htLeft`/`htRight` move the box instead, below.
       margin-inline: auto;
       // Never collapse in a narrow column, never grow past the header.
       min-width: min(calc(var(--ht-icon-size, 16px) + 8px), 100%);
@@ -31,7 +31,7 @@
     }
 
     // `text-align` used to place the text inside a full-width label. The label is now sized to its
-    // text, so the alignment has to move the box or every aligned header renders centred. Physical
+    // text, so the alignment has to move the box or every aligned header renders centered. Physical
     // margins, because `htLeft`/`htRight` are physical in either direction. Matched as an ancestor:
     // `headerClassName` puts the class on `.relative`, code that sets it by hand puts it on the
     // `th`.

--- a/handsontable/src/styles/components/plugins/_sheets-bar.scss
+++ b/handsontable/src/styles/components/plugins/_sheets-bar.scss
@@ -56,10 +56,10 @@ $all-sheets-visible-items: 8;
       overflow-x: hidden;
     }
 
-    // The shared menu styles paint the mark in the accent colour. That is the right colour in
+    // The shared menu styles paint the mark in the accent color. That is the right color in
     // the themes whose selected-row language is the accent, but classic marks a selected row in
-    // grey and keeps a pale blue accent, which leaves the check barely legible against the row.
-    // Following the token that tints the row keeps the mark in whatever colour the theme already
+    // gray and keeps a pale blue accent, which leaves the check barely legible against the row.
+    // Following the token that tints the row keeps the mark in whatever color the theme already
     // uses to say "this one", and is the accent again wherever that is what the theme means.
     &.htSheetsBarMenu table tbody tr td .htItemWrapper span.selected::after {
       color: var(--ht-menu-item-active-color, var(--ht-accent-color));

--- a/handsontable/src/utils/licenseBranding/index.ts
+++ b/handsontable/src/utils/licenseBranding/index.ts
@@ -32,7 +32,7 @@ import type { HotInstance } from '../../core/types';
  * not be read, and both resolve to open channels, so they reached the lock either way.
  *
  * This is a product decision recorded under DEV-2709, NOT a reading the specification states. S4.1
- * heads its behavior column "Behaviour (unless `silent`)" over a hard-stop row that says
+ * heads its behavior column "Behavior (unless `silent`)" over a hard-stop row that says
  * "Trial: block", which read literally puts the block inside the silenced set; S2.3's `trial` row
  * ("Trial messages + hard-stop block") separates the two. The split below is the answer to that
  * ambiguity and the specification still needs amending to match - do not revert this from S4.1 alone.

--- a/handsontable/src/utils/sanitizer.ts
+++ b/handsontable/src/utils/sanitizer.ts
@@ -65,7 +65,7 @@ export function getSanitizer(hot: HotInstance, warnWhenMissing = true): boolean 
 export function sanitizeHTML(
   hot: HotInstance, html: string, context: SanitizerContext, warnWhenMissing = true
 ): string | TrustedHTMLLike {
-  // An absent clipboard flavour reads as `''`. There is nothing to sanitize and nothing to warn
+  // An absent clipboard flavor reads as `''`. There is nothing to sanitize and nothing to warn
   // about, and calling the sanitizer would add a spurious entry to an auditing one on every paste.
   if (!html) {
     return html;

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.ts
@@ -213,7 +213,7 @@ export class BaseEditorAdapter extends Handsontable.editors.BaseEditor {
   /**
    * Unsubscribes the finish/cancel edit subscriptions if they are still active.
    * Without this, destroying the table while an editor was prepared but never
-   * finished/cancelled leaves the `take(1)` subscriptions hanging (they never emit).
+   * finished/canceled leaves the `take(1)` subscriptions hanging (they never emit).
    */
   private cleanupSubscriptions(): void {
     if (this._finishEditSubscription) {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
@@ -489,7 +489,7 @@ export class DynamicComponentService {
    * Idempotent: a TD recycled after `sweepDetachedViews` already destroyed its ref still maps to that
    * stale ref in `_tdComponentRefs`, so the next render path may reach this with an already-destroyed
    * ref. Guarding on `destroyed` skips the redundant detach/destroy instead of relying on Angular's
-   * internal no-op behaviour.
+   * internal no-op behavior.
    *
    * @param componentRef - The reference to the component to be destroyed.
    */

--- a/wrappers/react-wrapper/src/hotEditor.tsx
+++ b/wrappers/react-wrapper/src/hotEditor.tsx
@@ -226,7 +226,7 @@ function applyEditorPosition(
 }
 
 /**
- * Hook that allows encapsulating custom behaviours of component-based editor by customizing passed ref with overridden hooks object.
+ * Hook that allows encapsulating custom behaviors of component-based editor by customizing passed ref with overridden hooks object.
  *
  * @param {HotEditorHooks} overriddenHooks Overrides specific for the custom editor.
  * @param {DependencyList} deps Overridden hooks object React dependency list.


### PR DESCRIPTION
### Context

The PR fixes the remaining British spellings that live in source code comments, JSDoc, CSS/SCSS comments, and CI workflow comments. It is the follow-up to #13466, which Americanized documentation prose only; those changes were deliberately split from this one because this PR touches `handsontable/src/**`, `wrappers/**`, `docs/src/**`, and `.github/workflows/**` rather than documentation content. Per `.ai/DOC-STANDARDS.md`, American English is the standard for all source comments and JSDoc.

The change is prose-only. Every edit is inside a comment, a JSDoc block, a CSS/SCSS comment, or a YAML `#` comment. No code, string literal, or identifier changes, and no GitHub Actions API name (`cancelled()`, the `'cancelled'` conclusion value) is touched — so this is a non-functional refactor with no behavior change and no new tests.

Words Americanized (comments/JSDoc only): `behaviour`, `cancelled`/`cancelling`, `neighbour`, `flavour`, `travelled`, `colour`, `centre`/`centred`/`centres`, `grey`, `recognised`, `serialised`, `initialise`/`initialised`, `labelled`.

Deliberately left as-is because they are code, not prose: the `travelled` and `neighbour` local variables in the sheetsBar plugin, the `cancelled` object fields in `core.ts` and `MarkdownRendererFull.tsx`, the British `flavour` inside a `copyPaste` warning string, the `'Centre'` French translation, and every GitHub Actions `cancelled()` / `'cancelled'` expression.

`[skip changelog]` — comment/JSDoc/CI-comment spelling only, no user-facing change.

### How has this been tested?

- No behavioral change, so no new tests. Verified with `git diff` that every changed line touches only a spelling swap word and no code line was altered.
- Verified that the only British spellings remaining in the scanned paths are the intended code/string/API-name exclusions listed above.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

Non-functional refactor: comment/JSDoc/CI-comment spelling only.

### Related issue(s):

1. DEV-2894

### Affected project(s):

- [x] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2894

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation spelling only; executable code and GitHub Actions API literals are untouched, so there is no functional or security impact.
> 
> **Overview**
> Follow-up to documentation-only Americanization (#13466): this PR updates **comments, JSDoc, CSS/SCSS comments, and GitHub workflow `#` comments** across `handsontable/src`, `docs/src`, `wrappers/**`, and `.github/workflows/**` to match American English per project standards.
> 
> **What changes:** British spellings in prose are swapped for American equivalents (e.g. `behaviour`→`behavior`, `cancelled`/`cancelling`→`canceled`/`canceling` in comments, `neighbour`→`neighbor`, `flavour`→`flavor`, `colour`/`grey`→`color`/`gray`, `centre`/`centred`→`center`/`centered`, `recognised`→`recognized`, `serialised`/`initialise`→`serialized`/`initialize`, `labelled`→`labeled`). Touch points include Walkontable overlays/selection, core hooks and editors, copy-paste and plugins, docs Starlight components/styles, and CI gate comments.
> 
> **What does not change:** No runtime logic, identifiers, or user-facing strings. GitHub Actions API values and expressions such as `workflow_run.conclusion != 'cancelled'` and `!cancelled()` in `if:` conditions are **unchanged**; only human-readable comment text uses “canceled” where appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a84563b47fd344ed29b6b79e5eec3e42d415f752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->