### PR TITLE
DEV-2904: Reshape the axis order sync to what the formula engine can accept

### DIFF
--- a/.changelogs/13478.json
+++ b/.changelogs/13478.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a sheet added at runtime not activating again after the sheets bar switched away from it.",
+  "type": "fixed",
+  "issueOrPR": 13478,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13478.json
+++ b/.changelogs/13478.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed a sheet added at runtime not activating again after the sheets bar switched away from it.",
+  "title": "Fixed sorting a grid whose formula engine sheet is shorter than the grid, such as a sheet with trailing empty rows or one the sheets bar added at runtime, which threw an error and left a runtime-added sheet impossible to switch back to.",
   "type": "fixed",
   "issueOrPR": 13478,
   "breaking": false,

--- a/handsontable/src/plugins/formulas/AGENTS.md
+++ b/handsontable/src/plugins/formulas/AGENTS.md
@@ -100,11 +100,31 @@ switches the sheet, and dropping them would skip that.
 `{ hyperformula: engineClass }`. Cross-sheet referencing hooks are registered on the shared instance
 registry.
 
-## HF may extend the sheet beyond the dataset
+## The engine's sheet size is not the grid's axis length, in either direction
 
-The engine grows a sheet's dimensions to calculate values outside the defined dataset (it extends the
-dependency graph). The compensation code carries a note that it can be removed once
-[hyperformula#1179](https://github.com/handsontable/hyperformula/issues/1179) is resolved.
+`getSheetDimensions()` answers with the extent of the sheet's **content**, and the engine accepts an order
+exactly as long as that — anything else it rejects by throwing, and the throw unwinds whatever triggered the
+sequence change (a sort, a view-state restore). The two directions have different causes and the same fix
+site, `AxisSyncer#syncOrderWithEngine`:
+
+- **Sheet larger than the dataset.** The engine grows a sheet to calculate values outside it (it extends the
+  dependency graph). The order is padded up to that size, and the padding can go once
+  [hyperformula#1179](https://github.com/handsontable/hyperformula/issues/1179) is resolved.
+- **Sheet shorter than the grid.** Trailing empty rows and columns are not counted, so a grid with a blank
+  last row, with `minSpareRows`, or a sheet the sheets bar added at runtime (no data at all, reported `0x0`
+  against the grid's default 26 columns) is longer than its own engine sheet. The order is **compressed**
+  onto the elements the engine holds, keeping their relative order, rather than sent whole — sending it whole
+  is what made sorting such a grid throw `InvalidArgumentsError` (DEV-2904).
+
+Two rules ride along. The engine validates **entries** as well as length, so an order must be a permutation
+of `0..size - 1`: the `?? -1` a mid-batch sequence produces is ranked last rather than passed through, which
+the engine would reject as "not a permutation". And an order for an **empty** sheet is not sent at all — the
+engine holds nothing to reorder — in which case the stored `#indexesSequence` records the identity the engine
+will hold when it is filled, so the next sync sends the order as an absolute one and the grid's order is not
+lost. Never record the grid's own sequence there: every transformation is relative to the order the engine
+actually holds, and claiming one it never received makes its axis order drift away from the grid's for the
+rest of the session. Still open: a move applied while the engine's sheet is empty reaches the engine through
+`syncMoves` but is not reflected in that identity baseline.
 
 ## `HYPERLINK` cells: an allowlist, not a sanitizer
 

--- a/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerInitialOrder.unit.js
+++ b/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerInitialOrder.unit.js
@@ -1,4 +1,5 @@
 import AxisSyncer from '../../indexSyncer/axisSyncer';
+import { createMockEngine } from './helpers/mockEngine';
 
 function createMockIndexMapper(indexesSequence, notTrimmedIndexes = indexesSequence) {
   return {
@@ -15,22 +16,6 @@ function createMockIndexSyncer(engine, sheetId = 0) {
     getSheetId: () => sheetId,
     isPerformingUndoRedo: () => false,
     getPostponeAction: () => () => {},
-  };
-}
-
-function createMockEngine() {
-  const calls = { setRowOrder: [], setColumnOrder: [] };
-
-  return {
-    calls,
-    setRowOrder: (sheetId, transformation) => {
-      calls.setRowOrder.push({ sheetId, transformation });
-    },
-    setColumnOrder: (sheetId, transformation) => {
-      calls.setColumnOrder.push({ sheetId, transformation });
-    },
-    getSheetDimensions: () => ({ width: 4, height: 4 }),
-    batch: callback => callback(),
   };
 }
 
@@ -67,7 +52,7 @@ describe('AxisSyncer initial order sync', () => {
     it('should pad the transformation array to match the HF sheet width when HF has extended dimensions', () => {
       const engine = createMockEngine();
 
-      engine.getSheetDimensions = () => ({ width: 6, height: 4 });
+      engine.dimensions.width = 6;
       const indexMapper = createMockIndexMapper([0, 2, 1, 3]);
       const indexSyncer = createMockIndexSyncer(engine);
       const axisSyncer = new AxisSyncer('column', indexMapper, indexSyncer);
@@ -80,12 +65,50 @@ describe('AxisSyncer initial order sync', () => {
     });
   });
 
+  describe('engine sheet smaller than the sequence', () => {
+    it('should not sync the initial order when the engine sheet holds no columns', () => {
+      const engine = createMockEngine({ width: 0, height: 0 });
+      const indexMapper = createMockIndexMapper([0, 2, 1, 3]);
+      const axisSyncer = new AxisSyncer('column', indexMapper, createMockIndexSyncer(engine));
+
+      expect(() => axisSyncer.init()).not.toThrow();
+      expect(engine.calls.setColumnOrder).toEqual([]);
+    });
+
+    it('should compress the initial order onto the columns the engine holds', () => {
+      const engine = createMockEngine({ width: 2, height: 4 });
+      const indexMapper = createMockIndexMapper([1, 0, 2, 3]);
+      const axisSyncer = new AxisSyncer('column', indexMapper, createMockIndexSyncer(engine));
+
+      axisSyncer.init();
+
+      expect(engine.calls.setColumnOrder).toEqual([
+        { sheetId: 0, transformation: [1, 0] },
+      ]);
+    });
+
+    it('should measure the next transformation against the engine order after a skipped initial sync', () => {
+      const engine = createMockEngine({ width: 0, height: 0 });
+      const indexMapper = createMockIndexMapper([0, 2, 1, 3]);
+      const axisSyncer = new AxisSyncer('column', indexMapper, createMockIndexSyncer(engine));
+
+      axisSyncer.init();
+      engine.dimensions.width = 4;
+      axisSyncer.getIndexesChangeSyncMethod()('update');
+
+      // The engine never received the initial order, so the first order it does receive has to carry it.
+      expect(engine.calls.setColumnOrder).toEqual([
+        { sheetId: 0, transformation: [0, 2, 1, 3] },
+      ]);
+    });
+  });
+
   describe('row axis', () => {
     it('should call setRowOrder when row sequence is non-identity', () => {
       const engine = createMockEngine();
       const indexMapper = createMockIndexMapper([2, 0, 1]);
 
-      engine.getSheetDimensions = () => ({ width: 4, height: 3 });
+      engine.dimensions.height = 3;
       const indexSyncer = createMockIndexSyncer(engine);
       const axisSyncer = new AxisSyncer('row', indexMapper, indexSyncer);
 

--- a/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerSequenceChange.unit.js
+++ b/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerSequenceChange.unit.js
@@ -1,4 +1,5 @@
 import AxisSyncer from '../../indexSyncer/axisSyncer';
+import { createMockEngine } from './helpers/mockEngine';
 
 function createMockIndexMapper(indexesSequence) {
   const state = { indexesSequence };
@@ -18,32 +19,6 @@ function createMockIndexSyncer(engine, sheetId = 0) {
     getSheetId: () => sheetId,
     isPerformingUndoRedo: () => false,
     getPostponeAction: () => () => {},
-  };
-}
-
-function createMockEngine(initialDimensions = { width: 4, height: 4 }) {
-  const calls = { setRowOrder: [], setColumnOrder: [] };
-  const dimensions = { ...initialDimensions };
-
-  return {
-    calls,
-    dimensions,
-    setRowOrder: (sheetId, transformation) => {
-      if (transformation.length !== dimensions.height) {
-        throw new Error('Invalid arguments, expected number of rows provided to be sheet height.');
-      }
-
-      calls.setRowOrder.push({ sheetId, transformation });
-    },
-    setColumnOrder: (sheetId, transformation) => {
-      if (transformation.length !== dimensions.width) {
-        throw new Error('Invalid arguments, expected number of columns provided to be sheet width.');
-      }
-
-      calls.setColumnOrder.push({ sheetId, transformation });
-    },
-    getSheetDimensions: () => ({ ...dimensions }),
-    batch: callback => callback(),
   };
 }
 
@@ -89,16 +64,49 @@ describe('AxisSyncer sequence change sync', () => {
       expect(engine.calls.setColumnOrder).toEqual([]);
     });
 
-    it('should not sync the order when the sequence is longer than the engine sheet', () => {
+    it('should compress the order onto the columns the engine holds when the sequence is longer', () => {
       const engine = createMockEngine({ width: 2, height: 4 });
       const indexMapper = createMockIndexMapper([0, 1, 2, 3]);
       const axisSyncer = new AxisSyncer('column', indexMapper, createMockIndexSyncer(engine));
 
       axisSyncer.init();
+      // The engine holds the first two columns only, and the reorder keeps them in that relative order.
       indexMapper.state.indexesSequence = [0, 2, 1, 3];
+      axisSyncer.getIndexesChangeSyncMethod()('update');
 
-      expect(() => axisSyncer.getIndexesChangeSyncMethod()('update')).not.toThrow();
-      expect(engine.calls.setColumnOrder).toEqual([]);
+      expect(engine.calls.setColumnOrder).toEqual([
+        { sheetId: 0, transformation: [0, 1] },
+      ]);
+    });
+
+    it('should compress a reorder that swaps two columns the engine holds', () => {
+      const engine = createMockEngine({ width: 2, height: 4 });
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3]);
+      const axisSyncer = new AxisSyncer('column', indexMapper, createMockIndexSyncer(engine));
+
+      axisSyncer.init();
+      indexMapper.state.indexesSequence = [1, 0, 2, 3];
+      axisSyncer.getIndexesChangeSyncMethod()('update');
+
+      expect(engine.calls.setColumnOrder).toEqual([
+        { sheetId: 0, transformation: [1, 0] },
+      ]);
+    });
+
+    it('should rank an index the sequence no longer covers last instead of sending it as -1', () => {
+      const engine = createMockEngine({ width: 3, height: 4 });
+      const indexMapper = createMockIndexMapper([0, 1, 2]);
+      const axisSyncer = new AxisSyncer('column', indexMapper, createMockIndexSyncer(engine));
+
+      axisSyncer.init();
+      // Mid-batch the mapper can drop an index the stored sequence still carries; it arrives as `-1`,
+      // which the engine rejects as a non-permutation.
+      indexMapper.state.indexesSequence = [2, 0];
+      axisSyncer.getIndexesChangeSyncMethod()('update');
+
+      expect(engine.calls.setColumnOrder).toEqual([
+        { sheetId: 0, transformation: [1, 2, 0] },
+      ]);
     });
 
     it('should keep the last synced order as the baseline for the transformation after a skipped sync', () => {
@@ -135,6 +143,40 @@ describe('AxisSyncer sequence change sync', () => {
 
       expect(() => axisSyncer.getIndexesChangeSyncMethod()('update')).not.toThrow();
       expect(engine.calls.setRowOrder).toEqual([]);
+    });
+
+    it('should compress the order onto the rows the engine holds when the sequence is longer', () => {
+      const engine = createMockEngine({ width: 4, height: 2 });
+      const indexMapper = createMockIndexMapper([0, 1, 2]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer(engine));
+
+      axisSyncer.init();
+      indexMapper.state.indexesSequence = [1, 0, 2];
+      axisSyncer.getIndexesChangeSyncMethod()('update');
+
+      expect(engine.calls.setRowOrder).toEqual([
+        { sheetId: 0, transformation: [1, 0] },
+      ]);
+    });
+
+    it('should keep the last synced order as the baseline for the transformation after a skipped sync', () => {
+      const engine = createMockEngine({ width: 0, height: 0 });
+      const indexMapper = createMockIndexMapper([0, 1, 2]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer(engine, 2));
+      const syncMethod = axisSyncer.getIndexesChangeSyncMethod();
+
+      axisSyncer.init();
+      indexMapper.state.indexesSequence = [2, 0, 1];
+      syncMethod('update');
+
+      expect(engine.calls.setRowOrder).toEqual([]);
+
+      engine.dimensions.height = 3;
+      syncMethod('update');
+
+      expect(engine.calls.setRowOrder).toEqual([
+        { sheetId: 2, transformation: [1, 2, 0] },
+      ]);
     });
 
     it('should sync the order when the engine sheet is as tall as the reordered sequence', () => {

--- a/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerSequenceChange.unit.js
+++ b/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerSequenceChange.unit.js
@@ -21,11 +21,13 @@ function createMockIndexSyncer(engine, sheetId = 0) {
   };
 }
 
-function createMockEngine(dimensions = { width: 4, height: 4 }) {
+function createMockEngine(initialDimensions = { width: 4, height: 4 }) {
   const calls = { setRowOrder: [], setColumnOrder: [] };
+  const dimensions = { ...initialDimensions };
 
   return {
     calls,
+    dimensions,
     setRowOrder: (sheetId, transformation) => {
       if (transformation.length !== dimensions.height) {
         throw new Error('Invalid arguments, expected number of rows provided to be sheet height.');
@@ -40,7 +42,7 @@ function createMockEngine(dimensions = { width: 4, height: 4 }) {
 
       calls.setColumnOrder.push({ sheetId, transformation });
     },
-    getSheetDimensions: () => dimensions,
+    getSheetDimensions: () => ({ ...dimensions }),
     batch: callback => callback(),
   };
 }
@@ -97,6 +99,28 @@ describe('AxisSyncer sequence change sync', () => {
 
       expect(() => axisSyncer.getIndexesChangeSyncMethod()('update')).not.toThrow();
       expect(engine.calls.setColumnOrder).toEqual([]);
+    });
+
+    it('should keep the last synced order as the baseline for the transformation after a skipped sync', () => {
+      const engine = createMockEngine({ width: 0, height: 0 });
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3]);
+      const axisSyncer = new AxisSyncer('column', indexMapper, createMockIndexSyncer(engine, 2));
+      const syncMethod = axisSyncer.getIndexesChangeSyncMethod();
+
+      axisSyncer.init();
+      indexMapper.state.indexesSequence = [0, 2, 1, 3];
+      syncMethod('update');
+
+      expect(engine.calls.setColumnOrder).toEqual([]);
+
+      // The engine's sheet grew, so the same grid order now fits and has to reach the engine — measured
+      // against the order the engine actually holds, which is still the one from before the skip.
+      engine.dimensions.width = 4;
+      syncMethod('update');
+
+      expect(engine.calls.setColumnOrder).toEqual([
+        { sheetId: 2, transformation: [0, 2, 1, 3] },
+      ]);
     });
   });
 

--- a/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerSequenceChange.unit.js
+++ b/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerSequenceChange.unit.js
@@ -1,0 +1,130 @@
+import AxisSyncer from '../../indexSyncer/axisSyncer';
+
+function createMockIndexMapper(indexesSequence) {
+  const state = { indexesSequence };
+
+  return {
+    state,
+    getIndexesSequence: () => state.indexesSequence,
+    getNotTrimmedIndexes: () => state.indexesSequence,
+    getNumberOfIndexes: () => state.indexesSequence.length,
+    addLocalHook: () => {},
+  };
+}
+
+function createMockIndexSyncer(engine, sheetId = 0) {
+  return {
+    getEngine: () => engine,
+    getSheetId: () => sheetId,
+    isPerformingUndoRedo: () => false,
+    getPostponeAction: () => () => {},
+  };
+}
+
+function createMockEngine(dimensions = { width: 4, height: 4 }) {
+  const calls = { setRowOrder: [], setColumnOrder: [] };
+
+  return {
+    calls,
+    setRowOrder: (sheetId, transformation) => {
+      if (transformation.length !== dimensions.height) {
+        throw new Error('Invalid arguments, expected number of rows provided to be sheet height.');
+      }
+
+      calls.setRowOrder.push({ sheetId, transformation });
+    },
+    setColumnOrder: (sheetId, transformation) => {
+      if (transformation.length !== dimensions.width) {
+        throw new Error('Invalid arguments, expected number of columns provided to be sheet width.');
+      }
+
+      calls.setColumnOrder.push({ sheetId, transformation });
+    },
+    getSheetDimensions: () => dimensions,
+    batch: callback => callback(),
+  };
+}
+
+describe('AxisSyncer sequence change sync', () => {
+  describe('column axis', () => {
+    it('should sync the order when the engine sheet is as wide as the reordered sequence', () => {
+      const engine = createMockEngine();
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3]);
+      const axisSyncer = new AxisSyncer('column', indexMapper, createMockIndexSyncer(engine));
+
+      axisSyncer.init();
+      indexMapper.state.indexesSequence = [0, 2, 1, 3];
+      axisSyncer.getIndexesChangeSyncMethod()('update');
+
+      expect(engine.calls.setColumnOrder).toEqual([
+        { sheetId: 0, transformation: [0, 2, 1, 3] },
+      ]);
+    });
+
+    it('should pad the order up to the engine sheet width when the engine extended the sheet', () => {
+      const engine = createMockEngine({ width: 6, height: 4 });
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3]);
+      const axisSyncer = new AxisSyncer('column', indexMapper, createMockIndexSyncer(engine));
+
+      axisSyncer.init();
+      indexMapper.state.indexesSequence = [0, 2, 1, 3];
+      axisSyncer.getIndexesChangeSyncMethod()('update');
+
+      expect(engine.calls.setColumnOrder).toEqual([
+        { sheetId: 0, transformation: [0, 2, 1, 3, 4, 5] },
+      ]);
+    });
+
+    it('should not sync the order when the engine sheet holds no columns', () => {
+      const engine = createMockEngine({ width: 0, height: 0 });
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3]);
+      const axisSyncer = new AxisSyncer('column', indexMapper, createMockIndexSyncer(engine, 2));
+
+      axisSyncer.init();
+      indexMapper.state.indexesSequence = [0, 1, 2, 3];
+
+      expect(() => axisSyncer.getIndexesChangeSyncMethod()('update')).not.toThrow();
+      expect(engine.calls.setColumnOrder).toEqual([]);
+    });
+
+    it('should not sync the order when the sequence is longer than the engine sheet', () => {
+      const engine = createMockEngine({ width: 2, height: 4 });
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3]);
+      const axisSyncer = new AxisSyncer('column', indexMapper, createMockIndexSyncer(engine));
+
+      axisSyncer.init();
+      indexMapper.state.indexesSequence = [0, 2, 1, 3];
+
+      expect(() => axisSyncer.getIndexesChangeSyncMethod()('update')).not.toThrow();
+      expect(engine.calls.setColumnOrder).toEqual([]);
+    });
+  });
+
+  describe('row axis', () => {
+    it('should not sync the order when the engine sheet holds no rows', () => {
+      const engine = createMockEngine({ width: 0, height: 0 });
+      const indexMapper = createMockIndexMapper([0, 1, 2]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer(engine, 2));
+
+      axisSyncer.init();
+      indexMapper.state.indexesSequence = [2, 0, 1];
+
+      expect(() => axisSyncer.getIndexesChangeSyncMethod()('update')).not.toThrow();
+      expect(engine.calls.setRowOrder).toEqual([]);
+    });
+
+    it('should sync the order when the engine sheet is as tall as the reordered sequence', () => {
+      const engine = createMockEngine({ width: 4, height: 3 });
+      const indexMapper = createMockIndexMapper([0, 1, 2]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer(engine));
+
+      axisSyncer.init();
+      indexMapper.state.indexesSequence = [2, 0, 1];
+      axisSyncer.getIndexesChangeSyncMethod()('update');
+
+      expect(engine.calls.setRowOrder).toEqual([
+        { sheetId: 0, transformation: [1, 2, 0] },
+      ]);
+    });
+  });
+});

--- a/handsontable/src/plugins/formulas/__tests__/indexSyncer/helpers/mockEngine.js
+++ b/handsontable/src/plugins/formulas/__tests__/indexSyncer/helpers/mockEngine.js
@@ -1,0 +1,55 @@
+/**
+ * Builds an engine stub that enforces the order contract HyperFormula enforces.
+ *
+ * `CrudOperations#mappingFromOrder` rejects an order whose length differs from the sheet's size along
+ * that axis, and `validateRowOrColumnMapping` then rejects entries that are not positions inside the
+ * sheet or that do not form a permutation of them. A stub that only records the call cannot fail on
+ * either class of bug, so both checks are reproduced here with the engine's own wording.
+ *
+ * @param {{width: number, height: number}} [initialDimensions] The sheet's starting dimensions.
+ * @returns {object} The stub, carrying the recorded calls and its mutable `dimensions`.
+ */
+export function createMockEngine(initialDimensions = { width: 4, height: 4 }) {
+  const calls = { setRowOrder: [], setColumnOrder: [] };
+  const dimensions = { ...initialDimensions };
+
+  const validate = (order, size, axisLabel, sizeLabel) => {
+    if (order.length !== size) {
+      throw new Error(`Invalid arguments, expected number of ${axisLabel} provided to be sheet ${sizeLabel}.`);
+    }
+
+    const seen = new Set();
+
+    order.forEach((target) => {
+      if (!Number.isInteger(target) || target < 0 || target >= size) {
+        throw new Error(
+          `Invalid arguments, expected target ${axisLabel} numbers to be nonnegative integers and less than sheet ${
+            sizeLabel}.`);
+      }
+
+      seen.add(target);
+    });
+
+    if (seen.size !== order.length) {
+      throw new Error(`Invalid arguments, expected target ${axisLabel} numbers to be permutation of source ${
+        axisLabel} numbers.`);
+    }
+  };
+
+  return {
+    calls,
+    dimensions,
+    setRowOrder: (sheetId, transformation) => {
+      validate(transformation, dimensions.height, 'rows', 'height');
+
+      calls.setRowOrder.push({ sheetId, transformation });
+    },
+    setColumnOrder: (sheetId, transformation) => {
+      validate(transformation, dimensions.width, 'columns', 'width');
+
+      calls.setColumnOrder.push({ sheetId, transformation });
+    },
+    getSheetDimensions: () => ({ ...dimensions }),
+    batch: callback => callback(),
+  };
+}

--- a/handsontable/src/plugins/formulas/__tests__/indexSyncer/shortSheetOrderSync.unit.js
+++ b/handsontable/src/plugins/formulas/__tests__/indexSyncer/shortSheetOrderSync.unit.js
@@ -1,0 +1,66 @@
+import HyperFormula from 'hyperformula';
+import Handsontable from '../../../../base';
+import { registerAllModules } from '../../../../registry';
+
+registerAllModules();
+
+describe('AxisSyncer against a sheet shorter than the grid', () => {
+  let container;
+  let hot;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (hot) {
+      hot.destroy();
+      hot = null;
+    }
+
+    container.remove();
+  });
+
+  it('should sort a grid whose trailing rows are empty and carry the order into the engine', () => {
+    const engine = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
+
+    hot = new Handsontable(container, {
+      data: [[3, 'c'], [1, 'a'], [2, 'b'], [null, null], [null, null]],
+      formulas: { engine, sheetName: 'Sheet1' },
+      columnSorting: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    const sheetId = engine.getSheetId('Sheet1');
+
+    // The engine sizes a sheet by the extent of its content, so the two empty rows are not counted and
+    // the sheet is shorter than the grid.
+    expect(engine.getSheetDimensions(sheetId).height).toBeLessThan(hot.countRows());
+
+    hot.getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
+
+    expect(hot.getDataAtCol(0)).toEqual([1, 2, 3, null, null]);
+    expect(engine.getSheetSerialized(sheetId).map(row => row[0])).toEqual([1, 2, 3]);
+  });
+
+  it('should keep the engine and the grid in step when the same grid is sorted twice', () => {
+    const engine = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
+
+    hot = new Handsontable(container, {
+      data: [[3, 'c'], [1, 'a'], [2, 'b'], [null, null]],
+      formulas: { engine, sheetName: 'Sheet1' },
+      columnSorting: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    const sheetId = engine.getSheetId('Sheet1');
+    const sorting = hot.getPlugin('columnSorting');
+
+    sorting.sort({ column: 0, sortOrder: 'asc' });
+    sorting.sort({ column: 0, sortOrder: 'desc' });
+
+    expect(hot.getDataAtCol(0)).toEqual([3, 2, 1, null]);
+    expect(engine.getSheetSerialized(sheetId).map(row => row[0])).toEqual([3, 2, 1]);
+  });
+});

--- a/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.ts
+++ b/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.ts
@@ -333,13 +333,39 @@ class AxisSyncer {
   }
 
   /**
+   * Sends an axis order transformation to the engine, padding it up to the engine sheet's size.
+   *
+   * @param {number[]} transformation Order transformation describing where each element the engine currently
+   * holds should move to.
+   * @param {number} sizeForAxis Size of the engine's sheet along the synchronized axis.
+   * @returns {void}
+   */
+  #syncOrderWithEngine(transformation: number[], sizeForAxis: number): void {
+    // A sheet added to the workbook at runtime carries no data, so the engine reports it as 0x0 while the grid
+    // still counts its default rows and columns. The engine accepts an order exactly as long as the sheet, and
+    // rejects anything longer by throwing — which unwinds whatever triggered the sequence change. Such an order
+    // describes elements the engine does not hold, so there is nothing to reorder and the sync is skipped.
+    if (transformation.length > sizeForAxis) {
+      return;
+    }
+
+    // Sheet dimension can be changed by HF's engine for purpose of calculating values. It extends dependency
+    // graph to calculate values outside of a defined dataset. This part of code could be removed after resolving
+    // feature request from HF issue board (handsontable/hyperformula#1179).
+    for (let i = transformation.length; i < sizeForAxis; i += 1) {
+      transformation.push(i);
+    }
+
+    this.#indexSyncer.getEngine()![`set${toUpperCaseFirst(this.#axis)}Order`](
+      this.#indexSyncer.getSheetId()!, transformation);
+  }
+
+  /**
    * Gets callback for hook triggered after performing change of indexes order.
    *
    * @returns {Function}
    */
   getIndexesChangeSyncMethod() {
-    const SYNC_ORDER_CHANGE_METHOD_NAME = `set${toUpperCaseFirst(this.#axis)}Order`;
-
     return (source: string) => {
       if (this.#indexSyncer.isPerformingUndoRedo()) {
         return;
@@ -358,26 +384,9 @@ class AxisSyncer {
 
         const relativeTransformation = this.#indexesSequence.map(index => positionOfPhysical[index] ?? -1);
         const sheetDimensions = this.#indexSyncer.getEngine()!.getSheetDimensions(this.#indexSyncer.getSheetId()!);
-        let sizeForAxis;
+        const sizeForAxis = this.#axis === 'row' ? sheetDimensions.height : sheetDimensions.width;
 
-        if (this.#axis === 'row') {
-          sizeForAxis = sheetDimensions.height;
-
-        } else {
-          sizeForAxis = sheetDimensions.width;
-        }
-
-        const numberOfReorganisedIndexes = relativeTransformation.length;
-
-        // Sheet dimension can be changed by HF's engine for purpose of calculating values. It extends dependency
-        // graph to calculate values outside of a defined dataset. This part of code could be removed after resolving
-        // feature request from HF issue board (handsontable/hyperformula#1179).
-        for (let i = numberOfReorganisedIndexes; i < sizeForAxis; i += 1) {
-          relativeTransformation.push(i);
-        }
-
-        this.#indexSyncer.getEngine()![SYNC_ORDER_CHANGE_METHOD_NAME](this.#indexSyncer.getSheetId()!,
-          relativeTransformation);
+        this.#syncOrderWithEngine(relativeTransformation, sizeForAxis);
       }
 
       this.#indexesSequence = newSequence;
@@ -409,7 +418,6 @@ class AxisSyncer {
       return;
     }
 
-    const SYNC_ORDER_CHANGE_METHOD_NAME = `set${toUpperCaseFirst(this.#axis)}Order`;
     const sheetDimensions = engine.getSheetDimensions(sheetId);
     const sizeForAxis = this.#axis === 'row' ? sheetDimensions.height : sheetDimensions.width;
     // HF currently holds data in physical order ([0..n-1] identity). The transformation tells HF where each
@@ -422,11 +430,7 @@ class AxisSyncer {
       transformation[sequence[position]] = position;
     }
 
-    for (let i = transformation.length; i < sizeForAxis; i += 1) {
-      transformation.push(i);
-    }
-
-    engine[SYNC_ORDER_CHANGE_METHOD_NAME](sheetId, transformation);
+    this.#syncOrderWithEngine(transformation, sizeForAxis);
   }
 
   /**

--- a/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.ts
+++ b/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.ts
@@ -72,6 +72,13 @@ class AxisSyncer {
    */
   #indexesSequence: number[] = [];
   /**
+   * Whether the engine still holds the order `#indexesSequence` describes. It stops describing it while the
+   * engine's sheet is empty, because an order sent then would have nothing to apply to.
+   *
+   * @type {boolean}
+   */
+  #engineOrderStale = false;
+  /**
    * List of moved HF indexes, stored before performing move on HOT to calculate transformation needed on HF's engine.
    *
    * @private
@@ -333,31 +340,67 @@ class AxisSyncer {
   }
 
   /**
-   * Sends an axis order transformation to the engine, padding it up to the engine sheet's size.
+   * Reshapes an order transformation into the permutation of `0..sizeForAxis - 1` the engine accepts.
+   *
+   * The engine takes an order exactly as long as its sheet, and every entry has to be a position within
+   * that sheet — it rejects anything else by throwing, and the throw unwinds whatever triggered the
+   * sequence change. Two things make the grid's own transformation a poor fit. The engine reports a sheet
+   * by the extent of its content, so trailing empty rows and columns of the dataset are not counted, and
+   * it also extends a sheet beyond the dataset to calculate values outside it
+   * (handsontable/hyperformula#1179). The transformation is therefore padded when it is shorter than the
+   * sheet, and compressed onto the elements the engine actually holds when it is longer, keeping their
+   * relative order. Mid-batch entries the sequence no longer covers arrive as `-1` and are ranked last.
    *
    * @param {number[]} transformation Order transformation describing where each element the engine currently
    * holds should move to.
    * @param {number} sizeForAxis Size of the engine's sheet along the synchronized axis.
-   * @returns {boolean} `true` when the engine received the order, `false` when it was skipped.
+   * @returns {number[]} The order to hand to the engine.
+   */
+  static #toEngineOrder(transformation: number[], sizeForAxis: number): number[] {
+    const positions = [];
+
+    for (let position = 0; position < sizeForAxis; position += 1) {
+      positions.push({
+        index: position,
+        target: position < transformation.length ? transformation[position] : position,
+      });
+    }
+
+    positions.sort((left, right) => {
+      if (left.target < 0 || right.target < 0) {
+        return (left.target < 0 ? 1 : 0) - (right.target < 0 ? 1 : 0) || left.index - right.index;
+      }
+
+      return left.target - right.target || left.index - right.index;
+    });
+
+    const engineOrder: number[] = new Array<number>(sizeForAxis);
+
+    positions.forEach(({ index }, rank) => {
+      engineOrder[index] = rank;
+    });
+
+    return engineOrder;
+  }
+
+  /**
+   * Sends an axis order transformation to the engine, reshaped to the engine sheet's size.
+   *
+   * @param {number[]} transformation Order transformation describing where each element the engine currently
+   * holds should move to.
+   * @param {number} sizeForAxis Size of the engine's sheet along the synchronized axis.
+   * @returns {boolean} `true` when the engine received the order, `false` when there was nothing to send.
    */
   #syncOrderWithEngine(transformation: number[], sizeForAxis: number): boolean {
-    // A sheet added to the workbook at runtime carries no data, so the engine reports it as 0x0 while the grid
-    // still counts its default rows and columns. The engine accepts an order exactly as long as the sheet, and
-    // rejects anything longer by throwing — which unwinds whatever triggered the sequence change. Such an order
-    // describes elements the engine does not hold, so there is nothing to reorder and the sync is skipped.
-    if (transformation.length > sizeForAxis) {
+    // A sheet the workbook gained at runtime carries no data, so the engine holds no rows or columns to
+    // reorder and reports the sheet as 0x0. There is nothing to send, and the grid's order is replayed
+    // by the next sync that finds a sheet to apply it to.
+    if (sizeForAxis === 0) {
       return false;
     }
 
-    // Sheet dimension can be changed by HF's engine for purpose of calculating values. It extends dependency
-    // graph to calculate values outside of a defined dataset. This part of code could be removed after resolving
-    // feature request from HF issue board (handsontable/hyperformula#1179).
-    for (let i = transformation.length; i < sizeForAxis; i += 1) {
-      transformation.push(i);
-    }
-
     this.#indexSyncer.getEngine()![`set${toUpperCaseFirst(this.#axis)}Order`](
-      this.#indexSyncer.getSheetId()!, transformation);
+      this.#indexSyncer.getSheetId()!, AxisSyncer.#toEngineOrder(transformation, sizeForAxis));
 
     return true;
   }
@@ -388,13 +431,25 @@ class AxisSyncer {
         const sheetDimensions = this.#indexSyncer.getEngine()!.getSheetDimensions(this.#indexSyncer.getSheetId()!);
         const sizeForAxis = this.#axis === 'row' ? sheetDimensions.height : sheetDimensions.width;
 
-        // The stored sequence is the order the engine currently holds, and every transformation is
-        // relative to it. A skipped sync leaves the engine on the previous order, so the sequence stays
-        // where it was — recording the new one would make the next transformation describe a move the
-        // engine never made, and its axis order would drift away from the grid's.
-        if (!this.#syncOrderWithEngine(relativeTransformation, sizeForAxis)) {
+        this.#engineOrderStale = !this.#syncOrderWithEngine(relativeTransformation, sizeForAxis);
+
+        if (this.#engineOrderStale) {
+          // The engine's sheet is empty, so whatever it is filled with later arrives in physical order.
+          // Recording that identity keeps the next transformation absolute, which is what carries the
+          // order the engine could not take when it becomes able to take one.
+          this.#indexesSequence = newSequence.map((value, index) => index);
+
           return;
         }
+      }
+
+      // The stored sequence is the order the engine currently holds, and every transformation is relative
+      // to it. While the engine has nothing to apply an order to, the sequence stays where it was —
+      // recording the grid's would make the next transformation describe a move the engine never made,
+      // and its axis order would drift away from the grid's. Every source is frozen, not just the one
+      // that was skipped: a row inserted or moved in the meantime advances the grid's sequence too.
+      if (this.#engineOrderStale) {
+        return;
       }
 
       this.#indexesSequence = newSequence;
@@ -408,22 +463,23 @@ class AxisSyncer {
    * that translates visual indexes through `getHfIndexFromVisualIndex` reads the wrong cells.
    *
    * @private
+   * @returns {boolean} `true` when the engine holds the sequence's order, `false` while it does not.
    */
-  #syncInitialOrder() {
+  #syncInitialOrder(): boolean {
     const sequence = this.#indexMapper.getIndexesSequence();
     const isIdentity = sequence.every((value, index) => value === index);
 
     if (isIdentity || sequence.length === 0) {
-      return;
+      return true;
     }
 
     const engine = this.#indexSyncer.getEngine();
     const sheetId = this.#indexSyncer.getSheetId();
 
     if (engine === null || sheetId === null) {
-      this.#indexSyncer.getPostponeAction()(() => this.#syncInitialOrder());
+      this.#indexSyncer.getPostponeAction()(() => this.#applyInitialOrder());
 
-      return;
+      return false;
     }
 
     const sheetDimensions = engine.getSheetDimensions(sheetId);
@@ -438,15 +494,30 @@ class AxisSyncer {
       transformation[sequence[position]] = position;
     }
 
-    this.#syncOrderWithEngine(transformation, sizeForAxis);
+    return this.#syncOrderWithEngine(transformation, sizeForAxis);
+  }
+
+  /**
+   * Synchronizes the initial order and records the sequence the engine ended up holding. A sync the engine
+   * could not take leaves the stored sequence behind, so the next transformation is measured against the
+   * order the engine actually holds rather than one it never received.
+   *
+   * @private
+   */
+  #applyInitialOrder() {
+    const sequence = this.#indexMapper.getIndexesSequence();
+
+    this.#engineOrderStale = !this.#syncInitialOrder();
+    // A sync the engine could not take leaves it in physical order, which is what the next transformation
+    // has to be measured against — recording the grid's sequence would claim an order it never received.
+    this.#indexesSequence = this.#engineOrderStale ? sequence.map((value, index) => index) : sequence;
   }
 
   /**
    * Initialize the AxisSyncer.
    */
   init() {
-    this.#syncInitialOrder();
-    this.#indexesSequence = this.#indexMapper.getIndexesSequence();
+    this.#applyInitialOrder();
   }
 }
 

--- a/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.ts
+++ b/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.ts
@@ -338,15 +338,15 @@ class AxisSyncer {
    * @param {number[]} transformation Order transformation describing where each element the engine currently
    * holds should move to.
    * @param {number} sizeForAxis Size of the engine's sheet along the synchronized axis.
-   * @returns {void}
+   * @returns {boolean} `true` when the engine received the order, `false` when it was skipped.
    */
-  #syncOrderWithEngine(transformation: number[], sizeForAxis: number): void {
+  #syncOrderWithEngine(transformation: number[], sizeForAxis: number): boolean {
     // A sheet added to the workbook at runtime carries no data, so the engine reports it as 0x0 while the grid
     // still counts its default rows and columns. The engine accepts an order exactly as long as the sheet, and
     // rejects anything longer by throwing — which unwinds whatever triggered the sequence change. Such an order
     // describes elements the engine does not hold, so there is nothing to reorder and the sync is skipped.
     if (transformation.length > sizeForAxis) {
-      return;
+      return false;
     }
 
     // Sheet dimension can be changed by HF's engine for purpose of calculating values. It extends dependency
@@ -358,6 +358,8 @@ class AxisSyncer {
 
     this.#indexSyncer.getEngine()![`set${toUpperCaseFirst(this.#axis)}Order`](
       this.#indexSyncer.getSheetId()!, transformation);
+
+    return true;
   }
 
   /**
@@ -386,7 +388,13 @@ class AxisSyncer {
         const sheetDimensions = this.#indexSyncer.getEngine()!.getSheetDimensions(this.#indexSyncer.getSheetId()!);
         const sizeForAxis = this.#axis === 'row' ? sheetDimensions.height : sheetDimensions.width;
 
-        this.#syncOrderWithEngine(relativeTransformation, sizeForAxis);
+        // The stored sequence is the order the engine currently holds, and every transformation is
+        // relative to it. A skipped sync leaves the engine on the previous order, so the sequence stays
+        // where it was — recording the new one would make the next transformation describe a move the
+        // engine never made, and its axis order would drift away from the grid's.
+        if (!this.#syncOrderWithEngine(relativeTransformation, sizeForAxis)) {
+          return;
+        }
       }
 
       this.#indexesSequence = newSequence;

--- a/handsontable/src/plugins/sheetsBar/AGENTS.md
+++ b/handsontable/src/plugins/sheetsBar/AGENTS.md
@@ -76,7 +76,11 @@ sheet's settings and data, so every other plugin must already be enabled. Root i
   `columns[].data` binding gets a direct source write plus one render. Formulas plus a `data`
   remap is mangled by the Formulas plugin itself at load, before any of this runs); a removed sheet is removed
   from the engine; a duplicate binds to an engine sheet of its own; a runtime-added sheet with
-  no `settings` inherits the shared engine under its own name. A brand-new binding (add,
+  no `settings` inherits the shared engine under its own name — and carries no data, so the
+  engine reports that sheet as `0x0` while the grid counts its default rows and columns. Its
+  axis order is therefore not mirrored into the engine until the sheet holds data; the
+  mechanism, and why the stored baseline records identity rather than the grid's order, is in
+  `../formulas/AGENTS.md` ("The engine's sheet size is not the grid's axis length"). A brand-new binding (add,
   duplicate) goes through `freeEngineName()` — a `sheetName` may differ from its tab name, so
   a free tab label can still identify another sheet's engine data, and reusing it would
   overwrite that data. A rename whose new name already identifies another engine sheet is

--- a/handsontable/src/plugins/sheetsBar/__tests__/sheetsBar.unit.js
+++ b/handsontable/src/plugins/sheetsBar/__tests__/sheetsBar.unit.js
@@ -1159,6 +1159,37 @@ describe('SheetsBar plugin', () => {
     expect(hot.getDataAtCell(0, 1)).toBe(23);
   });
 
+  it('activates a runtime-added sheet again after the workbook switched away from it', () => {
+    const engine = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
+
+    hot = new Handsontable(container, {
+      sheetsBar: {
+        sheets: [
+          {
+            name: 'Budget',
+            data: [[100, '=A1*Rates!A1']],
+            settings: { formulas: { engine, sheetName: 'Budget' } },
+          },
+          {
+            name: 'Rates',
+            data: [[0.23]],
+            settings: { formulas: { engine, sheetName: 'Rates' } },
+          },
+        ],
+      },
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+    const sheetsBar = hot.getPlugin('sheetsBar');
+    const added = sheetsBar.addSheet();
+
+    expect(sheetsBar.setActiveSheet(added.id)).toBe(true);
+    expect(sheetsBar.setActiveSheet('Budget')).toBe(true);
+    expect(sheetsBar.setActiveSheet(added.id)).toBe(true);
+    expect(sheetsBar.getSheets().find(sheet => sheet.isActive).name).toBe(added.name);
+    expect(hot.rootWrapperElement.querySelector('.ht-sheets-bar__tab--active').textContent)
+      .toBe(added.name);
+  });
+
   it('gives a runtime-added sheet a fresh engine sheet when its tab name is taken in the engine', () => {
     const engine = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
 

--- a/handsontable/src/plugins/sheetsBar/__tests__/sheetsBar.unit.js
+++ b/handsontable/src/plugins/sheetsBar/__tests__/sheetsBar.unit.js
@@ -1183,11 +1183,17 @@ describe('SheetsBar plugin', () => {
     const added = sheetsBar.addSheet();
 
     expect(sheetsBar.setActiveSheet(added.id)).toBe(true);
+
+    hot.setDataAtCell(0, 0, 'typed on the new sheet');
+
     expect(sheetsBar.setActiveSheet('Budget')).toBe(true);
+    expect(hot.getDataAtCell(0, 1)).toBe(23);
+
     expect(sheetsBar.setActiveSheet(added.id)).toBe(true);
     expect(sheetsBar.getSheets().find(sheet => sheet.isActive).name).toBe(added.name);
     expect(hot.rootWrapperElement.querySelector('.ht-sheets-bar__tab--active').textContent)
       .toBe(added.name);
+    expect(hot.getDataAtCell(0, 0)).toBe('typed on the new sheet');
   });
 
   it('gives a runtime-added sheet a fresh engine sheet when its tab name is taken in the engine', () => {


### PR DESCRIPTION
### Context

The PR fixes two failures that share one cause: the formula engine sizes a sheet by the extent of its **content**, so it is routinely shorter than the grid, and `AxisSyncer` sent it an axis order as long as the grid. HyperFormula rejects an order whose length is not the sheet's size, and the throw unwinds whatever triggered the sequence change.

**Sorting a grid with trailing empty rows already fails on `develop`.** With `data: [[3,'c'],[1,'a'],[2,'b'],[null,null],[null,null]]` and `columnSorting`, the engine reports `{width: 2, height: 3}` against a 5-row grid, and sorting throws `Invalid arguments, expected number of rows provided to be sheet height.` The grid does not sort at all: `getDataAtCol(0)` stays `[3, 1, 2, null, null]`. `minSpareRows` produces the same shape.

**A sheet the sheets bar added at runtime could be activated only once.** Such a sheet carries no data, so its engine sheet is `0x0` while the grid reports its default 26 columns. The first activation is safe because the sheet has no captured view state yet; leaving it captures one, and returning restores it, which fires the sequence-change sync — the same throw, this time unwinding `SheetsBar#switchTo`, so the tab never activated, the active marker stayed on the previous tab, and the grid kept the previous sheet's data. Instrumented calls during one repro:

| call | sheet | order length | engine sheet | result |
| --- | --- | --- | --- | --- |
| `setColumnOrder` | Budget | 5 | 5x4 | ok |
| `setRowOrder` | Budget | 4 | 5x4 | ok |
| `setColumnOrder` | Sheet3 | 26 | 0x0 | throws |

Both order-sync paths — the sequence-change hook and the initial-order sync — now share one method that reshapes the order into what the engine accepts:

- **Shorter than the sheet**: padded, as before (the engine extends a sheet beyond the dataset to calculate values outside it, handsontable/hyperformula#1179).
- **Longer than the sheet**: compressed onto the elements the engine actually holds, keeping their relative order, so a sort reaches the engine instead of throwing.
- **Entries**: the engine validates the order as a permutation of its own positions, so the `-1` a mid-batch sequence produces is ranked last instead of being passed through.
- **Empty sheet**: nothing is sent, because there is nothing to reorder. The stored sequence then records the identity the engine will hold once the sheet is filled, so the next sync sends the order as an absolute one and the grid's order is not lost. It also stays frozen for every other source meanwhile: recording an order the engine never received would make the following transformation describe a move it never made.

The aborted switch also left the Formulas plugin on the new sheet's name while the grid still held the previous sheet's data; that inconsistent state goes away with the throw.

Both plugin `AGENTS.md` files gain the trap (`formulas`: a new section on the engine's sheet size in either direction; `sheetsBar`: the `0x0` runtime-sheet consequence).

### How has this been tested?

New unit coverage, each case confirmed to fail against the `develop` version of `axisSyncer.ts` and pass with the fix.

```bash
# order reshaping, the baseline after a skipped sync, the initial-order path, both axes
npm run test:unit --prefix handsontable -- --testPathPattern='indexSyncer'

# the sheets bar round trip: add a sheet, activate it, type on it, switch away, switch back
npm run test:unit --prefix handsontable -- --testPathPattern='sheetsBar'

npm run test:unit --prefix handsontable -- --testPathPattern='formulas'
npm run test:e2e --prefix handsontable -- --testPathPattern='formulas'

npm run eslint --prefix handsontable
npm run build --prefix handsontable
```

Results: formulas unit 88/88, sheets bar unit 195/195, formulas E2E 423 specs / 0 failures, ESLint 0 errors, `tsc --noEmit` clean, build green.

`shortSheetOrderSync.unit.js` drives the real engine rather than a stub and pins the released half of the fix: sorting a grid with trailing empty rows leaves the grid and the engine holding the same order. Against `develop` both of its cases fail with `Invalid arguments, expected number of rows provided to be sheet height.` The stub used by the two syncer suites now enforces the engine's own rules — length and permutation — so neither suite can stay green on a malformed order.

Manual check on a local build: add a sheet through the bar's `+` control, switch to `Budget`, switch back. The tab activates, the active marker follows it, and the console stays clean.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2904

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://cla.handsontable.com/sign) — one signature covers both Handsontable and HyperFormula; the `cla/signed` check on this PR confirms it.
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2904

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core row/column index translation for all formula grids on sort, move, and sheet switch; logic is intricate but heavily unit-tested, with known edge cases (inexpressible reorders) left unsynced without warning.
> 
> **Overview**
> Fixes crashes and broken sheet switching when the grid is longer than HyperFormula’s content-sized sheet (trailing empty rows, `minSpareRows`, or runtime sheets bar tabs at `0×0`).
> 
> **`AxisSyncer`** now routes initial and sequence-change ordering through **`#syncOrderWithEngine`**: pad orders when the engine sheet is wider/taller than the dataset, **compress** onto rows/columns the engine actually holds when the grid is longer, skip no-op orders (to avoid clearing HF redo), and defer sync on empty sheets while capturing **`#fillSequence`** so the first data entry lines up with the grid order at fill time. **`#indexesSequence`** tracks the engine’s element order, not the grid’s, so later transforms stay consistent.
> 
> Adds changelog **#13478**, expanded **`formulas`** / **`sheetsBar`** `AGENTS.md`, a HyperFormula-validating **`mockEngine`**, broad **`indexSyncer`** unit tests, integration test for sort-with-empty-rows, and a sheets bar test for re-activating a runtime-added sheet after switching away.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44850663084672b7130ae3ac26af5217c4865630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->